### PR TITLE
feat(mcp): add search, diff, and outline query tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,10 +220,13 @@ pip install "all2md[mcp]"
 all2md-mcp --temp --enable-from-md
 ```
 
+**Tools:** `read_document_as_markdown`, `save_document_from_markdown`, `edit_document`, plus three read-only query tools enabled by default — `search_documents` (grep + keyword/BM25 across a corpus), `diff_documents` (compare two documents), and `get_document_outline` (heading structure for navigation).
+
 **Key features:**
 - **Smart Auto-Detection**: Automatically detect source type (file path, data URI, base64, or plain text)
-- **Section Extraction**: Extract specific sections by heading name for targeted reading
-- **Simplified API**: Just 2-3 parameters per tool with server-level configuration
+- **Corpus Search**: Grep and keyword/BM25 search across many documents, returning ranked snippets instead of whole files
+- **Section Extraction & Outlines**: Extract sections by heading or list a document's structure for targeted reading
+- **Document Diffing**: Compare two documents (any format) and get a unified or JSON diff
 - **Security First**: File allowlists, network controls, and path validation
 - **vLLM Image Support**: Optionally embed images as base64 for vision-enabled models
 
@@ -242,8 +245,9 @@ required (the bundle pulls in all2md via `uv` on first run):
    and write to (defaults to your Documents folder; files outside it are
    rejected), and optionally adjust the toggles for writing/rendering,
    in-place editing, and network access.
-5. The `read_document_as_markdown`, `save_document_from_markdown`, and
-   `edit_document` tools then appear under the **"+" → Connectors** panel in a
+5. The all2md tools (`read_document_as_markdown`, `save_document_from_markdown`,
+   `edit_document`, `search_documents`, `diff_documents`, and
+   `get_document_outline`) then appear under the **"+" → Connectors** panel in a
    chat, ready to use on files in your workspace folder.
 
 > Requires a Claude Desktop build with MCPB extension support (late-2025 or

--- a/docs/source/environment_variables.rst
+++ b/docs/source/environment_variables.rst
@@ -180,6 +180,101 @@ This is disabled by default because it allows modification of document content.
    export ALL2MD_MCP_ENABLE_DOC_EDIT=true
    all2md-mcp
 
+ALL2MD_MCP_ENABLE_SEARCH
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+**Purpose:** Enable/disable the ``search_documents`` tool in MCP server.
+
+**Type:** Boolean
+
+**Default:** ``true`` (read-only; enabled by default)
+
+**Valid Values:** ``true``, ``false``, ``1``, ``0``, ``yes``, ``no``
+
+**Description:**
+
+When enabled, allows LLMs to search a corpus of documents (grep + keyword/BM25)
+and receive ranked snippets. Read-only, so enabled by default.
+
+**Example:**
+
+.. code-block:: bash
+
+   # Disable document search
+   export ALL2MD_MCP_ENABLE_SEARCH=false
+   all2md-mcp
+
+ALL2MD_MCP_ENABLE_DIFF
+~~~~~~~~~~~~~~~~~~~~~~~
+
+**Purpose:** Enable/disable the ``diff_documents`` tool in MCP server.
+
+**Type:** Boolean
+
+**Default:** ``true`` (read-only; enabled by default)
+
+**Valid Values:** ``true``, ``false``, ``1``, ``0``, ``yes``, ``no``
+
+**Description:**
+
+When enabled, allows LLMs to compare two documents and receive a unified or JSON
+diff. Read-only, so enabled by default.
+
+**Example:**
+
+.. code-block:: bash
+
+   # Disable document diffing
+   export ALL2MD_MCP_ENABLE_DIFF=false
+   all2md-mcp
+
+ALL2MD_MCP_ENABLE_OUTLINE
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+**Purpose:** Enable/disable the ``get_document_outline`` tool in MCP server.
+
+**Type:** Boolean
+
+**Default:** ``true`` (read-only; enabled by default)
+
+**Valid Values:** ``true``, ``false``, ``1``, ``0``, ``yes``, ``no``
+
+**Description:**
+
+When enabled, allows LLMs to retrieve a document's heading structure for
+navigation. Read-only, so enabled by default.
+
+**Example:**
+
+.. code-block:: bash
+
+   # Disable document outlines
+   export ALL2MD_MCP_ENABLE_OUTLINE=false
+   all2md-mcp
+
+ALL2MD_MCP_SEARCH_INDEX_DIR
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+**Purpose:** Directory used to persist and reuse the ``search_documents`` keyword index.
+
+**Type:** String (directory path)
+
+**Default:** *(none — a fresh index is built in memory on every call)*
+
+**Description:**
+
+When set, the keyword (BM25) index is saved to this directory and reused on
+subsequent searches, avoiding a rebuild each call. The directory must be within
+the write allowlist. Grep mode is always stateless and ignores this setting.
+
+**Example:**
+
+.. code-block:: bash
+
+   # Persist the keyword index between calls
+   export ALL2MD_MCP_SEARCH_INDEX_DIR="/workspace/.all2md-index"
+   all2md-mcp
+
 ALL2MD_MCP_INCLUDE_IMAGES
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/docs/source/mcp.rst
+++ b/docs/source/mcp.rst
@@ -20,11 +20,17 @@ The Model Context Protocol (MCP) is an open standard that enables AI assistants 
 * Convert Markdown to other formats (HTML, PDF, DOCX, etc.)
 * Process documents with comprehensive security controls
 
-The all2md MCP server exposes three primary tools:
+The all2md MCP server exposes six tools:
 
 1. **read_document_as_markdown** - Read and convert documents to Markdown format
 2. **save_document_from_markdown** - Save Markdown to other formats (disabled by default for security)
 3. **edit_document** - Edit markdown documents by manipulating their structure (disabled by default for security)
+4. **search_documents** - Search a corpus of documents (grep + keyword/BM25) and return ranked snippets
+5. **diff_documents** - Compare two documents and return a unified or JSON diff
+6. **get_document_outline** - List a document's heading structure for navigation
+
+Tools 4-6 are read-only and **enabled by default**. Tools 2 and 3 write or mutate
+files and remain disabled by default.
 
 Features
 ~~~~~~~~
@@ -353,6 +359,192 @@ Replace section content:
      "content": "# Updated Heading\n\nUpdated content."
    }
 
+search_documents
+~~~~~~~~~~~~~~~~~
+
+Search a corpus of documents and return ranked snippets instead of whole files,
+so an agent can locate information across many documents cheaply. Read-only;
+enabled by default.
+
+Two modes are supported:
+
+* ``keyword`` (default) - BM25 relevance ranking. Best for "find the most
+  relevant passages" queries. Requires the optional ``rank-bm25`` dependency
+  (``pip install 'all2md[search]'``).
+* ``grep`` - literal or regex line matching with highlighted spans. Best for
+  "find every occurrence of X". Stateless, no extra dependencies.
+
+Matched text in each snippet is wrapped in ``<<`` / ``>>`` markers.
+
+**Parameters:**
+
+.. list-table::
+   :header-rows: 1
+   :widths: 20 15 65
+
+   * - Parameter
+     - Type
+     - Description
+   * - ``query``
+     - string
+     - **REQUIRED.** Natural-language query (keyword mode) or literal/regex pattern (grep mode).
+   * - ``paths``
+     - list[string]
+     - *Optional.* Files, directories, or globs to search (each validated against the read allowlist). Defaults to the read allowlist.
+   * - ``mode``
+     - string
+     - *Optional.* ``keyword`` (default) or ``grep``.
+   * - ``top_k``
+     - integer
+     - *Optional.* Maximum number of results to return (default: 10).
+   * - ``ignore_case``
+     - boolean
+     - *Optional.* Case-insensitive matching (grep mode only; default: false).
+   * - ``regex``
+     - boolean
+     - *Optional.* Treat the query as a regular expression (grep mode only; default: false).
+   * - ``recursive``
+     - boolean
+     - *Optional.* Recurse into directories when collecting input files (default: true).
+
+**Persistent index (optional):**
+
+By default a fresh index is built in memory on every call. Set
+``--search-index-dir PATH`` (or ``ALL2MD_MCP_SEARCH_INDEX_DIR``) to persist the
+keyword index to disk and reuse it on subsequent calls. The directory must be
+within the write allowlist. Grep mode is always stateless and never persisted.
+
+**Returns:**
+
+A dictionary with:
+
+* ``results``: list of ``{snippet, score, document_path, section_heading, chunk_id}``
+* ``mode``: the search mode used
+* ``total``: number of results returned
+
+**Examples:**
+
+Keyword search across a directory:
+
+.. code-block:: json
+
+   {
+     "query": "data retention policy",
+     "paths": ["/workspace/contracts"],
+     "mode": "keyword",
+     "top_k": 5
+   }
+
+Grep for every occurrence of a pattern (case-insensitive):
+
+.. code-block:: json
+
+   {
+     "query": "TODO|FIXME",
+     "mode": "grep",
+     "regex": true,
+     "ignore_case": true
+   }
+
+diff_documents
+~~~~~~~~~~~~~~
+
+Compare two documents and return their differences. Read-only; enabled by
+default. Each input is auto-detected (file path within the read allowlist, data
+URI, base64, or inline content), so documents in any supported format can be
+compared — even across formats (e.g. a DOCX against its PDF export).
+
+**Parameters:**
+
+.. list-table::
+   :header-rows: 1
+   :widths: 20 15 65
+
+   * - Parameter
+     - Type
+     - Description
+   * - ``old``
+     - string
+     - **REQUIRED.** Original document (path or inline content).
+   * - ``new``
+     - string
+     - **REQUIRED.** Updated document (path or inline content).
+   * - ``format``
+     - string
+     - *Optional.* Output format: ``unified`` (default, plain text) or ``json`` (structured).
+   * - ``context_lines``
+     - integer
+     - *Optional.* Context lines around changes in unified output (default: 3).
+   * - ``granularity``
+     - string
+     - *Optional.* Comparison granularity: ``block`` (default), ``sentence``, or ``word``.
+   * - ``ignore_whitespace``
+     - boolean
+     - *Optional.* Normalize whitespace before comparing (default: false).
+
+**Returns:**
+
+A dictionary with:
+
+* ``diff``: the rendered diff (unified text or JSON string)
+* ``has_changes``: whether any differences were found
+
+**Example:**
+
+Compare two report versions:
+
+.. code-block:: json
+
+   {
+     "old": "/workspace/report_v1.docx",
+     "new": "/workspace/report_v2.docx",
+     "format": "unified"
+   }
+
+get_document_outline
+~~~~~~~~~~~~~~~~~~~~~
+
+Return the heading structure (table of contents) of a document so an agent can
+navigate a large file before extracting specific sections. Read-only; enabled by
+default. The ``doc`` parameter is auto-detected (path, data URI, base64, or
+inline content). The returned indices line up with ``edit_document``'s ``#N``
+target notation.
+
+**Parameters:**
+
+.. list-table::
+   :header-rows: 1
+   :widths: 20 15 65
+
+   * - Parameter
+     - Type
+     - Description
+   * - ``doc``
+     - string
+     - **REQUIRED.** Document to outline (path or inline content).
+   * - ``max_level``
+     - integer
+     - *Optional.* Deepest heading level to include, 1-6 (default: 6 = all levels).
+   * - ``format_hint``
+     - string
+     - *Optional.* Format hint for ambiguous/extensionless sources (``pdf``, ``docx``, ``html``, etc.).
+
+**Returns:**
+
+A dictionary with:
+
+* ``sections``: list of ``{index, level, heading}``
+* ``total``: number of headings returned
+
+**Example:**
+
+.. code-block:: json
+
+   {
+     "doc": "/workspace/manual.pdf",
+     "max_level": 2
+   }
+
 Configuration
 -------------
 
@@ -375,11 +567,19 @@ Command-Line Arguments
 * ``--no-to-md`` - Disable the read_document_as_markdown tool
 * ``--enable-from-md`` - Enable the save_document_from_markdown tool (default: false)
 * ``--no-from-md`` - Disable the save_document_from_markdown tool
+* ``--enable-doc-edit`` / ``--no-doc-edit`` - Toggle the edit_document tool (default: false)
+* ``--enable-search`` / ``--no-search`` - Toggle the search_documents tool (default: true)
+* ``--enable-diff`` / ``--no-diff`` - Toggle the diff_documents tool (default: true)
+* ``--enable-outline`` / ``--no-outline`` - Toggle the get_document_outline tool (default: true)
 
 **Path Allowlists:**
 
 * ``--read-dirs PATHS`` - Semicolon-separated list of allowed read directories
 * ``--write-dirs PATHS`` - Semicolon-separated list of allowed write directories
+
+**Search Index:**
+
+* ``--search-index-dir PATH`` - Persist/load the search keyword index in this directory (must be within the write allowlist). Omit to rebuild a fresh index on every call.
 
 **Image Inclusion:**
 
@@ -418,6 +618,18 @@ Environment Variables
    * - ``ALL2MD_MCP_ENABLE_DOC_EDIT``
      - ``false``
      - Enable edit_document tool
+   * - ``ALL2MD_MCP_ENABLE_SEARCH``
+     - ``true``
+     - Enable search_documents tool
+   * - ``ALL2MD_MCP_ENABLE_DIFF``
+     - ``true``
+     - Enable diff_documents tool
+   * - ``ALL2MD_MCP_ENABLE_OUTLINE``
+     - ``true``
+     - Enable get_document_outline tool
+   * - ``ALL2MD_MCP_SEARCH_INDEX_DIR``
+     - *(none)*
+     - Directory to persist the search keyword index (must be in write allowlist)
    * - ``ALL2MD_MCP_ALLOWED_READ_DIRS``
      - CWD
      - Semicolon-separated read allowlist paths
@@ -722,6 +934,11 @@ Embedding all2md-mcp in your own MCP server:
    from all2md.mcp import MCPConfig
    from all2md.mcp.server import create_server
    from all2md.mcp.document_tools import edit_document_impl
+   from all2md.mcp.query_tools import (
+       diff_documents_impl,
+       get_document_outline_impl,
+       search_documents_impl,
+   )
    from all2md.mcp.security import prepare_allowlist_dirs
    from all2md.mcp.tools import read_document_as_markdown_impl, save_document_from_markdown_impl
 
@@ -730,6 +947,9 @@ Embedding all2md-mcp in your own MCP server:
        enable_to_md=True,
        enable_from_md=False,
        enable_doc_edit=False,
+       enable_search=True,
+       enable_diff=True,
+       enable_outline=True,
        read_allowlist=prepare_allowlist_dirs(["/safe/documents"]),
        write_allowlist=prepare_allowlist_dirs(["/safe/output"]),
        include_images=True,
@@ -739,7 +959,15 @@ Embedding all2md-mcp in your own MCP server:
    )
 
    # Create MCP server with custom config
-   mcp = create_server(config, read_document_as_markdown_impl, save_document_from_markdown_impl, edit_document_impl)
+   mcp = create_server(
+       config,
+       read_document_as_markdown_impl,
+       save_document_from_markdown_impl,
+       edit_document_impl,
+       search_documents_impl,
+       diff_documents_impl,
+       get_document_outline_impl,
+   )
 
    # Run server
    mcp.run()

--- a/mcpb/manifest.json
+++ b/mcpb/manifest.json
@@ -4,7 +4,7 @@
   "display_name": "all2md",
   "version": "1.4.0",
   "description": "Convert PDFs, Office files, HTML, email, and 40+ formats to Markdown and back, directly inside Claude.",
-  "long_description": "all2md's built-in MCP server, packaged for one-click install. Lets AI assistants read and convert documents across 40+ formats via an AST-based conversion pipeline, render Markdown back out to PDF/DOCX/PPTX/EPUB/HTML/RST, and edit documents section-by-section. Includes smart source auto-detection (file path, data URI, base64, plain text), section extraction, and security controls (a user-chosen workspace folder, network off by default, and path validation).",
+  "long_description": "all2md's built-in MCP server, packaged for one-click install. Lets AI assistants read and convert documents across 40+ formats via an AST-based conversion pipeline, render Markdown back out to PDF/DOCX/PPTX/EPUB/HTML/RST, and edit documents section-by-section. Read-only query tools let assistants search across a corpus (grep + keyword/BM25), diff two documents, and outline a document's headings. Includes smart source auto-detection (file path, data URI, base64, plain text), section extraction, and security controls (a user-chosen workspace folder, network off by default, and path validation).",
   "author": {
     "name": "Tom Villani, Ph.D.",
     "url": "https://github.com/thomas-villani"

--- a/src/all2md/mcp/config.py
+++ b/src/all2md/mcp/config.py
@@ -42,6 +42,17 @@ class MCPConfig(CloneFrozenMixin):
         Whether to enable save_document_from_markdown tool (default: False for security)
     enable_doc_edit : bool
         Whether to enable edit_document tool (default: False for security)
+    enable_search : bool
+        Whether to enable search_documents tool (default: True; read-only)
+    enable_diff : bool
+        Whether to enable diff_documents tool (default: True; read-only)
+    enable_outline : bool
+        Whether to enable get_document_outline tool (default: True; read-only)
+    search_index_dir : str | Path | None
+        Optional directory for persisting/loading the search keyword index.
+        None (default) rebuilds a fresh in-memory index on every call. When set,
+        the keyword index is saved there and reused on subsequent calls. The
+        directory is validated against the write allowlist at startup.
     read_allowlist : list[str | Path] | None
         List of allowed read directory paths. Initially strings from env/CLI,
         then converted to resolved Path objects by prepare_allowlist_dirs.
@@ -70,6 +81,10 @@ class MCPConfig(CloneFrozenMixin):
     enable_to_md: bool = True
     enable_from_md: bool = False  # Disabled by default for security (writing)
     enable_doc_edit: bool = False  # Disabled by default for security (document manipulation)
+    enable_search: bool = True  # Read-only: search a document corpus (grep + keyword)
+    enable_diff: bool = True  # Read-only: compare two documents
+    enable_outline: bool = True  # Read-only: list a document's heading structure
+    search_index_dir: str | Path | None = None  # None = rebuild per call; set = persist keyword index
     read_allowlist: list[str | Path] | None = None  # Will be set to CWD if None, then to Path objects
     write_allowlist: list[str | Path] | None = None  # Will be set to CWD if None, then to Path objects
     include_images: bool = False  # Enable for vision-enabled LLMs
@@ -89,11 +104,20 @@ class MCPConfig(CloneFrozenMixin):
         # Validate flavor
         allowed_flavors = ("gfm", "commonmark", "multimarkdown", "pandoc", "kramdown", "markdown_plus")
         if self.flavor not in allowed_flavors:
-            raise ValueError(f"Invalid flavor: {self.flavor}. " f"Must be one of: {', '.join(allowed_flavors)}")
+            raise ValueError(f"Invalid flavor: {self.flavor}. Must be one of: {', '.join(allowed_flavors)}")
 
         # At least one tool must be enabled
-        if not self.enable_to_md and not self.enable_from_md and not self.enable_doc_edit:
-            raise ValueError("At least one tool must be enabled (to_md, from_md, or doc_edit)")
+        if not any(
+            (
+                self.enable_to_md,
+                self.enable_from_md,
+                self.enable_doc_edit,
+                self.enable_search,
+                self.enable_diff,
+                self.enable_outline,
+            )
+        ):
+            raise ValueError("At least one tool must be enabled (to_md, from_md, doc_edit, search, diff, or outline)")
 
 
 def _parse_semicolon_list(value: str | None) -> list[str] | None:
@@ -169,7 +193,7 @@ def _validate_log_level(value: str | None, default: str = "INFO") -> str:
     valid_levels = ("DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL")
 
     if normalized not in valid_levels:
-        raise ValueError(f"Invalid log level: {value!r}. " f"Must be one of: {', '.join(valid_levels)}")
+        raise ValueError(f"Invalid log level: {value!r}. Must be one of: {', '.join(valid_levels)}")
 
     return normalized
 
@@ -205,7 +229,7 @@ def _validate_flavor(value: str | None, default: str = "gfm") -> str:
     valid_flavors = ("gfm", "commonmark", "multimarkdown", "pandoc", "kramdown", "markdown_plus")
 
     if normalized not in valid_flavors:
-        raise ValueError(f"Invalid markdown flavor: {value!r}. " f"Must be one of: {', '.join(valid_flavors)}")
+        raise ValueError(f"Invalid markdown flavor: {value!r}. Must be one of: {', '.join(valid_flavors)}")
 
     return normalized
 
@@ -230,10 +254,17 @@ def load_config_from_env() -> MCPConfig:
     if write_allowlist_strs is None:
         write_allowlist_strs = [cwd]
 
+    # Optional persistent search index directory (None = rebuild per call)
+    search_index_dir = os.getenv("ALL2MD_MCP_SEARCH_INDEX_DIR") or None
+
     return MCPConfig(
         enable_to_md=_str_to_bool(os.getenv("ALL2MD_MCP_ENABLE_TO_MD"), default=True),
         enable_from_md=_str_to_bool(os.getenv("ALL2MD_MCP_ENABLE_FROM_MD"), default=False),  # Disabled by default
         enable_doc_edit=_str_to_bool(os.getenv("ALL2MD_MCP_ENABLE_DOC_EDIT"), default=False),  # Disabled by default
+        enable_search=_str_to_bool(os.getenv("ALL2MD_MCP_ENABLE_SEARCH"), default=True),  # Read-only
+        enable_diff=_str_to_bool(os.getenv("ALL2MD_MCP_ENABLE_DIFF"), default=True),  # Read-only
+        enable_outline=_str_to_bool(os.getenv("ALL2MD_MCP_ENABLE_OUTLINE"), default=True),  # Read-only
+        search_index_dir=search_index_dir,
         # Will be validated and converted to Path objects by prepare_allowlist_dirs
         read_allowlist=cast(list[str | Path], read_allowlist_strs),
         # Will be validated and converted to Path objects by prepare_allowlist_dirs
@@ -263,6 +294,10 @@ Environment Variables:
   ALL2MD_MCP_ENABLE_TO_MD          Enable read_document_as_markdown tool (default: true)
   ALL2MD_MCP_ENABLE_FROM_MD        Enable save_document_from_markdown tool (default: false)
   ALL2MD_MCP_ENABLE_DOC_EDIT       Enable edit_document tool (default: false)
+  ALL2MD_MCP_ENABLE_SEARCH         Enable search_documents tool (default: true)
+  ALL2MD_MCP_ENABLE_DIFF           Enable diff_documents tool (default: true)
+  ALL2MD_MCP_ENABLE_OUTLINE        Enable get_document_outline tool (default: true)
+  ALL2MD_MCP_SEARCH_INDEX_DIR      Directory to persist the search keyword index (default: none)
   ALL2MD_MCP_ALLOWED_READ_DIRS     Semicolon-separated read allowlist paths
   ALL2MD_MCP_ALLOWED_WRITE_DIRS    Semicolon-separated write allowlist paths
   ALL2MD_MCP_INCLUDE_IMAGES        Include images in output for vLLM visibility (default: false)
@@ -291,7 +326,7 @@ Examples:
 
     # Version flag
     try:
-        version_string = f'all2md-mcp {version("all2md")}'
+        version_string = f"all2md-mcp {version('all2md')}"
     except Exception:
         version_string = "all2md-mcp (version unknown)"
 
@@ -340,6 +375,49 @@ Examples:
         "--no-doc-edit", action="store_false", dest="enable_doc_edit", help="Disable edit_document tool"
     )
     parser.set_defaults(enable_doc_edit=None)  # None = use env default
+
+    search_group = parser.add_mutually_exclusive_group()
+    search_group.add_argument(
+        "--enable-search",
+        action="store_true",
+        dest="enable_search",
+        help="Enable search_documents tool (default: true; read-only)",
+    )
+    search_group.add_argument(
+        "--no-search", action="store_false", dest="enable_search", help="Disable search_documents tool"
+    )
+    parser.set_defaults(enable_search=None)  # None = use env default
+
+    diff_group = parser.add_mutually_exclusive_group()
+    diff_group.add_argument(
+        "--enable-diff",
+        action="store_true",
+        dest="enable_diff",
+        help="Enable diff_documents tool (default: true; read-only)",
+    )
+    diff_group.add_argument("--no-diff", action="store_false", dest="enable_diff", help="Disable diff_documents tool")
+    parser.set_defaults(enable_diff=None)  # None = use env default
+
+    outline_group = parser.add_mutually_exclusive_group()
+    outline_group.add_argument(
+        "--enable-outline",
+        action="store_true",
+        dest="enable_outline",
+        help="Enable get_document_outline tool (default: true; read-only)",
+    )
+    outline_group.add_argument(
+        "--no-outline", action="store_false", dest="enable_outline", help="Disable get_document_outline tool"
+    )
+    parser.set_defaults(enable_outline=None)  # None = use env default
+
+    # Persistent search index directory (opt-in; None = rebuild per call)
+    parser.add_argument(
+        "--search-index-dir",
+        type=str,
+        metavar="PATH",
+        help="Directory to persist/load the search keyword index (must be within write allowlist). "
+        "Omit to rebuild a fresh index on every call.",
+    )
 
     # Path allowlists
     parser.add_argument(
@@ -432,6 +510,18 @@ def load_config_from_args(args: argparse.Namespace) -> MCPConfig:
 
     if args.enable_doc_edit is not None:
         updated_kwargs.update(enable_doc_edit=args.enable_doc_edit)
+
+    if args.enable_search is not None:
+        updated_kwargs.update(enable_search=args.enable_search)
+
+    if args.enable_diff is not None:
+        updated_kwargs.update(enable_diff=args.enable_diff)
+
+    if args.enable_outline is not None:
+        updated_kwargs.update(enable_outline=args.enable_outline)
+
+    if getattr(args, "search_index_dir", None) is not None:
+        updated_kwargs.update(search_index_dir=args.search_index_dir)
 
     if args.read_dirs is not None:
         updated_kwargs.update(read_allowlist=_parse_semicolon_list(args.read_dirs))

--- a/src/all2md/mcp/query_tools.py
+++ b/src/all2md/mcp/query_tools.py
@@ -1,0 +1,328 @@
+"""Read-only query tool implementations for the MCP server.
+
+This module implements the search, diff, and outline tools. They are read-only
+companions to the conversion tools in :mod:`all2md.mcp.tools` and reuse the
+existing search, diff, and section subsystems rather than reimplementing them.
+
+Functions
+---------
+- search_documents_impl: Implementation of search_documents tool
+- diff_documents_impl: Implementation of diff_documents tool
+- get_document_outline_impl: Implementation of get_document_outline tool
+
+"""
+
+#  Copyright (c) 2025 Tom Villani, Ph.D.
+
+import logging
+from pathlib import Path
+from typing import cast
+
+from all2md.api import to_ast
+from all2md.ast.nodes import Document
+from all2md.ast.sections import get_all_sections
+from all2md.cli.commands.shared import collect_input_files
+from all2md.constants import DocumentFormat
+from all2md.diff.renderers import JsonDiffRenderer
+from all2md.diff.text_diff import compare_documents
+from all2md.exceptions import All2MdError, DependencyError
+from all2md.mcp.config import MCPConfig
+from all2md.mcp.schemas import (
+    DiffDocumentsInput,
+    DiffDocumentsOutput,
+    GetDocumentOutlineInput,
+    GetDocumentOutlineOutput,
+    SearchDocumentsInput,
+    SearchDocumentsOutput,
+    SearchResultItem,
+)
+from all2md.mcp.security import MCPSecurityError, validate_read_path
+from all2md.mcp.tools import _detect_source_type
+from all2md.options.search import SearchOptions
+from all2md.search.service import SearchDocumentInput, SearchService
+from all2md.search.types import SearchMode as ServiceSearchMode
+
+logger = logging.getLogger(__name__)
+
+# Map the (restricted) MCP mode strings to the internal search enum.
+_MODE_MAP: dict[str, ServiceSearchMode] = {
+    "keyword": ServiceSearchMode.KEYWORD,
+    "grep": ServiceSearchMode.GREP,
+}
+
+
+def _validate_index_dir(index_dir: str | Path, write_allowlist: list[str | Path] | None) -> Path:
+    """Validate that a search index directory is within the write allowlist.
+
+    Unlike :func:`validate_write_path`, the directory need not exist yet (it is
+    created on first save), so existence is not required — only containment
+    within an allowed write directory.
+
+    Parameters
+    ----------
+    index_dir : str | Path
+        Requested index directory.
+    write_allowlist : list[str | Path] | None
+        Allowed write directories (resolved Paths), or None to allow all.
+
+    Returns
+    -------
+    Path
+        The validated (absolute) index directory.
+
+    Raises
+    ------
+    MCPSecurityError
+        If the directory escapes the allowlist or uses parent traversal.
+
+    """
+    target = Path(index_dir)
+    if ".." in target.parts:
+        raise MCPSecurityError(f"Index directory contains parent references (..): {index_dir}", path=str(index_dir))
+
+    # Resolve as much of the path as exists; fall back to absolute for new dirs.
+    try:
+        resolved = target.resolve()
+    except (OSError, RuntimeError):
+        resolved = target.absolute()
+
+    if write_allowlist is None:
+        return resolved
+
+    for allowed_item in write_allowlist:
+        try:
+            allowed = Path(allowed_item).resolve() if isinstance(allowed_item, str) else allowed_item
+            resolved.relative_to(allowed)
+            return resolved
+        except ValueError:
+            continue
+        except (OSError, RuntimeError):
+            logger.warning(f"Invalid write allowlist directory: {allowed_item}")
+            continue
+
+    raise MCPSecurityError(f"Index directory not in write allowlist: {index_dir}", path=str(index_dir))
+
+
+def _collect_search_documents(input_data: SearchDocumentsInput, config: MCPConfig) -> list[SearchDocumentInput]:
+    """Resolve input paths to a validated list of documents to search."""
+    paths = input_data.paths
+    if not paths:
+        if config.read_allowlist:
+            paths = [str(p) for p in config.read_allowlist]
+        else:
+            raise ValueError("No search paths provided and no read allowlist is configured.")
+
+    items = collect_input_files(paths, recursive=input_data.recursive)
+
+    documents: list[SearchDocumentInput] = []
+    for item in items:
+        best = item.best_path()
+        if best is None:
+            # search operates on local files only (no stdin/remote in this slice)
+            continue
+        validated = validate_read_path(best, config.read_allowlist)
+        documents.append(SearchDocumentInput(source=validated))
+
+    if not documents:
+        raise ValueError("No readable documents found for the given paths.")
+    return documents
+
+
+def search_documents_impl(input_data: SearchDocumentsInput, config: MCPConfig) -> SearchDocumentsOutput:
+    """Implement the search_documents tool (grep + keyword modes).
+
+    Parameters
+    ----------
+    input_data : SearchDocumentsInput
+        Tool input parameters.
+    config : MCPConfig
+        Server configuration (allowlists, optional persistent index dir).
+
+    Returns
+    -------
+    SearchDocumentsOutput
+        Ranked search results.
+
+    Raises
+    ------
+    MCPSecurityError
+        If a path fails allowlist validation.
+    All2MdError
+        If the search backend is unavailable or fails.
+
+    """
+    mode = input_data.mode
+    if mode not in _MODE_MAP:
+        raise ValueError(f"Unsupported search mode: {mode!r}. Supported modes: keyword, grep.")
+    service_mode = _MODE_MAP[mode]
+
+    documents = _collect_search_documents(input_data, config)
+
+    options = SearchOptions(
+        default_mode=mode,
+        grep_regex=input_data.regex,
+        grep_ignore_case=input_data.ignore_case,
+    )
+
+    # Keyword mode can reuse a persisted index; grep needs the in-memory parsed
+    # documents (AST), so it always builds fresh and is never persisted.
+    persist_dir: Path | None = None
+    if config.search_index_dir and service_mode is ServiceSearchMode.KEYWORD:
+        persist_dir = _validate_index_dir(config.search_index_dir, config.write_allowlist)
+
+    try:
+        if persist_dir is not None and (persist_dir / "keyword").exists():
+            logger.info(f"Loading persisted keyword index from: {persist_dir}")
+            service = SearchService.load(persist_dir, options=options)
+        else:
+            service = SearchService(options=options)
+            service.build_indexes(documents, modes={service_mode})
+            if persist_dir is not None:
+                logger.info(f"Persisting keyword index to: {persist_dir}")
+                service.save(persist_dir)
+
+        results = service.search(input_data.query, mode=service_mode, top_k=input_data.top_k)
+    except DependencyError as e:
+        # Surface the optional-dependency requirement (e.g. rank-bm25) cleanly.
+        raise All2MdError(
+            f"Search mode '{mode}' is unavailable: {e}. Install with: pip install 'all2md[search]'."
+        ) from e
+    except All2MdError:
+        raise
+    except Exception as e:
+        logger.error(f"Search failed: {e}")
+        raise All2MdError(f"Search failed: {e}") from e
+
+    # Rank by score and trim (grep returns section matches in document order).
+    results = sorted(results, key=lambda r: r.score, reverse=True)[: input_data.top_k]
+
+    items = [
+        SearchResultItem(
+            snippet=r.chunk.text,
+            score=r.score,
+            document_path=_as_str(r.chunk.metadata.get("document_path")),
+            section_heading=_as_str(r.chunk.metadata.get("section_heading")),
+            chunk_id=r.chunk.chunk_id,
+        )
+        for r in results
+    ]
+
+    logger.info(f"Search ({mode}) returned {len(items)} results")
+    return SearchDocumentsOutput(results=items, mode=mode, total=len(items))
+
+
+def diff_documents_impl(input_data: DiffDocumentsInput, config: MCPConfig) -> DiffDocumentsOutput:
+    """Implement the diff_documents tool (unified + json output).
+
+    Parameters
+    ----------
+    input_data : DiffDocumentsInput
+        Tool input parameters.
+    config : MCPConfig
+        Server configuration (allowlists).
+
+    Returns
+    -------
+    DiffDocumentsOutput
+        Rendered diff and a change flag.
+
+    Raises
+    ------
+    MCPSecurityError
+        If a path source fails allowlist validation.
+    All2MdError
+        If conversion or diffing fails.
+
+    """
+    try:
+        old_source, old_kind = _detect_source_type(input_data.old, config)
+        new_source, new_kind = _detect_source_type(input_data.new, config)
+
+        old_label = input_data.old if old_kind == "path" else "old"
+        new_label = input_data.new if new_kind == "path" else "new"
+
+        old_doc = to_ast(old_source)
+        new_doc = to_ast(new_source)
+        if not isinstance(old_doc, Document) or not isinstance(new_doc, Document):
+            raise TypeError("Expected Document from to_ast for diff inputs")
+
+        diff_result = compare_documents(
+            old_doc,
+            new_doc,
+            old_label=old_label,
+            new_label=new_label,
+            context_lines=input_data.context_lines,
+            ignore_whitespace=input_data.ignore_whitespace,
+            granularity=input_data.granularity,
+        )
+
+        has_changes = any(op.tag != "equal" for op in diff_result.iter_operations())
+
+        if input_data.format == "json":
+            rendered = JsonDiffRenderer().render(diff_result)
+        else:
+            rendered = "\n".join(diff_result.iter_unified_diff())
+
+        logger.info(f"Diff complete (changes={has_changes}, format={input_data.format})")
+        return DiffDocumentsOutput(diff=rendered, has_changes=has_changes)
+
+    except All2MdError:
+        raise
+    except Exception as e:
+        logger.error(f"Diff failed: {e}")
+        raise All2MdError(f"Diff failed: {e}") from e
+
+
+def get_document_outline_impl(input_data: GetDocumentOutlineInput, config: MCPConfig) -> GetDocumentOutlineOutput:
+    """Implement the get_document_outline tool.
+
+    Parameters
+    ----------
+    input_data : GetDocumentOutlineInput
+        Tool input parameters.
+    config : MCPConfig
+        Server configuration (allowlists).
+
+    Returns
+    -------
+    GetDocumentOutlineOutput
+        Ordered heading list (index/level/heading).
+
+    Raises
+    ------
+    MCPSecurityError
+        If a path source fails allowlist validation.
+    All2MdError
+        If conversion fails.
+
+    """
+    if not (1 <= input_data.max_level <= 6):
+        raise ValueError(f"max_level must be between 1 and 6, got {input_data.max_level}")
+
+    try:
+        source, _kind = _detect_source_type(input_data.doc, config)
+        doc = to_ast(source, source_format=cast(DocumentFormat, input_data.format_hint or "auto"))
+        if not isinstance(doc, Document):
+            raise TypeError(f"Expected Document from to_ast, got {type(doc)}")
+
+        sections = get_all_sections(doc, max_level=input_data.max_level)
+        outline = [
+            {"index": idx, "level": section.level, "heading": section.get_heading_text()}
+            for idx, section in enumerate(sections)
+        ]
+
+        logger.info(f"Outline extracted: {len(outline)} headings")
+        return GetDocumentOutlineOutput(sections=outline, total=len(outline))
+
+    except All2MdError:
+        raise
+    except Exception as e:
+        logger.error(f"Outline extraction failed: {e}")
+        raise All2MdError(f"Outline extraction failed: {e}") from e
+
+
+def _as_str(value: object) -> str | None:
+    """Coerce optional metadata values to str (or None)."""
+    if value is None:
+        return None
+    return str(value)

--- a/src/all2md/mcp/schemas.py
+++ b/src/all2md/mcp/schemas.py
@@ -11,6 +11,13 @@ Classes
 - SaveDocumentFromMarkdownOutput: Output schema for save_document_from_markdown tool
 - EditDocumentSimpleInput: Input schema for edit_document tool (simplified)
 - EditDocumentSimpleOutput: Output schema for edit_document tool (simplified)
+- SearchDocumentsInput: Input schema for search_documents tool
+- SearchResultItem: Single result entry for search_documents tool
+- SearchDocumentsOutput: Output schema for search_documents tool
+- DiffDocumentsInput: Input schema for diff_documents tool
+- DiffDocumentsOutput: Output schema for diff_documents tool
+- GetDocumentOutlineInput: Input schema for get_document_outline tool
+- GetDocumentOutlineOutput: Output schema for get_document_outline tool
 
 
 Notes
@@ -209,3 +216,195 @@ class EditDocumentSimpleOutput:
     success: bool
     message: str
     content: str | None = None
+
+
+# search_documents tool schemas
+SearchMode = Literal["keyword", "grep"]
+
+
+@dataclass
+class SearchDocumentsInput:
+    """Input schema for search_documents tool.
+
+    Searches a corpus of documents and returns ranked snippets rather than whole
+    files. Two modes are supported in this slice:
+
+    - "keyword": BM25 relevance ranking (requires the optional ``rank-bm25``
+      dependency). Best for "find the most relevant passages" queries.
+    - "grep": literal/regex line matching with highlighted spans. Best for
+      "find every occurrence of X" queries. Stateless, no extra dependencies.
+
+    Attributes
+    ----------
+    query : str
+        Search query. For grep mode this is a literal string unless ``regex`` is
+        set; for keyword mode it is a natural-language query (required).
+    paths : list[str] | None
+        Files, directories, or globs to search (each validated against the read
+        allowlist). When omitted, the server's read allowlist is searched.
+    mode : SearchMode
+        "keyword" (default, BM25) or "grep".
+    top_k : int
+        Maximum number of results to return (default: 10).
+    ignore_case : bool
+        Case-insensitive matching (grep mode only; default: False).
+    regex : bool
+        Treat the query as a regular expression (grep mode only; default: False).
+    recursive : bool
+        Recurse into directories when collecting input files (default: True).
+
+    """
+
+    query: str
+    paths: list[str] | None = None
+    mode: SearchMode = "keyword"
+    top_k: int = 10
+    ignore_case: bool = False
+    regex: bool = False
+    recursive: bool = True
+
+
+@dataclass
+class SearchResultItem:
+    """A single search result.
+
+    Attributes
+    ----------
+    snippet : str
+        Matched text with hit spans wrapped in ``<<`` / ``>>`` markers.
+    score : float
+        Relevance score (BM25 score for keyword mode; match count for grep mode).
+    document_path : str | None
+        Path of the document the match came from, when available.
+    section_heading : str | None
+        Heading of the section the match was found in, when available.
+    chunk_id : str
+        Identifier of the underlying chunk/section the match belongs to.
+
+    """
+
+    snippet: str
+    score: float
+    document_path: str | None
+    section_heading: str | None
+    chunk_id: str
+
+
+@dataclass
+class SearchDocumentsOutput:
+    """Output schema for search_documents tool.
+
+    Attributes
+    ----------
+    results : list[SearchResultItem]
+        Ranked search results.
+    mode : str
+        The resolved search mode used.
+    total : int
+        Number of results returned.
+
+    """
+
+    results: list[SearchResultItem] = field(default_factory=list)
+    mode: str = "keyword"
+    total: int = 0
+
+
+# diff_documents tool schemas
+DiffFormat = Literal["unified", "json"]
+DiffGranularity = Literal["block", "sentence", "word"]
+
+
+@dataclass
+class DiffDocumentsInput:
+    """Input schema for diff_documents tool.
+
+    Compares two documents and returns their differences. Each of ``old`` and
+    ``new`` is auto-detected (file path within the read allowlist, data URI,
+    base64, or plain text content), so documents in any supported format can be
+    compared — even across formats.
+
+    Attributes
+    ----------
+    old : str
+        Original document (path or inline content).
+    new : str
+        Updated document (path or inline content).
+    format : DiffFormat
+        Output format: "unified" (default, plain text) or "json" (structured).
+    context_lines : int
+        Number of context lines around changes in unified output (default: 3).
+    granularity : DiffGranularity
+        Comparison granularity: "block" (default), "sentence", or "word".
+    ignore_whitespace : bool
+        Normalize whitespace before comparing (default: False).
+
+    """
+
+    old: str
+    new: str
+    format: DiffFormat = "unified"
+    context_lines: int = 3
+    granularity: DiffGranularity = "block"
+    ignore_whitespace: bool = False
+
+
+@dataclass
+class DiffDocumentsOutput:
+    """Output schema for diff_documents tool.
+
+    Attributes
+    ----------
+    diff : str
+        Rendered diff in the requested format (unified text or JSON string).
+    has_changes : bool
+        Whether any differences were found.
+
+    """
+
+    diff: str
+    has_changes: bool
+
+
+# get_document_outline tool schemas
+@dataclass
+class GetDocumentOutlineInput:
+    """Input schema for get_document_outline tool.
+
+    Returns the heading structure of a document so an agent can navigate a large
+    file before extracting specific sections. ``doc`` is auto-detected (file path
+    within the read allowlist, data URI, base64, or plain text content).
+
+    Attributes
+    ----------
+    doc : str
+        Document to outline (path or inline content).
+    max_level : int
+        Deepest heading level to include, 1-6 (default: 6, i.e. all levels).
+    format_hint : SourceFormat | None
+        Optional format hint for ambiguous/extensionless sources.
+
+    """
+
+    doc: str
+    max_level: int = 6
+    format_hint: SourceFormat | None = None
+
+
+@dataclass
+class GetDocumentOutlineOutput:
+    """Output schema for get_document_outline tool.
+
+    Attributes
+    ----------
+    sections : list[dict]
+        Ordered list of headings, each ``{"index": int, "level": int,
+        "heading": str}`` where ``index`` is the zero-based section index usable
+        with edit_document's ``#N`` target notation.
+    total : int
+        Number of headings returned.
+
+    """
+
+    sections: list[dict] = field(default_factory=list)
+    total: int = 0

--- a/src/all2md/mcp/server.py
+++ b/src/all2md/mcp/server.py
@@ -26,12 +26,21 @@ if TYPE_CHECKING:
 
 from all2md.mcp.config import MCPConfig, load_config
 from all2md.mcp.schemas import (
+    DiffDocumentsInput,
+    DiffDocumentsOutput,
+    DiffFormat,
+    DiffGranularity,
     EditDocumentAction,
     EditDocumentSimpleInput,
     EditDocumentSimpleOutput,
+    GetDocumentOutlineInput,
+    GetDocumentOutlineOutput,
     ReadDocumentAsMarkdownInput,
     SaveDocumentFromMarkdownInput,
     SaveDocumentFromMarkdownOutput,
+    SearchDocumentsInput,
+    SearchDocumentsOutput,
+    SearchMode,
     SourceFormat,
     TargetFormat,
 )
@@ -45,6 +54,9 @@ def create_server(
     read_impl: Callable[[ReadDocumentAsMarkdownInput, MCPConfig], list[Any]],
     save_impl: Callable[[SaveDocumentFromMarkdownInput, MCPConfig], SaveDocumentFromMarkdownOutput],
     edit_doc_impl: Callable[[EditDocumentSimpleInput, MCPConfig], EditDocumentSimpleOutput],
+    search_impl: Callable[[SearchDocumentsInput, MCPConfig], SearchDocumentsOutput],
+    diff_impl: Callable[[DiffDocumentsInput, MCPConfig], DiffDocumentsOutput],
+    outline_impl: Callable[[GetDocumentOutlineInput, MCPConfig], GetDocumentOutlineOutput],
 ) -> "FastMCP":
     """Create and configure FastMCP server with tools.
 
@@ -58,6 +70,12 @@ def create_server(
         Implementation function for save_document_from_markdown tool
     edit_doc_impl : callable
         Implementation function for edit_document tool
+    search_impl : callable
+        Implementation function for search_documents tool
+    diff_impl : callable
+        Implementation function for diff_documents tool
+    outline_impl : callable
+        Implementation function for get_document_outline tool
 
     Returns
     -------
@@ -233,6 +251,153 @@ def create_server(
 
         logger.info("Registered tool: edit_document")
 
+    # Conditionally register search_documents tool (read-only)
+    if config.enable_search:
+
+        @mcp.tool(name="search_documents")
+        def search_documents(
+            query: Annotated[
+                str,
+                "Search query. Natural language for keyword mode; a literal string (or regex) for grep mode. REQUIRED.",
+            ],
+            paths: Annotated[
+                list[str] | None,
+                "Files, directories, or globs to search (each must be within the read allowlist). "
+                "If omitted, the server's read allowlist is searched.",
+            ] = None,
+            mode: Annotated[
+                str,
+                "Search mode: 'keyword' (default, BM25 relevance ranking) or 'grep' (literal/regex line matching).",
+            ] = "keyword",
+            top_k: Annotated[int, "Maximum number of results to return (default: 10)."] = 10,
+            ignore_case: Annotated[bool, "Case-insensitive matching (grep mode only). Default: false."] = False,
+            regex: Annotated[bool, "Treat the query as a regular expression (grep mode only). Default: false."] = False,
+            recursive: Annotated[bool, "Recurse into directories when collecting input files. Default: true."] = True,
+        ) -> dict:
+            """Search a corpus of documents and return ranked snippets.
+
+            Instead of returning whole files, this tool returns the most relevant
+            passages (with hit spans wrapped in << >> markers), so an agent can
+            locate information across many documents cheaply.
+
+            Modes:
+            - keyword: BM25 relevance ranking (requires the optional rank-bm25
+              dependency). Best for "find the most relevant passages" queries.
+            - grep: literal/regex line matching. Best for "find every occurrence
+              of X". Stateless, no extra dependencies.
+
+            Supports all formats the read tool supports (PDF, DOCX, HTML, etc.);
+            files are converted to text before searching.
+
+            Returns a dictionary with:
+            - results: list of {snippet, score, document_path, section_heading, chunk_id}
+            - mode: the search mode used
+            - total: number of results returned
+            """
+            input_obj = SearchDocumentsInput(
+                query=query,
+                paths=paths,
+                mode=cast(SearchMode, mode),
+                top_k=top_k,
+                ignore_case=ignore_case,
+                regex=regex,
+                recursive=recursive,
+            )
+            result = search_impl(input_obj, config)
+            return {
+                "results": [
+                    {
+                        "snippet": item.snippet,
+                        "score": item.score,
+                        "document_path": item.document_path,
+                        "section_heading": item.section_heading,
+                        "chunk_id": item.chunk_id,
+                    }
+                    for item in result.results
+                ],
+                "mode": result.mode,
+                "total": result.total,
+            }
+
+        logger.info("Registered tool: search_documents")
+
+    # Conditionally register diff_documents tool (read-only)
+    if config.enable_diff:
+
+        @mcp.tool(name="diff_documents")
+        def diff_documents(
+            old: Annotated[
+                str,
+                "Original document: file path (within read allowlist), data URI, base64, or inline content. REQUIRED.",
+            ],
+            new: Annotated[
+                str,
+                "Updated document: file path (within read allowlist), data URI, base64, or inline content. REQUIRED.",
+            ],
+            format: Annotated[
+                str, "Output format: 'unified' (default, plain text) or 'json' (structured)."
+            ] = "unified",
+            context_lines: Annotated[int, "Context lines around changes in unified output (default: 3)."] = 3,
+            granularity: Annotated[str, "Comparison granularity: 'block' (default), 'sentence', or 'word'."] = "block",
+            ignore_whitespace: Annotated[bool, "Normalize whitespace before comparing. Default: false."] = False,
+        ) -> dict:
+            """Compare two documents and return their differences.
+
+            Each input is auto-detected (file path, data URI, base64, or inline
+            content), so documents in any supported format can be compared — even
+            across formats (e.g. a DOCX against its PDF export).
+
+            Returns a dictionary with:
+            - diff: the rendered diff (unified text or JSON string)
+            - has_changes: whether any differences were found
+            """
+            input_obj = DiffDocumentsInput(
+                old=old,
+                new=new,
+                format=cast(DiffFormat, format),
+                context_lines=context_lines,
+                granularity=cast(DiffGranularity, granularity),
+                ignore_whitespace=ignore_whitespace,
+            )
+            result = diff_impl(input_obj, config)
+            return {"diff": result.diff, "has_changes": result.has_changes}
+
+        logger.info("Registered tool: diff_documents")
+
+    # Conditionally register get_document_outline tool (read-only)
+    if config.enable_outline:
+
+        @mcp.tool(name="get_document_outline")
+        def get_document_outline(
+            doc: Annotated[
+                str,
+                "Document to outline: file path (within read allowlist), data URI, base64, "
+                "or inline content. REQUIRED.",
+            ],
+            max_level: Annotated[int, "Deepest heading level to include, 1-6 (default: 6 = all levels)."] = 6,
+            format_hint: Annotated[
+                str | None,
+                "Optional format hint for ambiguous/extensionless sources (e.g. 'pdf', 'docx', 'html').",
+            ] = None,
+        ) -> dict:
+            """Return the heading structure (table of contents) of a document.
+
+            Use this to navigate a large document before extracting specific
+            sections: the returned indices line up with edit_document's '#N'
+            target notation.
+
+            Returns a dictionary with:
+            - sections: list of {index, level, heading}
+            - total: number of headings returned
+            """
+            input_obj = GetDocumentOutlineInput(
+                doc=doc, max_level=max_level, format_hint=cast(SourceFormat | None, format_hint)
+            )
+            result = outline_impl(input_obj, config)
+            return {"sections": result.sections, "total": result.total}
+
+        logger.info("Registered tool: get_document_outline")
+
     return mcp
 
 
@@ -257,9 +422,13 @@ def main() -> int:
         logger.info("Starting all2md MCP server")
         logger.info(
             f"Configuration: enable_to_md={config.enable_to_md}, "
-            f"enable_from_md={config.enable_from_md}, enable_doc_edit={config.enable_doc_edit}"
+            f"enable_from_md={config.enable_from_md}, enable_doc_edit={config.enable_doc_edit}, "
+            f"enable_search={config.enable_search}, enable_diff={config.enable_diff}, "
+            f"enable_outline={config.enable_outline}"
         )
         logger.info(f"Include images: {config.include_images}")
+        if config.search_index_dir:
+            logger.info(f"Search index directory: {config.search_index_dir}")
 
         # Validate and prepare allowlists
         try:
@@ -292,11 +461,22 @@ def main() -> int:
 
         # Import tool implementations after setting env vars
         from all2md.mcp.document_tools import edit_document_impl
+        from all2md.mcp.query_tools import (
+            diff_documents_impl,
+            get_document_outline_impl,
+            search_documents_impl,
+        )
         from all2md.mcp.tools import read_document_as_markdown_impl, save_document_from_markdown_impl
 
         # Create and run server
         mcp = create_server(
-            config, read_document_as_markdown_impl, save_document_from_markdown_impl, edit_document_impl
+            config,
+            read_document_as_markdown_impl,
+            save_document_from_markdown_impl,
+            edit_document_impl,
+            search_documents_impl,
+            diff_documents_impl,
+            get_document_outline_impl,
         )
 
         logger.info("Server ready, listening on stdio")

--- a/tests/unit/test_mcp/test_mcp_config.py
+++ b/tests/unit/test_mcp/test_mcp_config.py
@@ -74,10 +74,22 @@ class TestMCPConfig:
         assert config.log_level == "INFO"
 
     def test_config_validate_no_tools_enabled(self):
-        """Test that at least one tool must be enabled."""
-        config = MCPConfig(enable_to_md=False, enable_from_md=False)
+        """Test that at least one tool must be enabled (all six disabled)."""
+        config = MCPConfig(
+            enable_to_md=False,
+            enable_from_md=False,
+            enable_doc_edit=False,
+            enable_search=False,
+            enable_diff=False,
+            enable_outline=False,
+        )
         with pytest.raises(ValueError, match="At least one tool must be enabled"):
             config.validate()
+
+    def test_config_validate_read_only_tools_sufficient(self):
+        """The read-only trio keeps a config valid even with the originals off."""
+        config = MCPConfig(enable_to_md=False, enable_from_md=False, enable_doc_edit=False)
+        config.validate()  # should not raise
 
 
 class TestLoadConfigFromEnv:

--- a/tests/unit/test_mcp/test_mcp_query_tools.py
+++ b/tests/unit/test_mcp/test_mcp_query_tools.py
@@ -1,0 +1,290 @@
+"""Unit tests for MCP query tool implementations (search, diff, outline)."""
+
+import importlib.util
+
+import pytest
+
+from all2md.mcp.config import MCPConfig
+from all2md.mcp.query_tools import (
+    diff_documents_impl,
+    get_document_outline_impl,
+    search_documents_impl,
+)
+from all2md.mcp.schemas import (
+    DiffDocumentsInput,
+    GetDocumentOutlineInput,
+    SearchDocumentsInput,
+)
+from all2md.mcp.security import MCPSecurityError, prepare_allowlist_dirs
+
+HAS_BM25 = importlib.util.find_spec("rank_bm25") is not None
+
+SAMPLE_MD = """# Introduction
+
+The alpha protocol governs the handshake.
+
+## Details
+
+Beta follows alpha in the sequence.
+
+### Edge Cases
+
+Gamma is rarely reached.
+
+# Conclusion
+
+The alpha protocol is complete.
+"""
+
+
+def _make_config(tmp_path, **overrides):
+    """Build an MCPConfig with read/write allowlists rooted at tmp_path."""
+    allow = prepare_allowlist_dirs([str(tmp_path)])
+    kwargs = {"read_allowlist": allow, "write_allowlist": allow}
+    kwargs.update(overrides)
+    return MCPConfig(**kwargs)
+
+
+def _write_corpus(tmp_path):
+    """Create a small markdown corpus and return the directory."""
+    (tmp_path / "doc1.md").write_text(SAMPLE_MD, encoding="utf-8")
+    (tmp_path / "doc2.md").write_text("# Other\n\nNothing relevant here, just delta.\n", encoding="utf-8")
+    return tmp_path
+
+
+# ---------------------------------------------------------------------------
+# get_document_outline
+# ---------------------------------------------------------------------------
+class TestOutline:
+    def test_outline_from_content(self):
+        config = MCPConfig()
+        result = get_document_outline_impl(GetDocumentOutlineInput(doc=SAMPLE_MD, format_hint="markdown"), config)
+        headings = [s["heading"] for s in result.sections]
+        assert headings == ["Introduction", "Details", "Edge Cases", "Conclusion"]
+        assert result.total == 4
+        # Indices are zero-based and contiguous
+        assert [s["index"] for s in result.sections] == [0, 1, 2, 3]
+        # Levels reflect heading depth
+        levels = {s["heading"]: s["level"] for s in result.sections}
+        assert levels["Introduction"] == 1
+        assert levels["Details"] == 2
+        assert levels["Edge Cases"] == 3
+
+    def test_outline_max_level_filters_deeper_headings(self):
+        config = MCPConfig()
+        result = get_document_outline_impl(
+            GetDocumentOutlineInput(doc=SAMPLE_MD, format_hint="markdown", max_level=2), config
+        )
+        headings = [s["heading"] for s in result.sections]
+        assert "Edge Cases" not in headings  # level 3 excluded
+        assert "Details" in headings
+
+    def test_outline_invalid_max_level(self):
+        config = MCPConfig()
+        with pytest.raises(ValueError):
+            get_document_outline_impl(
+                GetDocumentOutlineInput(doc=SAMPLE_MD, format_hint="markdown", max_level=9), config
+            )
+
+    def test_outline_from_file_path(self, tmp_path):
+        test_file = tmp_path / "outline.md"
+        test_file.write_text(SAMPLE_MD, encoding="utf-8")
+        config = _make_config(tmp_path)
+        result = get_document_outline_impl(GetDocumentOutlineInput(doc=str(test_file), format_hint="markdown"), config)
+        assert result.total == 4
+
+    def test_outline_path_outside_allowlist_denied(self, tmp_path):
+        # File exists but read allowlist points elsewhere
+        outside = tmp_path / "secret.md"
+        outside.write_text(SAMPLE_MD, encoding="utf-8")
+        allowed_dir = tmp_path / "allowed"
+        allowed_dir.mkdir()
+        config = MCPConfig(read_allowlist=prepare_allowlist_dirs([str(allowed_dir)]))
+        with pytest.raises(MCPSecurityError):
+            get_document_outline_impl(GetDocumentOutlineInput(doc=str(outside), format_hint="markdown"), config)
+
+
+# ---------------------------------------------------------------------------
+# diff_documents
+# ---------------------------------------------------------------------------
+class TestDiff:
+    def test_diff_unified_with_changes(self):
+        config = MCPConfig()
+        result = diff_documents_impl(DiffDocumentsInput(old="Hello world", new="Goodbye world"), config)
+        assert result.has_changes is True
+        assert "Hello" in result.diff
+        assert "Goodbye" in result.diff
+
+    def test_diff_no_changes(self):
+        config = MCPConfig()
+        result = diff_documents_impl(DiffDocumentsInput(old="Same content", new="Same content"), config)
+        assert result.has_changes is False
+
+    def test_diff_json_format(self):
+        config = MCPConfig()
+        result = diff_documents_impl(DiffDocumentsInput(old="Hello world", new="Goodbye world", format="json"), config)
+        assert result.has_changes is True
+        # JSON renderer returns a JSON document
+        import json
+
+        parsed = json.loads(result.diff)
+        assert isinstance(parsed, dict)
+
+    def test_diff_from_files(self, tmp_path):
+        old_file = tmp_path / "v1.md"
+        new_file = tmp_path / "v2.md"
+        old_file.write_text("# Title\n\nFirst version.\n", encoding="utf-8")
+        new_file.write_text("# Title\n\nSecond version.\n", encoding="utf-8")
+        config = _make_config(tmp_path)
+        result = diff_documents_impl(DiffDocumentsInput(old=str(old_file), new=str(new_file)), config)
+        assert result.has_changes is True
+
+
+# ---------------------------------------------------------------------------
+# search_documents
+# ---------------------------------------------------------------------------
+class TestSearch:
+    def test_grep_mode_finds_matches(self, tmp_path):
+        _write_corpus(tmp_path)
+        config = _make_config(tmp_path)
+        result = search_documents_impl(SearchDocumentsInput(query="alpha", mode="grep", paths=[str(tmp_path)]), config)
+        assert result.mode == "grep"
+        assert result.total >= 1
+        # Highlight markers present in snippets
+        assert any("<<" in item.snippet and ">>" in item.snippet for item in result.results)
+        # Document path metadata propagated
+        assert all(item.document_path for item in result.results)
+
+    def test_grep_ignore_case(self, tmp_path):
+        _write_corpus(tmp_path)
+        config = _make_config(tmp_path)
+        result = search_documents_impl(
+            SearchDocumentsInput(query="ALPHA", mode="grep", ignore_case=True, paths=[str(tmp_path)]),
+            config,
+        )
+        assert result.total >= 1
+
+    def test_grep_no_match_returns_empty(self, tmp_path):
+        _write_corpus(tmp_path)
+        config = _make_config(tmp_path)
+        result = search_documents_impl(
+            SearchDocumentsInput(query="nonexistentterm", mode="grep", paths=[str(tmp_path)]), config
+        )
+        assert result.total == 0
+        assert result.results == []
+
+    def test_unsupported_mode_rejected(self, tmp_path):
+        _write_corpus(tmp_path)
+        config = _make_config(tmp_path)
+        with pytest.raises(ValueError, match="Unsupported search mode"):
+            search_documents_impl(SearchDocumentsInput(query="alpha", mode="vector", paths=[str(tmp_path)]), config)
+
+    def test_search_path_outside_allowlist_denied(self, tmp_path):
+        _write_corpus(tmp_path)
+        outside = tmp_path / "doc1.md"
+        allowed_dir = tmp_path / "allowed"
+        allowed_dir.mkdir()
+        config = MCPConfig(read_allowlist=prepare_allowlist_dirs([str(allowed_dir)]))
+        with pytest.raises(MCPSecurityError):
+            search_documents_impl(SearchDocumentsInput(query="alpha", mode="grep", paths=[str(outside)]), config)
+
+    def test_no_documents_raises(self, tmp_path):
+        empty = tmp_path / "empty"
+        empty.mkdir()
+        config = _make_config(tmp_path)
+        with pytest.raises(ValueError, match="No readable documents"):
+            search_documents_impl(SearchDocumentsInput(query="alpha", mode="grep", paths=[str(empty)]), config)
+
+    @pytest.mark.skipif(not HAS_BM25, reason="rank-bm25 not installed")
+    def test_keyword_mode_ranks_results(self, tmp_path):
+        _write_corpus(tmp_path)
+        config = _make_config(tmp_path)
+        result = search_documents_impl(
+            SearchDocumentsInput(query="alpha protocol", mode="keyword", paths=[str(tmp_path)]), config
+        )
+        assert result.mode == "keyword"
+        assert result.total >= 1
+        # The alpha-heavy document should be among the results
+        assert any("alpha" in item.snippet.lower() for item in result.results)
+
+    @pytest.mark.skipif(not HAS_BM25, reason="rank-bm25 not installed")
+    def test_keyword_persistence_creates_and_reuses_index(self, tmp_path):
+        corpus = tmp_path / "corpus"
+        corpus.mkdir()
+        _write_corpus(corpus)
+        index_dir = tmp_path / "idx"
+        config = _make_config(tmp_path, search_index_dir=str(index_dir))
+
+        # First call builds and persists the index
+        first = search_documents_impl(
+            SearchDocumentsInput(query="alpha protocol", mode="keyword", paths=[str(corpus)]), config
+        )
+        assert first.total >= 1
+        assert (index_dir / "keyword").exists()
+        assert (index_dir / "chunks.jsonl").exists()
+
+        # Second call reuses the persisted index and still returns results
+        second = search_documents_impl(
+            SearchDocumentsInput(query="alpha protocol", mode="keyword", paths=[str(corpus)]), config
+        )
+        assert second.total >= 1
+
+    @pytest.mark.skipif(not HAS_BM25, reason="rank-bm25 not installed")
+    def test_index_dir_outside_write_allowlist_denied(self, tmp_path):
+        corpus = tmp_path / "corpus"
+        corpus.mkdir()
+        _write_corpus(corpus)
+        # Read allowlist covers corpus; write allowlist is a sibling that does NOT
+        # contain the requested index dir.
+        write_dir = tmp_path / "writable"
+        write_dir.mkdir()
+        config = MCPConfig(
+            read_allowlist=prepare_allowlist_dirs([str(corpus)]),
+            write_allowlist=prepare_allowlist_dirs([str(write_dir)]),
+            search_index_dir=str(tmp_path / "outside_idx"),
+        )
+        with pytest.raises(MCPSecurityError):
+            search_documents_impl(SearchDocumentsInput(query="alpha", mode="keyword", paths=[str(corpus)]), config)
+
+
+# ---------------------------------------------------------------------------
+# config flags
+# ---------------------------------------------------------------------------
+class TestConfigFlags:
+    def test_new_tools_enabled_by_default(self):
+        config = MCPConfig()
+        assert config.enable_search is True
+        assert config.enable_diff is True
+        assert config.enable_outline is True
+        assert config.search_index_dir is None
+
+    def test_validate_allows_only_read_only_tools(self):
+        # Disable the original three; the read-only trio should keep config valid
+        config = MCPConfig(enable_to_md=False, enable_from_md=False, enable_doc_edit=False)
+        config.validate()  # should not raise
+
+    def test_validate_requires_at_least_one_tool(self):
+        config = MCPConfig(
+            enable_to_md=False,
+            enable_from_md=False,
+            enable_doc_edit=False,
+            enable_search=False,
+            enable_diff=False,
+            enable_outline=False,
+        )
+        with pytest.raises(ValueError):
+            config.validate()
+
+    def test_env_vars_toggle_flags(self, monkeypatch):
+        from all2md.mcp.config import load_config_from_env
+
+        monkeypatch.setenv("ALL2MD_MCP_ENABLE_SEARCH", "false")
+        monkeypatch.setenv("ALL2MD_MCP_ENABLE_DIFF", "false")
+        monkeypatch.setenv("ALL2MD_MCP_ENABLE_OUTLINE", "false")
+        monkeypatch.setenv("ALL2MD_MCP_SEARCH_INDEX_DIR", "/tmp/all2md-index")
+
+        config = load_config_from_env()
+        assert config.enable_search is False
+        assert config.enable_diff is False
+        assert config.enable_outline is False
+        assert config.search_index_dir == "/tmp/all2md-index"


### PR DESCRIPTION
## Summary

Adds the first slice of read-only **query** tools to the all2md MCP server, so an agent can search/compare/navigate a document corpus rather than only convert single files. Each tool reuses an existing subsystem — no new conversion logic.

- **`search_documents`** — grep + keyword/BM25 search across a corpus, returning ranked snippets (matches wrapped in `<<` `>>`). Reuses `SearchService`.
- **`diff_documents`** — compare two documents (any format, auto-detected — even cross-format) with `unified` or `json` output. Reuses `compare_documents` + renderers.
- **`get_document_outline`** — list a document's heading structure for navigation; indices align with `edit_document`'s `#N` notation. Reuses `get_all_sections`.

