### PR TITLE
Force native find_tables() over pymupdf-layout's global hook in PDF parsing

### DIFF
--- a/src/all2md/parsers/_pdf_layout.py
+++ b/src/all2md/parsers/_pdf_layout.py
@@ -20,9 +20,11 @@ Commercial use requires an Artifex license.
 
 from __future__ import annotations
 
+import contextlib
 import logging
+import sys
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Iterator
 
 if TYPE_CHECKING:
     import fitz
@@ -34,9 +36,59 @@ __all__ = [
     "predict_page_layout",
     "match_predictions_to_blocks",
     "is_layout_available",
+    "native_find_tables",
 ]
 
 logger = logging.getLogger(__name__)
+
+
+@contextlib.contextmanager
+def native_find_tables() -> Iterator[None]:
+    """Force PyMuPDF's native ``find_tables()`` within the block.
+
+    Importing ``pymupdf.layout`` runs its module-level ``activate()``, which
+    installs a *process-global* hook (``pymupdf._get_layout``). PyMuPDF's
+    ``find_tables()`` consults that hook and, when present, reroutes table
+    detection through the GNN layout model instead of its native ruling-line
+    algorithm. On many real documents that model path is worse for our
+    purposes: it overdetects tables (spurious sub-grids) and reconstructs cell
+    text with dropped inter-word spaces and punctuation, because the model's
+    predicted cell boundaries disagree with the ruling-line grid that
+    ``Table.extract()`` then reads against.
+
+    all2md drives layout analysis explicitly via :func:`predict_page_layout`
+    and merges those predictions itself (header/footer trimming, list and
+    table-region supplementation), so the implicit ``find_tables()`` hook is
+    redundant and actively harmful. The whole table pipeline — and the corpus
+    benchmark it was tuned against — assumes native ``find_tables()`` output.
+
+    This context manager nulls the hook for the duration of the block and
+    restores the prior value on exit, so it both guarantees native behavior
+    for our ``find_tables()`` / ``Table.extract()`` calls and leaves global
+    state untouched for any other consumer in the same process. It is a no-op
+    when the hook was never installed (``pymupdf.layout`` not imported).
+
+    The hook is read off the canonical ``pymupdf`` module, but ``fitz`` (the
+    legacy alias) can be a distinct module object in some installs, so both are
+    neutralized defensively.
+    """
+    sentinel = object()
+    saved: list[tuple[Any, Any]] = []
+    for name in ("pymupdf", "fitz"):
+        mod: Any = sys.modules.get(name)
+        if mod is None:
+            continue
+        saved.append((mod, getattr(mod, "_get_layout", sentinel)))
+        mod._get_layout = None
+    try:
+        yield
+    finally:
+        for mod, prev in saved:
+            if prev is sentinel:
+                with contextlib.suppress(AttributeError):
+                    delattr(mod, "_get_layout")
+            else:
+                mod._get_layout = prev
 
 
 @dataclass(frozen=True)

--- a/src/all2md/parsers/pdf.py
+++ b/src/all2md/parsers/pdf.py
@@ -69,6 +69,7 @@ from all2md.parsers._pdf_layout import (
     annotate_blocks_with_layout,
     is_layout_available,
     match_predictions_to_blocks,
+    native_find_tables,
     predict_page_layout,
 )
 from all2md.parsers._pdf_numbering import parse_numbering_prefix
@@ -793,44 +794,51 @@ class PdfToAstConverter(BaseParser):
         attachment_sequencer = create_attachment_sequencer()
 
         pages_list = list(pages_to_use)
-        for idx, pno in enumerate(pages_list):
-            try:
-                page = doc[pno]
-                page_nodes = self._process_page_to_ast(page, pno, base_filename, attachment_sequencer, total_pages)
-                if page_nodes:
-                    children.extend(page_nodes)
+        # Suppress pymupdf-layout's global find_tables() hook for the whole
+        # page loop. We call predict_page_layout() explicitly inside
+        # _process_page_to_ast and merge its predictions ourselves; the
+        # implicit hook would additionally reroute find_tables()/Table.extract()
+        # through the layout model, overdetecting tables and garbling cell text.
+        # See native_find_tables() for the full rationale.
+        with native_find_tables():
+            for idx, pno in enumerate(pages_list):
+                try:
+                    page = doc[pno]
+                    page_nodes = self._process_page_to_ast(page, pno, base_filename, attachment_sequencer, total_pages)
+                    if page_nodes:
+                        children.extend(page_nodes)
 
