### PR TITLE
fix(mcpb): ship rank-bm25 so search_documents works out of the box

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   its AST handling existed, but the underlying mistune plugin was never enabled,
   so `Term` / `: definition` syntax was silently dropped. It is now wired up
   (and the handler updated for the current mistune `def_list_item` token).
+- **MCPB bundle now ships `rank-bm25`.** The `search_documents` MCP tool defaults
+  to keyword (BM25) mode, but the Claude Desktop bundle didn't install
+  `rank-bm25`, so corpus search failed out of the box with an install hint. The
+  bundle now depends on `rank-bm25` directly (not the full `search` extra, whose
+  `faiss-cpu` / `sentence-transformers` back the vector/hybrid modes that the MCP
+  server rejects).
 
 ## [1.4.0] - 2026-06-11
 

--- a/mcpb/README.md
+++ b/mcpb/README.md
@@ -39,6 +39,11 @@ broken. `pdf_layout` is deliberately excluded (Polyform Noncommercial license,
 as it is from `all2md[all]`). To bundle every format instead, replace the
 extras list with `all2md[all]` and re-pack.
 
+It also depends on `rank-bm25` directly so the `search_documents` tool's default
+keyword (BM25) mode works out of the box. The full `search` extra is *not* used:
+it additionally pulls `faiss-cpu` and `sentence-transformers` for vector/hybrid
+search, which the MCP server rejects, so they would only bloat the bundle.
+
 ## Rebuilding
 
 ```bash

--- a/mcpb/pyproject.toml
+++ b/mcpb/pyproject.toml
@@ -11,4 +11,9 @@ version = "1.4.0"
 requires-python = ">=3.10"
 dependencies = [
     "all2md[mcp,pdf,pdf_render,docx,html,xlsx,pptx,epub,rst,markdown,odf]>=1.4.0",
+    # The search_documents MCP tool defaults to keyword (BM25) mode, which needs
+    # rank-bm25. Depend on it directly rather than via the `search` extra: that
+    # extra also pulls faiss-cpu and sentence-transformers for vector/hybrid
+    # search, which the MCP server rejects, so they would only bloat the bundle.
+    "rank-bm25>=0.2.2",
 ]


### PR DESCRIPTION
## Problem
The `search_documents` MCP tool (added in #26) defaults to **keyword (BM25)** mode, which requires `rank-bm25`. The Claude Desktop bundle installs `all2md[mcp,pdf,pdf_render,docx,html,xlsx,pptx,epub,rst,markdown,odf]` — **no `search` extra** — so `rank-bm25` was never installed. A user calling `search_documents` out of the box hits:

> Search mode 'keyword' is unavailable: … Install with: pip install 'all2md[search]'.

…even though the bundle manifest advertises "search across a corpus (grep + keyword/BM25)".

## Fix
Depend on `rank-bm25` **directly** in `mcpb/pyproject.toml`, not via the full `search` extra. The `search` extra also pulls `faiss-cpu` and `sentence-transformers` for vector/hybrid search — modes the MCP server explicitly rejects — so bundling them would only bloat the install.

## Notes
- The three query tools (`search_documents`, `diff_documents`, `get_document_outline`) were **already wired in**: the bundle runs the real `all2md.mcp.server:main`, which registers them automatically. Only this optional search dependency was missing.
- `diff_documents` and `get_document_outline` need no extra deps (they reuse the conversion/section subsystems already bundled).
- Also updates the bundle README's "Dependency extras" section and adds a `[1.5.0]` changelog entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)