### PR TITLE
Pre-release cleanup: external-link tabs, config code blocks, context-menu, llm-minify, OCR

### DIFF
--- a/docs/source/cli.rst
+++ b/docs/source/cli.rst
@@ -5357,27 +5357,73 @@ the skill into an assistant. The topics are auto-discovered from the skill's
 Available topics are ``overview``, ``read``, ``convert``, ``generate``, ``grep``,
 ``search``, and ``diff``.
 
-Context Menu Command (Windows)
-------------------------------
+LLM Minify Command
+------------------
 
-On Windows, ``all2md context-menu`` manages a per-user right-click
-"View with all2md" shell entry (no administrator rights required).
+The ``all2md llm-minify`` command converts any supported document just like the
+default ``all2md <file>`` command, but strips filler that wastes LLM tokens. Use
+it when you only need the content, not the formatting or spacing.
+
+Two presets are available:
+
+* **Compact Markdown** (default) — keeps Markdown structure (headings, lists,
+  code, tables) while dropping comments, frontmatter and raw HTML, and collapsing
+  redundant blank lines/whitespace.
+* **Plain text** (``--aggressive`` / ``--text``) — strips *all* formatting down to
+  bare text.
 
 .. code-block:: bash
 
-   # Install the right-click entry
+   # Compact Markdown (default preset)
+   all2md llm-minify report.docx
+
+   # Strip all formatting to bare text
+   all2md llm-minify report.docx --aggressive
+
+   # Read from stdin, write to a file
+   cat notes.html | all2md llm-minify - --out notes.min.md
+
+Additional pruning flags layer on top of either preset:
+
+* ``--strip-links`` — drop link URLs, keep the link text
+* ``--strip-images`` — remove images entirely
+* ``--strip-formatting`` — remove inline emphasis/strong/strikethrough markers
+
+Context Menu Command (Windows)
+------------------------------
+
+On Windows, ``all2md context-menu`` manages per-user right-click shell entries
+(no administrator rights required). It can install three entries:
+
+* **View with all2md** — on files; opens the document in the browser preview.
+* **Edit with all2md** — on files; opens the in-browser editor (``all2md edit``).
+* **Serve with all2md** — on folders; serves the directory (``all2md serve``).
+
+``install`` registers the View entry by default. Add ``--edit`` and/or
+``--serve`` to install those entries too, or ``--all`` for all three. (The Edit
+and Serve entries require the ``all2md`` console launcher on PATH.)
+
+.. code-block:: bash
+
+   # Install just the View entry (default)
    all2md context-menu install
 
-   # Show whether the entry is installed
+   # Install View + Edit (files) + Serve (folders)
+   all2md context-menu install --all
+
+   # Install View plus the Edit entry only
+   all2md context-menu install --edit
+
+   # Show which entries are installed
    all2md context-menu status
 
-   # Remove the entry
+   # Remove all all2md entries
    all2md context-menu uninstall
 
-   # Limit the entry to specific extensions
+   # Limit the file entries to specific extensions
    all2md context-menu install --extensions "md,pdf,docx"
 
-   # Also show the entry on all text files
+   # Also show the file entries on all text files
    all2md context-menu install --all-text
 
 Command Aliases

--- a/docs/source/formats.rst
+++ b/docs/source/formats.rst
@@ -285,8 +285,10 @@ Data & Configuration Formats (JSON/YAML/TOML/INI)
 
 - Bidirectional conversion between structured data files and the common AST
 - JSON and INI are built-in; YAML uses ``pyyaml`` and TOML uses ``tomli-w`` for writing
-- Useful for turning configuration and data files into readable Markdown tables/sections,
-  or rendering AST content back out to a structured-data format
+- By default these formats are rendered as a fenced code block, preserving the native
+  syntax (and, for YAML/TOML/INI, comments) for syntax-highlighted viewing. Set
+  ``literal_block=False`` (CLI: ``--<fmt>-no-literal-block``) to instead convert the
+  data into a structured document with headings, tables for arrays of objects, and lists
 
 Other Built-in Formats
 ~~~~~~~~~~~~~~~~~~~~~~~

