### PR TITLE
Auto-read piped stdin when no input argument is given

### DIFF
--- a/src/all2md/cli/__init__.py
+++ b/src/all2md/cli/__init__.py
@@ -96,6 +96,23 @@ __all__ = [
 ]
 
 
+def _stdin_is_piped() -> bool:
+    """Return ``True`` when stdin has piped/redirected data rather than a terminal.
+
+    Used to auto-read stdin when no input argument is given, so ``head file.md |
+    rcat`` works like ``... | rcat -``. Defensive against a missing or closed
+    stdin (e.g. under ``pythonw``), in which case we report "not piped" so the
+    normal "input required" error path runs.
+    """
+    isatty = getattr(sys.stdin, "isatty", None)
+    if not callable(isatty):
+        return False
+    try:
+        return not isatty()
+    except (ValueError, OSError):  # closed/detached stdin
+        return False
+
+
 def _setup_logging_level(parsed_args: argparse.Namespace) -> None:
     """Set up logging level based on command-line arguments.
 
@@ -295,8 +312,14 @@ def main(args: list[str] | None = None) -> int:
     has_batch_list = hasattr(parsed_args, "batch_from_list") and parsed_args.batch_from_list
     has_merge_list = hasattr(parsed_args, "merge_from_list") and parsed_args.merge_from_list
     if not parsed_args.input and not has_batch_list and not has_merge_list:
-        print("Error: Input file is required", file=sys.stderr)
-        return EXIT_VALIDATION_ERROR
+        # No explicit input given. If stdin is piped (not a TTY), read from it
+        # automatically so `head file.md | rcat` / `... | all2md` work without an
+        # explicit "-". An interactive terminal still gets the usage error.
+        if _stdin_is_piped():
+            parsed_args.input = ["-"]
+        else:
+            print("Error: Input file is required", file=sys.stderr)
+            return EXIT_VALIDATION_ERROR
 
     # Set up logging
     _setup_logging_level(parsed_args)

--- a/tests/e2e/test_cli.py
+++ b/tests/e2e/test_cli.py
@@ -1683,12 +1683,41 @@ class TestExitCodes:
         assert result.returncode == 4
         assert "Error" in result.stderr
 
-    def test_exit_code_input_error_no_input(self):
-        """Test exit code 3 (VALIDATION_ERROR) when no input provided."""
-        result = self._run_cli([])
+    def test_exit_code_input_error_no_input_empty_pipe(self):
+        """No input arg with an empty stdin pipe is auto-read, then fails as no usable input.
 
-        assert result.returncode == 3
-        assert "Input file is required" in result.stderr
+        With no input argument and piped (non-TTY) stdin, the CLI auto-reads
+        stdin (so ``head file.md | all2md`` works without an explicit ``-``).
+        Feeding an empty pipe therefore reaches the converter with nothing to
+        convert and exits with FILE_ERROR (4). An interactive TTY instead reports
+        "Input file is required" (covered by unit tests, since a subprocess
+        cannot fake a TTY).
+        """
+        import sys
+
+        result = subprocess.run(
+            [sys.executable, "-m", "all2md"],
+            capture_output=True,
+            text=True,
+            input="",  # force a real, empty stdin pipe (deterministic across platforms)
+        )
+
+        assert result.returncode == 4
+        assert "No valid input files found" in result.stderr
+
+    def test_stdin_auto_read_without_dash(self):
+        """Piped content is converted even without an explicit ``-`` argument."""
+        import sys
+
+        result = subprocess.run(
+            [sys.executable, "-m", "all2md"],
+            capture_output=True,
+            text=True,
+            input="<h1>Piped Heading</h1><p>body</p>",
+        )
+
+        assert result.returncode == 0, f"stderr: {result.stderr}"
+        assert "Piped Heading" in result.stdout
 
     def test_exit_code_input_error_invalid_config(self, tmp_path):
         """Test exit code 3 (VALIDATION_ERROR) for invalid config file."""

--- a/tests/unit/cli/test_cli_main.py
+++ b/tests/unit/cli/test_cli_main.py
@@ -56,6 +56,52 @@ class TestRcatMain:
         mock_main.assert_called_once_with(["--rich"])
 
 
+@pytest.mark.unit
+class TestStdinAutoRead:
+    """Tests for stdin auto-detection when no input argument is given."""
+
+    def _fake_stdin(self, *, isatty=None):
+        from unittest.mock import MagicMock
+
+        fake = MagicMock()
+        if isatty is None:
+            fake.isatty.side_effect = ValueError("closed")
+        else:
+            fake.isatty.return_value = isatty
+        return fake
+
+    def test_stdin_is_piped_true_when_not_tty(self):
+        """A non-TTY stdin (pipe/redirect) is reported as piped."""
+        from all2md.cli import _stdin_is_piped
+
+        with patch("all2md.cli.sys.stdin", self._fake_stdin(isatty=False)):
+            assert _stdin_is_piped() is True
+
+    def test_stdin_is_piped_false_when_tty(self):
+        """An interactive TTY stdin is not treated as piped."""
+        from all2md.cli import _stdin_is_piped
+
+        with patch("all2md.cli.sys.stdin", self._fake_stdin(isatty=True)):
+            assert _stdin_is_piped() is False
+
+    def test_stdin_is_piped_false_when_isatty_raises(self):
+        """A closed/detached stdin falls back to 'not piped' rather than raising."""
+        from all2md.cli import _stdin_is_piped
+
+        with patch("all2md.cli.sys.stdin", self._fake_stdin(isatty=None)):
+            assert _stdin_is_piped() is False
+
+    def test_main_no_input_with_tty_errors(self, capsys):
+        """With no input and an interactive TTY, the usage error still fires."""
+        from all2md.cli import main
+
+        with patch("all2md.cli.sys.stdin", self._fake_stdin(isatty=True)):
+            rc = main([])
+
+        assert rc != 0
+        assert "Input file is required" in capsys.readouterr().err
+
+
 @pytest.mark.integration
 @pytest.mark.cli
 class TestCLIIntegration:


### PR DESCRIPTION
## Problem

`head file.md | rcat` (and `… | all2md`) failed with **"Error: Input file is required"**. The CLI only read stdin when given an explicit `-`, so the natural bare pipe never worked.

## Fix

When no input arg / `--batch-from-list` / `--merge-from-list` is present, detect a **piped (non-TTY) stdin** and inject `-`, so piped content is read automatically. An interactive terminal still gets the usage error. Detection is defensive — a missing/closed stdin reports "not piped" so the normal error path runs.

Rich output is unchanged: it remains gated on **stdout** being a TTY, so a real terminal renders rich while a redirected stdout stays plain. (`--force-rich` still forces ANSI through a pipe.)

## Tests

- e2e: rewrote the no-input test to drive a deterministic empty pipe (a subprocess can't fake a TTY), asserting the auto-read → "No valid input files found" (exit 4); added a positive test that piped HTML converts with no `-`.
- unit: `_stdin_is_piped` (piped / TTY / raising), and the TTY no-input usage-error path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)