-                # Add page separator between pages (but not after the last page)
-                if idx < len(pages_list) - 1 and self.options.include_page_numbers:
-                    # Add page separator as Comment node - renderers decide whether to display it
-                    # Format using page_separator_template with placeholders
-                    separator_text = self.options.page_separator_template.format(
-                        page_num=pno + 1, total_pages=total_pages
+                    # Add page separator between pages (but not after the last page)
+                    if idx < len(pages_list) - 1 and self.options.include_page_numbers:
+                        # Add page separator as Comment node - renderers decide whether to display it
+                        # Format using page_separator_template with placeholders
+                        separator_text = self.options.page_separator_template.format(
+                            page_num=pno + 1, total_pages=total_pages
+                        )
+                        children.append(Comment(content=separator_text, metadata={"comment_type": "page_separator"}))
+
+                    # Emit page done event
+                    self._emit_progress(
+                        "item_done",
+                        f"Page {pno + 1} of {total_pages} processed",
+                        current=idx + 1,
+                        total=total_pages,
+                        item_type="page",
+                        page=pno + 1,
                     )
-                    children.append(Comment(content=separator_text, metadata={"comment_type": "page_separator"}))
-
-                # Emit page done event
-                self._emit_progress(
-                    "item_done",
-                    f"Page {pno + 1} of {total_pages} processed",
-                    current=idx + 1,
-                    total=total_pages,
-                    item_type="page",
-                    page=pno + 1,
-                )
-            except Exception as e:
-                # Emit error event but continue processing
-                self._emit_progress(
-                    "error",
-                    f"Error processing page {pno + 1}: {str(e)}",
-                    current=idx + 1,
-                    total=total_pages,
-                    error=str(e),
-                    stage="page_processing",
-                    page=pno + 1,
-                )
-                # Re-raise to maintain existing error handling
-                raise
+                except Exception as e:
+                    # Emit error event but continue processing
+                    self._emit_progress(
+                        "error",
+                        f"Error processing page {pno + 1}: {str(e)}",
+                        current=idx + 1,
+                        total=total_pages,
+                        error=str(e),
+                        stage="page_processing",
+                        page=pno + 1,
+                    )
+                    # Re-raise to maintain existing error handling
+                    raise
 
         # Extract and attach metadata
         metadata = self.extract_metadata(doc)

--- a/tests/integration/formats/pdf/test_pdf_layout_advanced.py
+++ b/tests/integration/formats/pdf/test_pdf_layout_advanced.py
@@ -346,3 +346,51 @@ class TestPdfLayoutAdvanced:
         )
 
         doc.close()
+
+
+class TestNativeFindTablesHook:
+    """``native_find_tables()`` neutralizes pymupdf-layout's global find_tables hook.
+
+    Importing ``pymupdf.layout`` installs a process-global ``pymupdf._get_layout``
+    hook that reroutes PyMuPDF's ``find_tables()`` through the GNN model, which
+    garbles table cell text (dropped spaces/punctuation) and mis-detects grids.
+    The parser wraps its page loop in ``native_find_tables()`` to force native
+    behavior. These tests pin that suppress-and-restore contract without needing
+    the (noncommercial, optional) plugin installed.
+    """
+
+    def test_hook_suppressed_inside_and_restored_after(self):
+        import sys
+
+        from all2md.parsers._pdf_layout import native_find_tables
+
+        pymupdf = sys.modules.get("pymupdf")
+        assert pymupdf is not None, "pymupdf should already be imported by the parser"
+
+        def fake_hook(*args, **kwargs):  # stand-in for activate()'s installed hook
+            return []
+
+        sentinel = object()
+        had_attr = hasattr(pymupdf, "_get_layout")
+        prev = getattr(pymupdf, "_get_layout", sentinel)
+        pymupdf._get_layout = fake_hook
+        try:
+            with native_find_tables():
+                assert pymupdf._get_layout is None, "hook must be suppressed inside the block"
+            assert pymupdf._get_layout is fake_hook, "prior hook must be restored on exit"
+        finally:
+            if had_attr and prev is not sentinel:
+                pymupdf._get_layout = prev
+            else:
+                # Attribute did not exist before this test; remove what we added.
+                try:
+                    delattr(pymupdf, "_get_layout")
+                except AttributeError:
+                    pass
+
+    def test_noop_when_hook_absent(self):
+        """Must not raise when the plugin was never imported (no hook installed)."""
+        from all2md.parsers._pdf_layout import native_find_tables
+
+        with native_find_tables():
+            pass


### PR DESCRIPTION
## What

Importing `pymupdf-layout` installs a process-global hook (`pymupdf._get_layout`) that reroutes PyMuPDF's `find_tables()` through its GNN layout model. On real documents that path **overdetects tables** (spurious sub-grids) and **garbles cell text** (dropped inter-word spaces/punctuation), because the model's predicted cell boundaries disagree with the ruling-line grid that `Table.extract()` reads against.

all2md already drives layout analysis explicitly via `predict_page_layout()` and merges those predictions itself, so the implicit hook is redundant and actively harmful — and the whole table pipeline (plus its corpus benchmark) assumes native `find_tables()` output.

## Change

- Add a `native_find_tables()` context manager that nulls the hook (on both the `pymupdf` and `fitz` module aliases) for the duration of the page loop and restores prior global state on exit. No-op when `pymupdf-layout` was never imported.
- Wrap the page-processing loop in `pdf.py` with it.
- Add a regression test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)