### PR TITLE
serve: random-port fallback, index file timestamps, and --browse

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -76,15 +76,7 @@ ideas/
 AGENTS.md
 CLAUDE.md
 todo.md
-qa-*.txt
-helptxt*.txt
-orgmode.org
-out.txt
-claude-*.md
-gpt-*.md
-REFACTOR-STATUS.md
 completions*.ps1
-resume.pdf
 
 # Documentation builds
 docs/_build/
@@ -106,3 +98,6 @@ benchmarks/corpus/.cache/
 benchmarks/corpus/results/
 benchmarks/corpus/inspect/
 benchmarks/corpus/.test/
+
+.claude/
+broken/

--- a/docs/source/cli.rst
+++ b/docs/source/cli.rst
@@ -1999,7 +1999,10 @@ Arguments
 **Optional Arguments:**
 
 ``--port PORT``
-   Port to serve on. Default: ``8000``.
+   Port to serve on. Default: ``8000``. If the requested port is unavailable
+   (already in use, or access denied), the server automatically binds an
+   OS-assigned random free port instead and prints the actual URL, rather than
+   failing.
 
    .. code-block:: bash
 
@@ -2016,6 +2019,16 @@ Arguments
 
       # Localhost only (default)
       all2md serve ./docs --host 127.0.0.1
+
+``--browse``
+   Open the served URL in your default web browser once the server has started.
+   When bound to a wildcard host (e.g. ``0.0.0.0``), the browser is pointed at
+   ``127.0.0.1``.
+
+   .. code-block:: bash
+
+      # Serve and open in the browser
+      all2md serve ./docs --browse
 
 ``-r``, ``--recursive``
    Recursively serve subdirectories. When enabled, scans all nested folders for documents and generates a per-subdirectory index page for each folder. Each index lists immediate files and child directories, with breadcrumb navigation (e.g., ``Home > reports > 2026``) for easy traversal of the directory tree.

--- a/src/all2md/cli/commands/server.py
+++ b/src/all2md/cli/commands/server.py
@@ -10,13 +10,17 @@ themes, file upload forms, and REST API endpoints for development use.
 
 import argparse
 import base64
+import errno
 import fnmatch
 import http.server
 import io
 import json
+import os
 import socketserver
 import sys
 import threading
+import webbrowser
+from datetime import datetime
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
 from urllib.parse import quote, unquote
