### PR TITLE
Commit the logo asset and fix the broken README logo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <img src="logo.svg" alt="all2md logo" width="120" />
+  <img src="https://raw.githubusercontent.com/thomas-villani/all2md/main/docs/source/_static/logo.svg" alt="all2md logo" width="120" />
 </p>
 
 # `all2md`: The Universal Document Conversion Library

--- a/docs/source/_static/logo.svg
+++ b/docs/source/_static/logo.svg
@@ -1,0 +1,13 @@
+<svg viewBox="0 0 64 64" xmlns="http://www.w3.org/2000/svg">
+  <!-- Background -->
+  <rect width="64" height="64" rx="12" fill="#0d1117"/>
+
+  <!-- Three input dots: "all" formats -->
+  <circle cx="22" cy="16" r="3.2" fill="#ffffff" opacity="1.0"/>
+  <circle cx="32" cy="16" r="3.2" fill="#ffffff" opacity="1.0"/>
+  <circle cx="42" cy="16" r="3.2" fill="#ffffff" opacity="1.0"/>
+
+  <!-- Downward arrow: "to md" (markdown convention) -->
+  <path d="M 32 30 L 32 46" stroke="#ffffff" stroke-width="7" stroke-linecap="round"/>
+  <path d="M 22 38 L 32 50 L 42 38" stroke="#ffffff" stroke-width="7" stroke-linecap="round" stroke-linejoin="round" fill="none"/>
+</svg>

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -149,6 +149,8 @@ doctest_default_flags = 0
 
 html_theme = "sphinx_rtd_theme"
 html_static_path = ["_static"]
+html_logo = "_static/logo.svg"
+html_favicon = "_static/logo.svg"
 
 from generate_options_doc import generate_options_document  # noqa: E402
 


### PR DESCRIPTION
## Problem

The README has rendered `<img src="logo.svg">` since 16d5942 (already on `main`), but **`logo.svg` was never committed** — it sat untracked in the working tree. The logo therefore shows as a **broken image on GitHub and PyPI** right now.

## Fix

- **Commit the asset**, placed at `docs/source/_static/logo.svg` (out of the repo root).
- **Wire it into Sphinx** as `html_logo` + `html_favicon`, so the rendered docs site uses it too.
- **Repoint the README** at an absolute `raw.githubusercontent.com` URL. PyPI does not resolve relative image paths (GitHub does); the absolute URL renders on both.

## Not affected

The `all2md serve` / `view` favicon is inlined as a `data:` URI inside each theme template and never depended on this file — it already works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)