--- a/src/all2md/_converter_manifest.py
+++ b/src/all2md/_converter_manifest.py
@@ -222,7 +222,7 @@ _MANIFEST_RECORDS: list[ConverterMetadata] = [
         import_error_message="INI conversion uses Python standard library (no dependencies)",
         parser_options_class="all2md.options.ini.IniParserOptions",
         renderer_options_class="all2md.options.ini.IniRendererOptions",
-        description="Convert INI configuration files to/from readable documents with sections and key-value pairs",
+        description="Convert INI config files to/from a fenced code block (default) or a structured document",
         priority=10,
     ),
     ConverterMetadata(
@@ -258,7 +258,7 @@ _MANIFEST_RECORDS: list[ConverterMetadata] = [
         import_error_message="JSON conversion uses Python standard library (no dependencies)",
         parser_options_class="all2md.options.json.JsonParserOptions",
         renderer_options_class="all2md.options.json.JsonRendererOptions",
-        description="Convert JSON structures to/from readable documents with tables and lists",
+        description="Convert JSON to/from a fenced code block (default) or a structured document",
         priority=10,
     ),
     ConverterMetadata(
@@ -673,7 +673,7 @@ _MANIFEST_RECORDS: list[ConverterMetadata] = [
         import_error_message="TOML conversion requires tomli and tomli-w (pip install tomli tomli-w)",
         parser_options_class="all2md.options.toml.TomlParserOptions",
         renderer_options_class="all2md.options.toml.TomlRendererOptions",
-        description="Convert TOML structures to/from readable documents with tables and lists",
+        description="Convert TOML to/from a fenced code block (default) or a structured document",
         priority=10,
     ),
     ConverterMetadata(
@@ -713,7 +713,7 @@ _MANIFEST_RECORDS: list[ConverterMetadata] = [
         import_error_message="YAML conversion requires PyYAML (pip install pyyaml)",
         parser_options_class="all2md.options.yaml.YamlParserOptions",
         renderer_options_class="all2md.options.yaml.YamlRendererOptions",
-        description="Convert YAML structures to/from readable documents with tables and lists",
+        description="Convert YAML to/from a fenced code block (default) or a structured document",
         priority=5,
     ),
     ConverterMetadata(

--- a/src/all2md/cli/commands/__init__.py
+++ b/src/all2md/cli/commands/__init__.py
@@ -108,6 +108,12 @@ def dispatch_command(args: list[str] | None = None) -> int | None:  # noqa: C901
 
         return handle_lint_command(args[1:])
 
+    # Check for llm-minify command
+    if args[0] == "llm-minify":
+        from all2md.cli.commands.llm_minify import handle_llm_minify_command
+
+        return handle_llm_minify_command(args[1:])
+
     # Check for list-formats command
     if args[0] in ("list-formats", "formats"):
         from all2md.cli.commands.formats import handle_list_formats_command

--- a/src/all2md/cli/commands/context_menu.py
+++ b/src/all2md/cli/commands/context_menu.py
@@ -19,6 +19,7 @@ import os
 import re
 import shutil
 import sys
+from dataclasses import dataclass
 from importlib.resources import (  # nosemgrep: python.lang.compatibility.python37.python37-compatibility-importlib2
     as_file,
     files,
@@ -27,11 +28,36 @@ from pathlib import Path
 
 from all2md.cli.builder import EXIT_ERROR, EXIT_SUCCESS
 
-# Per-user registry layout (no admin needed). The leading ``*`` means "all
-# files"; ``AppliesTo`` then narrows visibility to the configured extensions.
-_MENU_KEY = r"Software\Classes\*\shell\all2mdView"
-_COMMAND_KEY = _MENU_KEY + r"\command"
-_MENU_TEXT = "View with all2md"
+
+@dataclass(frozen=True)
+class _MenuEntry:
+    r"""A single right-click entry installed under the per-user class hive.
+
+    ``scope`` is ``"file"`` (registered under ``*\shell`` and narrowed by an
+    ``AppliesTo`` query) or ``"directory"`` (registered under
+    ``Directory\shell`` for folders, with no extension filter).
+    """
+
+    id: str
+    menu_key: str
+    text: str
+    scope: str  # "file" or "directory"
+    arg: str  # "%1" for files, "%V" for directories
+
+    @property
+    def command_key(self) -> str:
+        return self.menu_key + r"\command"
+
+
+# All entries this command knows how to install. ``view``/``edit`` apply to
+# files (``*\shell``); ``serve`` applies to folders (``Directory\shell``).
+_ENTRIES: dict[str, _MenuEntry] = {
+    "view": _MenuEntry("view", r"Software\Classes\*\shell\all2mdView", "View with all2md", "file", "%1"),
+    "edit": _MenuEntry("edit", r"Software\Classes\*\shell\all2mdEdit", "Edit with all2md", "file", "%1"),
+    "serve": _MenuEntry(
+        "serve", r"Software\Classes\Directory\shell\all2mdServe", "Serve with all2md", "directory", "%V"
+    ),
+}
 
 # Default file types the entry appears on — formats all2md renders well in the
 # browser preview. Override with ``--extensions``.
@@ -81,33 +107,60 @@ def _copy_bundled_icon(dest: Path) -> Path | None:
         return None
 
 
-def _find_launcher() -> tuple[str, bool] | None:
-    """Locate the best available launcher executable.
+def _which_launcher(name: str) -> str | None:
+    """Locate a specific launcher executable on PATH or known script dirs."""
+    found = shutil.which(name)
+    if found:
+        return found
 
-    Prefers the console-less ``all2mdw`` GUI launcher; falls back to ``all2md``
-    (which flashes a console and uses the interactive ``view`` prompt).
-
-    Returns
-    -------
-    tuple[str, bool] or None
-        ``(path, windowed)`` where ``windowed`` is True for ``all2mdw``, or
-        None if no launcher could be found.
-
-    """
     search_dirs = [Path(sys.executable).parent]
     if os.environ.get("UV_TOOL_BIN_DIR"):
         search_dirs.append(Path(os.environ["UV_TOOL_BIN_DIR"]))
     if os.environ.get("USERPROFILE"):
         search_dirs.append(Path(os.environ["USERPROFILE"]) / ".local" / "bin")
 
-    for name, windowed in (("all2mdw", True), ("all2md", False)):
-        found = shutil.which(name)
-        if found:
-            return found, windowed
-        for directory in search_dirs:
-            candidate = directory / f"{name}.exe"
-            if candidate.is_file():
-                return str(candidate), windowed
+    for directory in search_dirs:
+        candidate = directory / f"{name}.exe"
+        if candidate.is_file():
+            return str(candidate)
+    return None
+
+
+def _resolve_launchers() -> dict[str, str]:
+    """Return a map of available launcher names to their resolved paths.
+
+    Looks for the console-less ``all2mdw`` GUI launcher (preferred for ``view``)
+    and the ``all2md`` console launcher (required for ``edit``/``serve``, which
+    host a live local server).
+    """
+    launchers: dict[str, str] = {}
+    for name in ("all2mdw", "all2md"):
+        path = _which_launcher(name)
+        if path:
+            launchers[name] = path
+    return launchers
+
+
+def _build_entry_command(entry: _MenuEntry, launchers: dict[str, str]) -> tuple[str, bool] | None:
+    """Build the shell command for an entry.
+
+    Returns ``(command, windowed)`` or None if no suitable launcher exists.
+    ``view`` prefers the windowless ``all2mdw``; ``edit``/``serve`` require the
+    ``all2md`` console launcher invoked with the matching subcommand.
+    """
+    all2mdw = launchers.get("all2mdw")
+    all2md = launchers.get("all2md")
+
+    if entry.id == "view":
+        if all2mdw:
+            return f'"{all2mdw}" "{entry.arg}"', True
+        if all2md:
+            return f'"{all2md}" view "{entry.arg}"', False
+        return None
+
+    # edit / serve: explicit subcommand on the console launcher.
+    if all2md:
+        return f'"{all2md}" {entry.id} "{entry.arg}"', False
     return None
 
 
@@ -127,19 +180,22 @@ def _build_applies_to(extensions: tuple[str, ...], include_text: bool) -> str:
     return " OR ".join(clauses)
 
 
-def _build_command(launcher: str, windowed: bool) -> str:
-    """Build the shell command string (``%1`` is the clicked file)."""
-    if windowed:
-        return f'"{launcher}" "%1"'
-    return f'"{launcher}" view "%1"'
+def _resolve_icon(fallback: str) -> str:
+    """Copy the bundled icon to a stable path; fall back to a launcher path."""
+    target = _icon_target()
+    if target is not None:
+        copied = _copy_bundled_icon(target)
+        if copied:
+            return str(copied)
+    return fallback
 
 
-def _install(extensions: tuple[str, ...], include_text: bool) -> int:
-    """Register the context-menu entry. Returns an exit code."""
+def _install(selected_ids: list[str], extensions: tuple[str, ...], include_text: bool) -> int:
+    """Register the selected context-menu entries. Returns an exit code."""
     import winreg
 
-    launcher = _find_launcher()
-    if launcher is None:
+    launchers = _resolve_launchers()
+    if not launchers:
         print(
             "Error: could not find the all2md launcher on PATH.\n"
             "Make sure all2md is installed (e.g. `uv tool install all2md`) and its "
@@ -147,92 +203,140 @@ def _install(extensions: tuple[str, ...], include_text: bool) -> int:
             file=sys.stderr,
         )
         return EXIT_ERROR
-    launcher_path, windowed = launcher
 
-    icon_value: str | None = None
-    target = _icon_target()
-    if target is not None:
-        copied = _copy_bundled_icon(target)
-        icon_value = str(copied) if copied else None
-    if icon_value is None:
-        # No bundled icon available — fall back to the launcher's own icon.
-        icon_value = launcher_path
-
+    icon_value = _resolve_icon(next(iter(launchers.values())))
     applies_to = _build_applies_to(extensions, include_text)
-    command = _build_command(launcher_path, windowed)
 
-    with winreg.CreateKey(winreg.HKEY_CURRENT_USER, _MENU_KEY) as menu:
-        winreg.SetValueEx(menu, "MUIVerb", 0, winreg.REG_SZ, _MENU_TEXT)
-        winreg.SetValueEx(menu, "Icon", 0, winreg.REG_SZ, icon_value)
-        winreg.SetValueEx(menu, "AppliesTo", 0, winreg.REG_SZ, applies_to)
-    with winreg.CreateKey(winreg.HKEY_CURRENT_USER, _COMMAND_KEY) as cmd:
-        winreg.SetValueEx(cmd, "", 0, winreg.REG_SZ, command)
+    installed: list[tuple[_MenuEntry, str]] = []
+    used_console_view = False
+    for entry_id in selected_ids:
+        entry = _ENTRIES[entry_id]
+        built = _build_entry_command(entry, launchers)
+        if built is None:
+            print(
+                f"Skipping '{entry.text}': the '{entry.id}' entry needs the 'all2md' console "
+                "launcher, which was not found on PATH.",
+                file=sys.stderr,
+            )
+            continue
+        command, windowed = built
+        if entry.id == "view" and not windowed:
+            used_console_view = True
 
-    print(f'Installed context-menu entry: "{_MENU_TEXT}"')
-    print(f"  Launcher: {launcher_path}")
-    print(f"  Icon:     {icon_value}")
-    print(f"  Shows on: {', '.join('.' + e for e in extensions)}" + (" + all text files" if include_text else ""))
-    if not windowed:
+        with winreg.CreateKey(winreg.HKEY_CURRENT_USER, entry.menu_key) as menu:
+            winreg.SetValueEx(menu, "MUIVerb", 0, winreg.REG_SZ, entry.text)
+            winreg.SetValueEx(menu, "Icon", 0, winreg.REG_SZ, icon_value)
+            # ``AppliesTo`` only applies to the file-scoped entries; directory
+            # entries (serve) appear on every folder.
+            if entry.scope == "file":
+                winreg.SetValueEx(menu, "AppliesTo", 0, winreg.REG_SZ, applies_to)
+        with winreg.CreateKey(winreg.HKEY_CURRENT_USER, entry.command_key) as cmd:
+            winreg.SetValueEx(cmd, "", 0, winreg.REG_SZ, command)
+        installed.append((entry, command))
+
+    if not installed:
+        print("No context-menu entries were installed.", file=sys.stderr)
+        return EXIT_ERROR
+
+    print("Installed context-menu entries:")
+    for entry, command in installed:
+        scope_note = (
+            "folders"
+            if entry.scope == "directory"
+            else (", ".join("." + e for e in extensions) + (" + all text files" if include_text else ""))
+        )
+        print(f'  "{entry.text}"  →  {command}')
+        print(f"      Shows on: {scope_note}")
+    print(f"  Icon: {icon_value}")
+    if used_console_view:
         print(
-            "\nNote: the console-less 'all2mdw' launcher was not found, so the entry uses "
+            "\nNote: the console-less 'all2mdw' launcher was not found, so the View entry uses "
             "'all2md view', which opens a console window and waits for Enter. Reinstall all2md "
             "to get 'all2mdw' for a clean, windowless launch.",
             file=sys.stderr,
         )
-    print("\nIf the entry doesn't appear right away, restart Explorer (or sign out and back in).")
+    print("\nIf the entries don't appear right away, restart Explorer (or sign out and back in).")
     return EXIT_SUCCESS
 
 
 def _uninstall() -> int:
-    """Remove the context-menu entry and the copied icon. Returns an exit code."""
+    """Remove ALL known context-menu entries and the copied icon."""
     import winreg
 
-    removed = False
-    for key in (_COMMAND_KEY, _MENU_KEY):
-        try:
-            winreg.DeleteKey(winreg.HKEY_CURRENT_USER, key)
-            removed = True
-        except FileNotFoundError:
-            # Subkey already absent (entry not installed or partially removed) —
-            # that's the desired end state, so leave `removed` as-is and move on.
-            pass
+    removed: list[str] = []
+    for entry in _ENTRIES.values():
+        entry_removed = False
+        for key in (entry.command_key, entry.menu_key):
+            try:
+                winreg.DeleteKey(winreg.HKEY_CURRENT_USER, key)
+                entry_removed = True
+            except FileNotFoundError:
+                # Subkey already absent — that's the desired end state.
+                pass
+        if entry_removed:
+            removed.append(entry.text)
 
     target = _icon_target()
     if target is not None and target.exists():
         try:
             target.unlink()
         except OSError:
-            # Best-effort cleanup; a leftover icon in %LOCALAPPDATA% is harmless
-            # and must not abort uninstalling the registry entry.
+            # Best-effort cleanup; a leftover icon in %LOCALAPPDATA% is harmless.
             pass
 
     if removed:
-        print(f'Removed context-menu entry: "{_MENU_TEXT}"')
+        print("Removed context-menu entries:")
+        for text in removed:
+            print(f'  "{text}"')
     else:
-        print(f'Context-menu entry not found: "{_MENU_TEXT}"')
+        print("No all2md context-menu entries were installed.")
     return EXIT_SUCCESS
 
 
 def _status() -> int:
-    """Report whether the entry is installed and what it points at."""
+    """Report which entries are installed and what they point at."""
     import winreg
 
-    try:
-        with winreg.OpenKey(winreg.HKEY_CURRENT_USER, _MENU_KEY) as menu:
-            applies_to = winreg.QueryValueEx(menu, "AppliesTo")[0]
-            icon = winreg.QueryValueEx(menu, "Icon")[0]
-        with winreg.OpenKey(winreg.HKEY_CURRENT_USER, _COMMAND_KEY) as cmd:
-            command = winreg.QueryValueEx(cmd, "")[0]
-    except FileNotFoundError:
-        print(f'Not installed: "{_MENU_TEXT}"')
-        print("Run: all2md context-menu install")
-        return EXIT_SUCCESS
+    any_installed = False
+    for entry in _ENTRIES.values():
+        try:
+            with winreg.OpenKey(winreg.HKEY_CURRENT_USER, entry.menu_key) as menu:
+                icon = winreg.QueryValueEx(menu, "Icon")[0]
+                try:
+                    applies_to = winreg.QueryValueEx(menu, "AppliesTo")[0]
+                except FileNotFoundError:
+                    applies_to = "(folders)"
+            with winreg.OpenKey(winreg.HKEY_CURRENT_USER, entry.command_key) as cmd:
+                command = winreg.QueryValueEx(cmd, "")[0]
+        except FileNotFoundError:
+            print(f'Not installed: "{entry.text}"')
+            continue
 
-    print(f'Installed: "{_MENU_TEXT}"')
-    print(f"  Command:   {command}")
-    print(f"  Icon:      {icon}")
-    print(f"  AppliesTo: {applies_to}")
+        any_installed = True
+        print(f'Installed: "{entry.text}"')
+        print(f"  Command:   {command}")
+        print(f"  Icon:      {icon}")
+        print(f"  AppliesTo: {applies_to}")
+
+    if not any_installed:
+        print("\nRun: all2md context-menu install [--edit] [--serve] [--all]")
     return EXIT_SUCCESS
+
+
+def _select_entries(parsed: argparse.Namespace) -> list[str]:
+    """Resolve which entry ids to install from the install flags.
+
+    ``view`` is always installed (backward compatible). ``--edit``/``--serve``
+    add those entries; ``--all`` installs every entry.
+    """
+    if parsed.all:
+        return list(_ENTRIES.keys())
+    selected = ["view"]
+    if parsed.edit:
+        selected.append("edit")
+    if parsed.serve:
+        selected.append("serve")
+    return selected
 
 
 def handle_context_menu_command(args: list[str] | None = None) -> int:
@@ -251,23 +355,39 @@ def handle_context_menu_command(args: list[str] | None = None) -> int:
     """
     parser = argparse.ArgumentParser(
         prog="all2md context-menu",
-        description='Manage the Windows right-click "View with all2md" entry (per-user, no admin).',
+        description="Manage the Windows right-click all2md entries (per-user, no admin). "
+        "Installs a View entry by default; add Edit (files) and Serve (folders) with flags.",
     )
     parser.add_argument(
         "action",
         choices=("install", "uninstall", "status"),
-        help="install / uninstall the menu entry, or show its current status",
+        help="install / uninstall the menu entries, or show their current status",
+    )
+    parser.add_argument(
+        "--edit",
+        action="store_true",
+        help="Also install an 'Edit with all2md' entry on files (in addition to View).",
+    )
+    parser.add_argument(
+        "--serve",
+        action="store_true",
+        help="Also install a 'Serve with all2md' entry on folders.",
+    )
+    parser.add_argument(
+        "--all",
+        action="store_true",
+        help="Install all entries (View + Edit + Serve).",
     )
     parser.add_argument(
         "--extensions",
         metavar="LIST",
-        help="Comma/space separated file extensions the entry shows on "
+        help="Comma/space separated file extensions the file entries show on "
         "(overrides the built-in default set, e.g. --extensions 'md,pdf,docx').",
     )
     parser.add_argument(
         "--all-text",
         action="store_true",
-        help="Also show the entry on all text files (adds System.Kind:=text).",
+        help="Also show the file entries on all text files (adds System.Kind:=text).",
     )
 
     try:
@@ -280,7 +400,7 @@ def handle_context_menu_command(args: list[str] | None = None) -> int:
         return EXIT_ERROR
 
     if parsed.action == "install":
-        return _install(_parse_extensions(parsed.extensions), parsed.all_text)
+        return _install(_select_entries(parsed), _parse_extensions(parsed.extensions), parsed.all_text)
     if parsed.action == "uninstall":
         return _uninstall()
     return _status()

--- a/src/all2md/cli/commands/llm_minify.py
+++ b/src/all2md/cli/commands/llm_minify.py
@@ -1,0 +1,225 @@
+#  Copyright (c) 2025 Tom Villani, Ph.D.
+
+# src/all2md/cli/commands/llm_minify.py
+"""Token-lean conversion command for all2md CLI.
+
+The ``llm-minify`` command converts any supported document the same way the
+default ``all2md <file>`` command does, but strips filler that wastes LLM
+tokens. Two presets are available:
+
+- **compact Markdown** (default): keep Markdown structure (headings, lists,
+  code, tables) while dropping comments, frontmatter, raw HTML and collapsing
+  redundant blank lines/whitespace.
+- **plain text** (``--aggressive`` / ``--text``): strip all formatting down to
+  bare text via the plain-text renderer.
+
+Optional ``--strip-*`` flags layer additional pruning on top of either preset.
+"""
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+from all2md import MarkdownRendererOptions, PlainTextOptions, from_ast, to_ast
+from all2md.ast import Image, Link, Node, NodeTransformer, Text, extract_text
+from all2md.cli import EXIT_FILE_ERROR
+from all2md.cli.builder import EXIT_ERROR, EXIT_SUCCESS
+from all2md.cli.config import apply_config_to_parser
+
+
+def _create_llm_minify_parser() -> argparse.ArgumentParser:
+    """Build the argument parser for the ``llm-minify`` command.
+
+    Exposed as a factory so ``config generate`` can introspect the command's
+    options to emit an ``[llm-minify]`` config-template section.
+    """
+    parser = argparse.ArgumentParser(
+        prog="all2md llm-minify",
+        description="Convert a document to token-lean Markdown (or plain text) for LLM consumption.",
+    )
+    parser.add_argument("input", help="File to convert (use '-' for stdin)")
+    parser.add_argument("-o", "--out", help="Write output to a file instead of stdout")
+    parser.add_argument(
+        "--aggressive",
+        "--text",
+        dest="aggressive",
+        action="store_true",
+        help="Strip ALL formatting to bare text (plain-text preset). The default keeps compact Markdown structure.",
+    )
+    parser.add_argument(
+        "--strip-links",
+        action="store_true",
+        help="Drop link URLs, keeping only the link text.",
+    )
+    parser.add_argument(
+        "--strip-images",
+        action="store_true",
+        help="Drop images entirely (removes data URIs and alt text).",
+    )
+    parser.add_argument(
+        "--strip-formatting",
+        action="store_true",
+        help="Remove inline emphasis/strong/strikethrough/underline markers, keeping the text.",
+    )
+    parser.add_argument(
+        "--config",
+        help="Path to a configuration file. Values in its [llm-minify] section provide defaults "
+        "(CLI flags still override). If omitted, ALL2MD_CONFIG and auto-discovered configs apply.",
+    )
+    parser.add_argument(
+        "--no-config",
+        action="store_true",
+        help="Disable configuration file loading for this command.",
+    )
+    return parser
+
+
+class _MinifyTransformer(NodeTransformer):
+    """Prune inline nodes according to the ``--strip-*`` flags.
+
+    Unwrapped nodes are replaced with a single ``Text`` node holding their
+    concatenated text so the result stays a valid inline child.
+    """
+
+    def __init__(self, strip_links: bool, strip_images: bool, strip_formatting: bool) -> None:
+        self._strip_links = strip_links
+        self._strip_images = strip_images
+        self._strip_formatting = strip_formatting
+
+    def visit_image(self, node: Image) -> Node | None:  # type: ignore[override]
+        if self._strip_images:
+            return None
+        return super().visit_image(node)
+
+    def visit_link(self, node: Link) -> Node:  # type: ignore[override]
+        if self._strip_links:
+            return Text(content=extract_text(node.content, joiner=""))
+        return super().visit_link(node)
+
+    def _unwrap(self, node: Node) -> Text:
+        return Text(content=extract_text(node.content, joiner=""))  # type: ignore[attr-defined]
+
+    def visit_emphasis(self, node: Node) -> Node:  # type: ignore[override]
+        return self._unwrap(node) if self._strip_formatting else super().visit_emphasis(node)  # type: ignore[arg-type]
+
+    def visit_strong(self, node: Node) -> Node:  # type: ignore[override]
+        return self._unwrap(node) if self._strip_formatting else super().visit_strong(node)  # type: ignore[arg-type]
+
+    def visit_strikethrough(self, node: Node) -> Node:  # type: ignore[override]
+        return self._unwrap(node) if self._strip_formatting else super().visit_strikethrough(node)  # type: ignore[arg-type]
+
+    def visit_underline(self, node: Node) -> Node:  # type: ignore[override]
+        return self._unwrap(node) if self._strip_formatting else super().visit_underline(node)  # type: ignore[arg-type]
+
+    def visit_superscript(self, node: Node) -> Node:  # type: ignore[override]
+        return self._unwrap(node) if self._strip_formatting else super().visit_superscript(node)  # type: ignore[arg-type]
+
+    def visit_subscript(self, node: Node) -> Node:  # type: ignore[override]
+        return self._unwrap(node) if self._strip_formatting else super().visit_subscript(node)  # type: ignore[arg-type]
+
+
+def _squeeze_whitespace(text: str) -> str:
+    """Collapse filler whitespace: trailing spaces, runs of blank lines, edges."""
+    # Strip trailing spaces/tabs on each line.
+    text = re.sub(r"[ \t]+(\r?\n)", r"\1", text)
+    # Collapse two or more blank lines into a single blank line.
+    text = re.sub(r"(\r?\n){3,}", "\n\n", text)
+    # Trim leading/trailing blank lines and ensure a single trailing newline.
+    return text.strip("\n") + "\n"
+
+
+def handle_llm_minify_command(args: list[str] | None = None) -> int:
+    """Handle the ``llm-minify`` command.
+
+    Parameters
+    ----------
+    args : list[str], optional
+        Command line arguments (beyond ``llm-minify``).
+
+    Returns
+    -------
+    int
+        Exit code (0 for success).
+
+    """
+    parser = _create_llm_minify_parser()
+
+    try:
+        # Pre-parse to discover config flags, fold the [llm-minify] config section
+        # in as defaults, then parse for real so explicit CLI flags win.
+        pre_args, _ = parser.parse_known_args(args or [])
+        apply_config_to_parser(parser, "llm-minify", explicit_path=pre_args.config, no_config=pre_args.no_config)
+        parsed = parser.parse_args(args or [])
+    except SystemExit as e:
+        return e.code if isinstance(e.code, int) else EXIT_ERROR
+
+    # Resolve input (file or stdin).
+    if parsed.input == "-":
+        stdin_data = sys.stdin.buffer.read()
+        if not stdin_data:
+            print("Error: No data received from stdin", file=sys.stderr)
+            return EXIT_FILE_ERROR
+        input_source: object = stdin_data
+    else:
+        input_path = Path(parsed.input)
+        if not input_path.exists():
+            print(f"Error: Input file not found: {parsed.input}", file=sys.stderr)
+            return EXIT_FILE_ERROR
+        input_source = parsed.input
+
+    try:
+        doc = to_ast(input_source)  # type: ignore[arg-type]
+
+        if parsed.strip_links or parsed.strip_images or parsed.strip_formatting:
+            transformer = _MinifyTransformer(
+                strip_links=parsed.strip_links,
+                strip_images=parsed.strip_images,
+                strip_formatting=parsed.strip_formatting,
+            )
+            transformed = transformer.transform(doc)
+            if transformed is not None:
+                doc = transformed  # type: ignore[assignment]
+
+        if parsed.aggressive:
+            result = from_ast(
+                doc,
+                "plaintext",
+                renderer_options=PlainTextOptions(
+                    max_line_width=None,
+                    preserve_blank_lines=False,
+                    comment_mode="ignore",
+                ),
+            )
+        else:
+            result = from_ast(
+                doc,
+                "markdown",
+                renderer_options=MarkdownRendererOptions(
+                    comment_mode="ignore",
+                    metadata_frontmatter=False,
+                    collapse_blank_lines=True,
+                    autolink_bare_urls=False,
+                    html_passthrough_mode="drop",
+                ),
+            )
+    except Exception as e:  # noqa: BLE001 - surface any conversion error as a CLI error
+        print(f"Error: {e}", file=sys.stderr)
+        return EXIT_ERROR
+
+    if not isinstance(result, str):
+        print("Error: minify produced non-text output", file=sys.stderr)
+        return EXIT_ERROR
+
+    output = _squeeze_whitespace(result)
+
+    if parsed.out:
+        try:
+            Path(parsed.out).write_text(output, encoding="utf-8")
+        except OSError as e:
+            print(f"Error: could not write output file: {e}", file=sys.stderr)
+            return EXIT_FILE_ERROR
+    else:
+        sys.stdout.write(output)
+
+    return EXIT_SUCCESS

--- a/src/all2md/cli/commands/server.py
+++ b/src/all2md/cli/commands/server.py
@@ -770,6 +770,7 @@ def handle_serve_command(args: list[str] | None = None) -> int:  # noqa: C901
             template_mode="replace",
             template_file=str(theme_path),
             include_toc=parsed.toc,
+            external_links_new_tab=True,
         )
         html_content = from_ast(doc, "html", renderer_options=html_opts)
         if not isinstance(html_content, str):

--- a/src/all2md/cli/commands/view.py
+++ b/src/all2md/cli/commands/view.py
@@ -170,6 +170,7 @@ def handle_view_command(args: list[str] | None = None) -> int:
             template_mode="replace",
             template_file=str(theme_path),
             include_toc=parsed.toc,
+            external_links_new_tab=True,
         )
         html_result = from_ast(doc, "html", renderer_options=html_opts)
 

--- a/src/all2md/cli/viewer_launch.py
+++ b/src/all2md/cli/viewer_launch.py
@@ -76,6 +76,7 @@ def _render_html(input_path: Path) -> str:
         template_mode="replace",
         template_file=str(theme_path),
         include_toc=False,
+        external_links_new_tab=True,
     )
     result = from_ast(doc, "html", renderer_options=options)
     if not isinstance(result, str):

--- a/src/all2md/constants.py
+++ b/src/all2md/constants.py
@@ -788,6 +788,7 @@ DEFAULT_OCR_LANGUAGES = "eng"
 DEFAULT_OCR_AUTO_DETECT_LANGUAGE = False
 DEFAULT_OCR_DPI = 300
 DEFAULT_OCR_TEXT_THRESHOLD = 50  # Minimum characters to consider page as text-based
+DEFAULT_OCR_DOC_TEXT_THRESHOLD = 16  # Whole-doc meaningful-char floor below which auto OCR retries
 DEFAULT_OCR_IMAGE_AREA_THRESHOLD = 0.5  # Ratio of image area to page area to trigger OCR
 DEFAULT_OCR_PRESERVE_EXISTING_TEXT = False
 DEFAULT_OCR_TESSERACT_CONFIG = ""

--- a/src/all2md/options/common.py
+++ b/src/all2md/options/common.py
@@ -30,6 +30,7 @@ from all2md.constants import (
     DEFAULT_MAX_REQUESTS_PER_SECOND,
     DEFAULT_NETWORK_TIMEOUT,
     DEFAULT_OCR_AUTO_DETECT_LANGUAGE,
+    DEFAULT_OCR_DOC_TEXT_THRESHOLD,
     DEFAULT_OCR_DPI,
     DEFAULT_OCR_ENABLED,
     DEFAULT_OCR_IMAGE_AREA_THRESHOLD,
@@ -558,6 +559,11 @@ class OCROptions(CloneFrozenMixin):
     text_threshold : int, default 50
         Minimum number of characters to consider content as text-based.
         Used by parsers in "auto" mode to decide if OCR is needed.
+    doc_text_threshold : int, default 16
+        Whole-document floor on meaningful (alphanumeric) characters. In "auto"
+        mode, if no page triggered OCR yet the rendered document has fewer
+        meaningful characters than this, the PDF parser retries once with OCR
+        forced. Catches scanned/image-only documents the per-page heuristic missed.
     image_area_threshold : float, default 0.5
         Minimum ratio of image area to total area (0.0-1.0) to consider
         content as image-based. Used by parsers in "auto" mode.
@@ -641,6 +647,14 @@ class OCROptions(CloneFrozenMixin):
         default=DEFAULT_OCR_TEXT_THRESHOLD,
         metadata={
             "help": "Minimum characters to consider content text-based (for auto mode)",
+            "type": int,
+            "importance": "advanced",
+        },
+    )
+    doc_text_threshold: int = field(
+        default=DEFAULT_OCR_DOC_TEXT_THRESHOLD,
+        metadata={
+            "help": "Whole-document meaningful-character floor below which auto mode retries with OCR forced",
             "type": int,
             "importance": "advanced",
         },

--- a/src/all2md/options/html.py
+++ b/src/all2md/options/html.py
@@ -96,6 +96,10 @@ class HtmlRendererOptions(BaseRendererOptions):
     language : str, default "en"
         Document language code (ISO 639-1) for the <html lang="..."> attribute.
         Can be overridden by document metadata.
+    external_links_new_tab : bool, default False
+        If True, external links (absolute http/https/ftp/mailto URLs) are rendered
+        with target="_blank" rel="noopener noreferrer" so they open in a new tab.
+        Relative and anchor links are unaffected. Used by the view/serve commands.
     template_mode : {"inject", "replace", "jinja"} or None, default None
         Template mode for rendering HTML:
         - None: Use standalone mode (default behavior)
@@ -227,6 +231,14 @@ class HtmlRendererOptions(BaseRendererOptions):
     language: str = field(
         default=DEFAULT_HTML_LANGUAGE,
         metadata={"help": "Document language code (ISO 639-1) for HTML lang attribute", "importance": "advanced"},
+    )
+    external_links_new_tab: bool = field(
+        default=False,
+        metadata={
+            "help": "Open external links (absolute http/https/ftp/mailto URLs) in a new tab "
+            'via target="_blank" rel="noopener noreferrer"',
+            "importance": "advanced",
+        },
     )
     template_mode: TemplateMode | None = field(
         default=None,

--- a/src/all2md/options/ini.py
+++ b/src/all2md/options/ini.py
@@ -19,7 +19,9 @@ from all2md.options.base import BaseParserOptions, BaseRendererOptions
 class IniParserOptions(BaseParserOptions):
     """Configuration options for INI to AST parsing.
 
-    The parser converts INI structures into human-readable document format:
+    By default the parser emits the INI as a fenced code block (``literal_block``).
+    Set ``literal_block=False`` to convert INI structures into a human-readable
+    document instead:
     - Sections become headings
     - Key-value pairs become definition lists (bullet lists with bold keys)
     - Comments are preserved
@@ -33,16 +35,20 @@ class IniParserOptions(BaseParserOptions):
         to lowercase (configparser default behavior).
     allow_no_value : bool, default = False
         If True, allow keys without values (e.g., standalone flags).
-    literal_block : bool, default = False
-        If True, render INI as a literal code block instead of converting to
-        structured document format. Useful when you want to preserve the original
-        INI formatting or show it as example code.
+    literal_block : bool, default = True
+        If True (the default), render INI as a literal fenced code block,
+        preserving the native syntax and comments. Set to False to convert into a
+        structured document (headings and definition lists).
 
     """
 
     literal_block: bool = field(
-        default=False,
-        metadata={"help": "Render as code block instead of structured document", "importance": "core"},
+        default=True,
+        metadata={
+            "help": "Render as a fenced code block (default) instead of a structured document",
+            "cli_name": "no-literal-block",
+            "importance": "core",
+        },
     )
     pretty_format_numbers: bool = field(
         default=True,

--- a/src/all2md/options/json.py
+++ b/src/all2md/options/json.py
@@ -20,7 +20,9 @@ from all2md.options.base import BaseParserOptions, BaseRendererOptions
 class JsonParserOptions(BaseParserOptions):
     """Configuration options for JSON to AST parsing.
 
-    The parser converts JSON structures into human-readable document format:
+    By default the parser emits the JSON as a fenced code block (``literal_block``).
+    Set ``literal_block=False`` to convert JSON structures into a human-readable
+    document instead:
     - Objects/dicts become heading hierarchies
     - Arrays of objects become tables
     - Arrays of primitives become lists
@@ -46,16 +48,20 @@ class JsonParserOptions(BaseParserOptions):
         If True, format large numbers with thousand separators for readability.
     sort_keys : bool, default = False
         If True, sort object keys alphabetically when rendering.
-    literal_block : bool, default = False
-        If True, render JSON as a literal code block instead of converting to
-        structured document format. Useful when you want to preserve the original
-        JSON formatting or show it as example code.
+    literal_block : bool, default = True
+        If True (the default), render JSON as a literal fenced code block,
+        preserving the native syntax. Set to False to convert into a structured
+        document (headings, tables for arrays of objects, lists).
 
     """
 
     literal_block: bool = field(
-        default=False,
-        metadata={"help": "Render as code block instead of structured document", "importance": "core"},
+        default=True,
+        metadata={
+            "help": "Render as a fenced code block (default) instead of a structured document",
+            "cli_name": "no-literal-block",
+            "importance": "core",
+        },
     )
     max_heading_depth: int = field(
         default=6,

--- a/src/all2md/options/toml.py
+++ b/src/all2md/options/toml.py
@@ -20,7 +20,9 @@ from all2md.options.base import BaseParserOptions, BaseRendererOptions
 class TomlParserOptions(BaseParserOptions):
     """Configuration options for TOML to AST parsing.
 
-    The parser converts TOML structures into human-readable document format:
+    By default the parser emits the TOML as a fenced code block (``literal_block``).
+    Set ``literal_block=False`` to convert TOML structures into a human-readable
+    document instead:
     - Sections/tables become heading hierarchies
     - Arrays of tables become markdown tables
     - Arrays of primitives become lists
@@ -46,16 +48,20 @@ class TomlParserOptions(BaseParserOptions):
         If True, format large numbers with thousand separators for readability.
     sort_keys : bool, default = False
         If True, sort object keys alphabetically when rendering.
-    literal_block : bool, default = False
-        If True, render TOML as a literal code block instead of converting to
-        structured document format. Useful when you want to preserve the original
-        TOML formatting or show it as example code.
+    literal_block : bool, default = True
+        If True (the default), render TOML as a literal fenced code block,
+        preserving the native syntax. Set to False to convert into a structured
+        document (headings, tables for arrays of objects, lists).
 
     """
 
     literal_block: bool = field(
-        default=False,
-        metadata={"help": "Render as code block instead of structured document", "importance": "core"},
+        default=True,
+        metadata={
+            "help": "Render as a fenced code block (default) instead of a structured document",
+            "cli_name": "no-literal-block",
+            "importance": "core",
+        },
     )
     max_heading_depth: int = field(
         default=6,

--- a/src/all2md/options/yaml.py
+++ b/src/all2md/options/yaml.py
@@ -20,7 +20,9 @@ from all2md.options.base import BaseParserOptions, BaseRendererOptions
 class YamlParserOptions(BaseParserOptions):
     """Configuration options for YAML to AST parsing.
 
-    The parser converts YAML structures into human-readable document format:
+    By default the parser emits the YAML as a fenced code block (``literal_block``).
+    Set ``literal_block=False`` to convert YAML structures into a human-readable
+    document instead:
     - Objects/dicts become heading hierarchies
     - Arrays of objects become tables
     - Arrays of primitives become lists
@@ -46,16 +48,20 @@ class YamlParserOptions(BaseParserOptions):
         If True, format large numbers with thousand separators for readability.
     sort_keys : bool, default = False
         If True, sort object keys alphabetically when rendering.
-    literal_block : bool, default = False
-        If True, render YAML as a literal code block instead of converting to
-        structured document format. Useful when you want to preserve the original
-        YAML formatting or show it as example code.
+    literal_block : bool, default = True
+        If True (the default), render YAML as a literal fenced code block,
+        preserving the native syntax. Set to False to convert into a structured
+        document (headings, tables for arrays of objects, lists).
 
     """
 
     literal_block: bool = field(
-        default=False,
-        metadata={"help": "Render as code block instead of structured document", "importance": "core"},
+        default=True,
+        metadata={
+            "help": "Render as a fenced code block (default) instead of a structured document",
+            "cli_name": "no-literal-block",
+            "importance": "core",
+        },
     )
     max_heading_depth: int = field(
         default=6,

--- a/src/all2md/parsers/_pdf_ocr.py
+++ b/src/all2md/parsers/_pdf_ocr.py
@@ -116,10 +116,16 @@ def should_use_ocr(page: "fitz.Page", extracted_text: str, options: PdfOptions) 
 
     # Auto mode: detect based on thresholds
     if ocr_opts.mode == "auto":
-        # Check text threshold
-        text_length = len(extracted_text.strip())
-        if text_length < ocr_opts.text_threshold:
-            logger.debug(f"Page has {text_length} chars (threshold: {ocr_opts.text_threshold}), triggering OCR")
+        # Check text threshold against *meaningful* characters only. Counting raw
+        # length (including whitespace and invisible glyphs) lets near-empty
+        # scanned pages slip past the threshold; alphanumeric characters are a
+        # far better proxy for real extractable text.
+        meaningful_chars = sum(1 for char in extracted_text if char.isalnum())
+        if meaningful_chars < ocr_opts.text_threshold:
+            logger.debug(
+                f"Page has {meaningful_chars} meaningful chars "
+                f"(threshold: {ocr_opts.text_threshold}), triggering OCR"
+            )
             return True
 
         # Check image coverage threshold

--- a/src/all2md/parsers/ini.py
+++ b/src/all2md/parsers/ini.py
@@ -318,6 +318,6 @@ CONVERTER_METADATA = ConverterMetadata(
     import_error_message="INI conversion uses Python standard library (no dependencies)",
     parser_options_class=IniParserOptions,
     renderer_options_class="all2md.options.ini.IniRendererOptions",
-    description="Convert INI configuration files to/from readable documents with sections and key-value pairs",
+    description="Convert INI config files to/from a fenced code block (default) or a structured document",
     priority=10,
 )

--- a/src/all2md/parsers/json.py
+++ b/src/all2md/parsers/json.py
@@ -549,6 +549,6 @@ CONVERTER_METADATA = ConverterMetadata(
     import_error_message="JSON conversion uses Python standard library (no dependencies)",
     parser_options_class=JsonParserOptions,
     renderer_options_class="all2md.options.json.JsonRendererOptions",
-    description="Convert JSON structures to/from readable documents with tables and lists",
+    description="Convert JSON to/from a fenced code block (default) or a structured document",
     priority=10,
 )

--- a/src/all2md/parsers/pdf.py
+++ b/src/all2md/parsers/pdf.py
@@ -49,6 +49,9 @@ from all2md.ast import (
 from all2md.ast import (
     Table as AstTable,
 )
+from all2md.ast import (
+    extract_text as extract_node_text,
+)
 from all2md.ast.transforms import InlineFormattingConsolidator
 from all2md.constants import (
     DEFAULT_OVERLAP_THRESHOLD_PX,
@@ -361,6 +364,7 @@ class PdfToAstConverter(BaseParser):
         self.options: PdfOptions = options
         self._hdr_identifier: Optional[IdentifyHeaders] = None
         self._attachment_footnotes: dict[str, str] = {}  # label -> content for footnote definitions
+        self._ocr_pages_applied: int = 0  # pages OCR was applied to in the current parse
         self._use_layout: bool = False
         # Most recent heading level emitted (any path). Used by
         # `_handle_header_line_with_layout` to pick a sibling-or-deeper level
@@ -779,9 +783,11 @@ class PdfToAstConverter(BaseParser):
         """
         # Reset footnote collection for this conversion
         self._attachment_footnotes = {}
+        # Count pages OCR was applied to this conversion (drives the doc-level
+        # OCR safety net below).
+        self._ocr_pages_applied = 0
 
         total_pages = len(list(pages_to_use))
-        children: list[Node] = []
 
         # Emit started event
         self._emit_progress(
@@ -794,51 +800,12 @@ class PdfToAstConverter(BaseParser):
         attachment_sequencer = create_attachment_sequencer()
 
         pages_list = list(pages_to_use)
-        # Suppress pymupdf-layout's global find_tables() hook for the whole
-        # page loop. We call predict_page_layout() explicitly inside
-        # _process_page_to_ast and merge its predictions ourselves; the
-        # implicit hook would additionally reroute find_tables()/Table.extract()
-        # through the layout model, overdetecting tables and garbling cell text.
-        # See native_find_tables() for the full rationale.
-        with native_find_tables():
-            for idx, pno in enumerate(pages_list):
-                try:
-                    page = doc[pno]
-                    page_nodes = self._process_page_to_ast(page, pno, base_filename, attachment_sequencer, total_pages)
-                    if page_nodes:
-                        children.extend(page_nodes)
+        children = self._render_pages(doc, pages_list, base_filename, attachment_sequencer, total_pages)
 
-                    # Add page separator between pages (but not after the last page)
-                    if idx < len(pages_list) - 1 and self.options.include_page_numbers:
-                        # Add page separator as Comment node - renderers decide whether to display it
-                        # Format using page_separator_template with placeholders
-                        separator_text = self.options.page_separator_template.format(
-                            page_num=pno + 1, total_pages=total_pages
-                        )
-                        children.append(Comment(content=separator_text, metadata={"comment_type": "page_separator"}))
-
-                    # Emit page done event
-                    self._emit_progress(
-                        "item_done",
-                        f"Page {pno + 1} of {total_pages} processed",
-                        current=idx + 1,
-                        total=total_pages,
-                        item_type="page",
-                        page=pno + 1,
-                    )
-                except Exception as e:
-                    # Emit error event but continue processing
-                    self._emit_progress(
-                        "error",
-                        f"Error processing page {pno + 1}: {str(e)}",
-                        current=idx + 1,
-                        total=total_pages,
-                        error=str(e),
-                        stage="page_processing",
-                        page=pno + 1,
-                    )
-                    # Re-raise to maintain existing error handling
-                    raise
+        # Document-level OCR safety net: when nothing triggered OCR in auto mode
+        # yet the rendered document is essentially empty, the per-page heuristic
+        # likely missed a scanned/image-only PDF — retry once with OCR forced.
+        children = self._maybe_retry_with_ocr(doc, pages_list, base_filename, total_pages, children)
 
         # Extract and attach metadata
         metadata = self.extract_metadata(doc)
@@ -888,6 +855,126 @@ class PdfToAstConverter(BaseParser):
             _demote_running_headings(ast_doc, total_pages)
 
         return ast_doc
+
+    def _render_pages(
+        self,
+        doc: "fitz.Document",
+        pages_list: list[int],
+        base_filename: str,
+        attachment_sequencer: Any,
+        total_pages: int,
+    ) -> list[Node]:
+        """Process each page to AST nodes, inserting page separators between pages.
+
+        Extracted from ``parse`` so the document-level OCR safety net can re-run
+        the whole page loop with OCR forced.
+        """
+        children: list[Node] = []
+        # Suppress pymupdf-layout's global find_tables() hook for the whole
+        # page loop. We call predict_page_layout() explicitly inside
+        # _process_page_to_ast and merge its predictions ourselves; the
+        # implicit hook would additionally reroute find_tables()/Table.extract()
+        # through the layout model, overdetecting tables and garbling cell text.
+        # See native_find_tables() for the full rationale.
+        with native_find_tables():
+            for idx, pno in enumerate(pages_list):
+                try:
+                    page = doc[pno]
+                    page_nodes = self._process_page_to_ast(page, pno, base_filename, attachment_sequencer, total_pages)
+                    if page_nodes:
+                        children.extend(page_nodes)
+
+                    # Add page separator between pages (but not after the last page)
+                    if idx < len(pages_list) - 1 and self.options.include_page_numbers:
+                        # Add page separator as Comment node - renderers decide whether to display it
+                        # Format using page_separator_template with placeholders
+                        separator_text = self.options.page_separator_template.format(
+                            page_num=pno + 1, total_pages=total_pages
+                        )
+                        children.append(Comment(content=separator_text, metadata={"comment_type": "page_separator"}))
+
+                    # Emit page done event
+                    self._emit_progress(
+                        "item_done",
+                        f"Page {pno + 1} of {total_pages} processed",
+                        current=idx + 1,
+                        total=total_pages,
+                        item_type="page",
+                        page=pno + 1,
+                    )
+                except Exception as e:
+                    # Emit error event but continue processing
+                    self._emit_progress(
+                        "error",
+                        f"Error processing page {pno + 1}: {str(e)}",
+                        current=idx + 1,
+                        total=total_pages,
+                        error=str(e),
+                        stage="page_processing",
+                        page=pno + 1,
+                    )
+                    # Re-raise to maintain existing error handling
+                    raise
+        return children
+
+    @staticmethod
+    def _count_meaningful_chars(children: list[Node]) -> int:
+        """Count alphanumeric characters across content nodes (ignoring separators)."""
+        content_nodes = [n for n in children if not isinstance(n, Comment)]
+        text = extract_node_text(content_nodes, joiner="")
+        return sum(1 for char in text if char.isalnum())
+
+    def _maybe_retry_with_ocr(
+        self,
+        doc: "fitz.Document",
+        pages_list: list[int],
+        base_filename: str,
+        total_pages: int,
+        children: list[Node],
+    ) -> list[Node]:
+        """Re-run page rendering with OCR forced if an auto-mode doc came out empty.
+
+        Returns the original ``children`` unless a forced-OCR retry produced
+        strictly more text. When OCR is unavailable/disabled, emits a one-line
+        hint instead of retrying.
+        """
+        ocr_opts = self.options.ocr
+        meaningful = self._count_meaningful_chars(children)
+        if meaningful >= ocr_opts.doc_text_threshold:
+            return children
+
+        # Already near-empty. Can we recover with OCR?
+        can_auto_ocr = ocr_opts.enabled and ocr_opts.mode == "auto" and self._ocr_pages_applied == 0
+        if not can_auto_ocr:
+            if not ocr_opts.enabled or ocr_opts.mode == "off":
+                logger.warning(
+                    "PDF produced almost no text (%d meaningful chars) and OCR is disabled. "
+                    "Re-run with --pdf-ocr-enabled --pdf-ocr-mode force (and install OCR extras, "
+                    "e.g. `pip install all2md[ocr]`) to extract scanned content.",
+                    meaningful,
+                )
+            return children
+
+        logger.info(
+            "Document produced almost no text (%d meaningful chars) under auto OCR; retrying with OCR forced.",
+            meaningful,
+        )
+        forced_options = self.options.create_updated(ocr=ocr_opts.create_updated(mode="force"))
+        original_options = self.options
+        self.options = forced_options
+        try:
+            retry_children = self._render_pages(
+                doc, pages_list, base_filename, create_attachment_sequencer(), total_pages
+            )
+        except Exception as e:  # noqa: BLE001 - retry is best-effort; keep the original result
+            logger.warning("Forced-OCR retry failed: %s. Keeping original extraction.", e)
+            return children
+        finally:
+            self.options = original_options
+
+        if self._count_meaningful_chars(retry_children) > meaningful:
+            return retry_children
+        return children
 
     @staticmethod
     @requires_dependencies("pdf", DEPS_PDF_OCR)
@@ -1118,10 +1205,12 @@ class PdfToAstConverter(BaseParser):
                     ],
                 }
                 all_blocks.append(ocr_block)
+                self._ocr_pages_applied += 1
                 return all_blocks, True
             else:
                 logger.debug(f"Replacing PyMuPDF text ({len(extracted_text)} chars) with OCR ({len(ocr_text)} chars)")
                 # Replace with OCR block
+                self._ocr_pages_applied += 1
                 return [
                     {
                         "type": 0,
@@ -2424,7 +2513,7 @@ class PdfToAstConverter(BaseParser):
                 return None
             if n_cols > MAX_TABLE_COLS or n_rows > MAX_TABLE_ROWS:
                 logger.debug(
-                    f"Rejecting pymupdf table on page {page_num + 1}: " f"{n_rows}x{n_cols} grid exceeds size caps"
+                    f"Rejecting pymupdf table on page {page_num + 1}: {n_rows}x{n_cols} grid exceeds size caps"
                 )
                 return None
             n_empty = sum(1 for r in table_data for c in r if c is None or not str(c).strip())

--- a/src/all2md/parsers/toml.py
+++ b/src/all2md/parsers/toml.py
@@ -175,19 +175,22 @@ class TomlParser(BaseParser):
             if self.options.literal_block:
                 self._emit_progress("completed", "TOML wrapped as code block", current=100, total=100)
 
-                # Optionally pretty-print the TOML
-                try:
-                    data = tomllib.loads(content)
-                    # Re-serialize with formatting using tomli_w
-                    import tomli_w
+                # Preserve the original source verbatim (including comments and
+                # formatting) for native viewing. TOML re-serialization via
+                # tomli_w would drop comments and reorder tables, so we only fall
+                # back to it when sort_keys explicitly asks for normalization.
+                formatted_toml = content
+                if self.options.sort_keys:
+                    try:
+                        data = tomllib.loads(content)
+                        import tomli_w
 
-                    formatted_toml = tomli_w.dumps(data)
-                except Exception:
-                    # If invalid TOML or tomli_w not available, just use the raw content
-                    formatted_toml = content
+                        formatted_toml = tomli_w.dumps(data)
+                    except Exception:
+                        formatted_toml = content
 
                 # Create code block
-                code_block = CodeBlock(content=formatted_toml, language="toml")
+                code_block = CodeBlock(content=formatted_toml.rstrip("\n"), language="toml")
                 metadata = DocumentMetadata()
                 return Document(children=[code_block], metadata=metadata.to_dict())
 
@@ -590,6 +593,6 @@ CONVERTER_METADATA = ConverterMetadata(
     import_error_message="TOML conversion requires tomli and tomli-w (pip install tomli tomli-w)",
     parser_options_class=TomlParserOptions,
     renderer_options_class="all2md.options.toml.TomlRendererOptions",
-    description="Convert TOML structures to/from readable documents with tables and lists",
+    description="Convert TOML to/from a fenced code block (default) or a structured document",
     priority=10,
 )

--- a/src/all2md/parsers/yaml.py
+++ b/src/all2md/parsers/yaml.py
@@ -165,19 +165,21 @@ class YamlParser(BaseParser):
             if self.options.literal_block:
                 self._emit_progress("completed", "YAML wrapped as code block", current=100, total=100)
 
-                # Optionally pretty-print the YAML
-                try:
-                    data = yaml.safe_load(content)
-                    # Re-serialize with formatting
-                    formatted_yaml = yaml.dump(
-                        data, default_flow_style=False, allow_unicode=True, sort_keys=self.options.sort_keys
-                    )
-                except yaml.YAMLError:
-                    # If invalid YAML, just use the raw content
+                # Preserve the original source verbatim (including comments and
+                # formatting) for native viewing. If sort_keys is requested, fall
+                # back to a normalized re-serialization, since that intentionally
+                # reorders keys.
+                if self.options.sort_keys:
+                    try:
+                        data = yaml.safe_load(content)
+                        formatted_yaml = yaml.dump(data, default_flow_style=False, allow_unicode=True, sort_keys=True)
+                    except yaml.YAMLError:
+                        formatted_yaml = content
+                else:
                     formatted_yaml = content
 
                 # Create code block
-                code_block = CodeBlock(content=formatted_yaml, language="yaml")
+                code_block = CodeBlock(content=formatted_yaml.rstrip("\n"), language="yaml")
                 metadata = DocumentMetadata()
                 return Document(children=[code_block], metadata=metadata.to_dict())
 
@@ -601,6 +603,6 @@ CONVERTER_METADATA = ConverterMetadata(
     import_error_message="YAML conversion requires PyYAML (pip install pyyaml)",
     parser_options_class=YamlParserOptions,
     renderer_options_class="all2md.options.yaml.YamlRendererOptions",
-    description="Convert YAML structures to/from readable documents with tables and lists",
+    description="Convert YAML to/from a fenced code block (default) or a structured document",
     priority=5,
 )

--- a/src/all2md/renderers/html.py
+++ b/src/all2md/renderers/html.py
@@ -1080,7 +1080,23 @@ hr {
         title_attr = f' title="{escape_html(node.title, enabled=self.options.escape_html)}"' if node.title else ""
         css_class = self._get_custom_css_class("Link")
         href = escape_html(node.url, enabled=self.options.escape_html)
-        self._output.append(f'<a href="{href}"{title_attr}{css_class}>{content}</a>')
+        target_attr = ""
+        if self.options.external_links_new_tab and self._is_external_url(node.url):
+            target_attr = ' target="_blank" rel="noopener noreferrer"'
+        self._output.append(f'<a href="{href}"{title_attr}{target_attr}{css_class}>{content}</a>')
+
+    @staticmethod
+    def _is_external_url(url: str) -> bool:
+        """Return True if a link URL points off-site (opens in a new tab).
+
+        Absolute ``http``/``https``/``ftp`` URLs, ``mailto:`` links, and
+        protocol-relative ``//host`` URLs are treated as external. Relative
+        paths and in-page anchors (``#``, ``/path``, ``./x``) are internal.
+        """
+        stripped = url.strip().lower()
+        if stripped.startswith("//"):
+            return True
+        return stripped.startswith(("http://", "https://", "ftp://", "ftps://", "mailto:"))
 
     def visit_image(self, node: Image) -> None:
         """Render an Image node.

--- a/tests/integration/test_structured_formats.py
+++ b/tests/integration/test_structured_formats.py
@@ -6,6 +6,10 @@ import json
 
 import pytest
 
+from all2md.options.ini import IniParserOptions
+from all2md.options.json import JsonParserOptions
+from all2md.options.toml import TomlParserOptions
+from all2md.options.yaml import YamlParserOptions
 from all2md.parsers.ini import IniParser
 from all2md.parsers.json import JsonParser
 from all2md.parsers.toml import TomlParser
@@ -27,7 +31,7 @@ class TestRoundTripConversion:
         }
 
         # Parse
-        parser = JsonParser()
+        parser = JsonParser(JsonParserOptions(literal_block=False))
         doc = parser.parse(json.dumps(original))
 
         # Render
@@ -59,7 +63,7 @@ users:
         """
 
         # Parse
-        parser = YamlParser()
+        parser = YamlParser(YamlParserOptions(literal_block=False))
         doc = parser.parse(original_yaml)
 
         # Render
@@ -95,7 +99,7 @@ active = false
         """
 
         # Parse
-        parser = TomlParser()
+        parser = TomlParser(TomlParserOptions(literal_block=False))
         doc = parser.parse(original_toml)
 
         # Render
@@ -129,7 +133,7 @@ timeout = 30
         """
 
         # Parse
-        parser = IniParser()
+        parser = IniParser(IniParserOptions(literal_block=False))
         doc = parser.parse(original_ini)
 
         # Render
@@ -156,7 +160,7 @@ class TestCrossFormatConversion:
         json_str = '{"name": "John", "age": 30}'
 
         # Parse JSON
-        json_parser = JsonParser()
+        json_parser = JsonParser(JsonParserOptions(literal_block=False))
         doc = json_parser.parse(json_str)
 
         # Render as YAML
@@ -175,7 +179,7 @@ class TestCrossFormatConversion:
         yaml_str = "name: John\nage: 30"
 
         # Parse YAML
-        yaml_parser = YamlParser()
+        yaml_parser = YamlParser(YamlParserOptions(literal_block=False))
         doc = yaml_parser.parse(yaml_str)
 
         # Render as JSON
@@ -192,7 +196,7 @@ class TestCrossFormatConversion:
         toml_str = '[section]\nkey = "value"'
 
         # Parse TOML
-        toml_parser = TomlParser()
+        toml_parser = TomlParser(TomlParserOptions(literal_block=False))
         doc = toml_parser.parse(toml_str)
 
         # Render as JSON
@@ -208,7 +212,7 @@ class TestCrossFormatConversion:
         ini_str = "[section]\nkey = value"
 
         # Parse INI
-        ini_parser = IniParser()
+        ini_parser = IniParser(IniParserOptions(literal_block=False))
         doc = ini_parser.parse(ini_str)
 
         # Render as JSON
@@ -227,7 +231,7 @@ class TestComplexDataStructures:
         """Test deeply nested JSON structures."""
         nested = {"level1": {"level2": {"level3": {"level4": {"level5": {"value": "deep"}}}}}}
 
-        parser = JsonParser()
+        parser = JsonParser(JsonParserOptions(literal_block=False))
         doc = parser.parse(json.dumps(nested))
 
         renderer = JsonRenderer()
@@ -242,7 +246,7 @@ class TestComplexDataStructures:
         users = [{"id": i, "name": f"User{i}", "active": i % 2 == 0} for i in range(100)]
         data = {"users": users}
 
-        parser = JsonParser()
+        parser = JsonParser(JsonParserOptions(literal_block=False))
         doc = parser.parse(json.dumps(data))
 
         renderer = JsonRenderer()
@@ -256,7 +260,7 @@ class TestComplexDataStructures:
         """Test arrays with mixed primitive types."""
         data = {"values": [1, "two", 3.14, True, None]}
 
-        parser = JsonParser()
+        parser = JsonParser(JsonParserOptions(literal_block=False))
         doc = parser.parse(json.dumps(data))
 
         # Should handle mixed types gracefully
@@ -266,7 +270,7 @@ class TestComplexDataStructures:
         """Test Unicode content across formats."""
         data = {"chinese": "你好世界", "emoji": "🎉🎊", "greek": "Γεια σου κόσμε", "arabic": "مرحبا بالعالم"}
 
-        parser = JsonParser()
+        parser = JsonParser(JsonParserOptions(literal_block=False))
         doc = parser.parse(json.dumps(data, ensure_ascii=False))
 
         renderer = JsonRenderer()
@@ -284,7 +288,7 @@ class TestEdgeCases:
         """Test empty objects and arrays."""
         data = {"empty_obj": {}, "empty_arr": [], "null": None}
 
-        parser = JsonParser()
+        parser = JsonParser(JsonParserOptions(literal_block=False))
         doc = parser.parse(json.dumps(data))
 
         # Should handle empty structures
@@ -294,7 +298,7 @@ class TestEdgeCases:
         """Test arrays with single values."""
         data = {"single": [{"key": "value"}]}
 
-        parser = JsonParser()
+        parser = JsonParser(JsonParserOptions(literal_block=False))
         doc = parser.parse(json.dumps(data))
 
         renderer = JsonRenderer()
@@ -307,7 +311,7 @@ class TestEdgeCases:
         """Test special characters in object keys."""
         data = {"key-with-dash": 1, "key.with.dots": 2, "key_with_underscore": 3, "key with spaces": 4}
 
-        parser = JsonParser()
+        parser = JsonParser(JsonParserOptions(literal_block=False))
         doc = parser.parse(json.dumps(data))
 
         renderer = JsonRenderer()
@@ -320,7 +324,7 @@ class TestEdgeCases:
         """Test numeric strings as keys."""
         data = {"123": "numeric key", "456": "another"}
 
-        parser = JsonParser()
+        parser = JsonParser(JsonParserOptions(literal_block=False))
         doc = parser.parse(json.dumps(data))
 
         # Should treat as strings
@@ -331,7 +335,7 @@ class TestEdgeCases:
         long_text = "x" * 10000
         data = {"long": long_text}
 
-        parser = JsonParser()
+        parser = JsonParser(JsonParserOptions(literal_block=False))
         doc = parser.parse(json.dumps(data))
 
         # Should handle long strings
@@ -345,7 +349,7 @@ class TestFormatSpecificFeatures:
         """Test JSON null value support."""
         data = {"value": None}
 
-        parser = JsonParser()
+        parser = JsonParser(JsonParserOptions(literal_block=False))
         doc = parser.parse(json.dumps(data))
 
         renderer = JsonRenderer()
@@ -360,7 +364,7 @@ class TestFormatSpecificFeatures:
         pytest.importorskip("yaml", reason="pyyaml not installed")
         yaml_str = "date: 2025-01-15\ntime: 14:30:00"
 
-        parser = YamlParser()
+        parser = YamlParser(YamlParserOptions(literal_block=False))
         doc = parser.parse(yaml_str)
 
         # Should handle dates
@@ -372,7 +376,7 @@ class TestFormatSpecificFeatures:
         # TOML doesn't have null values
         toml_str = '[section]\nkey = "value"'
 
-        parser = TomlParser()
+        parser = TomlParser(TomlParserOptions(literal_block=False))
         doc = parser.parse(toml_str)
 
         # Should work without null
@@ -382,7 +386,7 @@ class TestFormatSpecificFeatures:
         """Test INI flat structure (no nesting)."""
         ini_str = "[section]\nkey1 = value1\nkey2 = value2"
 
-        parser = IniParser()
+        parser = IniParser(IniParserOptions(literal_block=False))
         doc = parser.parse(ini_str)
 
         renderer = IniRenderer()
@@ -400,7 +404,7 @@ class TestPerformance:
         # Create a large structure
         data = {"items": [{"id": i, "value": f"item_{i}"} for i in range(1000)]}
 
-        parser = JsonParser()
+        parser = JsonParser(JsonParserOptions(literal_block=False))
         doc = parser.parse(json.dumps(data))
 
         renderer = JsonRenderer()
@@ -417,7 +421,7 @@ class TestPerformance:
         ini_parts = [f"[section{i}]\nkey = value{i}\n" for i in range(100)]
         ini_str = "\n".join(ini_parts)
 
-        parser = IniParser()
+        parser = IniParser(IniParserOptions(literal_block=False))
         doc = parser.parse(ini_str)
 
         renderer = IniRenderer()

--- a/tests/unit/cli/test_context_menu.py
+++ b/tests/unit/cli/test_context_menu.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import argparse
 import sys
 from pathlib import Path
 
@@ -45,41 +46,59 @@ def test_build_applies_to() -> None:
     assert with_text.endswith("System.FileExtension:=.md")
 
 
-def test_build_command() -> None:
-    assert context_menu._build_command(r"C:\bin\all2mdw.exe", windowed=True) == r'"C:\bin\all2mdw.exe" "%1"'
-    assert context_menu._build_command(r"C:\bin\all2md.exe", windowed=False) == r'"C:\bin\all2md.exe" view "%1"'
+def test_build_entry_command_view_prefers_windowed() -> None:
+    launchers = {"all2mdw": r"C:\bin\all2mdw.exe", "all2md": r"C:\bin\all2md.exe"}
+    built = context_menu._build_entry_command(context_menu._ENTRIES["view"], launchers)
+    assert built == (r'"C:\bin\all2mdw.exe" "%1"', True)
 
 
-def test_find_launcher_prefers_windowed(monkeypatch: pytest.MonkeyPatch) -> None:
-    def fake_which(name: str) -> str | None:
-        return rf"C:\bin\{name}.exe" if name == "all2mdw" else None
-
-    monkeypatch.setattr(context_menu.shutil, "which", fake_which)
-    result = context_menu._find_launcher()
-    assert result == (r"C:\bin\all2mdw.exe", True)
+def test_build_entry_command_view_console_fallback() -> None:
+    launchers = {"all2md": r"C:\bin\all2md.exe"}
+    built = context_menu._build_entry_command(context_menu._ENTRIES["view"], launchers)
+    assert built == (r'"C:\bin\all2md.exe" view "%1"', False)
 
 
-def test_find_launcher_falls_back_to_console(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
-    def fake_which(name: str) -> str | None:
-        return rf"C:\bin\{name}.exe" if name == "all2md" else None
-
-    monkeypatch.setattr(context_menu.shutil, "which", fake_which)
-    # Neutralize the directory scan so only `which` can resolve a launcher
-    # (otherwise the real all2mdw.exe in this dev env would be found first).
-    monkeypatch.setattr(context_menu.sys, "executable", str(tmp_path / "python.exe"))
-    monkeypatch.delenv("UV_TOOL_BIN_DIR", raising=False)
-    monkeypatch.delenv("USERPROFILE", raising=False)
-    result = context_menu._find_launcher()
-    assert result == (r"C:\bin\all2md.exe", False)
+def test_build_entry_command_edit_and_serve_use_console() -> None:
+    launchers = {"all2mdw": r"C:\bin\all2mdw.exe", "all2md": r"C:\bin\all2md.exe"}
+    edit = context_menu._build_entry_command(context_menu._ENTRIES["edit"], launchers)
+    assert edit == (r'"C:\bin\all2md.exe" edit "%1"', False)
+    serve = context_menu._build_entry_command(context_menu._ENTRIES["serve"], launchers)
+    assert serve == (r'"C:\bin\all2md.exe" serve "%V"', False)
 
 
-def test_find_launcher_none_when_absent(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+def test_build_entry_command_edit_requires_console() -> None:
+    # Only the windowed launcher is present → edit/serve cannot be built.
+    launchers = {"all2mdw": r"C:\bin\all2mdw.exe"}
+    assert context_menu._build_entry_command(context_menu._ENTRIES["edit"], launchers) is None
+
+
+def test_select_entries_default() -> None:
+    ns = argparse.Namespace(edit=False, serve=False, all=False)
+    assert context_menu._select_entries(ns) == ["view"]
+
+
+def test_select_entries_flags() -> None:
+    ns = argparse.Namespace(edit=True, serve=True, all=False)
+    assert context_menu._select_entries(ns) == ["view", "edit", "serve"]
+
+
+def test_select_entries_all() -> None:
+    ns = argparse.Namespace(edit=False, serve=False, all=True)
+    assert context_menu._select_entries(ns) == ["view", "edit", "serve"]
+
+
+def test_which_launcher_uses_which(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(context_menu.shutil, "which", lambda name: rf"C:\bin\{name}.exe" if name == "all2mdw" else None)
+    assert context_menu._which_launcher("all2mdw") == r"C:\bin\all2mdw.exe"
+
+
+def test_which_launcher_none_when_absent(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     monkeypatch.setattr(context_menu.shutil, "which", lambda name: None)
     # Point the interpreter dir at an empty tmp dir and clear install-location envs.
     monkeypatch.setattr(context_menu.sys, "executable", str(tmp_path / "python.exe"))
     monkeypatch.delenv("UV_TOOL_BIN_DIR", raising=False)
     monkeypatch.delenv("USERPROFILE", raising=False)
-    assert context_menu._find_launcher() is None
+    assert context_menu._which_launcher("all2mdw") is None
 
 
 def test_non_windows_returns_error(monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]) -> None:
@@ -158,29 +177,39 @@ def test_cleanup_stale_previews(tmp_path: Path, monkeypatch: pytest.MonkeyPatch)
 def test_registry_round_trip(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     import winreg
 
+    view_entry = context_menu._ENTRIES["view"]
+    serve_entry = context_menu._ENTRIES["serve"]
+
     # Never clobber a real, pre-existing user entry.
     try:
-        with winreg.OpenKey(winreg.HKEY_CURRENT_USER, context_menu._MENU_KEY):
+        with winreg.OpenKey(winreg.HKEY_CURRENT_USER, view_entry.menu_key):
             pytest.skip("context-menu entry already installed; skipping to avoid clobbering it")
     except FileNotFoundError:
         pass
 
-    fake_launcher = tmp_path / "all2mdw.exe"
-    fake_launcher.write_bytes(b"")
-    monkeypatch.setattr(context_menu, "_find_launcher", lambda: (str(fake_launcher), True))
+    fake_w = tmp_path / "all2mdw.exe"
+    fake_w.write_bytes(b"")
+    fake_c = tmp_path / "all2md.exe"
+    fake_c.write_bytes(b"")
+    monkeypatch.setattr(context_menu, "_resolve_launchers", lambda: {"all2mdw": str(fake_w), "all2md": str(fake_c)})
     # Keep the copied icon out of the real LOCALAPPDATA.
     monkeypatch.setattr(context_menu, "_icon_target", lambda: tmp_path / "icon.ico")
 
     try:
-        assert context_menu._install(("md", "pdf"), include_text=False) == 0
-        with winreg.OpenKey(winreg.HKEY_CURRENT_USER, context_menu._COMMAND_KEY) as cmd:
+        assert context_menu._install(["view", "serve"], ("md", "pdf"), include_text=False) == 0
+        with winreg.OpenKey(winreg.HKEY_CURRENT_USER, view_entry.command_key) as cmd:
             command = winreg.QueryValueEx(cmd, "")[0]
-        assert command == f'"{fake_launcher}" "%1"'
-        with winreg.OpenKey(winreg.HKEY_CURRENT_USER, context_menu._MENU_KEY) as menu:
+        assert command == f'"{fake_w}" "%1"'
+        with winreg.OpenKey(winreg.HKEY_CURRENT_USER, view_entry.menu_key) as menu:
             applies_to = winreg.QueryValueEx(menu, "AppliesTo")[0]
         assert "System.FileExtension:=.md" in applies_to
+        # The serve entry is a directory entry with a folder command and no AppliesTo.
+        with winreg.OpenKey(winreg.HKEY_CURRENT_USER, serve_entry.command_key) as cmd:
+            serve_command = winreg.QueryValueEx(cmd, "")[0]
+        assert serve_command == f'"{fake_c}" serve "%V"'
     finally:
         context_menu._uninstall()
 
-    with pytest.raises(FileNotFoundError):
-        winreg.OpenKey(winreg.HKEY_CURRENT_USER, context_menu._MENU_KEY)
+    for entry in (view_entry, serve_entry):
+        with pytest.raises(FileNotFoundError):
+            winreg.OpenKey(winreg.HKEY_CURRENT_USER, entry.menu_key)

--- a/tests/unit/cli/test_llm_minify.py
+++ b/tests/unit/cli/test_llm_minify.py
@@ -1,0 +1,82 @@
+#  Copyright (c) 2025 Tom Villani, Ph.D.
+
+"""Unit tests for the ``llm-minify`` CLI command."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from all2md.cli.commands.llm_minify import _squeeze_whitespace, handle_llm_minify_command
+
+pytestmark = pytest.mark.unit
+
+
+SAMPLE = (
+    "# Title\n\n\n\n"
+    "Some **bold** and *italic* text with a [link](https://example.com) "
+    "and ![img](data:image/png;base64,AAAA).\n\n\n"
+    "<!-- a comment -->\n\n<div>raw html</div>\n\n\nDone.\n"
+)
+
+
+@pytest.fixture
+def sample_md(tmp_path: Path) -> Path:
+    path = tmp_path / "sample.md"
+    path.write_text(SAMPLE, encoding="utf-8")
+    return path
+
+
+def test_squeeze_whitespace_collapses_blank_lines() -> None:
+    out = _squeeze_whitespace("a\n\n\n\nb\n   \nc   \n\n\n")
+    assert out == "a\n\nb\n\nc\n"
+
+
+def test_default_preset_keeps_markdown_drops_filler(sample_md: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    rc = handle_llm_minify_command([str(sample_md), "--no-config"])
+    assert rc == 0
+    out = capsys.readouterr().out
+    # Structure kept.
+    assert "# Title" in out
+    assert "**bold**" in out
+    # Filler dropped: comment, raw HTML, and excess blank lines.
+    assert "a comment" not in out
+    assert "<div>" not in out
+    assert "\n\n\n" not in out
+
+
+def test_aggressive_preset_strips_formatting(sample_md: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    rc = handle_llm_minify_command([str(sample_md), "--aggressive", "--no-config"])
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "# Title" not in out
+    assert "Title" in out
+    assert "**" not in out
+    assert "bold" in out
+
+
+def test_strip_flags(sample_md: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    rc = handle_llm_minify_command(
+        [str(sample_md), "--strip-links", "--strip-images", "--strip-formatting", "--no-config"]
+    )
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "**" not in out  # formatting stripped
+    assert "https://example.com" not in out  # link url dropped
+    assert "link" in out  # link text kept
+    assert "data:image" not in out  # image dropped
+
+
+def test_out_file(sample_md: Path, tmp_path: Path) -> None:
+    dest = tmp_path / "out.md"
+    rc = handle_llm_minify_command([str(sample_md), "--out", str(dest), "--no-config"])
+    assert rc == 0
+    assert dest.exists()
+    assert "# Title" in dest.read_text(encoding="utf-8")
+
+
+def test_missing_input_returns_error(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    rc = handle_llm_minify_command([str(tmp_path / "nope.md"), "--no-config"])
+    assert rc != 0
+    assert "not found" in capsys.readouterr().err.lower()

--- a/tests/unit/parsers/test_ini_parser.py
+++ b/tests/unit/parsers/test_ini_parser.py
@@ -32,7 +32,7 @@ class TestIniBasicParsing:
     def test_parse_simple_ini(self) -> None:
         """Test parsing a simple INI file."""
         ini_content = b"[server]\nhost = localhost\nport = 8080"
-        parser = IniParser()
+        parser = IniParser(IniParserOptions(literal_block=False))
         doc = parser.parse(BytesIO(ini_content))
 
         assert isinstance(doc, Document)
@@ -43,7 +43,7 @@ class TestIniBasicParsing:
     def test_parse_multiple_sections(self) -> None:
         """Test parsing INI with multiple sections."""
         ini_content = b"[server]\nhost = localhost\n\n[database]\nname = mydb"
-        parser = IniParser()
+        parser = IniParser(IniParserOptions(literal_block=False))
         doc = parser.parse(BytesIO(ini_content))
 
         assert isinstance(doc, Document)
@@ -56,7 +56,7 @@ class TestIniBasicParsing:
         ini_file = tmp_path / "test.ini"
         ini_file.write_text("[section]\nkey = value")
 
-        parser = IniParser()
+        parser = IniParser(IniParserOptions(literal_block=False))
         doc = parser.parse(str(ini_file))
 
         assert isinstance(doc, Document)
@@ -67,7 +67,7 @@ class TestIniBasicParsing:
         ini_file = tmp_path / "test.ini"
         ini_file.write_text("[section]\nkey = value")
 
-        parser = IniParser()
+        parser = IniParser(IniParserOptions(literal_block=False))
         doc = parser.parse(ini_file)
 
         assert isinstance(doc, Document)
@@ -75,7 +75,7 @@ class TestIniBasicParsing:
     def test_parse_from_string(self) -> None:
         """Test parsing INI from string content."""
         ini_content = "[section]\nkey = value"
-        parser = IniParser()
+        parser = IniParser(IniParserOptions(literal_block=False))
         doc = parser.parse(ini_content)
 
         assert isinstance(doc, Document)
@@ -88,7 +88,7 @@ class TestIniSectionHandling:
     def test_section_becomes_heading(self) -> None:
         """Test that sections are converted to headings."""
         ini_content = b"[my_section]\nkey = value"
-        parser = IniParser()
+        parser = IniParser(IniParserOptions(literal_block=False))
         doc = parser.parse(BytesIO(ini_content))
 
         assert isinstance(doc.children[0], Heading)
@@ -97,7 +97,7 @@ class TestIniSectionHandling:
     def test_multiple_keys_in_section(self) -> None:
         """Test parsing multiple keys in a section."""
         ini_content = b"[config]\nhost = localhost\nport = 8080\ntimeout = 30"
-        parser = IniParser()
+        parser = IniParser(IniParserOptions(literal_block=False))
         doc = parser.parse(BytesIO(ini_content))
 
         # Should have heading + list
@@ -112,7 +112,7 @@ class TestIniCasePreservation:
     def test_preserve_case_option(self) -> None:
         """Test that preserve_case option preserves key case."""
         ini_content = b"[Section]\nMyKey = value"
-        options = IniParserOptions(preserve_case=True)
+        options = IniParserOptions(literal_block=False, preserve_case=True)
         parser = IniParser(options)
         doc = parser.parse(BytesIO(ini_content))
 
@@ -121,7 +121,7 @@ class TestIniCasePreservation:
     def test_case_normalization_default(self) -> None:
         """Test default case handling."""
         ini_content = b"[SECTION]\nKEY = value"
-        parser = IniParser()
+        parser = IniParser(IniParserOptions(literal_block=False))
         doc = parser.parse(BytesIO(ini_content))
 
         assert isinstance(doc, Document)
@@ -151,7 +151,7 @@ class TestIniAllowNoValue:
     def test_allow_no_value_option(self) -> None:
         """Test parsing keys without values."""
         ini_content = b"[section]\nkey_without_value"
-        options = IniParserOptions(allow_no_value=True)
+        options = IniParserOptions(literal_block=False, allow_no_value=True)
         parser = IniParser(options)
         doc = parser.parse(BytesIO(ini_content))
 
@@ -160,7 +160,7 @@ class TestIniAllowNoValue:
     def test_reject_no_value_default(self) -> None:
         """Test that keys without values fail without option."""
         ini_content = b"[section]\nkey_without_value"
-        parser = IniParser()
+        parser = IniParser(IniParserOptions(literal_block=False))
 
         with pytest.raises(ParsingError):
             parser.parse(BytesIO(ini_content))
@@ -173,7 +173,7 @@ class TestIniNumberFormatting:
     def test_pretty_format_numbers_enabled(self) -> None:
         """Test pretty number formatting."""
         ini_content = b"[section]\ncount = 1000000"
-        options = IniParserOptions(pretty_format_numbers=True)
+        options = IniParserOptions(literal_block=False, pretty_format_numbers=True)
         parser = IniParser(options)
         doc = parser.parse(BytesIO(ini_content))
 
@@ -182,7 +182,7 @@ class TestIniNumberFormatting:
     def test_pretty_format_numbers_disabled(self) -> None:
         """Test with number formatting disabled."""
         ini_content = b"[section]\ncount = 1000000"
-        options = IniParserOptions(pretty_format_numbers=False)
+        options = IniParserOptions(literal_block=False, pretty_format_numbers=False)
         parser = IniParser(options)
         doc = parser.parse(BytesIO(ini_content))
 
@@ -196,7 +196,7 @@ class TestIniMetadataExtraction:
     def test_extract_title_from_metadata_section(self) -> None:
         """Test extracting title from metadata section."""
         ini_content = b"[metadata]\ntitle = My Document\n\n[config]\nkey = value"
-        parser = IniParser()
+        parser = IniParser(IniParserOptions(literal_block=False))
         doc = parser.parse(BytesIO(ini_content))
 
         # Metadata should be extracted
@@ -205,7 +205,7 @@ class TestIniMetadataExtraction:
     def test_extract_title_from_info_section(self) -> None:
         """Test extracting title from info section."""
         ini_content = b"[info]\nname = My App\n\n[settings]\nkey = value"
-        parser = IniParser()
+        parser = IniParser(IniParserOptions(literal_block=False))
         doc = parser.parse(BytesIO(ini_content))
 
         assert isinstance(doc, Document)
@@ -247,7 +247,7 @@ class TestIniEdgeCases:
     def test_empty_section(self) -> None:
         """Test parsing empty section."""
         ini_content = b"[empty_section]"
-        parser = IniParser()
+        parser = IniParser(IniParserOptions(literal_block=False))
         doc = parser.parse(BytesIO(ini_content))
 
         assert isinstance(doc, Document)
@@ -255,7 +255,7 @@ class TestIniEdgeCases:
     def test_empty_value(self) -> None:
         """Test parsing key with empty value."""
         ini_content = b"[section]\nkey = "
-        parser = IniParser()
+        parser = IniParser(IniParserOptions(literal_block=False))
         doc = parser.parse(BytesIO(ini_content))
 
         assert isinstance(doc, Document)
@@ -263,7 +263,7 @@ class TestIniEdgeCases:
     def test_multiline_value(self) -> None:
         """Test parsing multiline value (not standard but common)."""
         ini_content = b"[section]\nkey = value"
-        parser = IniParser()
+        parser = IniParser(IniParserOptions(literal_block=False))
         doc = parser.parse(BytesIO(ini_content))
 
         assert isinstance(doc, Document)
@@ -272,7 +272,7 @@ class TestIniEdgeCases:
         """Test that invalid INI raises ParsingError."""
         # This should cause a configparser error
         invalid_ini = b"[unclosed_section"
-        parser = IniParser()
+        parser = IniParser(IniParserOptions(literal_block=False))
 
         with pytest.raises(ParsingError):
             parser.parse(BytesIO(invalid_ini))
@@ -285,7 +285,7 @@ class TestIniEdgeCases:
     def test_utf8_content(self) -> None:
         """Test parsing UTF-8 content."""
         ini_content = "[section]\nname = Müller".encode("utf-8")
-        parser = IniParser()
+        parser = IniParser(IniParserOptions(literal_block=False))
         doc = parser.parse(BytesIO(ini_content))
 
         assert isinstance(doc, Document)

--- a/tests/unit/parsers/test_json_parser.py
+++ b/tests/unit/parsers/test_json_parser.py
@@ -16,7 +16,7 @@ class TestJsonParserBasic:
     def test_parse_simple_object(self):
         """Test parsing a simple JSON object."""
         json_str = '{"name": "John", "age": 30}'
-        parser = JsonParser()
+        parser = JsonParser(JsonParserOptions(literal_block=False))
         doc = parser.parse(json_str)
 
         assert isinstance(doc, Document)
@@ -35,7 +35,7 @@ class TestJsonParserBasic:
     def test_parse_simple_array(self):
         """Test parsing a simple JSON array."""
         json_str = '["apple", "banana", "cherry"]'
-        parser = JsonParser()
+        parser = JsonParser(JsonParserOptions(literal_block=False))
         doc = parser.parse(json_str)
 
         assert isinstance(doc, Document)
@@ -63,7 +63,7 @@ class TestJsonParserBasic:
             }
         }
         """
-        parser = JsonParser()
+        parser = JsonParser(JsonParserOptions(literal_block=False))
         doc = parser.parse(json_str)
 
         assert isinstance(doc, Document)
@@ -81,7 +81,7 @@ class TestJsonParserBasic:
             ]
         }
         """
-        parser = JsonParser()
+        parser = JsonParser(JsonParserOptions(literal_block=False))
         doc = parser.parse(json_str)
 
         assert isinstance(doc, Document)
@@ -99,7 +99,7 @@ class TestJsonParserBasic:
     def test_parse_empty_object(self):
         """Test parsing empty JSON object."""
         json_str = "{}"
-        parser = JsonParser()
+        parser = JsonParser(JsonParserOptions(literal_block=False))
         doc = parser.parse(json_str)
 
         assert isinstance(doc, Document)
@@ -108,7 +108,7 @@ class TestJsonParserBasic:
     def test_parse_invalid_json(self):
         """Test parsing invalid JSON raises error."""
         json_str = '{"invalid": json}'
-        parser = JsonParser()
+        parser = JsonParser(JsonParserOptions(literal_block=False))
 
         with pytest.raises(ParsingError):
             parser.parse(json_str)
@@ -132,7 +132,7 @@ class TestJsonParserComplex:
             }
         }
         """
-        parser = JsonParser()
+        parser = JsonParser(JsonParserOptions(literal_block=False))
         doc = parser.parse(json_str)
 
         assert isinstance(doc, Document)
@@ -153,7 +153,7 @@ class TestJsonParserComplex:
             "object": {"nested": "value"}
         }
         """
-        parser = JsonParser()
+        parser = JsonParser(JsonParserOptions(literal_block=False))
         doc = parser.parse(json_str)
 
         assert isinstance(doc, Document)
@@ -162,7 +162,7 @@ class TestJsonParserComplex:
     def test_parse_large_numbers(self):
         """Test parsing large numbers with formatting."""
         json_str = '{"population": 7800000000, "small": 100}'
-        parser = JsonParser(JsonParserOptions(pretty_format_numbers=True))
+        parser = JsonParser(JsonParserOptions(literal_block=False, pretty_format_numbers=True))
         doc = parser.parse(json_str)
 
         assert isinstance(doc, Document)
@@ -180,7 +180,7 @@ class TestJsonParserComplex:
     def test_parse_multiline_string(self):
         """Test parsing multiline strings."""
         json_str = '{"description": "Line 1\\nLine 2\\nLine 3"}'
-        parser = JsonParser()
+        parser = JsonParser(JsonParserOptions(literal_block=False))
         doc = parser.parse(json_str)
 
         assert isinstance(doc, Document)
@@ -196,7 +196,7 @@ class TestJsonParserComplex:
         }
         """
         # With default threshold=1, single item should become a table
-        parser = JsonParser()
+        parser = JsonParser(JsonParserOptions(literal_block=False))
         doc = parser.parse(json_str)
 
         assert isinstance(doc, Document)
@@ -205,7 +205,7 @@ class TestJsonParserComplex:
         assert len(tables) == 1  # Should have one table
 
         # Test with higher threshold - should NOT become table
-        parser_high_threshold = JsonParser(JsonParserOptions(array_as_table_threshold=2))
+        parser_high_threshold = JsonParser(JsonParserOptions(literal_block=False, array_as_table_threshold=2))
         doc_high = parser_high_threshold.parse(json_str)
         tables_high = [child for child in doc_high.children if isinstance(child, Table)]
         assert len(tables_high) == 0  # Should not have a table with threshold=2
@@ -229,7 +229,7 @@ class TestJsonParserOptions:
     def test_sort_keys(self):
         """Test sorting keys alphabetically."""
         json_str = '{"zebra": 1, "apple": 2, "monkey": 3}'
-        parser = JsonParser(JsonParserOptions(sort_keys=True))
+        parser = JsonParser(JsonParserOptions(literal_block=False, sort_keys=True))
         doc = parser.parse(json_str)
 
         assert isinstance(doc, Document)
@@ -239,7 +239,7 @@ class TestJsonParserOptions:
     def test_flatten_single_keys(self):
         """Test flattening single-key objects."""
         json_str = '{"wrapper": {"data": {"value": 42}}}'
-        parser = JsonParser(JsonParserOptions(flatten_single_keys=True))
+        parser = JsonParser(JsonParserOptions(literal_block=False, flatten_single_keys=True))
         doc = parser.parse(json_str)
 
         assert isinstance(doc, Document)
@@ -260,7 +260,7 @@ class TestJsonParserOptions:
             }
         }
         """
-        parser = JsonParser(JsonParserOptions(max_heading_depth=2))
+        parser = JsonParser(JsonParserOptions(literal_block=False, max_heading_depth=2))
         doc = parser.parse(json_str)
 
         assert isinstance(doc, Document)
@@ -278,7 +278,7 @@ class TestJsonParserEdgeCases:
         json_file = tmp_path / "test.json"
         json_file.write_text('{"name": "John"}', encoding="utf-8")
 
-        parser = JsonParser()
+        parser = JsonParser(JsonParserOptions(literal_block=False))
         doc = parser.parse(json_file)
 
         assert isinstance(doc, Document)
@@ -286,7 +286,7 @@ class TestJsonParserEdgeCases:
     def test_parse_from_bytes(self):
         """Test parsing from bytes."""
         json_bytes = b'{"name": "John"}'
-        parser = JsonParser()
+        parser = JsonParser(JsonParserOptions(literal_block=False))
         doc = parser.parse(json_bytes)
 
         assert isinstance(doc, Document)
@@ -294,7 +294,7 @@ class TestJsonParserEdgeCases:
     def test_parse_unicode(self):
         """Test parsing Unicode content."""
         json_str = '{"name": "José", "greeting": "你好"}'
-        parser = JsonParser()
+        parser = JsonParser(JsonParserOptions(literal_block=False))
         doc = parser.parse(json_str)
 
         assert isinstance(doc, Document)
@@ -302,7 +302,7 @@ class TestJsonParserEdgeCases:
     def test_parse_special_characters(self):
         """Test parsing special characters."""
         json_str = r'{"text": "Line with \"quotes\" and \\ backslash"}'
-        parser = JsonParser()
+        parser = JsonParser(JsonParserOptions(literal_block=False))
         doc = parser.parse(json_str)
 
         assert isinstance(doc, Document)
@@ -310,7 +310,7 @@ class TestJsonParserEdgeCases:
     def test_metadata_extraction(self):
         """Test metadata extraction."""
         json_str = '{"title": "My Document", "data": {"value": 42}}'
-        parser = JsonParser()
+        parser = JsonParser(JsonParserOptions(literal_block=False))
         doc = parser.parse(json_str)
 
         assert isinstance(doc, Document)
@@ -332,7 +332,7 @@ class TestJsonParserTableConversion:
             {"id": 3, "name": "Charlie", "status": "active"}
         ]
         """
-        parser = JsonParser()
+        parser = JsonParser(JsonParserOptions(literal_block=False))
         doc = parser.parse(json_str)
 
         assert isinstance(doc, Document)
@@ -355,7 +355,7 @@ class TestJsonParserTableConversion:
             {"different": "keys"}
         ]
         """
-        parser = JsonParser()
+        parser = JsonParser(JsonParserOptions(literal_block=False))
         doc = parser.parse(json_str)
 
         assert isinstance(doc, Document)
@@ -371,7 +371,7 @@ class TestJsonParserTableConversion:
             {"name": "Bob", "tags": ["user"]}
         ]
         """
-        parser = JsonParser()
+        parser = JsonParser(JsonParserOptions(literal_block=False))
         doc = parser.parse(json_str)
 
         assert isinstance(doc, Document)

--- a/tests/unit/parsers/test_pdf_ocr.py
+++ b/tests/unit/parsers/test_pdf_ocr.py
@@ -30,6 +30,7 @@ class TestOCROptions:
         assert opts.auto_detect_language is False
         assert opts.dpi == 300
         assert opts.text_threshold == 50
+        assert opts.doc_text_threshold == 16
         assert opts.image_area_threshold == 0.5
         assert opts.preserve_existing_text is False
         assert opts.tesseract_config == ""
@@ -171,6 +172,33 @@ class TestShouldUseOCR:
         # Text above threshold should not trigger OCR
         result = _should_use_ocr(mock_page, "A" * 100, options)
         assert result is False
+
+    def test_should_use_ocr_auto_whitespace_only_text(self) -> None:
+        """Whitespace/invisible text triggers OCR even when raw length is high."""
+        mock_page = Mock()
+        mock_page.rect.width = 612
+        mock_page.rect.height = 792
+        mock_page.get_images.return_value = []
+
+        options = PdfOptions(ocr=OCROptions(enabled=True, mode="auto", text_threshold=10))
+
+        # 90 chars of whitespace/punctuation but zero meaningful characters.
+        result = _should_use_ocr(mock_page, "   \n\t . . . \n   " * 6, options)
+        assert result is True
+
+    def test_should_use_ocr_auto_counts_alnum_not_length(self) -> None:
+        """Punctuation padding must not mask a near-empty page (meaningful-char count)."""
+        mock_page = Mock()
+        mock_page.rect.width = 612
+        mock_page.rect.height = 792
+        mock_page.get_images.return_value = []
+
+        options = PdfOptions(ocr=OCROptions(enabled=True, mode="auto", text_threshold=10))
+
+        # 5 meaningful chars padded with punctuation -> below threshold -> OCR.
+        assert _should_use_ocr(mock_page, "abcde" + "-" * 100, options) is True
+        # 20 meaningful chars -> above threshold -> no OCR.
+        assert _should_use_ocr(mock_page, "a" * 20 + "  ...", options) is False
 
     @patch("all2md.parsers._pdf_ocr.calculate_image_coverage")
     def test_should_use_ocr_auto_high_image_coverage(self, mock_coverage: Mock) -> None:

--- a/tests/unit/parsers/test_toml_parser.py
+++ b/tests/unit/parsers/test_toml_parser.py
@@ -21,13 +21,13 @@ class TestTomlParserInitialization:
 
     def test_default_initialization(self):
         """Test parser initializes with default options."""
-        parser = TomlParser()
+        parser = TomlParser(TomlParserOptions(literal_block=False))
         assert parser.options is not None
         assert isinstance(parser.options, TomlParserOptions)
 
     def test_initialization_with_options(self):
         """Test parser initializes with custom options."""
-        options = TomlParserOptions(max_heading_depth=3, sort_keys=True)
+        options = TomlParserOptions(literal_block=False, max_heading_depth=3, sort_keys=True)
         parser = TomlParser(options)
         assert parser.options.max_heading_depth == 3
         assert parser.options.sort_keys is True
@@ -92,21 +92,21 @@ class TestTomlParserPrimitiveTypes:
 
     def test_parse_string(self):
         """Test parsing string values."""
-        parser = TomlParser()
+        parser = TomlParser(TomlParserOptions(literal_block=False))
         doc = parser.parse('name = "John Doe"')
 
         assert isinstance(doc, Document)
 
     def test_parse_integer(self):
         """Test parsing integer values."""
-        parser = TomlParser()
+        parser = TomlParser(TomlParserOptions(literal_block=False))
         doc = parser.parse("count = 42")
 
         assert isinstance(doc, Document)
 
     def test_parse_large_integer_with_formatting(self):
         """Test parsing large integers with thousand separators."""
-        options = TomlParserOptions(pretty_format_numbers=True)
+        options = TomlParserOptions(literal_block=False, pretty_format_numbers=True)
         parser = TomlParser(options)
         doc = parser.parse("count = 1000000")
 
@@ -115,7 +115,7 @@ class TestTomlParserPrimitiveTypes:
 
     def test_parse_large_integer_without_formatting(self):
         """Test parsing large integers without formatting."""
-        options = TomlParserOptions(pretty_format_numbers=False)
+        options = TomlParserOptions(literal_block=False, pretty_format_numbers=False)
         parser = TomlParser(options)
         doc = parser.parse("count = 1000000")
 
@@ -123,21 +123,21 @@ class TestTomlParserPrimitiveTypes:
 
     def test_parse_float(self):
         """Test parsing float values."""
-        parser = TomlParser()
+        parser = TomlParser(TomlParserOptions(literal_block=False))
         doc = parser.parse("pi = 3.14159")
 
         assert isinstance(doc, Document)
 
     def test_parse_boolean_true(self):
         """Test parsing boolean true."""
-        parser = TomlParser()
+        parser = TomlParser(TomlParserOptions(literal_block=False))
         doc = parser.parse("enabled = true")
 
         assert isinstance(doc, Document)
 
     def test_parse_boolean_false(self):
         """Test parsing boolean false."""
-        parser = TomlParser()
+        parser = TomlParser(TomlParserOptions(literal_block=False))
         doc = parser.parse("enabled = false")
 
         assert isinstance(doc, Document)
@@ -151,28 +151,28 @@ Line 2
 Line 3
 """
 '''
-        parser = TomlParser()
+        parser = TomlParser(TomlParserOptions(literal_block=False))
         doc = parser.parse(toml_content)
 
         assert isinstance(doc, Document)
 
     def test_parse_datetime(self):
         """Test parsing datetime values."""
-        parser = TomlParser()
+        parser = TomlParser(TomlParserOptions(literal_block=False))
         doc = parser.parse("timestamp = 2024-06-15T12:30:00")
 
         assert isinstance(doc, Document)
 
     def test_parse_date(self):
         """Test parsing date values."""
-        parser = TomlParser()
+        parser = TomlParser(TomlParserOptions(literal_block=False))
         doc = parser.parse("birthday = 2024-06-15")
 
         assert isinstance(doc, Document)
 
     def test_parse_time(self):
         """Test parsing time values."""
-        parser = TomlParser()
+        parser = TomlParser(TomlParserOptions(literal_block=False))
         doc = parser.parse("meeting = 14:30:00")
 
         assert isinstance(doc, Document)
@@ -186,7 +186,7 @@ class TestTomlParserArrays:
         toml_content = """
 items = ["apple", "banana", "cherry"]
 """
-        parser = TomlParser()
+        parser = TomlParser(TomlParserOptions(literal_block=False))
         doc = parser.parse(toml_content)
 
         assert isinstance(doc, Document)
@@ -196,14 +196,14 @@ items = ["apple", "banana", "cherry"]
         toml_content = """
 numbers = [1, 2, 3, 4, 5]
 """
-        parser = TomlParser()
+        parser = TomlParser(TomlParserOptions(literal_block=False))
         doc = parser.parse(toml_content)
 
         assert isinstance(doc, Document)
 
     def test_parse_empty_array(self):
         """Test parsing empty array."""
-        parser = TomlParser()
+        parser = TomlParser(TomlParserOptions(literal_block=False))
         doc = parser.parse("items = []")
 
         assert isinstance(doc, Document)
@@ -213,7 +213,7 @@ numbers = [1, 2, 3, 4, 5]
         toml_content = """
 matrix = [[1, 2, 3], [4, 5, 6], [7, 8, 9]]
 """
-        parser = TomlParser()
+        parser = TomlParser(TomlParserOptions(literal_block=False))
         doc = parser.parse(toml_content)
 
         assert isinstance(doc, Document)
@@ -223,7 +223,7 @@ matrix = [[1, 2, 3], [4, 5, 6], [7, 8, 9]]
         toml_content = """
 mixed = ["string", 123, true, 3.14]
 """
-        parser = TomlParser()
+        parser = TomlParser(TomlParserOptions(literal_block=False))
         doc = parser.parse(toml_content)
 
         assert isinstance(doc, Document)
@@ -239,7 +239,7 @@ class TestTomlParserTables:
 host = "localhost"
 port = 8080
 """
-        parser = TomlParser()
+        parser = TomlParser(TomlParserOptions(literal_block=False))
         doc = parser.parse(toml_content)
 
         assert isinstance(doc, Document)
@@ -259,7 +259,7 @@ port = 5432
 host = "db2.example.com"
 port = 5432
 """
-        parser = TomlParser()
+        parser = TomlParser(TomlParserOptions(literal_block=False))
         doc = parser.parse(toml_content)
 
         assert isinstance(doc, Document)
@@ -270,7 +270,7 @@ port = 5432
 database.primary.host = "db1.example.com"
 database.primary.port = 5432
 """
-        parser = TomlParser()
+        parser = TomlParser(TomlParserOptions(literal_block=False))
         doc = parser.parse(toml_content)
 
         assert isinstance(doc, Document)
@@ -280,7 +280,7 @@ database.primary.port = 5432
         toml_content = """
 point = { x = 1, y = 2, z = 3 }
 """
-        parser = TomlParser()
+        parser = TomlParser(TomlParserOptions(literal_block=False))
         doc = parser.parse(toml_content)
 
         assert isinstance(doc, Document)
@@ -300,7 +300,7 @@ role = "admin"
 name = "Bob"
 role = "user"
 """
-        parser = TomlParser()
+        parser = TomlParser(TomlParserOptions(literal_block=False))
         doc = parser.parse(toml_content)
 
         assert isinstance(doc, Document)
@@ -318,7 +318,7 @@ name = "Mouse"
 price = 29.99
 specs = { dpi = 1600, buttons = 5 }
 """
-        parser = TomlParser()
+        parser = TomlParser(TomlParserOptions(literal_block=False))
         doc = parser.parse(toml_content)
 
         assert isinstance(doc, Document)
@@ -330,7 +330,7 @@ specs = { dpi = 1600, buttons = 5 }
 name = "Alice"
 role = "admin"
 """
-        options = TomlParserOptions(array_as_table_threshold=2)
+        options = TomlParserOptions(literal_block=False, array_as_table_threshold=2)
         parser = TomlParser(options)
         doc = parser.parse(toml_content)
 
@@ -348,7 +348,7 @@ zebra = "last"
 apple = "first"
 banana = "second"
 """
-        options = TomlParserOptions(sort_keys=True)
+        options = TomlParserOptions(literal_block=False, sort_keys=True)
         parser = TomlParser(options)
         doc = parser.parse(toml_content)
 
@@ -361,7 +361,7 @@ zebra = "last"
 apple = "first"
 banana = "second"
 """
-        options = TomlParserOptions(sort_keys=False)
+        options = TomlParserOptions(literal_block=False, sort_keys=False)
         parser = TomlParser(options)
         doc = parser.parse(toml_content)
 
@@ -374,7 +374,7 @@ banana = "second"
 [wrapper.actual_data]
 value = 123
 """
-        options = TomlParserOptions(flatten_single_keys=True)
+        options = TomlParserOptions(literal_block=False, flatten_single_keys=True)
         parser = TomlParser(options)
         doc = parser.parse(toml_content)
 
@@ -387,7 +387,7 @@ value = 123
 [wrapper.actual_data]
 value = 123
 """
-        options = TomlParserOptions(flatten_single_keys=False)
+        options = TomlParserOptions(literal_block=False, flatten_single_keys=False)
         parser = TomlParser(options)
         doc = parser.parse(toml_content)
 
@@ -402,7 +402,7 @@ value = 123
 [level1.level2.level3.level4]
 value = "deep"
 """
-        options = TomlParserOptions(max_heading_depth=2)
+        options = TomlParserOptions(literal_block=False, max_heading_depth=2)
         parser = TomlParser(options)
         doc = parser.parse(toml_content)
 
@@ -414,14 +414,14 @@ class TestTomlParserInputTypes:
 
     def test_parse_string_input(self):
         """Test parsing string input."""
-        parser = TomlParser()
+        parser = TomlParser(TomlParserOptions(literal_block=False))
         doc = parser.parse('key = "value"')
 
         assert isinstance(doc, Document)
 
     def test_parse_bytes_input(self):
         """Test parsing bytes input."""
-        parser = TomlParser()
+        parser = TomlParser(TomlParserOptions(literal_block=False))
         doc = parser.parse(b'key = "value"')
 
         assert isinstance(doc, Document)
@@ -431,7 +431,7 @@ class TestTomlParserInputTypes:
         toml_file = tmp_path / "test.toml"
         toml_file.write_text('key = "value"\n', encoding="utf-8")
 
-        parser = TomlParser()
+        parser = TomlParser(TomlParserOptions(literal_block=False))
         doc = parser.parse(toml_file)
 
         assert isinstance(doc, Document)
@@ -441,7 +441,7 @@ class TestTomlParserInputTypes:
         toml_file = tmp_path / "test.toml"
         toml_file.write_text('key = "value"\n', encoding="utf-8")
 
-        parser = TomlParser()
+        parser = TomlParser(TomlParserOptions(literal_block=False))
         doc = parser.parse(str(toml_file))
 
         assert isinstance(doc, Document)
@@ -451,7 +451,7 @@ class TestTomlParserInputTypes:
         toml_bytes = b'key = "value"\n'
         file_like = BytesIO(toml_bytes)
 
-        parser = TomlParser()
+        parser = TomlParser(TomlParserOptions(literal_block=False))
         doc = parser.parse(file_like)
 
         assert isinstance(doc, Document)
@@ -466,7 +466,7 @@ class TestTomlParserErrorHandling:
 [section
 key = value
 """
-        parser = TomlParser()
+        parser = TomlParser(TomlParserOptions(literal_block=False))
 
         with pytest.raises(ParsingError) as excinfo:
             parser.parse(invalid_toml)
@@ -475,7 +475,7 @@ key = value
     def test_parse_malformed_toml(self):
         """Test parsing malformed TOML."""
         malformed = '[section]\nkey = "unclosed string'
-        parser = TomlParser()
+        parser = TomlParser(TomlParserOptions(literal_block=False))
 
         with pytest.raises(ParsingError):
             parser.parse(malformed)
@@ -486,7 +486,7 @@ key = value
 key = "value1"
 key = "value2"
 """
-        parser = TomlParser()
+        parser = TomlParser(TomlParserOptions(literal_block=False))
 
         with pytest.raises(ParsingError):
             parser.parse(duplicate)
@@ -494,7 +494,7 @@ key = "value2"
     def test_parse_nonexistent_file(self, tmp_path):
         """Test parsing nonexistent file."""
         nonexistent = tmp_path / "nonexistent.toml"
-        parser = TomlParser()
+        parser = TomlParser(TomlParserOptions(literal_block=False))
 
         with pytest.raises(Exception):
             parser.parse(nonexistent)
@@ -512,7 +512,7 @@ author = "John Doe"
 [data]
 key = "value"
 """
-        parser = TomlParser()
+        parser = TomlParser(TomlParserOptions(literal_block=False))
         doc = parser.parse(toml_content)
 
         assert isinstance(doc, Document)
@@ -520,7 +520,7 @@ key = "value"
 
     def test_metadata_with_empty_document(self):
         """Test metadata with empty document."""
-        parser = TomlParser()
+        parser = TomlParser(TomlParserOptions(literal_block=False))
         doc = parser.parse("")
 
         assert isinstance(doc, Document)
@@ -561,7 +561,7 @@ hosts = [
   "omega"
 ]
 """
-        parser = TomlParser()
+        parser = TomlParser(TomlParserOptions(literal_block=False))
         doc = parser.parse(toml_content)
 
         assert isinstance(doc, Document)
@@ -586,7 +586,7 @@ version = "6.0"
 pytest = "7.0.0"
 mypy = "0.991"
 """
-        parser = TomlParser()
+        parser = TomlParser(TomlParserOptions(literal_block=False))
         doc = parser.parse(toml_content)
 
         assert isinstance(doc, Document)
@@ -640,7 +640,7 @@ dev = [
 [tool.pytest.ini_options]
 testpaths = ["tests"]
 """
-        parser = TomlParser()
+        parser = TomlParser(TomlParserOptions(literal_block=False))
         doc = parser.parse(toml_content)
 
         assert isinstance(doc, Document)
@@ -652,7 +652,7 @@ class TestTomlParserEdgeCases:
 
     def test_parse_empty_string(self):
         """Test parsing empty string."""
-        parser = TomlParser()
+        parser = TomlParser(TomlParserOptions(literal_block=False))
         doc = parser.parse("")
 
         assert isinstance(doc, Document)
@@ -663,14 +663,14 @@ class TestTomlParserEdgeCases:
 # This is a comment
 # Another comment
 """
-        parser = TomlParser()
+        parser = TomlParser(TomlParserOptions(literal_block=False))
         doc = parser.parse(toml_content)
 
         assert isinstance(doc, Document)
 
     def test_parse_whitespace_only(self):
         """Test parsing whitespace-only content."""
-        parser = TomlParser()
+        parser = TomlParser(TomlParserOptions(literal_block=False))
         doc = parser.parse("   \n\n  \t  \n")
 
         assert isinstance(doc, Document)
@@ -681,7 +681,7 @@ class TestTomlParserEdgeCases:
 message = "Hello, 世界! 🌍"
 emoji = "🎉🎊🎈"
 """
-        parser = TomlParser()
+        parser = TomlParser(TomlParserOptions(literal_block=False))
         doc = parser.parse(toml_content)
 
         assert isinstance(doc, Document)
@@ -693,7 +693,7 @@ path = "C:\\Users\\Documents"
 quote = "He said \"hello\""
 newline = "Line 1\nLine 2"
 """
-        parser = TomlParser()
+        parser = TomlParser(TomlParserOptions(literal_block=False))
         doc = parser.parse(toml_content)
 
         assert isinstance(doc, Document)
@@ -704,7 +704,7 @@ newline = "Line 1\nLine 2"
 regex = '<\\i\\c*\\s*>'
 path = 'C:\\Users\\Documents'
 """
-        parser = TomlParser()
+        parser = TomlParser(TomlParserOptions(literal_block=False))
         doc = parser.parse(toml_content)
 
         assert isinstance(doc, Document)
@@ -716,7 +716,7 @@ poem = '''
 Roses are red
 Violets are blue'''
 """
-        parser = TomlParser()
+        parser = TomlParser(TomlParserOptions(literal_block=False))
         doc = parser.parse(toml_content)
 
         assert isinstance(doc, Document)
@@ -728,7 +728,7 @@ hex = 0xDEADBEEF
 oct = 0o01234567
 bin = 0b11010110
 """
-        parser = TomlParser()
+        parser = TomlParser(TomlParserOptions(literal_block=False))
         doc = parser.parse(toml_content)
 
         assert isinstance(doc, Document)
@@ -740,7 +740,7 @@ pos_inf = inf
 neg_inf = -inf
 not_a_number = nan
 """
-        parser = TomlParser()
+        parser = TomlParser(TomlParserOptions(literal_block=False))
         doc = parser.parse(toml_content)
 
         assert isinstance(doc, Document)
@@ -780,7 +780,7 @@ content = "Content 1"
 name = "Section 2"
 content = "Content 2"
 """
-        parser = TomlParser()
+        parser = TomlParser(TomlParserOptions(literal_block=False))
         doc = parser.parse(toml_content)
 
         assert isinstance(doc, Document)
@@ -809,7 +809,7 @@ criterion = "0.5"
 name = "my_benchmark"
 harness = false
 """
-        parser = TomlParser()
+        parser = TomlParser(TomlParserOptions(literal_block=False))
         doc = parser.parse(toml_content)
 
         assert isinstance(doc, Document)

--- a/tests/unit/parsers/test_yaml_parser.py
+++ b/tests/unit/parsers/test_yaml_parser.py
@@ -20,13 +20,13 @@ class TestYamlParserInitialization:
 
     def test_default_initialization(self):
         """Test parser initializes with default options."""
-        parser = YamlParser()
+        parser = YamlParser(YamlParserOptions(literal_block=False))
         assert parser.options is not None
         assert isinstance(parser.options, YamlParserOptions)
 
     def test_initialization_with_options(self):
         """Test parser initializes with custom options."""
-        options = YamlParserOptions(max_heading_depth=3, sort_keys=True)
+        options = YamlParserOptions(literal_block=False, max_heading_depth=3, sort_keys=True)
         parser = YamlParser(options)
         assert parser.options.max_heading_depth == 3
         assert parser.options.sort_keys is True
@@ -93,7 +93,7 @@ class TestYamlParserPrimitiveTypes:
 
     def test_parse_null_value(self):
         """Test parsing null values."""
-        parser = YamlParser()
+        parser = YamlParser(YamlParserOptions(literal_block=False))
         doc = parser.parse("value: null")
 
         assert isinstance(doc, Document)
@@ -102,28 +102,28 @@ class TestYamlParserPrimitiveTypes:
 
     def test_parse_boolean_true(self):
         """Test parsing boolean true."""
-        parser = YamlParser()
+        parser = YamlParser(YamlParserOptions(literal_block=False))
         doc = parser.parse("enabled: true")
 
         assert isinstance(doc, Document)
 
     def test_parse_boolean_false(self):
         """Test parsing boolean false."""
-        parser = YamlParser()
+        parser = YamlParser(YamlParserOptions(literal_block=False))
         doc = parser.parse("enabled: false")
 
         assert isinstance(doc, Document)
 
     def test_parse_integer(self):
         """Test parsing integer values."""
-        parser = YamlParser()
+        parser = YamlParser(YamlParserOptions(literal_block=False))
         doc = parser.parse("count: 42")
 
         assert isinstance(doc, Document)
 
     def test_parse_large_integer_with_formatting(self):
         """Test parsing large integers with thousand separators."""
-        options = YamlParserOptions(pretty_format_numbers=True)
+        options = YamlParserOptions(literal_block=False, pretty_format_numbers=True)
         parser = YamlParser(options)
         doc = parser.parse("count: 1000000")
 
@@ -132,7 +132,7 @@ class TestYamlParserPrimitiveTypes:
 
     def test_parse_large_integer_without_formatting(self):
         """Test parsing large integers without formatting."""
-        options = YamlParserOptions(pretty_format_numbers=False)
+        options = YamlParserOptions(literal_block=False, pretty_format_numbers=False)
         parser = YamlParser(options)
         doc = parser.parse("count: 1000000")
 
@@ -140,14 +140,14 @@ class TestYamlParserPrimitiveTypes:
 
     def test_parse_float(self):
         """Test parsing float values."""
-        parser = YamlParser()
+        parser = YamlParser(YamlParserOptions(literal_block=False))
         doc = parser.parse("pi: 3.14159")
 
         assert isinstance(doc, Document)
 
     def test_parse_string(self):
         """Test parsing string values."""
-        parser = YamlParser()
+        parser = YamlParser(YamlParserOptions(literal_block=False))
         doc = parser.parse("name: John Doe")
 
         assert isinstance(doc, Document)
@@ -160,21 +160,21 @@ description: |
   Line 2
   Line 3
 """
-        parser = YamlParser()
+        parser = YamlParser(YamlParserOptions(literal_block=False))
         doc = parser.parse(yaml_content)
 
         assert isinstance(doc, Document)
 
     def test_parse_datetime(self):
         """Test parsing datetime values."""
-        parser = YamlParser()
+        parser = YamlParser(YamlParserOptions(literal_block=False))
         doc = parser.parse("timestamp: 2024-06-15T12:30:00")
 
         assert isinstance(doc, Document)
 
     def test_parse_date(self):
         """Test parsing date values."""
-        parser = YamlParser()
+        parser = YamlParser(YamlParserOptions(literal_block=False))
         doc = parser.parse("birthday: 2024-06-15")
 
         assert isinstance(doc, Document)
@@ -191,7 +191,7 @@ items:
   - banana
   - cherry
 """
-        parser = YamlParser()
+        parser = YamlParser(YamlParserOptions(literal_block=False))
         doc = parser.parse(yaml_content)
 
         assert isinstance(doc, Document)
@@ -213,7 +213,7 @@ users:
   - name: Bob
     role: user
 """
-        parser = YamlParser()
+        parser = YamlParser(YamlParserOptions(literal_block=False))
         doc = parser.parse(yaml_content)
 
         assert isinstance(doc, Document)
@@ -225,7 +225,7 @@ users:
   - name: Alice
     role: admin
 """
-        options = YamlParserOptions(array_as_table_threshold=2)
+        options = YamlParserOptions(literal_block=False, array_as_table_threshold=2)
         parser = YamlParser(options)
         doc = parser.parse(yaml_content)
 
@@ -234,7 +234,7 @@ users:
 
     def test_parse_empty_array(self):
         """Test parsing empty array."""
-        parser = YamlParser()
+        parser = YamlParser(YamlParserOptions(literal_block=False))
         doc = parser.parse("items: []")
 
         assert isinstance(doc, Document)
@@ -247,7 +247,7 @@ matrix:
   - [4, 5, 6]
   - [7, 8, 9]
 """
-        parser = YamlParser()
+        parser = YamlParser(YamlParserOptions(literal_block=False))
         doc = parser.parse(yaml_content)
 
         assert isinstance(doc, Document)
@@ -263,7 +263,7 @@ server:
   host: localhost
   port: 8080
 """
-        parser = YamlParser()
+        parser = YamlParser(YamlParserOptions(literal_block=False))
         doc = parser.parse(yaml_content)
 
         assert isinstance(doc, Document)
@@ -273,7 +273,7 @@ server:
 
     def test_parse_empty_object(self):
         """Test parsing empty object."""
-        parser = YamlParser()
+        parser = YamlParser(YamlParserOptions(literal_block=False))
         doc = parser.parse("config: {}")
 
         assert isinstance(doc, Document)
@@ -285,7 +285,7 @@ zebra: last
 apple: first
 banana: second
 """
-        options = YamlParserOptions(sort_keys=True)
+        options = YamlParserOptions(literal_block=False, sort_keys=True)
         parser = YamlParser(options)
         doc = parser.parse(yaml_content)
 
@@ -298,7 +298,7 @@ zebra: last
 apple: first
 banana: second
 """
-        options = YamlParserOptions(sort_keys=False)
+        options = YamlParserOptions(literal_block=False, sort_keys=False)
         parser = YamlParser(options)
         doc = parser.parse(yaml_content)
 
@@ -315,7 +315,7 @@ database:
     host: db2.example.com
     port: 5432
 """
-        parser = YamlParser()
+        parser = YamlParser(YamlParserOptions(literal_block=False))
         doc = parser.parse(yaml_content)
 
         assert isinstance(doc, Document)
@@ -329,7 +329,7 @@ config:
   enabled: true
   timeout: 30
 """
-        parser = YamlParser()
+        parser = YamlParser(YamlParserOptions(literal_block=False))
         doc = parser.parse(yaml_content)
 
         assert isinstance(doc, Document)
@@ -345,7 +345,7 @@ wrapper:
   actual_data:
     value: 123
 """
-        options = YamlParserOptions(flatten_single_keys=True)
+        options = YamlParserOptions(literal_block=False, flatten_single_keys=True)
         parser = YamlParser(options)
         doc = parser.parse(yaml_content)
 
@@ -358,7 +358,7 @@ wrapper:
   actual_data:
     value: 123
 """
-        options = YamlParserOptions(flatten_single_keys=False)
+        options = YamlParserOptions(literal_block=False, flatten_single_keys=False)
         parser = YamlParser(options)
         doc = parser.parse(yaml_content)
 
@@ -369,7 +369,7 @@ wrapper:
         yaml_content = """
 wrapper: simple_value
 """
-        options = YamlParserOptions(flatten_single_keys=True)
+        options = YamlParserOptions(literal_block=False, flatten_single_keys=True)
         parser = YamlParser(options)
         doc = parser.parse(yaml_content)
 
@@ -390,7 +390,7 @@ level1:
           level6:
             level7: value
 """
-        parser = YamlParser()
+        parser = YamlParser(YamlParserOptions(literal_block=False))
         doc = parser.parse(yaml_content)
 
         assert isinstance(doc, Document)
@@ -403,7 +403,7 @@ level1:
     level3:
       level4: value
 """
-        options = YamlParserOptions(max_heading_depth=2)
+        options = YamlParserOptions(literal_block=False, max_heading_depth=2)
         parser = YamlParser(options)
         doc = parser.parse(yaml_content)
 
@@ -418,7 +418,7 @@ level1:
       level4:
         level5: value
 """
-        options = YamlParserOptions(max_heading_depth=3)
+        options = YamlParserOptions(literal_block=False, max_heading_depth=3)
         parser = YamlParser(options)
         doc = parser.parse(yaml_content)
 
@@ -430,14 +430,14 @@ class TestYamlParserInputTypes:
 
     def test_parse_string_input(self):
         """Test parsing string input."""
-        parser = YamlParser()
+        parser = YamlParser(YamlParserOptions(literal_block=False))
         doc = parser.parse("key: value")
 
         assert isinstance(doc, Document)
 
     def test_parse_bytes_input(self):
         """Test parsing bytes input."""
-        parser = YamlParser()
+        parser = YamlParser(YamlParserOptions(literal_block=False))
         doc = parser.parse(b"key: value")
 
         assert isinstance(doc, Document)
@@ -447,7 +447,7 @@ class TestYamlParserInputTypes:
         yaml_file = tmp_path / "test.yaml"
         yaml_file.write_text("key: value\n", encoding="utf-8")
 
-        parser = YamlParser()
+        parser = YamlParser(YamlParserOptions(literal_block=False))
         doc = parser.parse(yaml_file)
 
         assert isinstance(doc, Document)
@@ -457,7 +457,7 @@ class TestYamlParserInputTypes:
         yaml_file = tmp_path / "test.yaml"
         yaml_file.write_text("key: value\n", encoding="utf-8")
 
-        parser = YamlParser()
+        parser = YamlParser(YamlParserOptions(literal_block=False))
         doc = parser.parse(str(yaml_file))
 
         assert isinstance(doc, Document)
@@ -467,7 +467,7 @@ class TestYamlParserInputTypes:
         yaml_bytes = b"key: value\n"
         file_like = BytesIO(yaml_bytes)
 
-        parser = YamlParser()
+        parser = YamlParser(YamlParserOptions(literal_block=False))
         doc = parser.parse(file_like)
 
         assert isinstance(doc, Document)
@@ -480,7 +480,7 @@ class TestYamlParserErrorHandling:
         """Test parsing invalid YAML raises ParsingError."""
         # YAML with invalid structure - unclosed flow sequence
         invalid_yaml = "key: [value1, value2"
-        parser = YamlParser()
+        parser = YamlParser(YamlParserOptions(literal_block=False))
 
         with pytest.raises(ParsingError) as excinfo:
             parser.parse(invalid_yaml)
@@ -489,7 +489,7 @@ class TestYamlParserErrorHandling:
     def test_parse_malformed_yaml(self):
         """Test parsing malformed YAML."""
         malformed = "key: [unclosed list"
-        parser = YamlParser()
+        parser = YamlParser(YamlParserOptions(literal_block=False))
 
         with pytest.raises(ParsingError):
             parser.parse(malformed)
@@ -497,7 +497,7 @@ class TestYamlParserErrorHandling:
     def test_parse_nonexistent_file(self, tmp_path):
         """Test parsing nonexistent file."""
         nonexistent = tmp_path / "nonexistent.yaml"
-        parser = YamlParser()
+        parser = YamlParser(YamlParserOptions(literal_block=False))
 
         with pytest.raises(Exception):
             parser.parse(nonexistent)
@@ -514,7 +514,7 @@ author: John Doe
 data:
   key: value
 """
-        parser = YamlParser()
+        parser = YamlParser(YamlParserOptions(literal_block=False))
         doc = parser.parse(yaml_content)
 
         assert isinstance(doc, Document)
@@ -522,7 +522,7 @@ data:
 
     def test_metadata_with_empty_document(self):
         """Test metadata with empty document."""
-        parser = YamlParser()
+        parser = YamlParser(YamlParserOptions(literal_block=False))
         doc = parser.parse("")
 
         assert isinstance(doc, Document)
@@ -554,7 +554,7 @@ application:
     retries: 3
     debug: false
 """
-        parser = YamlParser()
+        parser = YamlParser(YamlParserOptions(literal_block=False))
         doc = parser.parse(yaml_content)
 
         assert isinstance(doc, Document)
@@ -570,7 +570,7 @@ mixed:
   - null
   - 3.14
 """
-        parser = YamlParser()
+        parser = YamlParser(YamlParserOptions(literal_block=False))
         doc = parser.parse(yaml_content)
 
         assert isinstance(doc, Document)
@@ -621,7 +621,7 @@ logging:
     - type: console
       format: json
 """
-        parser = YamlParser()
+        parser = YamlParser(YamlParserOptions(literal_block=False))
         doc = parser.parse(yaml_content)
 
         assert isinstance(doc, Document)
@@ -633,7 +633,7 @@ class TestYamlParserEdgeCases:
 
     def test_parse_empty_string(self):
         """Test parsing empty string."""
-        parser = YamlParser()
+        parser = YamlParser(YamlParserOptions(literal_block=False))
         doc = parser.parse("")
 
         assert isinstance(doc, Document)
@@ -644,14 +644,14 @@ class TestYamlParserEdgeCases:
 # This is a comment
 # Another comment
 """
-        parser = YamlParser()
+        parser = YamlParser(YamlParserOptions(literal_block=False))
         doc = parser.parse(yaml_content)
 
         assert isinstance(doc, Document)
 
     def test_parse_whitespace_only(self):
         """Test parsing whitespace-only content."""
-        parser = YamlParser()
+        parser = YamlParser(YamlParserOptions(literal_block=False))
         # Spaces and newlines only (no tabs which can cause YAML scan errors)
         doc = parser.parse("   \n\n     \n")
 
@@ -663,7 +663,7 @@ class TestYamlParserEdgeCases:
 message: Hello, 世界! 🌍
 emoji: 🎉🎊🎈
 """
-        parser = YamlParser()
+        parser = YamlParser(YamlParserOptions(literal_block=False))
         doc = parser.parse(yaml_content)
 
         assert isinstance(doc, Document)
@@ -684,7 +684,7 @@ folded: >
   This is a
   folded string
 """
-        parser = YamlParser()
+        parser = YamlParser(YamlParserOptions(literal_block=False))
         doc = parser.parse(yaml_content)
 
         assert isinstance(doc, Document)
@@ -720,7 +720,7 @@ sections:
   - name: Section 2
     content: Content 2
 """
-        parser = YamlParser()
+        parser = YamlParser(YamlParserOptions(literal_block=False))
         doc = parser.parse(yaml_content)
 
         assert isinstance(doc, Document)

--- a/tests/unit/renderers/test_html_renderer.py
+++ b/tests/unit/renderers/test_html_renderer.py
@@ -220,6 +220,41 @@ class TestLinkAndImageRendering:
         result = renderer.render_to_string(doc)
         assert 'title="Example Site"' in result
 
+    def test_external_links_new_tab_disabled_by_default(self):
+        """Without the option, external links are not given target=_blank."""
+        doc = Document(
+            children=[Paragraph(content=[Link(url="https://example.com", content=[Text(content="Example")])])]
+        )
+        renderer = HtmlRenderer(HtmlRendererOptions(standalone=False))
+        result = renderer.render_to_string(doc)
+        assert "target=" not in result
+
+    def test_external_links_new_tab_external(self):
+        """With the option enabled, external links open in a new tab."""
+        doc = Document(
+            children=[Paragraph(content=[Link(url="https://example.com", content=[Text(content="Example")])])]
+        )
+        renderer = HtmlRenderer(HtmlRendererOptions(standalone=False, external_links_new_tab=True))
+        result = renderer.render_to_string(doc)
+        assert 'target="_blank"' in result
+        assert 'rel="noopener noreferrer"' in result
+
+    def test_external_links_new_tab_internal_unaffected(self):
+        """Relative/anchor links stay in-place even when the option is enabled."""
+        doc = Document(
+            children=[
+                Paragraph(
+                    content=[
+                        Link(url="#section", content=[Text(content="Anchor")]),
+                        Link(url="./other.html", content=[Text(content="Relative")]),
+                    ]
+                )
+            ]
+        )
+        renderer = HtmlRenderer(HtmlRendererOptions(standalone=False, external_links_new_tab=True))
+        result = renderer.render_to_string(doc)
+        assert "target=" not in result
+
     def test_image(self):
         """Test image rendering."""
         doc = Document(children=[Paragraph(content=[Image(url="image.png", alt_text="Description")])])

--- a/tests/unit/renderers/test_json_renderer.py
+++ b/tests/unit/renderers/test_json_renderer.py
@@ -394,10 +394,12 @@ class TestJsonRendererComplexCases:
             "users": [{"name": "Alice", "age": 30, "active": True}, {"name": "Bob", "age": 25, "active": False}]
         }
 
-        # Parse
+        # Parse in structured mode so the renderer can reconstruct the data
+        # (the default literal_block=True emits a code block, not a table).
+        from all2md.options.json import JsonParserOptions
         from all2md.parsers.json import JsonParser
 
-        parser = JsonParser()
+        parser = JsonParser(JsonParserOptions(literal_block=False))
         doc = parser.parse(json.dumps(original_data))
 
         # Render back


### PR DESCRIPTION
Five independent pre-release items, one commit each.

## 1. External links open in a new tab (view/serve)
`HtmlRendererOptions.external_links_new_tab` (default off). When on, the HTML renderer adds `target="_blank" rel="noopener noreferrer"` to absolute http/https/ftp/mailto/protocol-relative links; relative/anchor links are untouched. Enabled in `view`, `serve`, and the windowless `all2mdw` viewer. Plain `--format html` output is unchanged.

## 2. JSON/YAML/TOML/INI render as code blocks by default
Flipped the `literal_block` default to True for these parsers — config/data files now convert to a fenced, syntax-highlighted code block. YAML/TOML/INI preserve the original source verbatim (comments kept); JSON is pretty-printed. The structured document (headings/tables/lists) is still available via `literal_block=False` (CLI `--<fmt>-no-literal-block`). Converter manifest regenerated.

## 3. Context-menu: Edit and Serve entries
The Windows `context-menu` command now manages View (files), Edit (files, `all2md edit`), and Serve (folders, `all2md serve`). `install` registers View by default; `--edit`/`--serve` add those, `--all` installs all three. Uninstall clears all entries; status reports each.

## 4. `all2md llm-minify` command
Token-lean conversion for LLMs. Two presets: compact-Markdown (default — drops comments/frontmatter/raw HTML, collapses whitespace) and plain-text (`--aggressive`). Plus `--strip-links`, `--strip-images`, `--strip-formatting`.

## 5. Better OCR-needed detection
Auto OCR could skip a scanned PDF that rendered to ~0 bytes. Now: the per-page heuristic counts meaningful (alphanumeric) characters rather than raw length, and a document-level safety net re-runs with OCR forced when an auto-mode document comes out near-empty (new `OCROptions.doc_text_threshold`). A hint is logged when OCR is disabled.

## Testing
- `ruff check`, `ruff format`/`black`, and `mypy src/` clean (pre-existing `bleach`-stub mypy notes only).
- Full unit suite green (`pytest -m unit`); added tests for external-link tabs, the OCR heuristic, and `llm-minify`; updated structured-format/round-trip tests to opt into structured mode.

🤖 Generated with [Claude Code](https://claude.com/claude-code)