### PR TITLE
docs: prepare v1.5.0 release notes and fill doc gaps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,36 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [1.5.0] - 2026-06-15
 
 ### Added
 
+- **MCP query tools.** The MCP server gained three read-only tools so an agent
+  can query a document corpus, not just convert single files: `search_documents`
+  (grep plus keyword/BM25 search across a corpus, returning ranked snippets),
+  `diff_documents` (compare two documents of any format with unified or JSON
+  output), and `get_document_outline` (list a document's heading structure, with
+  indices aligned to `edit_document`'s `#N` notation). All three are enabled by
+  default and read-only; each has its own `--no-<tool>` flag and
+  `ALL2MD_MCP_ENABLE_<TOOL>` environment switch, and path inputs are enforced
+  against the read allowlist. `search_documents` rebuilds a fresh in-memory index
+  per call by default; opt into a persistent keyword index with
+  `--search-index-dir` / `ALL2MD_MCP_SEARCH_INDEX_DIR` (validated against the
+  write allowlist). Vector/hybrid search modes are rejected with a clear error.
+- **Interactive `all2md batch` wizard.** A guided workflow that walks through file
+  selection (with a file-type preview), output layout, attachment handling,
+  per-format options, and advanced parameters, then prints the equivalent
+  command and offers to run it. Uses Rich when available, with a plain-input
+  fallback.
+- **Near-source batch attachments.** With `--preserve-structure` and
+  `--attachment-mode save` (and no explicit `--attachment-output-dir` /
+  `--attachment-base-url`), saved attachments are now co-located in a shared
+  `.attachments` folder beside each output file and linked with relative paths.
+  Explicit overrides and the legacy single-folder behavior are preserved.
+- **Batch help and docs.** The multi-file flags are now grouped under a "Batch
+  options" group so `all2md help batch` works, `all2md help attachments` resolves
+  to the global attachment topic, and a new `batch` page documents the
+  batch-conversion CLI.
 - **Material for MkDocs markdown syntax.** The markdown parser now understands
   several niche flavor constructs common on MkDocs sites: admonitions
   (`!!! note "Title"`) and their collapsible `???` / `???+` variants, and the

--- a/README.md
+++ b/README.md
@@ -136,7 +136,8 @@ While tools like Pandoc excel at document conversion, all2md is designed specifi
 -   **Bidirectional Conversion**: Not just to Markdown! Convert from Markdown to formats like DOCX, PDF, and HTML.
 -   **Document Comparison**: Built-in `diff` command that works like Unix `diff` but for any document format. Compare PDFs, Word docs, or mixed formats with text-based, symmetric comparison.
 -   **Custom Template Rendering**: Use Jinja2 templates to create any text-based output format (DocBook XML, YAML, ANSI terminal, custom markup) without writing Python code.
--   **MCP Server**: Built-in Model Context Protocol (MCP) server for direct AI assistant integration. Enable Claude, ChatGPT, and other AI models to read and convert documents directly.
+-   **MCP Server**: Built-in Model Context Protocol (MCP) server for direct AI assistant integration. Enable Claude, ChatGPT, and other AI models to read and convert documents directly, plus query tools to search a corpus, diff two documents, and outline a document's headings.
+-   **In-Browser Preview & Editor**: `all2md view` renders any document in your browser and `all2md edit` gives you a live Markdown editor — both with a dark-mode toggle and an optional standalone-window mode (`--window`, `pip install all2md[window]`).
 -   **Agent Skills**: Pre-built skill files that teach AI coding assistants (Claude Code, Cursor, Windsurf) how to use all2md. Install with `all2md install-skills`.
 -   **AST-Based Pipeline**: At its core, `all2md` uses an Abstract Syntax Tree (AST) to represent documents, enabling powerful and consistent manipulation across all formats.
 -   **Advanced PDF Parsing**: Intelligent table detection, multi-column layout analysis, optional GNN-based semantic layout classification (`pdf_layout` extra), header/footer removal, OCR support for scanned documents, and robust text extraction powered by PyMuPDF.

--- a/docs/source/ast_guide.rst
+++ b/docs/source/ast_guide.rst
@@ -149,6 +149,7 @@ Inline nodes represent inline formatting:
        LineBreak,     # Line breaks
        Strikethrough, # Strikethrough text
        Underline,     # Underlined text
+       Mark,          # Highlighted/marked text (==text==)
        Superscript,   # Superscript
        Subscript,     # Subscript
        HTMLInline,    # Inline HTML

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -410,6 +410,22 @@ Jupyter Notebook support is built into the base installation - no additional dep
 
 **Formats:** Jupyter Notebook .ipynb files with code, output, and markdown cells
 
+Standalone Window (view/edit)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The ``--window`` flag for ``all2md view`` and ``all2md edit`` opens the
+preview/editor in a native OS window with no browser chrome. It needs the
+``window`` extra:
+
+.. code-block:: bash
+
+   pip install all2md[window]
+
+**Dependencies:** pywebview (pulls in platform-specific webview backends)
+
+This extra is GUI-only and is intentionally **not** part of the ``all`` extra.
+Without it, ``--window`` prints a hint and falls back to a normal browser tab.
+
 Combined Installations
 ----------------------
 


### PR DESCRIPTION
Prep for the **v1.5.0** release. Audited the docs and closed the gaps found.

## Changelog
The release-blocking gap: PRs #26 (MCP query tools) and #29 (batch UX) never updated the changelog, so `[Unreleased]` was missing both features. This PR:
- Adds entries for the MCP query tools (`search_documents`, `diff_documents`, `get_document_outline`) and the batch-conversion UX (interactive `all2md batch` wizard, near-source `.attachments`, batch help/docs).
- Promotes `[Unreleased]` → `[1.5.0] - 2026-06-15`.

## Doc gaps
- **installation.rst** — document the `window` extra (`pip install all2md[window]`, pywebview) for `--window` standalone-window mode; noted it's intentionally excluded from `all`.
- **README** — feature list now mentions the MCP query tools and the in-browser view/edit tools (dark mode, standalone window).
- **ast_guide.rst** — list the new `Mark` inline node.

## Not changed (verified fine)
- `mcpb/manifest.json` version → bumped automatically by the bumpversion config.
- `mcp.rst` / `batch.rst` / `environment_variables.rst` → already updated by their PRs.
- `options.rst` → auto-generated at Sphinx build; not hand-edited.

## Release step (held)
The version bump (1.4.0 → 1.5.0) and `v1.5.0` tag are **not** in this PR. Merge this, then run bumpversion on `main`; pushing the tag triggers the PyPI publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)