All three are **read-only and enabled by default**, each with its own `--no-<tool>` / `ALL2MD_MCP_ENABLE_<TOOL>` off-switch. Path inputs are enforced against the read allowlist via the existing detection/validation helpers.

## Design decisions

- **Search index:** defaults to a fresh in-memory index per call. Opt into a persistent keyword index with `--search-index-dir` / `ALL2MD_MCP_SEARCH_INDEX_DIR`, validated against the **write** allowlist. Grep stays stateless.
- **Modes:** `grep` + `keyword` only this slice. `vector`/`hybrid` rejected with a clear error; missing `rank-bm25` surfaces an `all2md[search]` install hint.
- **Diff output:** `unified` + `json` (no HTML — not useful to a headless agent).

## Known follow-up

Persistent keyword indexes are keyed only by directory, so reusing one across a changed corpus or a different `paths` set can return stale results. Noted for a later slice that unifies persistent indices with a content-hash/mtime conversion cache.

## Tests / verification

- New `tests/unit/test_mcp/test_mcp_query_tools.py`: grep/keyword, mode rejection, read-allowlist enforcement, index persistence + write-allowlist denial, diff (unified/json/no-change), outline (levels/indices/max_level), config flags + env toggles. Updated one existing config test for the new defaults.
- `ruff check` + `ruff format`: clean. `mypy src/`: clean for new code. `pytest tests/unit/test_mcp tests/integration/mcp`: all pass (2 platform skips).

## Docs

Updated `docs/source/mcp.rst`, `docs/source/environment_variables.rst`, `README.md`, and the MCPB `manifest.json` description.

🤖 Generated with [Claude Code](https://claude.com/claude-code)