### PR TITLE
Sync uv.lock to all2md 1.1.3

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -18,7 +18,7 @@ wheels = [
 
 [[package]]
 name = "all2md"
-version = "1.1.2"
+version = "1.1.3"
 source = { editable = "." }
 dependencies = [
     { name = "pyyaml" },


### PR DESCRIPTION
## What

The editable `all2md` entry in `uv.lock` was stale at `1.1.2` while `pyproject.toml` is at `1.1.3`. This re-locks so the lockfile matches the current package version.

This is what the `format-sync` pre-commit hook regenerates on every commit until the lock is in sync — landing it unblocks that hook going forward.

🤖 Generated with [Claude Code](https://claude.com/claude-code)