### PR TITLE
Release of v1.2.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -72,19 +72,14 @@ Thumbs.db
 review/
 ideas/
 
+
 # Development and debugging files
+.claude/
+broken/
 AGENTS.md
 CLAUDE.md
 todo.md
-qa-*.txt
-helptxt*.txt
-orgmode.org
-out.txt
-claude-*.md
-gpt-*.md
-REFACTOR-STATUS.md
 completions*.ps1
-resume.pdf
 
 # Documentation builds
 docs/_build/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.2.0] - 2026-05-29
+
 ### Added
 - Config-file support for the `view`, `serve`, `diff`, `edit`, `arxiv`, and `generate-site` subcommands. Each command reads its own same-named section — `[view]`, `[serve]`, `[diff]`, `[edit]`, `[arxiv]`, `[generate-site]` — from `.all2md.toml`/`.yaml`/`.json` (or the equivalent `[tool.all2md.<command>]` block in `pyproject.toml`), so flags like `view --no-wait` or `serve --port` can be set once instead of typed every time. Precedence is built-in default < config section < explicit CLI flag, and every one of these commands now also accepts `--config <path>` and `--no-config`, mirroring the main converter. Keys are the option name (hyphens or underscores both work); only the matching section is read, so subcommand config never affects a normal conversion and vice versa. A config value can also satisfy an otherwise-required option (e.g. `[arxiv]` with `output = "paper.tar.gz"` lets `all2md arxiv paper.tex` run without `-o`).
 - `all2md config generate` now emits a template section for each of those subcommands alongside the format sections, so generating a config is the quickest way to discover every available subcommand key and its default. See the new "Subcommand Options" section in `docs/source/configuration.rst`.

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -37,7 +37,7 @@ if str(SCRIPTS_PATH) not in sys.path:
 project = "all2md"
 copyright = "2025, Tom Villani, Ph.D."
 author = "Tom Villani, Ph.D."
-release = "1.1.3"
+release = "1.2.0"
 
 # -- General configuration ---------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration

--- a/mcpb/manifest.json
+++ b/mcpb/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": "0.4",
   "name": "all2md",
   "display_name": "all2md",
-  "version": "1.1.3",
+  "version": "1.2.0",
   "description": "Convert PDFs, Office files, HTML, email, and 40+ formats to Markdown and back, directly inside Claude.",
   "long_description": "all2md's built-in MCP server, packaged for one-click install. Lets AI assistants read and convert documents across 40+ formats via an AST-based conversion pipeline, render Markdown back out to PDF/DOCX/PPTX/EPUB/HTML/RST, and edit documents section-by-section. Includes smart source auto-detection (file path, data URI, base64, plain text), section extraction, and security controls (a user-chosen workspace folder, network off by default, and path validation).",
   "author": {

--- a/mcpb/pyproject.toml
+++ b/mcpb/pyproject.toml
@@ -7,8 +7,8 @@
 # [tool.bumpversion] config — do NOT hand-edit the version strings below.
 [project]
 name = "all2md-mcpb"
-version = "1.1.3"
+version = "1.2.0"
 requires-python = ">=3.10"
 dependencies = [
-    "all2md[mcp,pdf,pdf_render,docx,html,xlsx,pptx,epub,rst,markdown,odf]>=1.1.3",
+    "all2md[mcp,pdf,pdf_render,docx,html,xlsx,pptx,epub,rst,markdown,odf]>=1.2.0",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "all2md"
-version = "1.1.3"
+version = "1.2.0"
 description = "Rapid, lightweight conversion of various document formats to markdown for LLMs"
 readme = "README.md"
 authors = [
@@ -412,7 +412,7 @@ skips = [
 ]
 
 [tool.bumpversion]
-current_version = "1.1.3"
+current_version = "1.2.0"
 parse = "(?P<major>\\d+)\\.(?P<minor>\\d+)\\.(?P<patch>\\d+)"
 serialize = ["{major}.{minor}.{patch}"]
 commit = true

--- a/src/all2md/__init__.py
+++ b/src/all2md/__init__.py
@@ -86,7 +86,7 @@ if sys.version_info < (3, 10):
         f"You are using Python {sys.version_info.major}.{sys.version_info.minor}."
     )
 
-__version__ = "1.1.3"
+__version__ = "1.2.0"
 
 from typing import TYPE_CHECKING, Any
 

--- a/uv.lock
+++ b/uv.lock
@@ -18,7 +18,7 @@ wheels = [
 
 [[package]]
 name = "all2md"
-version = "1.1.3"
+version = "1.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "pyyaml" },


### PR DESCRIPTION
- **Updated gitignore**
- **Bump version: 1.1.3 → 1.2.0**
- Config-file support for the `view`, `serve`, `diff`, `edit`, `arxiv`, and `generate-site` subcommands. Each command reads its own same-named section — `[view]`, `[serve]`, `[diff]`, `[edit]`, `[arxiv]`, `[generate-site]` — from `.all2md.toml`/`.yaml`/`.json` (or the equivalent `[tool.all2md.<command>]` block in `pyproject.toml`), so flags like `view --no-wait` or `serve --port` can be set once instead of typed every time. Precedence is built-in default < config section < explicit CLI flag, and every one of these commands now also accepts `--config <path>` and `--no-config`, mirroring the main converter. Keys are the option name (hyphens or underscores both work); only the matching section is read, so subcommand config never affects a normal conversion and vice versa. A config value can also satisfy an otherwise-required option (e.g. `[arxiv]` with `output = "paper.tar.gz"` lets `all2md arxiv paper.tex` run without `-o`).
- `all2md config generate` now emits a template section for each of those subcommands alongside the format sections, so generating a config is the quickest way to discover every available subcommand key and its default. See the new "Subcommand Options" section in `docs/source/configuration.rst`.
- Added `all2md llm-help` command for agents
- Fixed conflicting table detection due to `pdf_layout`
- Added MCP Bundle (MCPB) for easy install into Claude Desktop and other LLM apps
