### PR TITLE
Add MkDocs, Zola, and Eleventy generate-site generators

### DIFF
--- a/README.md
+++ b/README.md
@@ -441,17 +441,17 @@ all2md ./reports/*.docx --output-dir ./markdown_reports
 all2md ./source_docs --recursive --output-dir ./converted_docs
 
 # Preserve the source directory structure in the output
-all2md ./source_docs -r -o ./converted_docs --preserve-structure
+all2md ./source_docs -r --output-dir ./converted_docs --preserve-structure
 ```
 
 **Advanced Processing**
 
 ```bash
 # Process files in parallel using 4 worker processes
-all2md ./large_docs -r -o ./output -p 4
+all2md ./large_docs -r --output-dir ./output -p 4
 
 # Watch a directory for changes and convert automatically
-all2md ./watched_folder -r -o ./output --watch
+all2md ./watched_folder -r --output-dir ./output --watch
 
 # Pipe content from stdin
 cat report.html | all2md - > report.md
@@ -508,11 +508,11 @@ all2md list-formats
 # Check which optional dependencies are installed
 all2md check-deps
 
-# Quick HTML preview with themes (dark, docs, minimal, newspaper, sidebar)
-all2md document.pdf view --theme docs
+# Quick HTML preview with themes (minimal, dark, newspaper, docs, sidebar)
+all2md view document.pdf --theme docs
 
-# Generate a static website from markdown files
-all2md generate-site ./content --output ./site --theme newspaper
+# Generate a static site (Hugo, Jekyll, MkDocs, Zola, or Eleventy) from markdown files
+all2md generate-site ./content --output-dir ./site --generator hugo
 
 # Package a document for ArXiv submission
 all2md arxiv paper.md -o submission.tar.gz
@@ -529,21 +529,30 @@ all2md config validate all2md.toml
 
 **Static Site Generation**
 
-all2md includes a built-in static site generator for creating documentation sites and blogs from Markdown:
+The `generate-site` command converts document collections into ready-to-deploy [Hugo](https://gohugo.io/), [Jekyll](https://jekyllrb.com/), [MkDocs](https://www.mkdocs.org/), [Zola](https://www.getzola.org/), or [Eleventy](https://www.11ty.dev/) sites:
 
 ```bash
-# Generate a site from markdown files with frontmatter support
-all2md generate-site ./content --output ./public --theme docs
+# Generate a Hugo site (default frontmatter: TOML)
+all2md generate-site ./content --output-dir ./site --generator hugo
 
-# The generator supports:
-# - Markdown with YAML frontmatter (title, date, author, etc.)
-# - Multiple built-in themes
-# - Automatic navigation generation
-# - Blog-style post listings
-# - Custom styling via CSS
+# Generate a Jekyll blog (date-prefixed posts, YAML frontmatter)
+all2md generate-site ./posts --output-dir ./blog --generator jekyll --scaffold
+
+# Generate an MkDocs documentation site
+all2md generate-site ./docs --output-dir ./public --generator mkdocs --scaffold --recursive
+
+# Also supported: Zola (TOML, Rust) and Eleventy/11ty (YAML, JS)
+all2md generate-site ./docs --output-dir ./site --generator zola --scaffold
+all2md generate-site ./docs --output-dir ./site --generator eleventy --scaffold
+
+# The command handles:
+# - Frontmatter generated from document metadata (title, date, author, tags, ...)
+# - Generator-specific directory structure and config (--scaffold)
+# - Image/asset collection, copying, and path rewriting
+# - Recursive batch conversion with exclusion patterns (--recursive, --exclude)
 ```
 
-See [examples/flask_markdown_site.py](examples/flask_markdown_site.py) for a complete Flask integration example.
+For a dynamic, Flask-served Markdown site instead, see [examples/flask_markdown_site.py](examples/flask_markdown_site.py).
 
 ## Python API Usage
 
@@ -752,10 +761,10 @@ convert("output.md", "final_report.docx", target_format="docx")
 
 ```bash
 # Watch a directory and convert new documents automatically
-all2md ./incoming -r -o ./processed --watch
+all2md ./incoming -r --output-dir ./processed --watch
 
 # Batch process with parallel workers
-all2md ./documents/*.pdf -o ./markdown --parallel 8
+all2md ./documents/*.pdf --output-dir ./markdown --parallel 8
 
 # Integrate into CI/CD pipeline
 for doc in ./docs/*.docx; do
@@ -763,10 +772,10 @@ for doc in ./docs/*.docx; do
 done
 
 # Generate documentation site from markdown files
-all2md generate-site ./docs --output ./public --theme docs
+all2md generate-site ./docs --output-dir ./public --generator mkdocs
 
 # Quick preview before committing
-all2md README.md view --theme minimal
+all2md view README.md --theme minimal
 ```
 
 **Examples:** [vcs-converter/](examples/vcs-converter/) (Git pre-commit hook integration)
@@ -777,13 +786,19 @@ all2md README.md view --theme minimal
 
 ```python
 from all2md import to_markdown, to_ast
-from all2md.ast import Document, Table
+from all2md.ast import Table, CodeBlock
+
+# Recursively yield every node in the document AST
+def iter_nodes(node):
+    yield node
+    for attr in ("children", "content"):
+        for child in getattr(node, attr, None) or []:
+            yield from iter_nodes(child)
 
 # Extract tables from PDFs for analysis
 def extract_tables(pdf_path):
     doc = to_ast(pdf_path)
-    tables = [node for node in doc.walk() if isinstance(node, Table)]
-    return tables
+    return [node for node in iter_nodes(doc) if isinstance(node, Table)]
 
 # Process email archives for NLP
 def process_email_archive(mbox_path):
@@ -798,9 +813,7 @@ def process_email_archive(mbox_path):
 # Extract code examples from documentation
 def extract_code_blocks(doc_path):
     doc = to_ast(doc_path)
-    from all2md.ast import CodeBlock
-    code_blocks = [node for node in doc.walk() if isinstance(node, CodeBlock)]
-    return code_blocks
+    return [node for node in iter_nodes(doc) if isinstance(node, CodeBlock)]
 ```
 
 **Examples:** [api_doc_extractor.py](examples/api_doc_extractor.py), [code_example_generator.py](examples/code_example_generator.py)
@@ -837,7 +850,7 @@ A: Yes! Version 1.0.0 is stable and production-ready. The library includes compr
 
 **Q: How do I handle large document batches efficiently?**
 
-A: Use parallel processing: `all2md ./docs -r -o ./output --parallel 8` or in Python use multiprocessing with `to_markdown()` calls. For very large batches, consider the watch mode for incremental processing.
+A: Use parallel processing: `all2md ./docs -r --output-dir ./output --parallel 8` or in Python use multiprocessing with `to_markdown()` calls. For very large batches, consider the watch mode for incremental processing.
 
 ## Getting Help
 

--- a/docs/source/cli.rst
+++ b/docs/source/cli.rst
@@ -1096,7 +1096,7 @@ group.
 Static Site Generation
 -----------------------
 
-The ``all2md generate-site`` subcommand converts document collections into Hugo or Jekyll static sites with proper frontmatter, asset organization, and directory structures.
+The ``all2md generate-site`` subcommand converts document collections into Hugo, Jekyll, MkDocs, Zola, or Eleventy static sites with proper frontmatter, asset organization, and directory structures.
 
 .. code-block:: bash
 
@@ -1124,6 +1124,16 @@ Convert blog posts to a Jekyll site:
        --generator jekyll \
        --scaffold
 
+Convert a directory of documents to an MkDocs site:
+
+.. code-block:: bash
+
+   all2md generate-site docs/ \
+       --output-dir my-mkdocs-site \
+       --generator mkdocs \
+       --scaffold \
+       --recursive
+
 Arguments
 ~~~~~~~~~
 
@@ -1135,8 +1145,8 @@ Arguments
 ``--output-dir DIR``
    Output directory for the generated site
 
-``--generator {hugo,jekyll}``
-   Static site generator to target (hugo or jekyll)
+``--generator {hugo,jekyll,mkdocs,zola,eleventy}``
+   Static site generator to target (hugo, jekyll, mkdocs, zola, or eleventy)
 
 **Optional Arguments:**
 
@@ -1145,7 +1155,7 @@ Arguments
 
 ``--frontmatter-format {yaml,toml}``
    Override default frontmatter format
-   (Hugo defaults to TOML, Jekyll to YAML)
+   (Hugo and Zola default to TOML; Jekyll, MkDocs, and Eleventy to YAML)
 
 ``--content-subdir PATH``
    Subdirectory within content dir for output
@@ -1208,6 +1218,73 @@ Examples
    # │   └── post.html
    # └── _includes/
 
+**MkDocs Site with Scaffolding:**
+
+.. code-block:: bash
+
+   # Create complete MkDocs site structure
+   all2md generate-site documentation/ \
+       --output-dir my-mkdocs-site \
+       --generator mkdocs \
+       --scaffold \
+       --recursive
+
+   # Result:
+   # my-mkdocs-site/
+   # ├── mkdocs.yml
+   # └── docs/
+   #     ├── index.md
+   #     ├── page1.md
+   #     ├── page2.md
+   #     └── images/
+   #         └── (copied images)
+
+**Zola Site with Scaffolding:**
+
+.. code-block:: bash
+
+   # Create complete Zola site structure (TOML frontmatter, like Hugo)
+   all2md generate-site documentation/ \
+       --output-dir my-zola-site \
+       --generator zola \
+       --scaffold \
+       --recursive
+
+   # Result:
+   # my-zola-site/
+   # ├── config.toml
+   # ├── content/
+   # │   ├── _index.md
+   # │   └── page1.md
+   # ├── static/images/
+   # │   └── (copied images)
+   # └── templates/
+   #     ├── base.html
+   #     ├── index.html
+   #     ├── section.html
+   #     └── page.html
+
+**Eleventy (11ty) Site with Scaffolding:**
+
+.. code-block:: bash
+
+   # Create complete Eleventy site structure
+   all2md generate-site documentation/ \
+       --output-dir my-eleventy-site \
+       --generator eleventy \
+       --scaffold \
+       --recursive
+
+   # Result:
+   # my-eleventy-site/
+   # ├── .eleventy.js
+   # ├── package.json
+   # └── src/
+   #     ├── index.md
+   #     ├── page1.md
+   #     └── images/
+   #         └── (copied images)
+
 **Without Scaffolding (Content Only):**
 
 .. code-block:: bash
@@ -1264,6 +1341,16 @@ The command automatically generates frontmatter from document metadata:
 - ``layout: post`` (default)
 - ``permalink`` (if present in metadata)
 
+*MkDocs:*
+- Common fields only (``title``, ``date``, ``author``, ``description``, ``tags``); no generator-specific fields are added
+
+*Zola:*
+- ``draft: false`` (always set), ``weight`` (if present in metadata)
+- ``tags``/``categories`` nested under ``[taxonomies]`` and ``author`` under ``[extra]`` (Zola rejects unknown top-level keys)
+
+*Eleventy:*
+- Common fields only; ``tags`` double as Eleventy collection names
+
 **Example frontmatter output (Hugo/TOML):**
 
 .. code-block:: text
@@ -1304,6 +1391,12 @@ Images and other assets are automatically:
 **Hugo:** Assets → ``static/images/``, referenced as ``/images/filename``
 
 **Jekyll:** Assets → ``assets/images/``, referenced as ``/assets/images/filename``
+
+**MkDocs:** Assets → ``docs/images/``, referenced as ``/images/filename``
+
+**Zola:** Assets → ``static/images/``, referenced as ``/images/filename``
+
+**Eleventy:** Assets → ``src/images/`` (passthrough-copied), referenced as ``/images/filename``
 
 See Also
 ~~~~~~~~

--- a/docs/source/formats.rst
+++ b/docs/source/formats.rst
@@ -92,7 +92,7 @@ HTML & Web Archives
 - Optional readability extraction (``--html-extract-readable``) removes navigation chrome using readability-lxml
 - Secure remote fetching through ``NetworkFetchOptions`` (rate limiting, host allowlists, HTTPS enforcement)
 - Template modes (inject/replace/jinja) in the renderer support custom HTML generation
-- Native Hugo/Jekyll site generation via ``generate-site`` command (:doc:`static_sites`)
+- Native Hugo, Jekyll, MkDocs, Zola, and Eleventy site generation via ``generate-site`` command (:doc:`static_sites`)
 
 Email Messages (EML/MSG)
 ~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/source/python_api.rst
+++ b/docs/source/python_api.rst
@@ -368,8 +368,9 @@ Standalone HTML Documents
 .. note::
    all2md supports two approaches for static sites:
 
-   1. **Hugo/Jekyll Generation**: Use the ``generate-site`` command for turnkey
-      static site creation with scaffolding and frontmatter. See :doc:`static_sites`.
+   1. **Static Site Generation**: Use the ``generate-site`` command for turnkey
+      Hugo, Jekyll, MkDocs, Zola, or Eleventy site creation with scaffolding and
+      frontmatter. See :doc:`static_sites`.
 
    2. **Custom HTML Templates**: Use HTML renderer template modes (inject/replace/jinja)
       for full control over HTML output. See :doc:`api/all2md.renderers.html`.

--- a/docs/source/static_sites.rst
+++ b/docs/source/static_sites.rst
@@ -675,7 +675,7 @@ Zola Frontmatter
 
 Zola validates page frontmatter against a fixed schema and **errors on unknown top-level keys**. ``generate-site`` handles this by nesting tags/categories under ``[taxonomies]`` and non-standard fields (such as ``author``) under ``[extra]``:
 
-.. code-block:: toml
+.. code-block:: text
 
    +++
    title = "Getting Started with all2md"

--- a/docs/source/static_sites.rst
+++ b/docs/source/static_sites.rst
@@ -1,7 +1,7 @@
 Static Site Generation
 ======================
 
-all2md includes a powerful ``generate-site`` command that converts document collections into production-ready Hugo or Jekyll static sites. The command handles frontmatter generation, asset copying, directory scaffolding, and metadata mapping, enabling you to transform documentation folders or blog posts into fully-functional static sites.
+all2md includes a powerful ``generate-site`` command that converts document collections into production-ready Hugo, Jekyll, MkDocs, Zola, or Eleventy static sites. The command handles frontmatter generation, asset copying, directory scaffolding, and metadata mapping, enabling you to transform documentation folders or blog posts into fully-functional static sites.
 
 .. contents::
    :local:
@@ -10,12 +10,12 @@ all2md includes a powerful ``generate-site`` command that converts document coll
 Overview
 --------
 
-The ``generate-site`` command is purpose-built for creating static sites from document collections. Unlike the HTML template-based approach (which remains available for custom HTML generation), ``generate-site`` produces complete Hugo or Jekyll site structures with proper frontmatter, asset organization, and configuration files.
+The ``generate-site`` command is purpose-built for creating static sites from document collections. Unlike the HTML template-based approach (which remains available for custom HTML generation), ``generate-site`` produces complete Hugo, Jekyll, MkDocs, Zola, or Eleventy site structures with proper frontmatter, asset organization, and configuration files.
 
 Key Features
 ~~~~~~~~~~~~
 
-- **Hugo and Jekyll Support** - Target either static site generator with appropriate directory structures and frontmatter formats
+- **Hugo, Jekyll, MkDocs, Zola, and Eleventy Support** - Target any of the five static site generators with appropriate directory structures and frontmatter formats
 - **Automatic Frontmatter** - Intelligently maps document metadata to frontmatter fields (title, date, author, tags, categories)
 - **Asset Management** - Collects images from documents, copies them to the correct static directories, and updates references
 - **Scaffolding** - Optionally creates complete site structures with config files and layout templates
@@ -27,7 +27,7 @@ When to Use generate-site
 
 Choose ``generate-site`` when you want to:
 
-- Convert documentation folders to Hugo or Jekyll sites
+- Convert documentation folders to Hugo, Jekyll, MkDocs, Zola, or Eleventy sites
 - Migrate blog posts to a static site generator
 - Create a documentation site from markdown files
 - Build a knowledge base with proper categorization
@@ -92,6 +92,30 @@ Convert blog posts to a Jekyll site:
    # │   └── post.html
    # └── _includes/
 
+Basic MkDocs Example
+~~~~~~~~~~~~~~~~~~~~~
+
+Convert a documentation folder to an MkDocs site:
+
+.. code-block:: bash
+
+   # Create a complete MkDocs site with scaffolding
+   all2md generate-site docs/ \
+       --output-dir my-mkdocs-site \
+       --generator mkdocs \
+       --scaffold \
+       --recursive
+
+   # Result:
+   # my-mkdocs-site/
+   # ├── mkdocs.yml
+   # └── docs/
+   #     ├── index.md
+   #     ├── getting-started.md
+   #     ├── api-reference.md
+   #     └── images/
+   #         └── (copied images)
+
 Command Syntax
 ~~~~~~~~~~~~~~
 
@@ -99,7 +123,7 @@ Command Syntax
 
    all2md generate-site INPUT... \
        --output-dir DIR \
-       --generator {hugo|jekyll} \
+       --generator {hugo|jekyll|mkdocs|zola|eleventy} \
        [--scaffold] \
        [--frontmatter-format {yaml|toml}] \
        [--content-subdir PATH] \
@@ -120,7 +144,7 @@ Command Reference
 ``--output-dir DIR``
    Output directory for the generated site. Will be created if it doesn't exist.
 
-``--generator {hugo|jekyll}``
+``--generator {hugo|jekyll|mkdocs|zola|eleventy}``
    Target static site generator. Determines directory structure, frontmatter defaults, and asset paths.
 
 **Optional Arguments:**
@@ -129,7 +153,7 @@ Command Reference
    Create complete site structure including config files, layouts, and directory placeholders. Without this flag, only the content and static assets are generated.
 
 ``--frontmatter-format {yaml|toml}``
-   Override default frontmatter format. Hugo defaults to TOML (``+++`` delimiters), Jekyll to YAML (``---`` delimiters).
+   Override default frontmatter format. Hugo and Zola default to TOML (``+++`` delimiters); Jekyll, MkDocs, and Eleventy default to YAML (``---`` delimiters).
 
 ``--content-subdir PATH``
    Subdirectory within the content directory for output files. For example, ``--content-subdir posts`` with Hugo creates files in ``content/posts/``.
@@ -516,6 +540,209 @@ Jekyll requires blog posts to use date-prefixed filenames in the format ``YYYY-M
    # Source: tutorial.md (no date metadata)
    # Output: _posts/tutorial.md (no date prefix)
 
+MkDocs Static Sites
+-------------------
+
+MkDocs Overview
+~~~~~~~~~~~~~~~
+
+MkDocs is a fast, Python-based static site generator geared toward project documentation. All content lives under a single ``docs/`` directory, and the site is configured by a ``mkdocs.yml`` file at the project root.
+
+**Standard MkDocs Directory Structure:**
+
+.. code-block:: text
+
+   mkdocs-site/
+   ├── mkdocs.yml           # Site configuration
+   └── docs/                # Content directory (site root)
+       ├── index.md         # Homepage
+       ├── guide.md         # Content pages
+       └── images/          # Image files
+
+Generating an MkDocs Site
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+**With Scaffolding:**
+
+.. code-block:: bash
+
+   # Create complete MkDocs site structure
+   all2md generate-site documentation/ \
+       --output-dir my-docs \
+       --generator mkdocs \
+       --scaffold \
+       --recursive
+
+This creates:
+
+- ``mkdocs.yml`` with basic site configuration
+- ``docs/index.md`` homepage placeholder
+- Converted markdown files in ``docs/``
+- Copied images in ``docs/images/``
+
+**Without Scaffolding:**
+
+.. code-block:: bash
+
+   # Only convert content and copy assets
+   all2md generate-site docs/*.md \
+       --output-dir my-docs \
+       --generator mkdocs
+
+This creates only:
+
+- Converted markdown files in ``docs/``
+- Copied images in ``docs/images/``
+
+MkDocs Frontmatter
+~~~~~~~~~~~~~~~~~~
+
+MkDocs reads page metadata from YAML frontmatter with ``---`` delimiters (the same ``meta`` convention used by the Material theme):
+
+.. code-block:: yaml
+
+   ---
+   title: Getting Started with all2md
+   date: 2025-01-22 10:00:00
+   author: Jane Developer
+   description: A comprehensive guide to document conversion
+   tags:
+     - tutorial
+     - documentation
+   ---
+
+Only the common metadata fields (``title``, ``date``, ``author``, ``description``, ``tags``) are emitted; MkDocs does not use Hugo's ``draft``/``weight`` or Jekyll's ``layout``/``permalink`` fields.
+
+MkDocs Asset Organization
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Because MkDocs serves everything under ``docs/``, images are copied to ``docs/images/`` and referenced with the ``/images/`` path prefix:
+
+**Before conversion** (in source document):
+
+.. code-block:: markdown
+
+   ![Architecture Diagram](./diagrams/architecture.png)
+
+**After conversion** (in MkDocs content):
+
+.. code-block:: markdown
+
+   ![Architecture Diagram](/images/architecture.png)
+
+The actual file is copied to ``docs/images/architecture.png``.
+
+**MkDocs Theme Note:**
+
+The scaffolded ``mkdocs.yml`` references the popular Material theme (``theme: name: material``), which requires ``pip install mkdocs-material``. Switch to the built-in ``readthedocs`` or ``mkdocs`` theme if you prefer no extra dependency.
+
+Zola Static Sites
+-----------------
+
+Zola Overview
+~~~~~~~~~~~~~
+
+Zola is a fast, single-binary static site generator written in Rust. Like Hugo, it keeps pages in a ``content/`` directory and assets in ``static/`` (served at the site root), and it defaults to **TOML** ``+++`` frontmatter. Tera templates live in ``templates/``.
+
+**Standard Zola Directory Structure:**
+
+.. code-block:: text
+
+   zola-site/
+   ├── config.toml          # Site configuration
+   ├── content/             # Markdown content (with _index.md sections)
+   ├── static/              # Static assets (served at the root)
+   │   └── images/
+   └── templates/           # Tera templates
+
+Generating a Zola Site
+~~~~~~~~~~~~~~~~~~~~~~
+
+**With Scaffolding:**
+
+.. code-block:: bash
+
+   all2md generate-site documentation/ \
+       --output-dir my-docs \
+       --generator zola \
+       --scaffold \
+       --recursive
+
+This creates ``config.toml``, a ``content/_index.md`` homepage, minimal working Tera templates (``base.html``, ``index.html``, ``section.html``, ``page.html``), converted pages in ``content/``, and copied images in ``static/images/``.
+
+Zola Frontmatter
+~~~~~~~~~~~~~~~~
+
+Zola validates page frontmatter against a fixed schema and **errors on unknown top-level keys**. ``generate-site`` handles this by nesting tags/categories under ``[taxonomies]`` and non-standard fields (such as ``author``) under ``[extra]``:
+
+.. code-block:: toml
+
+   +++
+   title = "Getting Started with all2md"
+   date = 2025-01-22T10:00:00
+   description = "A comprehensive guide to document conversion"
+   draft = false
+
+   [taxonomies]
+   tags = ["tutorial", "documentation"]
+
+   [extra]
+   author = "Jane Developer"
+   +++
+
+Zola Asset Organization
+~~~~~~~~~~~~~~~~~~~~~~~
+
+Images are copied to ``static/images/`` and referenced with the ``/images/`` path prefix (Zola serves ``static/`` at the site root), identical to Hugo.
+
+Eleventy Static Sites
+---------------------
+
+Eleventy Overview
+~~~~~~~~~~~~~~~~~
+
+Eleventy (11ty) is a flexible JavaScript static site generator. ``generate-site`` scaffolds a conventional layout that reads content from a ``src/`` input directory and uses **YAML** ``---`` frontmatter.
+
+**Standard Eleventy Directory Structure:**
+
+.. code-block:: text
+
+   eleventy-site/
+   ├── .eleventy.js         # Site configuration
+   ├── package.json         # Declares the @11ty/eleventy dependency
+   └── src/                 # Input directory
+       ├── index.md         # Homepage
+       └── images/          # Passthrough-copied to the output
+
+Generating an Eleventy Site
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+**With Scaffolding:**
+
+.. code-block:: bash
+
+   all2md generate-site documentation/ \
+       --output-dir my-docs \
+       --generator eleventy \
+       --scaffold \
+       --recursive
+
+This creates ``.eleventy.js`` (input ``src/``, output ``_site/``, with ``src/images`` passthrough copy), a ``package.json`` declaring the Eleventy dependency, a ``src/index.md`` homepage, converted pages in ``src/``, and copied images in ``src/images/``.
+
+Eleventy Frontmatter
+~~~~~~~~~~~~~~~~~~~~
+
+Eleventy imposes no frontmatter schema, so only the common fields are emitted (``title``, ``date``, ``author``, ``description``, ``tags``). Note that ``tags`` also double as Eleventy collection names.
+
+Eleventy Asset Organization
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Images are copied to ``src/images/`` and referenced with the ``/images/`` path prefix. The scaffolded ``.eleventy.js`` configures a passthrough copy so ``src/images/`` is emitted to ``/images/`` in the built site.
+
+**Eleventy Dependency Note:**
+
+Eleventy is an npm package. After scaffolding, run ``npm install`` (which installs ``@11ty/eleventy`` from the generated ``package.json``) before ``npx @11ty/eleventy --serve``.
+
 Frontmatter Generation
 -----------------------
 
@@ -745,6 +972,21 @@ Generator-Specific Paths
 
 - Static directory: ``assets/images/``
 - Markdown reference: ``/assets/images/filename``
+
+**MkDocs:**
+
+- Static directory: ``docs/images/``
+- Markdown reference: ``/images/filename``
+
+**Zola:**
+
+- Static directory: ``static/images/``
+- Markdown reference: ``/images/filename``
+
+**Eleventy:**
+
+- Static directory: ``src/images/`` (passthrough-copied)
+- Markdown reference: ``/images/filename``
 
 Output File Naming
 ------------------
@@ -1030,6 +1272,75 @@ After generating the scaffolded structure:
    cd output-dir
    bundle exec jekyll serve  # Start development server
    bundle exec jekyll build  # Build for production
+
+MkDocs Scaffolding
+~~~~~~~~~~~~~~~~~~
+
+With ``--scaffold``, a complete MkDocs site structure is created:
+
+**Directory Structure:**
+
+.. code-block:: text
+
+   output-dir/
+   ├── mkdocs.yml           # Site configuration
+   └── docs/                # Content directory
+       ├── index.md         # Homepage placeholder
+       └── images/          # Image directory
+
+**mkdocs.yml Contents:**
+
+.. code-block:: yaml
+
+   site_name: My Site
+   site_description: Site generated with all2md
+
+   theme:
+     name: material
+
+   markdown_extensions:
+     - admonition
+     - tables
+     - fenced_code
+     - toc:
+         permalink: true
+
+**Building the Site:**
+
+After generating the scaffolded structure:
+
+.. code-block:: bash
+
+   cd output-dir
+   mkdocs serve  # Start development server
+   mkdocs build  # Build for production
+
+Zola Scaffolding
+~~~~~~~~~~~~~~~~
+
+With ``--scaffold``, a complete Zola site structure is created (``config.toml``, ``content/_index.md``, ``static/images/``, and minimal Tera templates under ``templates/``).
+
+**Building the Site:**
+
+.. code-block:: bash
+
+   cd output-dir
+   zola serve  # Start development server
+   zola build  # Build for production
+
+Eleventy Scaffolding
+~~~~~~~~~~~~~~~~~~~~
+
+With ``--scaffold``, a complete Eleventy site structure is created (``.eleventy.js``, ``package.json``, ``src/index.md``, and ``src/images/``).
+
+**Building the Site:**
+
+.. code-block:: bash
+
+   cd output-dir
+   npm install                  # Install @11ty/eleventy
+   npx @11ty/eleventy --serve   # Start development server
+   npx @11ty/eleventy           # Build for production
 
 Complete Examples
 -----------------
@@ -1333,14 +1644,14 @@ generate-site Command (This Document)
 
 **Best for:**
 
-- Creating Hugo or Jekyll sites quickly
+- Creating Hugo, Jekyll, MkDocs, Zola, or Eleventy sites quickly
 - Migrating documentation to static site generators
 - Working with established static site ecosystems
 - Batch converting document collections
 
 **Features:**
 
-- Purpose-built for Hugo/Jekyll
+- Purpose-built for Hugo, Jekyll, MkDocs, Zola, and Eleventy
 - Automatic frontmatter generation
 - Site scaffolding
 - Generator-specific conventions

--- a/src/all2md/cli/commands/generate_site.py
+++ b/src/all2md/cli/commands/generate_site.py
@@ -4,9 +4,9 @@
 """Static site generation command for all2md CLI.
 
 This module provides the generate-site command for converting documents
-to Hugo or Jekyll static site formats. It handles frontmatter generation,
-asset copying, and site scaffolding to create ready-to-deploy static sites
-from various document formats.
+to Hugo, Jekyll, MkDocs, Zola, or Eleventy static site formats. It handles
+frontmatter generation, asset copying, and site scaffolding to create
+ready-to-deploy static sites from various document formats.
 """
 
 import argparse
@@ -39,12 +39,15 @@ def _create_generate_site_parser() -> argparse.ArgumentParser:
     """
     parser = argparse.ArgumentParser(
         prog="all2md generate-site",
-        description="Generate Hugo or Jekyll static site from documents.",
+        description="Generate Hugo, Jekyll, MkDocs, Zola, or Eleventy static site from documents.",
     )
     parser.add_argument("input", nargs="+", help="Input files or directories to convert")
     parser.add_argument("--output-dir", required=True, help="Output directory for the static site")
     parser.add_argument(
-        "--generator", choices=["hugo", "jekyll"], required=True, help="Static site generator (hugo or jekyll)"
+        "--generator",
+        choices=["hugo", "jekyll", "mkdocs", "zola", "eleventy"],
+        required=True,
+        help="Static site generator (hugo, jekyll, mkdocs, zola, or eleventy)",
     )
     parser.add_argument(
         "--scaffold", action="store_true", help="Create full site structure with config files and layouts"
@@ -73,7 +76,7 @@ def _create_generate_site_parser() -> argparse.ArgumentParser:
 
 
 def handle_generate_site_command(args: list[str] | None = None) -> int:
-    """Handle generate-site command for Hugo/Jekyll static site generation.
+    """Handle generate-site command for Hugo/Jekyll/MkDocs/Zola/Eleventy static site generation.
 
     Parameters
     ----------
@@ -100,11 +103,13 @@ def handle_generate_site_command(args: list[str] | None = None) -> int:
     # Parse generator type
     generator = StaticSiteGenerator(parsed.generator)
 
-    # Determine frontmatter format
+    # Determine frontmatter format (Hugo and Zola default to TOML, the rest to YAML)
     if parsed.frontmatter_format:
         fm_format = FrontmatterFormat(parsed.frontmatter_format)
+    elif generator in (StaticSiteGenerator.HUGO, StaticSiteGenerator.ZOLA):
+        fm_format = FrontmatterFormat.TOML
     else:
-        fm_format = FrontmatterFormat.TOML if generator == StaticSiteGenerator.HUGO else FrontmatterFormat.YAML
+        fm_format = FrontmatterFormat.YAML
 
     # Create output directory
     output_dir = Path(parsed.output_dir)
@@ -124,8 +129,16 @@ def handle_generate_site_command(args: list[str] | None = None) -> int:
         return EXIT_VALIDATION_ERROR
 
     # Determine content directory
-    if generator == StaticSiteGenerator.HUGO:
+    if generator in (StaticSiteGenerator.HUGO, StaticSiteGenerator.ZOLA):
         content_dir = output_dir / "content"
+        if parsed.content_subdir:
+            content_dir = content_dir / parsed.content_subdir
+    elif generator == StaticSiteGenerator.MKDOCS:
+        content_dir = output_dir / "docs"
+        if parsed.content_subdir:
+            content_dir = content_dir / parsed.content_subdir
+    elif generator == StaticSiteGenerator.ELEVENTY:
+        content_dir = output_dir / "src"
         if parsed.content_subdir:
             content_dir = content_dir / parsed.content_subdir
     else:  # Jekyll
@@ -196,6 +209,19 @@ def handle_generate_site_command(args: list[str] | None = None) -> int:
         print("\nTo preview your Hugo site:")
         print(f"  cd {output_dir}")
         print("  hugo server")
+    elif generator == StaticSiteGenerator.MKDOCS:
+        print("\nTo preview your MkDocs site:")
+        print(f"  cd {output_dir}")
+        print("  mkdocs serve")
+    elif generator == StaticSiteGenerator.ZOLA:
+        print("\nTo preview your Zola site:")
+        print(f"  cd {output_dir}")
+        print("  zola serve")
+    elif generator == StaticSiteGenerator.ELEVENTY:
+        print("\nTo preview your Eleventy site:")
+        print(f"  cd {output_dir}")
+        print("  npm install")
+        print("  npx @11ty/eleventy --serve")
     else:
         print("\nTo preview your Jekyll site:")
         print(f"  cd {output_dir}")

--- a/src/all2md/cli/help_formatter.py
+++ b/src/all2md/cli/help_formatter.py
@@ -162,7 +162,7 @@ _SUBCOMMAND_SUMMARIES: Sequence[tuple[str, str]] = (
     ("search", "Search documents using keyword, vector, or hybrid retrieval"),
     ("grep", "Search for text patterns in documents (like grep for any format)"),
     ("lint", "Lint converted documents for structural, heading, link, list, table, and typography issues"),
-    ("generate-site", "Generate Hugo or Jekyll static site from documents"),
+    ("generate-site", "Generate Hugo, Jekyll, MkDocs, Zola, or Eleventy static site from documents"),
     ("arxiv", "Generate an ArXiv-ready LaTeX submission package from a document"),
     ("install-skills", "Install bundled agent skills to a skills directory"),
 )

--- a/src/all2md/skills/all2md/references/generate.md
+++ b/src/all2md/skills/all2md/references/generate.md
@@ -90,6 +90,13 @@ all2md generate-site ./docs --output-dir site --generator hugo
 
 # Generate a Jekyll site instead
 all2md generate-site ./docs --output-dir site --generator jekyll
+
+# Generate an MkDocs site instead
+all2md generate-site ./docs --output-dir site --generator mkdocs
+
+# Other supported generators: Zola and Eleventy (11ty)
+all2md generate-site ./docs --output-dir site --generator zola
+all2md generate-site ./docs --output-dir site --generator eleventy
 ```
 
 ### ArXiv Packaging

--- a/src/all2md/utils/static_site.py
+++ b/src/all2md/utils/static_site.py
@@ -1,10 +1,10 @@
 #  Copyright (c) 2025 Tom Villani, Ph.D.
 #
 # src/all2md/utils/static_site.py
-"""Static site generator utilities for Hugo and Jekyll.
+"""Static site generator utilities for Hugo, Jekyll, MkDocs, Zola, and Eleventy.
 
 This module provides utilities for converting documents to static site
-generator formats (Hugo, Jekyll). It handles:
+generator formats (Hugo, Jekyll, MkDocs, Zola, Eleventy). It handles:
 - Frontmatter generation from document metadata
 - Site structure scaffolding
 - Asset management for static sites
@@ -12,7 +12,7 @@ generator formats (Hugo, Jekyll). It handles:
 Functions
 ---------
 - generate_frontmatter: Convert Document metadata to frontmatter
-- create_site_scaffold: Create Hugo/Jekyll site directory structure
+- create_site_scaffold: Create static site directory structure
 - process_document_for_static_site: Convert document with frontmatter and assets
 """
 
@@ -40,6 +40,9 @@ class StaticSiteGenerator(str, Enum):
 
     HUGO = "hugo"
     JEKYLL = "jekyll"
+    MKDOCS = "mkdocs"
+    ZOLA = "zola"
+    ELEVENTY = "eleventy"
 
 
 class FrontmatterFormat(str, Enum):
@@ -84,7 +87,8 @@ class FrontmatterGenerator:
         generator : StaticSiteGenerator
             Target static site generator
         format : FrontmatterFormat, optional
-            Frontmatter format. If None, uses TOML for Hugo and YAML for Jekyll.
+            Frontmatter format. If None, uses TOML for Hugo and Zola, and
+            YAML for Jekyll, MkDocs, and Eleventy.
 
         """
         self.generator = generator
@@ -105,7 +109,8 @@ class FrontmatterGenerator:
             Default format for the generator
 
         """
-        if generator == StaticSiteGenerator.HUGO:
+        # Hugo and Zola both default to TOML (+++); the rest default to YAML (---).
+        if generator in (StaticSiteGenerator.HUGO, StaticSiteGenerator.ZOLA):
             return FrontmatterFormat.TOML
         return FrontmatterFormat.YAML
 
@@ -209,6 +214,26 @@ class FrontmatterGenerator:
                 normalized["layout"] = "post"  # Default Jekyll layout
             if "permalink" in metadata:
                 normalized["permalink"] = metadata["permalink"]
+        elif self.generator == StaticSiteGenerator.ZOLA:
+            # Zola validates front matter against a fixed schema and errors on
+            # unknown top-level keys: tags/categories must live under
+            # [taxonomies] and non-standard fields (author) under [extra].
+            taxonomies: Dict[str, Any] = {}
+            if "tags" in normalized:
+                taxonomies["tags"] = normalized.pop("tags")
+            if "categories" in normalized:
+                taxonomies["categories"] = normalized.pop("categories")
+            extra: Dict[str, Any] = {}
+            if "author" in normalized:
+                extra["author"] = normalized.pop("author")
+            normalized["draft"] = metadata.get("draft", False)
+            if "weight" in metadata:
+                normalized["weight"] = metadata["weight"]
+            if taxonomies:
+                normalized["taxonomies"] = taxonomies
+            if extra:
+                normalized["extra"] = extra
+        # Eleventy and MkDocs use the common fields as-is (no schema constraints).
 
         return normalized
 
@@ -275,7 +300,7 @@ class SiteScaffolder:
     """Create directory structure for static site generators.
 
     This class handles creation of the basic directory structure and
-    configuration files for Hugo and Jekyll sites.
+    configuration files for Hugo, Jekyll, MkDocs, Zola, and Eleventy sites.
 
     Parameters
     ----------
@@ -308,6 +333,12 @@ class SiteScaffolder:
             self._scaffold_hugo(output_dir)
         elif self.generator == StaticSiteGenerator.JEKYLL:
             self._scaffold_jekyll(output_dir)
+        elif self.generator == StaticSiteGenerator.MKDOCS:
+            self._scaffold_mkdocs(output_dir)
+        elif self.generator == StaticSiteGenerator.ZOLA:
+            self._scaffold_zola(output_dir)
+        elif self.generator == StaticSiteGenerator.ELEVENTY:
+            self._scaffold_eleventy(output_dir)
 
     def _scaffold_hugo(self, output_dir: Path) -> None:
         """Create Hugo site structure.
@@ -401,6 +432,103 @@ This site was generated using all2md.
 
         logger.info(f"Created Jekyll site structure at {output_dir}")
 
+    def _scaffold_mkdocs(self, output_dir: Path) -> None:
+        """Create MkDocs site structure.
+
+        Parameters
+        ----------
+        output_dir : Path
+            Root directory for the MkDocs site
+
+        """
+        # Create directory structure. MkDocs keeps all content (and assets)
+        # under the docs/ directory; mkdocs.yml lives at the project root.
+        (output_dir / "docs" / "images").mkdir(parents=True, exist_ok=True)
+
+        # Create mkdocs.yml
+        config_content = self._get_mkdocs_config()
+        (output_dir / "mkdocs.yml").write_text(config_content, encoding="utf-8")
+
+        # Create homepage (MkDocs uses docs/index.md as the site root)
+        index_content = """# Welcome
+
+This site was generated using all2md.
+"""
+        (output_dir / "docs" / "index.md").write_text(index_content, encoding="utf-8")
+
+        logger.info(f"Created MkDocs site structure at {output_dir}")
+
+    def _scaffold_zola(self, output_dir: Path) -> None:
+        """Create Zola site structure.
+
+        Parameters
+        ----------
+        output_dir : Path
+            Root directory for the Zola site
+
+        """
+        # Create directory structure. Zola uses content/ for pages, static/
+        # for assets (served at the site root), and templates/ for Tera templates.
+        (output_dir / "content").mkdir(parents=True, exist_ok=True)
+        (output_dir / "static" / "images").mkdir(parents=True, exist_ok=True)
+        (output_dir / "templates").mkdir(parents=True, exist_ok=True)
+
+        # Create config.toml
+        (output_dir / "config.toml").write_text(self._get_zola_config(), encoding="utf-8")
+
+        # Create section index (Zola renders content/_index.md via templates/index.html)
+        index_content = """+++
+title = "Home"
++++
+
+# Welcome
+
+This site was generated using all2md.
+"""
+        (output_dir / "content" / "_index.md").write_text(index_content, encoding="utf-8")
+
+        # Create minimal Tera templates so `zola build` works out of the box
+        templates = {
+            "base.html": self._get_zola_base_template(),
+            "index.html": self._get_zola_index_template(),
+            "section.html": self._get_zola_index_template(),
+            "page.html": self._get_zola_page_template(),
+        }
+        for name, content in templates.items():
+            (output_dir / "templates" / name).write_text(content, encoding="utf-8")
+
+        logger.info(f"Created Zola site structure at {output_dir}")
+
+    def _scaffold_eleventy(self, output_dir: Path) -> None:
+        """Create Eleventy (11ty) site structure.
+
+        Parameters
+        ----------
+        output_dir : Path
+            Root directory for the Eleventy site
+
+        """
+        # Create directory structure. Eleventy reads content from the input
+        # directory (src/) and passes src/images/ straight through to the output.
+        (output_dir / "src" / "images").mkdir(parents=True, exist_ok=True)
+
+        # Create config and package.json
+        (output_dir / ".eleventy.js").write_text(self._get_eleventy_config(), encoding="utf-8")
+        (output_dir / "package.json").write_text(self._get_eleventy_package_json(), encoding="utf-8")
+
+        # Create homepage
+        index_content = """---
+title: Home
+---
+
+# Welcome
+
+This site was generated using all2md.
+"""
+        (output_dir / "src" / "index.md").write_text(index_content, encoding="utf-8")
+
+        logger.info(f"Created Eleventy site structure at {output_dir}")
+
     @staticmethod
     def _get_hugo_config() -> str:
         """Get Hugo configuration template.
@@ -456,6 +584,151 @@ defaults:
       type: "posts"
     values:
       layout: "post"
+"""
+
+    @staticmethod
+    def _get_mkdocs_config() -> str:
+        """Get MkDocs configuration template.
+
+        Returns
+        -------
+        str
+            MkDocs mkdocs.yml content
+
+        """
+        return """site_name: My Site
+site_description: Site generated with all2md
+
+# The Material theme is recommended (pip install mkdocs-material).
+# Switch to the built-in "readthedocs" or "mkdocs" theme to avoid the extra dependency.
+theme:
+  name: material
+
+markdown_extensions:
+  - admonition
+  - tables
+  - fenced_code
+  - toc:
+      permalink: true
+"""
+
+    @staticmethod
+    def _get_zola_config() -> str:
+        """Get Zola configuration template.
+
+        Returns
+        -------
+        str
+            Zola config.toml content
+
+        """
+        return """base_url = "https://example.org"
+title = "My Site"
+description = "Site generated with all2md"
+
+compile_sass = false
+build_search_index = false
+
+[markdown]
+highlight_code = true
+
+[taxonomies]
+tags = []
+categories = []
+
+[extra]
+"""
+
+    @staticmethod
+    def _get_zola_base_template() -> str:
+        """Get the base Tera template for a scaffolded Zola site."""
+        return """<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>{% block title %}{{ config.title }}{% endblock title %}</title>
+</head>
+<body>
+    <header>
+        <h1><a href="{{ config.base_url }}">{{ config.title }}</a></h1>
+    </header>
+    <main>
+        {% block content %}{% endblock content %}
+    </main>
+</body>
+</html>
+"""
+
+    @staticmethod
+    def _get_zola_index_template() -> str:
+        """Get the section (index) Tera template for a scaffolded Zola site."""
+        return """{% extends "base.html" %}
+{% block content %}
+{{ section.content | safe }}
+<ul>
+{% for page in section.pages %}
+    <li><a href="{{ page.permalink }}">{{ page.title }}</a></li>
+{% endfor %}
+</ul>
+{% endblock content %}
+"""
+
+    @staticmethod
+    def _get_zola_page_template() -> str:
+        """Get the page Tera template for a scaffolded Zola site."""
+        return """{% extends "base.html" %}
+{% block title %}{{ page.title }} - {{ config.title }}{% endblock title %}
+{% block content %}
+<article>
+    <h1>{{ page.title }}</h1>
+    {{ page.content | safe }}
+</article>
+{% endblock content %}
+"""
+
+    @staticmethod
+    def _get_eleventy_config() -> str:
+        """Get Eleventy configuration template.
+
+        Returns
+        -------
+        str
+            Eleventy .eleventy.js content
+
+        """
+        return """module.exports = function (eleventyConfig) {
+  // Copy images straight through to the output directory
+  eleventyConfig.addPassthroughCopy("src/images");
+
+  return {
+    dir: {
+      input: "src",
+      output: "_site",
+      includes: "_includes",
+    },
+    // Don't run converted Markdown through a template engine, which avoids
+    // clashes with any literal {{ }} in the document content.
+    markdownTemplateEngine: false,
+  };
+};
+"""
+
+    @staticmethod
+    def _get_eleventy_package_json() -> str:
+        """Get the package.json template for a scaffolded Eleventy site."""
+        return """{
+  "name": "my-site",
+  "version": "1.0.0",
+  "private": true,
+  "scripts": {
+    "build": "eleventy",
+    "serve": "eleventy --serve"
+  },
+  "devDependencies": {
+    "@11ty/eleventy": "^3.0.0"
+  }
+}
 """
 
     @staticmethod
@@ -598,7 +871,7 @@ def copy_document_assets(
     output_dir : Path
         Root output directory for the static site
     generator : StaticSiteGenerator
-        Target static site generator (Hugo or Jekyll)
+        Target static site generator (Hugo, Jekyll, MkDocs, Zola, or Eleventy)
     source_file : Path, optional
         Source file path (used to resolve relative image paths)
 
@@ -621,8 +894,15 @@ def copy_document_assets(
 
     """
     # Determine static directory based on generator
-    if generator == StaticSiteGenerator.HUGO:
+    if generator in (StaticSiteGenerator.HUGO, StaticSiteGenerator.ZOLA):
+        # Hugo and Zola both serve the static/ directory at the site root.
         static_dir = output_dir / "static" / "images"
+    elif generator == StaticSiteGenerator.MKDOCS:
+        # MkDocs serves everything under docs/, so assets live there too.
+        static_dir = output_dir / "docs" / "images"
+    elif generator == StaticSiteGenerator.ELEVENTY:
+        # Eleventy reads from src/ and passes src/images/ through to the output.
+        static_dir = output_dir / "src" / "images"
     else:  # Jekyll
         static_dir = output_dir / "assets" / "images"
 
@@ -667,13 +947,14 @@ def copy_document_assets(
             logger.debug(f"Copied asset: {image_path} -> {dest_path}")
 
             # Update image URL in AST to reference static location
-            # Use relative path from content directory
-            if generator == StaticSiteGenerator.HUGO:
-                # Hugo uses /static/ prefix
-                image.url = f"/images/{dest_path.name}"
-            else:  # Jekyll
-                # Jekyll uses /assets/ prefix
+            # Use root-relative path served by the generator
+            if generator == StaticSiteGenerator.JEKYLL:
+                # Jekyll serves assets/ at /assets/
                 image.url = f"/assets/images/{dest_path.name}"
+            else:
+                # Hugo/Zola (static/images), MkDocs (docs/images), and Eleventy
+                # (src/images via passthrough) all serve images at /images/
+                image.url = f"/images/{dest_path.name}"
 
             copied_assets.append(str(dest_path))
 

--- a/tests/e2e/test_generate_site_cli.py
+++ b/tests/e2e/test_generate_site_cli.py
@@ -444,6 +444,221 @@ Some content here with **bold** and *italic* text.
         content = generated_files[0].read_text()
         assert "![Test Image](/assets/images/test.png)" in content, "Image path not updated to Jekyll format"
 
+    # MkDocs Tests
+    # ------------
+
+    def test_mkdocs_with_scaffolding(self):
+        """Test generating an MkDocs site with scaffolding."""
+        self._create_test_markdown("test.md")
+
+        output_dir = self.temp_dir / "mkdocs-site"
+
+        result = self._run_cli(
+            [
+                str(self.source_dir / "test.md"),
+                "--output-dir",
+                str(output_dir),
+                "--generator",
+                "mkdocs",
+                "--scaffold",
+            ]
+        )
+
+        # Check process succeeded
+        assert result.returncode == 0, f"CLI failed with stderr: {result.stderr}"
+
+        # Verify directory structure
+        assert (output_dir / "mkdocs.yml").exists(), "mkdocs.yml not created"
+        assert (output_dir / "docs").exists(), "docs directory not created"
+        assert (output_dir / "docs" / "index.md").exists(), "docs/index.md not created"
+        assert (output_dir / "docs" / "images").exists(), "docs/images directory not created"
+
+        # Verify mkdocs.yml contents
+        config_content = (output_dir / "mkdocs.yml").read_text()
+        assert "site_name:" in config_content
+
+        # Verify converted file exists with YAML frontmatter (MkDocs default)
+        content = (output_dir / "docs" / "test-document.md").read_text()
+        assert content.startswith("---"), "YAML frontmatter delimiter not found"
+        assert "title: Test Document" in content or 'title: "Test Document"' in content
+        # MkDocs does not use Hugo draft or Jekyll layout fields
+        assert "draft" not in content
+        assert "layout: post" not in content
+
+    def test_mkdocs_without_scaffolding(self):
+        """Test generating an MkDocs site without scaffolding."""
+        self._create_test_markdown("test.md")
+
+        output_dir = self.temp_dir / "mkdocs-content"
+
+        result = self._run_cli(
+            [
+                str(self.source_dir / "test.md"),
+                "--output-dir",
+                str(output_dir),
+                "--generator",
+                "mkdocs",
+            ]
+        )
+
+        # Check process succeeded
+        assert result.returncode == 0, f"CLI failed with stderr: {result.stderr}"
+
+        # Verify content directory exists but scaffolding does not
+        assert (output_dir / "docs").exists(), "docs directory not created"
+        assert not (output_dir / "mkdocs.yml").exists(), "mkdocs.yml should not be created"
+
+        # Verify converted file exists (slugified from title)
+        assert (output_dir / "docs" / "test-document.md").exists(), "Converted file not created"
+
+    def test_mkdocs_with_images(self):
+        """Test MkDocs site generation with image copying."""
+        self._create_test_image()
+        self._create_test_markdown("test.md", with_image=True)
+
+        output_dir = self.temp_dir / "mkdocs-images"
+
+        result = self._run_cli(
+            [
+                str(self.source_dir / "test.md"),
+                "--output-dir",
+                str(output_dir),
+                "--generator",
+                "mkdocs",
+            ]
+        )
+
+        # Check process succeeded
+        assert result.returncode == 0, f"CLI failed with stderr: {result.stderr}"
+
+        # Verify image was copied under docs/images
+        assert (output_dir / "docs" / "images" / "test.png").exists(), "Image not copied"
+
+        # Verify image reference was updated to MkDocs path
+        content = (output_dir / "docs" / "test-document.md").read_text()
+        assert "![Test Image](/images/test.png)" in content, "Image path not updated"
+
+    # Zola Tests
+    # ----------
+
+    def test_zola_with_scaffolding(self):
+        """Test generating a Zola site with scaffolding."""
+        self._create_test_markdown("test.md")
+
+        output_dir = self.temp_dir / "zola-site"
+
+        result = self._run_cli(
+            [
+                str(self.source_dir / "test.md"),
+                "--output-dir",
+                str(output_dir),
+                "--generator",
+                "zola",
+                "--scaffold",
+            ]
+        )
+
+        # Check process succeeded
+        assert result.returncode == 0, f"CLI failed with stderr: {result.stderr}"
+
+        # Verify directory structure
+        assert (output_dir / "config.toml").exists(), "config.toml not created"
+        assert (output_dir / "content" / "_index.md").exists(), "_index.md not created"
+        assert (output_dir / "static" / "images").exists(), "static/images not created"
+        assert (output_dir / "templates" / "base.html").exists(), "base.html template not created"
+
+        # Verify converted file has TOML frontmatter (Zola default)
+        content = (output_dir / "content" / "test-document.md").read_text()
+        assert content.startswith("+++"), "TOML frontmatter delimiter not found"
+        assert 'title = "Test Document"' in content
+        # author is routed under [extra], not a top-level key
+        assert "[extra]" in content
+        assert 'author = "Test Author"' in content
+
+    def test_zola_with_images(self):
+        """Test Zola site generation with image copying."""
+        self._create_test_image()
+        self._create_test_markdown("test.md", with_image=True)
+
+        output_dir = self.temp_dir / "zola-images"
+
+        result = self._run_cli(
+            [
+                str(self.source_dir / "test.md"),
+                "--output-dir",
+                str(output_dir),
+                "--generator",
+                "zola",
+            ]
+        )
+
+        # Check process succeeded
+        assert result.returncode == 0, f"CLI failed with stderr: {result.stderr}"
+
+        # Verify image copied to static/images and reference rewritten
+        assert (output_dir / "static" / "images" / "test.png").exists(), "Image not copied"
+        content = (output_dir / "content" / "test-document.md").read_text()
+        assert "![Test Image](/images/test.png)" in content, "Image path not updated"
+
+    # Eleventy Tests
+    # --------------
+
+    def test_eleventy_with_scaffolding(self):
+        """Test generating an Eleventy site with scaffolding."""
+        self._create_test_markdown("test.md")
+
+        output_dir = self.temp_dir / "eleventy-site"
+
+        result = self._run_cli(
+            [
+                str(self.source_dir / "test.md"),
+                "--output-dir",
+                str(output_dir),
+                "--generator",
+                "eleventy",
+                "--scaffold",
+            ]
+        )
+
+        # Check process succeeded
+        assert result.returncode == 0, f"CLI failed with stderr: {result.stderr}"
+
+        # Verify directory structure
+        assert (output_dir / ".eleventy.js").exists(), ".eleventy.js not created"
+        assert (output_dir / "package.json").exists(), "package.json not created"
+        assert (output_dir / "src" / "index.md").exists(), "src/index.md not created"
+        assert (output_dir / "src" / "images").exists(), "src/images not created"
+
+        # Verify converted file has YAML frontmatter (Eleventy default)
+        content = (output_dir / "src" / "test-document.md").read_text()
+        assert content.startswith("---"), "YAML frontmatter delimiter not found"
+        assert "title: Test Document" in content or 'title: "Test Document"' in content
+
+    def test_eleventy_with_images(self):
+        """Test Eleventy site generation with image copying."""
+        self._create_test_image()
+        self._create_test_markdown("test.md", with_image=True)
+
+        output_dir = self.temp_dir / "eleventy-images"
+
+        result = self._run_cli(
+            [
+                str(self.source_dir / "test.md"),
+                "--output-dir",
+                str(output_dir),
+                "--generator",
+                "eleventy",
+            ]
+        )
+
+        # Check process succeeded
+        assert result.returncode == 0, f"CLI failed with stderr: {result.stderr}"
+
+        # Verify image copied to src/images and reference rewritten
+        assert (output_dir / "src" / "images" / "test.png").exists(), "Image not copied"
+        content = (output_dir / "src" / "test-document.md").read_text()
+        assert "![Test Image](/images/test.png)" in content, "Image path not updated"
+
     # Options Tests
     # -------------
 

--- a/tests/unit/cli/test_cli_generate_site.py
+++ b/tests/unit/cli/test_cli_generate_site.py
@@ -98,6 +98,107 @@ class TestHandleGenerateSiteCommand:
         posts_dir = output_dir / "_posts"
         assert posts_dir.exists()
 
+    def test_mkdocs_basic(self, tmp_path: Path, sample_markdown_files):
+        """Test basic MkDocs site generation."""
+        output_dir = tmp_path / "mkdocs_site"
+
+        result = handle_generate_site_command(
+            [str(sample_markdown_files[0]), "--output-dir", str(output_dir), "--generator", "mkdocs"]
+        )
+
+        assert result == 0
+        assert output_dir.exists()
+        # Check docs content directory was created
+        docs_dir = output_dir / "docs"
+        assert docs_dir.exists()
+        assert len(list(docs_dir.glob("*.md"))) >= 1
+
+    def test_mkdocs_scaffold(self, tmp_path: Path, sample_markdown_files):
+        """Test MkDocs site generation with scaffolding."""
+        output_dir = tmp_path / "mkdocs_site"
+
+        result = handle_generate_site_command(
+            [str(sample_markdown_files[0]), "--output-dir", str(output_dir), "--generator", "mkdocs", "--scaffold"]
+        )
+
+        assert result == 0
+        assert (output_dir / "mkdocs.yml").exists()
+        assert (output_dir / "docs").exists()
+
+    def test_mkdocs_content_subdir(self, tmp_path: Path, sample_markdown_files):
+        """Test MkDocs content subdirectory option."""
+        output_dir = tmp_path / "mkdocs_site"
+
+        result = handle_generate_site_command(
+            [
+                str(sample_markdown_files[0]),
+                "--output-dir",
+                str(output_dir),
+                "--generator",
+                "mkdocs",
+                "--content-subdir",
+                "guide",
+            ]
+        )
+
+        assert result == 0
+        # Content should be in docs/guide subdirectory
+        assert (output_dir / "docs" / "guide").exists()
+
+    def test_zola_basic(self, tmp_path: Path, sample_markdown_files):
+        """Test basic Zola site generation."""
+        output_dir = tmp_path / "zola_site"
+
+        result = handle_generate_site_command(
+            [str(sample_markdown_files[0]), "--output-dir", str(output_dir), "--generator", "zola"]
+        )
+
+        assert result == 0
+        content_dir = output_dir / "content"
+        assert content_dir.exists()
+        # Zola defaults to TOML frontmatter
+        md_files = list(content_dir.glob("*.md"))
+        assert md_files
+        assert md_files[0].read_text(encoding="utf-8").startswith("+++")
+
+    def test_zola_scaffold(self, tmp_path: Path, sample_markdown_files):
+        """Test Zola site generation with scaffolding."""
+        output_dir = tmp_path / "zola_site"
+
+        result = handle_generate_site_command(
+            [str(sample_markdown_files[0]), "--output-dir", str(output_dir), "--generator", "zola", "--scaffold"]
+        )
+
+        assert result == 0
+        assert (output_dir / "config.toml").exists()
+        assert (output_dir / "templates" / "base.html").exists()
+
+    def test_eleventy_basic(self, tmp_path: Path, sample_markdown_files):
+        """Test basic Eleventy site generation."""
+        output_dir = tmp_path / "eleventy_site"
+
+        result = handle_generate_site_command(
+            [str(sample_markdown_files[0]), "--output-dir", str(output_dir), "--generator", "eleventy"]
+        )
+
+        assert result == 0
+        # Eleventy content lives under src/
+        src_dir = output_dir / "src"
+        assert src_dir.exists()
+        assert len(list(src_dir.glob("*.md"))) >= 1
+
+    def test_eleventy_scaffold(self, tmp_path: Path, sample_markdown_files):
+        """Test Eleventy site generation with scaffolding."""
+        output_dir = tmp_path / "eleventy_site"
+
+        result = handle_generate_site_command(
+            [str(sample_markdown_files[0]), "--output-dir", str(output_dir), "--generator", "eleventy", "--scaffold"]
+        )
+
+        assert result == 0
+        assert (output_dir / ".eleventy.js").exists()
+        assert (output_dir / "package.json").exists()
+
     def test_hugo_scaffold(self, tmp_path: Path, sample_markdown_files):
         """Test Hugo site generation with scaffolding."""
         output_dir = tmp_path / "hugo_site"

--- a/tests/unit/utils/test_static_site.py
+++ b/tests/unit/utils/test_static_site.py
@@ -193,6 +193,93 @@ class TestFrontmatterGenerator:
         data = _parse_yaml_frontmatter(result)
         assert data["permalink"] == "/custom/path/"
 
+    def test_mkdocs_defaults_to_yaml(self):
+        """Test MkDocs frontmatter defaults to YAML format."""
+        gen = FrontmatterGenerator(StaticSiteGenerator.MKDOCS)
+        assert gen.format == FrontmatterFormat.YAML
+
+        metadata = {
+            "title": "Test Page",
+            "author": "Jane Doe",
+            "keywords": "python, docs",
+            "description": "A test page",
+        }
+
+        result = gen.generate(metadata)
+
+        data = _parse_yaml_frontmatter(result)
+        assert data["title"] == "Test Page"
+        assert data["author"] == "Jane Doe"
+        assert data["description"] == "A test page"
+        assert data["tags"] == ["python", "docs"]
+
+    def test_mkdocs_omits_generator_specific_fields(self):
+        """Test MkDocs frontmatter excludes Hugo/Jekyll-specific fields."""
+        gen = FrontmatterGenerator(StaticSiteGenerator.MKDOCS)
+        metadata = {"title": "Post"}
+
+        result = gen.generate(metadata)
+
+        data = _parse_yaml_frontmatter(result)
+        # MkDocs uses neither Hugo's draft/weight nor Jekyll's layout/permalink
+        assert "draft" not in data
+        assert "layout" not in data
+        assert "weight" not in data
+        assert "permalink" not in data
+
+    def test_zola_defaults_to_toml(self):
+        """Test Zola frontmatter defaults to TOML format."""
+        gen = FrontmatterGenerator(StaticSiteGenerator.ZOLA)
+        assert gen.format == FrontmatterFormat.TOML
+
+    def test_zola_nests_taxonomies_and_extra(self):
+        """Test Zola routes tags/categories to taxonomies and author to extra."""
+        gen = FrontmatterGenerator(StaticSiteGenerator.ZOLA)
+        metadata = {
+            "title": "My Post",
+            "author": "Jane Doe",
+            "keywords": "python, docs",
+            "category": "tutorial",
+            "weight": 5,
+        }
+
+        result = gen.generate(metadata)
+
+        data = _parse_toml_frontmatter(result)
+        # Standard schema fields stay top-level
+        assert data["title"] == "My Post"
+        assert data["draft"] is False
+        assert data["weight"] == 5
+        # tags/categories nest under [taxonomies]; author under [extra]
+        assert data["taxonomies"]["tags"] == ["python", "docs"]
+        assert data["taxonomies"]["categories"] == ["tutorial"]
+        assert data["extra"]["author"] == "Jane Doe"
+        # Non-schema keys must NOT appear at the top level (Zola would error)
+        assert "author" not in data
+        assert "tags" not in data
+        assert "categories" not in data
+
+    def test_eleventy_defaults_to_yaml(self):
+        """Test Eleventy frontmatter defaults to YAML with flat common fields."""
+        gen = FrontmatterGenerator(StaticSiteGenerator.ELEVENTY)
+        assert gen.format == FrontmatterFormat.YAML
+
+        metadata = {
+            "title": "Test Page",
+            "author": "Jane Doe",
+            "keywords": "python, docs",
+        }
+
+        result = gen.generate(metadata)
+
+        data = _parse_yaml_frontmatter(result)
+        assert data["title"] == "Test Page"
+        assert data["author"] == "Jane Doe"
+        assert data["tags"] == ["python", "docs"]
+        # No Hugo/Jekyll-specific fields
+        assert "draft" not in data
+        assert "layout" not in data
+
 
 class TestImageCollector:
     """Tests for ImageCollector visitor."""
@@ -387,6 +474,68 @@ class TestSiteScaffolder:
         post_content = post_layout.read_text()
         assert "{{ page.title }}" in post_content
 
+    def test_mkdocs_scaffold_creates_directories(self, tmp_path):
+        """Test MkDocs scaffolding creates expected directory structure."""
+        scaffolder = SiteScaffolder(StaticSiteGenerator.MKDOCS)
+        scaffolder.scaffold(tmp_path)
+
+        assert (tmp_path / "docs").exists()
+        assert (tmp_path / "docs" / "images").exists()
+
+    def test_mkdocs_scaffold_creates_config(self, tmp_path):
+        """Test MkDocs scaffolding creates mkdocs.yml."""
+        scaffolder = SiteScaffolder(StaticSiteGenerator.MKDOCS)
+        scaffolder.scaffold(tmp_path)
+
+        config_file = tmp_path / "mkdocs.yml"
+        assert config_file.exists()
+
+        content = config_file.read_text()
+        assert "site_name:" in content
+        # Config must be valid YAML
+        assert yaml.safe_load(content)["site_name"]
+
+    def test_mkdocs_scaffold_creates_index(self, tmp_path):
+        """Test MkDocs scaffolding creates docs/index.md."""
+        scaffolder = SiteScaffolder(StaticSiteGenerator.MKDOCS)
+        scaffolder.scaffold(tmp_path)
+
+        index_file = tmp_path / "docs" / "index.md"
+        assert index_file.exists()
+        assert "Welcome" in index_file.read_text()
+
+    def test_zola_scaffold_creates_structure(self, tmp_path):
+        """Test Zola scaffolding creates expected directories and files."""
+        scaffolder = SiteScaffolder(StaticSiteGenerator.ZOLA)
+        scaffolder.scaffold(tmp_path)
+
+        assert (tmp_path / "content" / "_index.md").exists()
+        assert (tmp_path / "static" / "images").exists()
+        assert (tmp_path / "templates" / "base.html").exists()
+        assert (tmp_path / "templates" / "index.html").exists()
+        assert (tmp_path / "templates" / "page.html").exists()
+
+        config = tmp_path / "config.toml"
+        assert config.exists()
+        data = tomllib.loads(config.read_text())
+        assert data["base_url"]
+        assert data["title"]
+
+    def test_eleventy_scaffold_creates_structure(self, tmp_path):
+        """Test Eleventy scaffolding creates expected directories and files."""
+        scaffolder = SiteScaffolder(StaticSiteGenerator.ELEVENTY)
+        scaffolder.scaffold(tmp_path)
+
+        assert (tmp_path / ".eleventy.js").exists()
+        assert (tmp_path / "src" / "index.md").exists()
+        assert (tmp_path / "src" / "images").exists()
+
+        # package.json must be valid JSON referencing eleventy
+        import json
+
+        pkg = json.loads((tmp_path / "package.json").read_text())
+        assert "@11ty/eleventy" in pkg["devDependencies"]
+
 
 class TestCopyDocumentAssets:
     """Tests for copy_document_assets function."""
@@ -468,3 +617,64 @@ class TestCopyDocumentAssets:
         jekyll_static = output_dir / "assets" / "images"
         assert jekyll_static.exists()
         assert (jekyll_static / "test.jpg").exists()
+
+    def test_mkdocs_asset_paths(self, tmp_path):
+        """Test MkDocs copies assets under docs/images and uses /images/ prefix."""
+        # Create a source image file
+        source_dir = tmp_path / "source"
+        source_dir.mkdir()
+        image_file = source_dir / "diagram.png"
+        image_file.write_bytes(b"test")
+
+        # Create document
+        doc = Document(children=[Paragraph(content=[Image(url=str(image_file), alt_text="Test")])])
+
+        # Copy with MkDocs generator
+        output_dir = tmp_path / "site"
+        modified_doc, assets = copy_document_assets(doc, output_dir, StaticSiteGenerator.MKDOCS, source_file=image_file)
+
+        # Check MkDocs path prefix
+        collector = ImageCollector()
+        collector.collect(modified_doc)
+        assert collector.images[0].url == "/images/diagram.png"
+
+        # Check file exists in MkDocs location (under docs/)
+        mkdocs_static = output_dir / "docs" / "images"
+        assert mkdocs_static.exists()
+        assert (mkdocs_static / "diagram.png").exists()
+
+    def test_zola_asset_paths(self, tmp_path):
+        """Test Zola copies assets under static/images and uses /images/ prefix."""
+        source_dir = tmp_path / "source"
+        source_dir.mkdir()
+        image_file = source_dir / "diagram.png"
+        image_file.write_bytes(b"test")
+
+        doc = Document(children=[Paragraph(content=[Image(url=str(image_file), alt_text="Test")])])
+
+        output_dir = tmp_path / "site"
+        modified_doc, assets = copy_document_assets(doc, output_dir, StaticSiteGenerator.ZOLA, source_file=image_file)
+
+        collector = ImageCollector()
+        collector.collect(modified_doc)
+        assert collector.images[0].url == "/images/diagram.png"
+        assert (output_dir / "static" / "images" / "diagram.png").exists()
+
+    def test_eleventy_asset_paths(self, tmp_path):
+        """Test Eleventy copies assets under src/images and uses /images/ prefix."""
+        source_dir = tmp_path / "source"
+        source_dir.mkdir()
+        image_file = source_dir / "diagram.png"
+        image_file.write_bytes(b"test")
+
+        doc = Document(children=[Paragraph(content=[Image(url=str(image_file), alt_text="Test")])])
+
+        output_dir = tmp_path / "site"
+        modified_doc, assets = copy_document_assets(
+            doc, output_dir, StaticSiteGenerator.ELEVENTY, source_file=image_file
+        )
+
+        collector = ImageCollector()
+        collector.collect(modified_doc)
+        assert collector.images[0].url == "/images/diagram.png"
+        assert (output_dir / "src" / "images" / "diagram.png").exists()


### PR DESCRIPTION
## Summary

Extends `all2md generate-site --generator` beyond `hugo`/`jekyll` to also support **`mkdocs`**, **`zola`**, and **`eleventy`**. Each new generator gets the full treatment: enum support, a site scaffolder, frontmatter defaults, asset paths, and CLI/completion/help wiring, plus unit and e2e tests.

Also fixes a batch of stale CLI/API examples in the README and docs that were already incorrect before this work.

## New generators

| Generator | Config | Content dir | Frontmatter | Assets → reference |
|---|---|---|---|---|
| **MkDocs** | `mkdocs.yml` | `docs/` | YAML (`---`) | `docs/images/` → `/images/` |
| **Zola** | `config.toml` + Tera `templates/` | `content/` | TOML (`+++`) | `static/images/` → `/images/` |
| **Eleventy** | `.eleventy.js` + `package.json` | `src/` | YAML (`---`) | `src/images/` (passthrough) → `/images/` |

**Zola schema handling:** Zola validates page frontmatter against a fixed schema and errors on unknown top-level keys, so the normalizer routes `tags`/`categories` under `[taxonomies]` and `author` under `[extra]`. Scaffolds ship minimal working Tera templates so `zola build` runs out of the box.

**Eleventy:** scaffolds a `package.json` so `npm install && npx @11ty/eleventy --serve` works; `markdownTemplateEngine` is disabled to avoid clashes with literal `{{ }}` in converted content.

## Stale README/docs fixes (pre-existing)

- `generate-site` used nonexistent `--output`/`--theme` flags → corrected to `--output-dir`/`--generator`; removed fictional "built-in themes / navigation / blog listings" description
- `<file> view` → `view <file>` (subcommand order)
- batch `-r -o ./dir` → `--output-dir ./dir` (verified `-o` on a directory silently writes to stdout)
- replaced nonexistent `doc.walk()` with a real recursive `iter_nodes()` helper
- generator enumerations across README, `cli.rst`, `static_sites.rst`, `formats.rst`, `python_api.rst`, and the skill reference now list all five generators, with dedicated Zola/Eleventy doc sections

## Testing

- `tests/unit/utils/test_static_site.py` — frontmatter (incl. Zola taxonomy/extra nesting), scaffold structure, asset paths
- `tests/unit/cli/test_cli_generate_site.py` — basic + scaffold for each generator
- `tests/e2e/test_generate_site_cli.py` — scaffold + image-copy e2e for each generator
- Full generate-site suite + `ruff`/`mypy` clean; pre-commit hooks pass

> Note: docs were not built with Sphinx to check for rST warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)