@@ -367,14 +371,21 @@ def _generate_directory_index(
         for file in sorted(current_files, key=lambda f: f.name.lower()):
             rel_path = file.relative_to(base_dir)
             url = "/" + quote(str(rel_path).replace("\\", "/"))
+            modified_str: Optional[str] = None
+            created_str: Optional[str] = None
             try:
-                file_size = file.stat().st_size
-                size_str = _format_file_size(file_size)
+                stat_result = file.stat()
+                size_str = _format_file_size(stat_result.st_size)
+                modified_str = f"modified {_format_timestamp(stat_result.st_mtime)}"
+                created_ts = _file_created_timestamp(stat_result)
+                if created_ts is not None:
+                    created_str = f"created {_format_timestamp(created_ts)}"
             except OSError:
                 size_str = "?"
+            details = " · ".join(part for part in (size_str, modified_str, created_str) if part)
             content += "<li style='margin: 5px 0;'>"
             content += f"<a href='{url}' style='text-decoration: none; font-size: 1.0em;'>{file.name}</a>"
-            content += f" <span style='color: #888; font-size: 0.9em;'>({size_str})</span>"
+            content += f" <span style='color: #888; font-size: 0.9em;'>({details})</span>"
             content += "</li>"
         content += "</ul></div>"
 
@@ -384,6 +395,57 @@ def _generate_directory_index(
     html = html.replace("{CONTENT}", content)
 
     return html
+
+
+def _format_timestamp(timestamp: float) -> str:
+    """Format an epoch timestamp as a compact local ``YYYY-MM-DD HH:MM`` string."""
+    return datetime.fromtimestamp(timestamp).strftime("%Y-%m-%d %H:%M")
+
+
+def _file_created_timestamp(stat_result: os.stat_result) -> Optional[float]:
+    """Best-effort file creation time, or ``None`` when it isn't reliably available.
+
+    Uses ``st_birthtime`` when the platform provides it (macOS, *BSD, and Windows
+    on Python 3.12+). On Windows without ``st_birthtime``, ``st_ctime`` is the
+    creation time. On Linux ``st_ctime`` is the inode-change time (not creation),
+    so we return ``None`` there rather than display a misleading value.
+    """
+    birthtime = getattr(stat_result, "st_birthtime", None)
+    if birthtime is not None:
+        return float(birthtime)
+    # os.name (not sys.platform) avoids mypy's platform-specific narrowing, which
+    # would otherwise flag one branch as unreachable depending on the OS mypy runs on.
+    if os.name == "nt":
+        return stat_result.st_ctime
+    return None
+
+
+def _bind_http_server(
+    host: str, port: int, handler: type[http.server.BaseHTTPRequestHandler]
+) -> Tuple["_ThreadingHTTPServer", bool]:
+    """Bind the serve HTTP server, falling back to a random free port if taken.
+
+    Returns ``(httpd, fell_back)`` where ``fell_back`` is ``True`` when the
+    requested ``port`` was unavailable and the OS assigned a random free port
+    (bind to port 0) instead. Re-raises the original ``OSError`` for failures
+    other than "address in use".
+    """
+    try:
+        return _ThreadingHTTPServer((host, port), handler), False
+    except OSError as e:
+        # Treat the port as unavailable when it is already in use (EADDRINUSE) or
+        # access is denied (EACCES) -- on Windows, an in-use listening port with
+        # SO_REUSEADDR set surfaces as WSAEACCES (WinError 10013) rather than
+        # WSAEADDRINUSE (10048), and privileged ports raise EACCES everywhere.
+        # In all of these cases, fall back to an OS-assigned free port.
+        winerror = getattr(e, "winerror", None)
+        if (
+            e.errno in (errno.EADDRINUSE, errno.EACCES)
+            or winerror in (10048, 10013)
+            or "Address already in use" in str(e)
+        ):
+            return _ThreadingHTTPServer((host, 0), handler), True
+        raise
 
 
 def _format_file_size(size_bytes: int) -> str:
@@ -559,6 +621,11 @@ def _create_serve_parser() -> argparse.ArgumentParser:
     parser.add_argument(
         "--theme",
         help="Custom theme template path or built-in theme name (minimal, dark, newspaper, docs, sidebar)",
+    )
+    parser.add_argument(
+        "--browse",
+        action="store_true",
+        help="Open the served URL in the default web browser once the server starts",
     )
     parser.add_argument(
         "--enable-upload",
@@ -1098,20 +1165,23 @@ def handle_serve_command(args: list[str] | None = None) -> int:  # noqa: C901
                 error = {"error": "Internal server error", "message": str(e)}
                 self.wfile.write(json.dumps(error).encode("utf-8"))
 
-    # Start server
+    # Start server. If the requested port is taken, fall back to an OS-assigned
+    # random free port instead of giving up (port 8000 is frequently in use).
     try:
-        httpd = _ThreadingHTTPServer((parsed.host, parsed.port), ServeHandler)
+        httpd, fell_back = _bind_http_server(parsed.host, parsed.port, ServeHandler)
     except OSError as e:
-        if e.errno == 98 or "Address already in use" in str(e):
-            print(f"Error: Port {parsed.port} is already in use", file=sys.stderr)
-        else:
-            print(f"Error: Could not start server: {e}", file=sys.stderr)
+        print(f"Error: Could not start server: {e}", file=sys.stderr)
         return EXIT_ERROR
     except Exception as e:
         print(f"Error: {e}", file=sys.stderr)
         return EXIT_ERROR
 
-    url = f"http://{parsed.host}:{parsed.port}/"
+    # Use the port we actually bound (differs from --port when we fell back).
+    bound_port = httpd.server_address[1]
+    if fell_back:
+        print(f"Port {parsed.port} is unavailable; bound a random free port instead.", file=sys.stderr)
+
+    url = f"http://{parsed.host}:{bound_port}/"
     print(f"\nServing at {url}")
 
     # Print development warning if upload or API is enabled
@@ -1129,6 +1199,21 @@ def handle_serve_command(args: list[str] | None = None) -> int:  # noqa: C901
         print("=" * 70 + "\n")
 
     print("Press Ctrl+C to stop")
+
+    # Open the served URL in the browser when requested (skipped under test mode,
+    # matching `all2md view`). Use a loopback host for the browser when bound to a
+    # wildcard address, which browsers can't navigate to directly.
+    if parsed.browse and not os.environ.get("ALL2MD_TEST_NO_BROWSER"):
+        # nosec B104: not binding here -- detecting a wildcard bind host so the
+        # browser is pointed at a reachable loopback address instead.
+        wildcard_hosts = ("0.0.0.0", "::", "")  # nosec B104
+        browse_host = "127.0.0.1" if parsed.host in wildcard_hosts else parsed.host
+        browse_url = f"http://{browse_host}:{bound_port}/"
+        print(f"Opening {browse_url} in browser...")
+        try:
+            webbrowser.open(browse_url)
+        except Exception as e:  # pragma: no cover - browser launch is best-effort
+            print(f"Could not open browser: {e}", file=sys.stderr)
 
     stop_event = threading.Event()
 

--- a/tests/unit/cli/commands/test_server.py
+++ b/tests/unit/cli/commands/test_server.py
@@ -4,12 +4,17 @@ This module tests the serve command handler directly,
 providing coverage for argument parsing, setup, and helper functions.
 """
 
+import errno
+from datetime import datetime
 from unittest.mock import patch
 
 import pytest
 
+from all2md.cli.commands import server as server_mod
 from all2md.cli.commands.server import (
+    _bind_http_server,
     _format_file_size,
+    _format_timestamp,
     _generate_breadcrumbs,
     _generate_directory_index,
     _generate_upload_form,
@@ -74,6 +79,85 @@ class TestServerHelpers:
     def test_format_file_size_zero(self):
         """Test formatting zero bytes."""
         assert _format_file_size(0) == "0.0 B"
+
+    def test_format_timestamp(self):
+        """Timestamps render as compact local YYYY-MM-DD HH:MM."""
+        # Build from a local datetime so the assertion is timezone-independent.
+        ts = datetime(2021, 1, 2, 3, 4, 5).timestamp()
+        assert _format_timestamp(ts) == "2021-01-02 03:04"
+
+
+@pytest.mark.unit
+class TestBindHttpServer:
+    """Test the port-binding fallback for the serve command."""
+
+    def _fake_server_factory(self, calls, *, in_use_ports):
+        """Build a fake _ThreadingHTTPServer that raises EADDRINUSE for given ports."""
+
+        class FakeServer:
+            def __init__(self, addr, handler):
+                calls.append(addr)
+                if addr[1] in in_use_ports:
+                    raise OSError(errno.EADDRINUSE, "Address already in use")
+                # Port 0 -> OS would assign a real port; simulate one.
+                assigned = 54321 if addr[1] == 0 else addr[1]
+                self.server_address = (addr[0], assigned)
+
+        return FakeServer
+
+    def test_no_fallback_when_port_free(self):
+        """A free port binds directly without falling back."""
+        calls: list = []
+        fake = self._fake_server_factory(calls, in_use_ports=set())
+        with patch.object(server_mod, "_ThreadingHTTPServer", fake):
+            httpd, fell_back = _bind_http_server("127.0.0.1", 8000, object)  # type: ignore[arg-type]
+
+        assert fell_back is False
+        assert httpd.server_address == ("127.0.0.1", 8000)
+        assert calls == [("127.0.0.1", 8000)]
+
+    def test_falls_back_to_random_port_when_in_use(self):
+        """A taken port triggers a second bind to port 0 (OS-assigned)."""
+        calls: list = []
+        fake = self._fake_server_factory(calls, in_use_ports={8000})
+        with patch.object(server_mod, "_ThreadingHTTPServer", fake):
+            httpd, fell_back = _bind_http_server("127.0.0.1", 8000, object)  # type: ignore[arg-type]
+
+        assert fell_back is True
+        assert httpd.server_address == ("127.0.0.1", 54321)
+        assert calls == [("127.0.0.1", 8000), ("127.0.0.1", 0)]
+
+    def test_falls_back_on_windows_access_denied(self):
+        """On Windows an in-use port surfaces as WinError 10013; that still falls back."""
+        calls: list = []
+
+        class FakeServer:
+            def __init__(self, addr, handler):
+                calls.append(addr)
+                if addr[1] != 0:
+                    err = OSError(errno.EACCES, "access forbidden")
+                    err.winerror = 10013  # type: ignore[attr-defined]
+                    raise err
+                self.server_address = (addr[0], 54321)
+
+        with patch.object(server_mod, "_ThreadingHTTPServer", FakeServer):
+            httpd, fell_back = _bind_http_server("127.0.0.1", 8000, object)  # type: ignore[arg-type]
+
+        assert fell_back is True
+        assert httpd.server_address == ("127.0.0.1", 54321)
+
+    def test_reraises_unrelated_oserror(self):
+        """OSErrors unrelated to port availability propagate (no silent fallback)."""
+
+        class FakeServer:
+            def __init__(self, addr, handler):
+                raise OSError(errno.EADDRNOTAVAIL, "Cannot assign requested address")
+
+        with patch.object(server_mod, "_ThreadingHTTPServer", FakeServer):
+            with pytest.raises(OSError) as excinfo:
+                _bind_http_server("203.0.113.1", 8000, object)  # type: ignore[arg-type]
+
+        assert excinfo.value.errno == errno.EADDRNOTAVAIL
 
     def test_get_content_type_md(self):
         """Test getting content type for md alias."""
@@ -340,6 +424,13 @@ class TestHandleServeCommand:
         assert exit_code == 0
         captured = capsys.readouterr()
         assert "--host" in captured.out
+
+    def test_serve_browse_flag_in_help(self, capsys):
+        """Test serve --browse flag is advertised in help."""
+        exit_code = handle_serve_command(["--help"])
+        assert exit_code == 0
+        captured = capsys.readouterr()
+        assert "--browse" in captured.out
 
 
 @pytest.mark.unit
@@ -635,6 +726,23 @@ class TestGenerateDirectoryIndex:
 
         # Should contain file size
         assert "B" in html  # Size in bytes
+
+    def test_generate_directory_index_shows_modified_time(self, tmp_path):
+        """Test that the directory index shows each file's last-modified time."""
+        file1 = tmp_path / "doc.md"
+        file1.write_text("# Doc")
+
+        theme_path = tmp_path / "theme.html"
+        theme_path.write_text("{TITLE} {CONTENT}")
+
+        html = _generate_directory_index(
+            [file1],
+            theme_path,
+            tmp_path,
+            enable_upload=False,
+        )
+
+        assert "modified" in html
 
     def test_generate_directory_index_empty_files(self, tmp_path):
         """Test directory index with empty file list."""


### PR DESCRIPTION
Three quality-of-life improvements to `all2md serve`, plus a small `.gitignore` tidy-up.

## `serve` enhancements

- **Random-port fallback** — when the requested `--port` (default 8000) is unavailable, bind an OS-assigned random free port instead of failing, and print the actual URL. Handles the Windows `SO_REUSEADDR` quirk where an in-use listening port surfaces as `WSAEACCES` (WinError 10013) rather than `WSAEADDRINUSE`. Unrelated bind errors still propagate. Verified against a real busy socket on Windows.
- **Index file details** — each file in the directory listing now shows its **last-modified** time next to the size, plus **creation** time where the OS reports it reliably (`st_birthtime`, or `st_ctime` on Windows). Linux `st_ctime` is the inode-change time, not creation, so it's omitted there rather than shown misleadingly.
- **`--browse`** — opens the served URL in the default browser once the server is up, mirroring `all2md view` (honors `ALL2MD_TEST_NO_BROWSER` in tests). Wildcard bind hosts (`0.0.0.0`/`::`) are rewritten to `127.0.0.1` for the browser.

## Other

- `.gitignore`: ignore `.claude/` and `broken/` (bundled in, per request).
- Docs: `cli.rst` updated for the `--port` fallback and `--browse`.

## Tests

New unit tests for `_bind_http_server` (free / in-use→fallback / Windows WinError 10013 / unrelated-error re-raise), `_format_timestamp`, the index modified-time, and `--browse` in `--help`. Full `tests/unit/cli/` suite passes; `black`/`ruff`/`mypy`/`bandit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)