### PR TITLE
feat(mcp): batch in-place editing, workspace paths, stdout safety, file listing

### DIFF
--- a/mcpb/manifest.json
+++ b/mcpb/manifest.json
@@ -26,6 +26,7 @@
       "env": {
         "ALL2MD_MCP_ALLOWED_READ_DIRS": "${user_config.workspace_directory}",
         "ALL2MD_MCP_ALLOWED_WRITE_DIRS": "${user_config.workspace_directory}",
+        "ALL2MD_MCP_ADDITIONAL_READ_DIRS": "${user_config.additional_read_dirs}",
         "ALL2MD_MCP_ENABLE_FROM_MD": "${user_config.enable_write}",
         "ALL2MD_MCP_ENABLE_DOC_EDIT": "${user_config.enable_edit}",
         "ALL2MD_DISABLE_NETWORK": "${user_config.disable_network}"
@@ -40,6 +41,13 @@
       "required": true,
       "default": "${DOCUMENTS}",
       "multiple": false
+    },
+    "additional_read_dirs": {
+      "type": "directory",
+      "title": "Additional read-only folders",
+      "description": "Extra folders all2md may read from but never write to. Optional; leave empty to restrict access to the workspace folder only.",
+      "required": false,
+      "multiple": true
     },
     "enable_write": {
       "type": "boolean",

--- a/src/all2md/mcp/config.py
+++ b/src/all2md/mcp/config.py
@@ -17,6 +17,7 @@ Classes
 import argparse
 import logging
 import os
+import re
 import tempfile
 from dataclasses import dataclass
 from importlib.metadata import version
@@ -48,6 +49,8 @@ class MCPConfig(CloneFrozenMixin):
         Whether to enable diff_documents tool (default: True; read-only)
     enable_outline : bool
         Whether to enable get_document_outline tool (default: True; read-only)
+    enable_list_files : bool
+        Whether to enable list_workspace_files tool (default: True; read-only)
     search_index_dir : str | Path | None
         Optional directory for persisting/loading the search keyword index.
         None (default) rebuilds a fresh in-memory index on every call. When set,
@@ -84,6 +87,7 @@ class MCPConfig(CloneFrozenMixin):
     enable_search: bool = True  # Read-only: search a document corpus (grep + keyword)
     enable_diff: bool = True  # Read-only: compare two documents
     enable_outline: bool = True  # Read-only: list a document's heading structure
+    enable_list_files: bool = True  # Read-only: list files in the workspace/read allowlist
     search_index_dir: str | Path | None = None  # None = rebuild per call; set = persist keyword index
     read_allowlist: list[str | Path] | None = None  # Will be set to CWD if None, then to Path objects
     write_allowlist: list[str | Path] | None = None  # Will be set to CWD if None, then to Path objects
@@ -115,9 +119,12 @@ class MCPConfig(CloneFrozenMixin):
                 self.enable_search,
                 self.enable_diff,
                 self.enable_outline,
+                self.enable_list_files,
             )
         ):
-            raise ValueError("At least one tool must be enabled (to_md, from_md, doc_edit, search, diff, or outline)")
+            raise ValueError(
+                "At least one tool must be enabled " "(to_md, from_md, doc_edit, search, diff, outline, or list_files)"
+            )
 
 
 def _parse_semicolon_list(value: str | None) -> list[str] | None:
@@ -139,6 +146,34 @@ def _parse_semicolon_list(value: str | None) -> list[str] | None:
 
     parts = [p.strip() for p in value.split(";") if p.strip()]
     return parts if parts else None
+
+
+def _parse_dir_list(value: str | None) -> list[str] | None:
+    """Parse a directory list tolerant of how hosts join multiple values.
+
+    Accepts ``;``, the OS path separator, and newlines as separators (MCPB may
+    join a multi-value directory config with any of these). Unsubstituted
+    ``${...}`` placeholders (e.g. an optional config the host left blank) are
+    ignored.
+
+    Parameters
+    ----------
+    value : str | None
+        Raw separator-joined string, or None.
+
+    Returns
+    -------
+    list[str] | None
+        List of directory strings, or None if empty.
+
+    """
+    if not value:
+        return None
+
+    separators = {";", os.pathsep, "\n", "\r"}
+    pattern = "[" + "".join(re.escape(c) for c in separators) + "]"
+    parts = [p.strip() for p in re.split(pattern, value) if p.strip() and "${" not in p]
+    return parts or None
 
 
 def _str_to_bool(value: str | None, default: bool = False) -> bool:
@@ -254,6 +289,12 @@ def load_config_from_env() -> MCPConfig:
     if write_allowlist_strs is None:
         write_allowlist_strs = [cwd]
 
+    # Additional read-only folders are appended to the read allowlist only (never
+    # the write allowlist), so files there can be read but not modified.
+    additional_read_strs = _parse_dir_list(os.getenv("ALL2MD_MCP_ADDITIONAL_READ_DIRS"))
+    if additional_read_strs:
+        read_allowlist_strs = read_allowlist_strs + additional_read_strs
+
     # Optional persistent search index directory (None = rebuild per call)
     search_index_dir = os.getenv("ALL2MD_MCP_SEARCH_INDEX_DIR") or None
 
@@ -264,6 +305,7 @@ def load_config_from_env() -> MCPConfig:
         enable_search=_str_to_bool(os.getenv("ALL2MD_MCP_ENABLE_SEARCH"), default=True),  # Read-only
         enable_diff=_str_to_bool(os.getenv("ALL2MD_MCP_ENABLE_DIFF"), default=True),  # Read-only
         enable_outline=_str_to_bool(os.getenv("ALL2MD_MCP_ENABLE_OUTLINE"), default=True),  # Read-only
+        enable_list_files=_str_to_bool(os.getenv("ALL2MD_MCP_ENABLE_LIST_FILES"), default=True),  # Read-only
         search_index_dir=search_index_dir,
         # Will be validated and converted to Path objects by prepare_allowlist_dirs
         read_allowlist=cast(list[str | Path], read_allowlist_strs),
@@ -297,9 +339,11 @@ Environment Variables:
   ALL2MD_MCP_ENABLE_SEARCH         Enable search_documents tool (default: true)
   ALL2MD_MCP_ENABLE_DIFF           Enable diff_documents tool (default: true)
   ALL2MD_MCP_ENABLE_OUTLINE        Enable get_document_outline tool (default: true)
+  ALL2MD_MCP_ENABLE_LIST_FILES     Enable list_workspace_files tool (default: true)
   ALL2MD_MCP_SEARCH_INDEX_DIR      Directory to persist the search keyword index (default: none)
   ALL2MD_MCP_ALLOWED_READ_DIRS     Semicolon-separated read allowlist paths
   ALL2MD_MCP_ALLOWED_WRITE_DIRS    Semicolon-separated write allowlist paths
+  ALL2MD_MCP_ADDITIONAL_READ_DIRS  Extra read-only folders (appended to the read allowlist)
   ALL2MD_MCP_INCLUDE_IMAGES        Include images in output for vLLM visibility (default: false)
   ALL2MD_MCP_FLAVOR                Markdown flavor: gfm, commonmark, multimarkdown, pandoc, kramdown,
                                    markdown_plus (default: gfm)
@@ -410,6 +454,18 @@ Examples:
     )
     parser.set_defaults(enable_outline=None)  # None = use env default
 
+    list_files_group = parser.add_mutually_exclusive_group()
+    list_files_group.add_argument(
+        "--enable-list-files",
+        action="store_true",
+        dest="enable_list_files",
+        help="Enable list_workspace_files tool (default: true; read-only)",
+    )
+    list_files_group.add_argument(
+        "--no-list-files", action="store_false", dest="enable_list_files", help="Disable list_workspace_files tool"
+    )
+    parser.set_defaults(enable_list_files=None)  # None = use env default
+
     # Persistent search index directory (opt-in; None = rebuild per call)
     parser.add_argument(
         "--search-index-dir",
@@ -422,6 +478,13 @@ Examples:
     # Path allowlists
     parser.add_argument(
         "--read-dirs", type=str, metavar="PATHS", help="Semicolon-separated list of allowed read directories"
+    )
+
+    parser.add_argument(
+        "--additional-read-dirs",
+        type=str,
+        metavar="PATHS",
+        help="Extra read-only directories appended to the read allowlist (separator-joined)",
     )
 
     parser.add_argument(
@@ -520,11 +583,21 @@ def load_config_from_args(args: argparse.Namespace) -> MCPConfig:
     if args.enable_outline is not None:
         updated_kwargs.update(enable_outline=args.enable_outline)
 
+    if getattr(args, "enable_list_files", None) is not None:
+        updated_kwargs.update(enable_list_files=args.enable_list_files)
+
     if getattr(args, "search_index_dir", None) is not None:
         updated_kwargs.update(search_index_dir=args.search_index_dir)
 
     if args.read_dirs is not None:
         updated_kwargs.update(read_allowlist=_parse_semicolon_list(args.read_dirs))
+
+    # Additional read-only dirs append to whatever read allowlist is in effect.
+    if getattr(args, "additional_read_dirs", None):
+        extra = _parse_dir_list(args.additional_read_dirs)
+        if extra:
+            base = cast(list, updated_kwargs.get("read_allowlist") or config.read_allowlist or [])
+            updated_kwargs.update(read_allowlist=cast(list[str | Path], list(base) + extra))
 
     if args.write_dirs is not None:
         updated_kwargs.update(write_allowlist=_parse_semicolon_list(args.write_dirs))

--- a/src/all2md/mcp/document_tools.py
+++ b/src/all2md/mcp/document_tools.py
@@ -1,7 +1,7 @@
 """Document manipulation tool implementation for MCP server.
 
-This module implements the edit_document tool that allows LLMs to
-manipulate document structure at the AST level with a simplified interface.
+This module implements the edit_document tool that applies a batch of edits to
+a document at the AST level and writes the result back to disk in place.
 
 Functions
 ---------
@@ -12,43 +12,74 @@ Functions
 #  Copyright (c) 2025 Tom Villani, Ph.D.
 
 import logging
-from typing import Literal
+from typing import Any
 
 from all2md.api import from_ast, to_ast
 from all2md.ast.nodes import Document
 from all2md.ast.sections import extract_sections, get_all_sections
+from all2md.constants import DocumentFormat
 from all2md.exceptions import All2MdError
 from all2md.mcp.config import MCPConfig
 from all2md.mcp.schemas import (
-    EditDocumentSimpleInput,
-    EditDocumentSimpleOutput,
+    EditDocumentInput,
+    EditDocumentOutput,
+    EditOperation,
+    EditResultItem,
 )
-from all2md.mcp.security import MCPSecurityError, validate_read_path
+from all2md.mcp.security import (
+    MCPSecurityError,
+    resolve_workspace_path,
+    secure_open_for_write,
+    validate_read_path,
+    validate_write_path,
+)
 
 logger = logging.getLogger(__name__)
 
+# Actions that change the document (and therefore trigger a write-back).
+_MUTATING_ACTIONS = {
+    "add:before",
+    "add:after",
+    "remove",
+    "replace",
+    "insert:start",
+    "insert:end",
+    "insert:after_heading",
+}
+
+_CONTENT_REQUIRED_ACTIONS = {
+    "add:before",
+    "add:after",
+    "replace",
+    "insert:start",
+    "insert:end",
+    "insert:after_heading",
+}
+
+# Map a source file extension to the renderable target format used for in-place
+# write-back. PDF is intentionally excluded: re-rendering reflows the entire
+# document, which is too destructive for an in-place edit. Extensions absent
+# here cannot be persisted in place; the agent is told to export instead.
+_WRITABLE_FORMAT_BY_EXT: dict[str, DocumentFormat] = {
+    ".md": "markdown",
+    ".markdown": "markdown",
+    ".mdown": "markdown",
+    ".mkd": "markdown",
+    ".txt": "markdown",
+    ".html": "html",
+    ".htm": "html",
+    ".docx": "docx",
+    ".pptx": "pptx",
+    ".rst": "rst",
+    ".epub": "epub",
+}
+
+# Formats rendered as bytes (vs. text) by from_ast.
+_BINARY_FORMATS = {"docx", "pptx", "epub", "pdf"}
+
 
 def _parse_markdown_content(content: str, config: MCPConfig) -> Document:
-    """Parse markdown content string to Document AST.
-
-    Parameters
-    ----------
-    content : str
-        Markdown content to parse
-    config : MCPConfig
-        Server configuration (for flavor)
-
-    Returns
-    -------
-    Document
-        Parsed document AST
-
-    Raises
-    ------
-    TypeError
-        If parsing doesn't return a Document
-
-    """
+    """Parse markdown content string to a Document AST."""
     doc = to_ast(content, source_format="markdown", flavor=config.flavor)
     if not isinstance(doc, Document):
         raise TypeError(f"Expected Document, got {type(doc)}")
@@ -56,26 +87,7 @@ def _parse_markdown_content(content: str, config: MCPConfig) -> Document:
 
 
 def _serialize_to_markdown(doc: Document, config: MCPConfig) -> str:
-    """Serialize Document AST to markdown string.
-
-    Parameters
-    ----------
-    doc : Document
-        Document AST to serialize
-    config : MCPConfig
-        Server configuration (for flavor)
-
-    Returns
-    -------
-    str
-        Markdown string
-
-    Raises
-    ------
-    TypeError
-        If serialization doesn't return a string
-
-    """
+    """Serialize a Document AST to a markdown string."""
     result = from_ast(doc, target_format="markdown", flavor=config.flavor)
     if not isinstance(result, str):
         raise TypeError(f"Expected str from from_ast, got {type(result)}")
@@ -83,347 +95,324 @@ def _serialize_to_markdown(doc: Document, config: MCPConfig) -> str:
 
 
 def _format_target_description(target: str | int) -> str:
-    """Format target for user-facing messages.
-
-    Parameters
-    ----------
-    target : str or int
-        Target section (heading text or index)
-
-    Returns
-    -------
-    str
-        Formatted target description
-
-    """
+    """Format a target for user-facing messages."""
     return f"section #{target}" if isinstance(target, int) else f"section '{target}'"
 
 
-def _handle_list_sections(doc: Document) -> EditDocumentSimpleOutput:
-    """Handle list-sections action.
-
-    Parameters
-    ----------
-    doc : Document
-        Document to list sections from
-
-    Returns
-    -------
-    EditDocumentSimpleOutput
-        Result with section listing
-
-    """
+def _list_sections_text(doc: Document) -> str:
+    """Render a human-readable listing of a document's sections."""
     sections = get_all_sections(doc)
-    if sections:
-        lines = ["Document Sections:"]
-        for idx, section in enumerate(sections):
-            indent = "  " * (section.level - 1)
-            lines.append(
-                f"{indent}[#{idx}] "
-                f"{'#' * section.level} {section.get_heading_text()} "
-                f"({len(section.content)} nodes)"
-            )
-        content = "\n".join(lines)
-    else:
-        content = "No sections found in document."
-
-    return EditDocumentSimpleOutput(success=True, message=f"Found {len(sections)} section(s).", content=content)
+    if not sections:
+        return "No sections found in document."
+    lines = ["Document Sections:"]
+    for idx, section in enumerate(sections):
+        indent = "  " * (section.level - 1)
+        lines.append(
+            f"{indent}[#{idx}] {'#' * section.level} {section.get_heading_text()} ({len(section.content)} nodes)"
+        )
+    return "\n".join(lines)
 
 
-def _handle_extract(doc: Document, target: str | int, config: MCPConfig) -> EditDocumentSimpleOutput:
-    """Handle extract action.
+def _parse_target(raw: str | None) -> str | int | None:
+    """Parse a target into heading text or a zero-based index (``#N``)."""
+    if raw is None:
+        return None
+    s = raw.strip()
+    if s.startswith("#"):
+        try:
+            return int(s[1:])
+        except ValueError as e:
+            raise ValueError(f"Invalid target index format: {raw!r}. Expected '#0', '#1', '#2', etc.") from e
+    return s
 
-    Parameters
-    ----------
-    doc : Document
-        Source document
-    target : str or int
-        Target section to extract
-    config : MCPConfig
-        Server configuration (for flavor)
 
-    Returns
-    -------
-    EditDocumentSimpleOutput
-        Result with extracted section
+def _validate_op(op: EditOperation) -> tuple[str, str | int | None, str | None]:
+    """Validate a single edit operation, returning (action, target, content)."""
+    valid_actions = {"list-sections", "extract", *_MUTATING_ACTIONS}
+    if op.action not in valid_actions:
+        raise ValueError(f"Invalid action: {op.action!r}")
 
+    target = _parse_target(op.target)
+    if op.action != "list-sections" and target is None:
+        raise ValueError(f"The {op.action!r} action requires a target (heading text or index like '#0').")
+
+    if op.action in _CONTENT_REQUIRED_ACTIONS and not op.content:
+        raise ValueError(f"The {op.action!r} action requires a content parameter.")
+
+    return op.action, target, op.content
+
+
+def _safe_region(doc: Document, target: str | int, config: MCPConfig) -> str | None:
+    """Return the markdown for ``target`` after an edit, or None if unavailable."""
+    try:
+        section_doc = extract_sections(doc, target, case_sensitive=False, combine=False)
+        return _serialize_to_markdown(section_doc, config)
+    except Exception:  # noqa: BLE001 - region is best-effort, never fatal
+        return None
+
+
+def _apply_edit(doc: Document, op: EditOperation, config: MCPConfig) -> tuple[Document, str | None, str]:
+    """Apply a single edit, returning (modified_doc, edited_region, message).
+
+    Read-only actions return ``doc`` unchanged. Raises on any failure so the
+    caller can abort the batch atomically.
     """
-    section_doc = extract_sections(doc, target, case_sensitive=False, combine=False)
-    result_md = _serialize_to_markdown(section_doc, config)
-    target_desc = _format_target_description(target)
-    return EditDocumentSimpleOutput(success=True, message=f"Successfully extracted {target_desc}.", content=result_md)
+    action, target, content = _validate_op(op)
 
+    if action == "list-sections":
+        return doc, _list_sections_text(doc), f"Listed {len(get_all_sections(doc))} section(s)."
 
-def _handle_add(
-    doc: Document, target: str | int, content: str, action: str, config: MCPConfig
-) -> EditDocumentSimpleOutput:
-    """Handle add:before and add:after actions.
+    if action == "extract":
+        assert target is not None
+        region = _serialize_to_markdown(extract_sections(doc, target, case_sensitive=False, combine=False), config)
+        return doc, region, f"Extracted {_format_target_description(target)}."
 
-    Parameters
-    ----------
-    doc : Document
-        Source document
-    target : str or int
-        Target section
-    content : str
-        Content to add
-    action : str
-        Either "add:before" or "add:after"
-    config : MCPConfig
-        Server configuration (for flavor)
+    assert target is not None
 
-    Returns
-    -------
-    EditDocumentSimpleOutput
-        Result with modified document
+    if action in ("add:before", "add:after"):
+        assert content is not None
+        new_doc = _parse_markdown_content(content, config)
+        if action == "add:before":
+            modified = doc.add_section_before(target, new_doc, case_sensitive=False)
+            where = "before"
+        else:
+            modified = doc.add_section_after(target, new_doc, case_sensitive=False)
+            where = "after"
+        return modified, content.strip(), f"Added section {where} {_format_target_description(target)}."
 
-    """
-    new_doc = _parse_markdown_content(content, config)
+    if action == "remove":
+        modified = doc.remove_section(target, case_sensitive=False)
+        return modified, None, f"Removed {_format_target_description(target)}."
 
-    if action == "add:before":
-        modified_doc = doc.add_section_before(target, new_doc, case_sensitive=False)
-        position_desc = "before"
-    else:
-        modified_doc = doc.add_section_after(target, new_doc, case_sensitive=False)
-        position_desc = "after"
+    if action == "replace":
+        assert content is not None
+        new_doc = _parse_markdown_content(content, config)
+        modified = doc.replace_section(target, new_doc, case_sensitive=False)
+        return modified, _safe_region(modified, target, config), f"Replaced {_format_target_description(target)}."
 
-    result_md = _serialize_to_markdown(modified_doc, config)
-    target_desc = _format_target_description(target)
-    return EditDocumentSimpleOutput(
-        success=True, message=f"Successfully added content {position_desc} {target_desc}.", content=result_md
-    )
-
-
-def _handle_remove(doc: Document, target: str | int, config: MCPConfig) -> EditDocumentSimpleOutput:
-    """Handle remove action.
-
-    Parameters
-    ----------
-    doc : Document
-        Source document
-    target : str or int
-        Target section to remove
-    config : MCPConfig
-        Server configuration (for flavor)
-
-    Returns
-    -------
-    EditDocumentSimpleOutput
-        Result with modified document
-
-    """
-    modified_doc = doc.remove_section(target, case_sensitive=False)
-    result_md = _serialize_to_markdown(modified_doc, config)
-    target_desc = _format_target_description(target)
-    return EditDocumentSimpleOutput(success=True, message=f"Successfully removed {target_desc}.", content=result_md)
-
-
-def _handle_replace(doc: Document, target: str | int, content: str, config: MCPConfig) -> EditDocumentSimpleOutput:
-    """Handle replace action.
-
-    Parameters
-    ----------
-    doc : Document
-        Source document
-    target : str or int
-        Target section to replace
-    content : str
-        Replacement content
-    config : MCPConfig
-        Server configuration (for flavor)
-
-    Returns
-    -------
-    EditDocumentSimpleOutput
-        Result with modified document
-
-    """
-    new_doc = _parse_markdown_content(content, config)
-    modified_doc = doc.replace_section(target, new_doc, case_sensitive=False)
-    result_md = _serialize_to_markdown(modified_doc, config)
-    target_desc = _format_target_description(target)
-    return EditDocumentSimpleOutput(success=True, message=f"Successfully replaced {target_desc}.", content=result_md)
-
-
-def _handle_insert(
-    doc: Document, target: str | int, content: str, action: str, config: MCPConfig
-) -> EditDocumentSimpleOutput:
-    """Handle insert:start, insert:end, and insert:after_heading actions.
-
-    Parameters
-    ----------
-    doc : Document
-        Source document
-    target : str or int
-        Target section
-    content : str
-        Content to insert
-    action : str
-        One of "insert:start", "insert:end", or "insert:after_heading"
-    config : MCPConfig
-        Server configuration (for flavor)
-
-    Returns
-    -------
-    EditDocumentSimpleOutput
-        Result with modified document
-
-    """
+    # insert:start / insert:end / insert:after_heading
+    assert content is not None
     content_doc = _parse_markdown_content(content, config)
-
-    position_map: dict[str, Literal["start", "end", "after_heading"]] = {
-        "insert:start": "start",
-        "insert:end": "end",
-        "insert:after_heading": "after_heading",
-    }
-    position = position_map[action]
-
-    modified_doc = doc.insert_into_section(
+    position_map = {"insert:start": "start", "insert:end": "end", "insert:after_heading": "after_heading"}
+    modified = doc.insert_into_section(
         target,
         content_doc.children,
-        position=position,
+        position=position_map[action],  # type: ignore[arg-type]
         case_sensitive=False,
     )
-
-    result_md = _serialize_to_markdown(modified_doc, config)
-    target_desc = _format_target_description(target)
-    return EditDocumentSimpleOutput(
-        success=True, message=f"Successfully inserted content into {target_desc}.", content=result_md
-    )
+    edited = _safe_region(modified, target, config)
+    return modified, edited, f"Inserted content into {_format_target_description(target)}."
 
 
-def edit_document_impl(input_data: EditDocumentSimpleInput, config: MCPConfig) -> EditDocumentSimpleOutput:
-    """Implement edit_document tool (simplified LLM-friendly interface).
+def _format_error(e: Exception) -> str:
+    """Build a clear, LLM-friendly error message for a failed edit."""
+    msg = str(e)
+    if isinstance(e, ValueError) and "not found" in msg.lower():
+        return f"Target not found: {msg}"
+    if isinstance(e, MCPSecurityError):
+        return f"Security violation: {msg}"
+    return msg
 
-    This function provides a streamlined interface for document manipulation
-    with sensible defaults for LLM usage. All errors are caught and returned
-    as error messages (no exceptions thrown).
+
+def _normalize_edits(raw_edits: Any) -> list[EditOperation] | None:
+    """Coerce incoming edits (EditOperation or dict) into EditOperation list.
+
+    Returns None if any item has an unrecognized shape.
+    """
+    normalized: list[EditOperation] = []
+    for item in raw_edits or []:
+        if isinstance(item, EditOperation):
+            normalized.append(item)
+        elif isinstance(item, dict):
+            normalized.append(
+                EditOperation(
+                    action=item.get("action"),  # type: ignore[arg-type]
+                    target=item.get("target"),
+                    content=item.get("content"),
+                )
+            )
+        else:
+            return None
+    return normalized
+
+
+def edit_document_impl(input_data: EditDocumentInput, config: MCPConfig) -> EditDocumentOutput:
+    """Implement the edit_document tool (batch, atomic, in-place).
+
+    Applies the batch of edits to a single parse of the document. The batch is
+    atomic: if any edit fails, none are persisted. When the batch contains a
+    mutating action, the modified document is written back to disk in its
+    original format (the file must be within the write allowlist). Mutating
+    results echo only the edited region, not the whole document.
 
     Parameters
     ----------
-    input_data : EditDocumentSimpleInput
-        Simplified tool input parameters
+    input_data : EditDocumentInput
+        Tool input (document path and ordered edits).
     config : MCPConfig
-        Server configuration (for allowlists, etc.)
+        Server configuration (allowlists, flavor).
 
     Returns
     -------
-    EditDocumentSimpleOutput
-        Operation result with success flag, message, and optional content
+    EditDocumentOutput
+        Per-edit results, write confirmation, and any warnings.
 
     """
+    edits = _normalize_edits(input_data.edits)
+    if edits is None:
+        return EditDocumentOutput(success=False, warnings=["One or more edits had an unrecognized shape."])
+    if not edits:
+        return EditDocumentOutput(success=False, warnings=["No edits provided."])
+
+    # Resolve (workspace-relative allowed) and validate read access.
+    resolved = resolve_workspace_path(input_data.doc, config.read_allowlist, must_exist=True)
+    if resolved is None:
+        searched = ", ".join(str(d) for d in (config.read_allowlist or [])) or "(no read folders configured)"
+        return EditDocumentOutput(
+            success=False,
+            warnings=[f"File not found: {input_data.doc!r}. Looked relative to the workspace folder(s): {searched}."],
+        )
     try:
-        # Validate action
-        valid_actions = {
-            "list-sections",
-            "extract",
-            "add:before",
-            "add:after",
-            "remove",
-            "replace",
-            "insert:start",
-            "insert:end",
-            "insert:after_heading",
-        }
-        if input_data.action not in valid_actions:
-            return EditDocumentSimpleOutput(success=False, message=f"[ERROR] Invalid action: {input_data.action!r}")
+        read_path = validate_read_path(resolved, config.read_allowlist)
+    except MCPSecurityError as e:
+        return EditDocumentOutput(success=False, warnings=[f"Read access denied: {e}"])
 
-        # Parse target (heading text or index notation like "#3")
-        target: str | int | None = None
-        if input_data.target is not None:
-            target_str = input_data.target.strip()
-            # Check if it's index notation (e.g., "#3")
-            if target_str.startswith("#"):
-                try:
-                    target = int(target_str[1:])
-                except ValueError:
-                    return EditDocumentSimpleOutput(
-                        success=False,
-                        message=f"[ERROR] Invalid target index format: {input_data.target!r}. "
-                        "Expected format like '#0', '#1', '#2'.",
-                    )
-            else:
-                target = target_str
+    mutating = any(op.action in _MUTATING_ACTIONS for op in edits)
 
-        # Validate target is provided when needed
-        if input_data.action != "list-sections" and target is None:
-            return EditDocumentSimpleOutput(
-                success=False,
-                message=f"[ERROR] The '{input_data.action}' action requires a target "
-                "(heading text or index like '#0').",
-            )
-
-        # Validate content is provided when needed
-        content_required_actions = {
-            "add:before",
-            "add:after",
-            "replace",
-            "insert:start",
-            "insert:end",
-            "insert:after_heading",
-        }
-        if input_data.action in content_required_actions and not input_data.content:
-            return EditDocumentSimpleOutput(
-                success=False, message=f"[ERROR] The '{input_data.action}' action requires content parameter."
-            )
-
-        # Validate and load document
+    # For mutating batches, confirm we can persist this file before doing work.
+    write_path = None
+    out_format: DocumentFormat | None = None
+    if mutating:
         try:
-            validated_path = validate_read_path(input_data.doc, config.read_allowlist)
+            write_path = validate_write_path(read_path, config.write_allowlist)
         except MCPSecurityError as e:
-            return EditDocumentSimpleOutput(success=False, message=f"[ERROR] Read access denied: {e}")
+            return EditDocumentOutput(
+                success=False,
+                warnings=[f"Cannot edit in place: {e}. The file may be in a read-only folder."],
+            )
+        ext = read_path.suffix.lower()
+        out_format = _WRITABLE_FORMAT_BY_EXT.get(ext)
+        if out_format is None:
+            return EditDocumentOutput(
+                success=False,
+                warnings=[
+                    f"edit_document cannot write changes back to '{ext or read_path.name}' files in place. "
+                    "Supported in-place formats: .md, .html, .docx, .pptx, .rst, .epub. "
+                    "Use save_document_from_markdown to export to another format instead."
+                ],
+            )
 
-        logger.info(f"Loading document from: {validated_path}")
-        doc = to_ast(validated_path, source_format="markdown", flavor=config.flavor)
+    # Parse the document once (format auto-detected from the file).
+    try:
+        doc = to_ast(read_path, source_format="auto", flavor=config.flavor)
         if not isinstance(doc, Document):
             raise TypeError(f"Expected Document from to_ast, got {type(doc)}")
-
-        logger.info(f"Executing action: {input_data.action}")
-
-        # Execute action using dispatch pattern
-        if input_data.action == "list-sections":
-            return _handle_list_sections(doc)
-        elif input_data.action == "extract":
-            assert target is not None  # Already validated above
-            return _handle_extract(doc, target, config)
-        elif input_data.action in ("add:before", "add:after"):
-            assert target is not None  # Already validated above
-            assert input_data.content is not None  # Already validated above
-            return _handle_add(doc, target, input_data.content, input_data.action, config)
-        elif input_data.action == "remove":
-            assert target is not None  # Already validated above
-            return _handle_remove(doc, target, config)
-        elif input_data.action == "replace":
-            assert target is not None  # Already validated above
-            assert input_data.content is not None  # Already validated above
-            return _handle_replace(doc, target, input_data.content, config)
-        elif input_data.action in ("insert:start", "insert:end", "insert:after_heading"):
-            assert target is not None  # Already validated above
-            assert input_data.content is not None  # Already validated above
-            return _handle_insert(doc, target, input_data.content, input_data.action, config)
-        else:
-            # Should never reach here due to validation above
-            return EditDocumentSimpleOutput(success=False, message=f"[ERROR] Unhandled action: {input_data.action}")
-
-    except ValueError as e:
-        # Handle validation errors from AST functions
-        error_msg = str(e)
-        if "not found" in error_msg.lower():
-            return EditDocumentSimpleOutput(success=False, message=f"[ERROR] Target not found: {error_msg}")
-        return EditDocumentSimpleOutput(success=False, message=f"[ERROR] Invalid input: {error_msg}")
-
-    except MCPSecurityError as e:
-        # Handle security violations
-        return EditDocumentSimpleOutput(success=False, message=f"[ERROR] Security violation: {e}")
-
     except All2MdError as e:
-        # Handle document processing errors
-        return EditDocumentSimpleOutput(success=False, message=f"[ERROR] Document processing failed: {e}")
+        return EditDocumentOutput(success=False, warnings=[f"Could not read document: {e}"])
 
-    except Exception as e:
-        # Catch-all for unexpected errors
-        logger.error(f"Unexpected error in edit_document: {e}", exc_info=True)
-        return EditDocumentSimpleOutput(success=False, message=f"[ERROR] Unexpected error: {e}")
+    source_path_attr = getattr(doc, "source_path", None)
+
+    # Apply edits in order to an in-memory copy; persist only if all succeed.
+    results: list[EditResultItem] = []
+    current = doc
+    failed_index: int | None = None
+    for i, op in enumerate(edits):
+        try:
+            current, region, message = _apply_edit(current, op, config)
+            results.append(
+                EditResultItem(
+                    index=i, action=op.action, target=op.target, success=True, message=message, edited_region=region
+                )
+            )
+        except (ValueError, MCPSecurityError, All2MdError, TypeError) as e:
+            results.append(
+                EditResultItem(index=i, action=op.action, target=op.target, success=False, message=_format_error(e))
+            )
+            failed_index = i
+            break
+
+    if failed_index is not None:
+        for j in range(failed_index + 1, len(edits)):
+            op = edits[j]
+            results.append(
+                EditResultItem(
+                    index=j,
+                    action=op.action,
+                    target=op.target,
+                    success=False,
+                    message="Not applied (atomic batch aborted).",
+                )
+            )
+        return EditDocumentOutput(
+            success=False,
+            disk_written=False,
+            results=results,
+            warnings=[f"Batch aborted at edit #{failed_index}; no changes were written."],
+        )
+
+    # All edits succeeded. Persist if the batch changed anything.
+    warnings: list[str] = []
+    disk_written = False
+    output_path: str | None = None
+    if mutating and out_format is not None and write_path is not None:
+        # Preserve the original source path so docx round-trips can template.
+        if source_path_attr is not None and getattr(current, "source_path", None) is None:
+            try:
+                current.source_path = source_path_attr  # type: ignore[attr-defined]
+            except Exception:  # noqa: BLE001
+                pass
+        try:
+            rendered = from_ast(
+                current,
+                target_format=out_format,
+                flavor=config.flavor,
+                preserve_formatting=(out_format == "docx"),
+            )
+        except All2MdError as e:
+            return EditDocumentOutput(
+                success=False,
+                disk_written=False,
+                results=results,
+                warnings=[f"Edits applied in memory but rendering to {out_format} failed: {e}"],
+            )
+
+        data = rendered.encode("utf-8") if isinstance(rendered, str) else rendered
+        if not isinstance(data, (bytes, bytearray)):
+            return EditDocumentOutput(
+                success=False,
+                results=results,
+                warnings=[f"Unexpected render output type for {out_format}: {type(data)}."],
+            )
+        try:
+            handle = secure_open_for_write(write_path)
+            try:
+                handle.write(bytes(data))
+            finally:
+                handle.close()
+        except (OSError, MCPSecurityError) as e:
+            return EditDocumentOutput(
+                success=False,
+                disk_written=False,
+                results=results,
+                warnings=[f"Edits applied in memory but writing to disk failed: {e}"],
+            )
+
+        disk_written = True
+        output_path = str(write_path)
+        logger.info(f"edit_document wrote {len(edits)} edit(s) to: {output_path}")
+        if out_format in _BINARY_FORMATS:
+            warnings.append(
+                f"{out_format.upper()} was re-rendered from the edited content; "
+                "some fine-grained formatting may differ from the original."
+            )
+
+    return EditDocumentOutput(
+        success=True,
+        disk_written=disk_written,
+        output_path=output_path,
+        results=results,
+        warnings=warnings,
+    )
 
 
 __all__ = [

--- a/src/all2md/mcp/query_tools.py
+++ b/src/all2md/mcp/query_tools.py
@@ -32,11 +32,13 @@ from all2md.mcp.schemas import (
     DiffDocumentsOutput,
     GetDocumentOutlineInput,
     GetDocumentOutlineOutput,
+    ListWorkspaceFilesInput,
+    ListWorkspaceFilesOutput,
     SearchDocumentsInput,
     SearchDocumentsOutput,
     SearchResultItem,
 )
-from all2md.mcp.security import MCPSecurityError, validate_read_path
+from all2md.mcp.security import MCPSecurityError, resolve_workspace_path, validate_read_path
 from all2md.mcp.tools import _detect_source_type
 from all2md.options.search import SearchOptions
 from all2md.search.service import SearchDocumentInput, SearchService
@@ -326,3 +328,97 @@ def _as_str(value: object) -> str | None:
     if value is None:
         return None
     return str(value)
+
+
+# Cap on files returned by list_workspace_files to keep responses bounded.
+_LIST_FILES_CAP = 1000
+
+
+def _is_within(path: Path, root: Path) -> bool:
+    """Return True if ``path`` is inside ``root``."""
+    try:
+        path.relative_to(root)
+        return True
+    except ValueError:
+        return False
+
+
+def list_workspace_files_impl(input_data: ListWorkspaceFilesInput, config: MCPConfig) -> ListWorkspaceFilesOutput:
+    """Implement the list_workspace_files tool.
+
+    Lists files within the read allowlist (workspace folder plus any additional
+    read-only folders) so an agent can orient itself before reading or editing.
+
+    Parameters
+    ----------
+    input_data : ListWorkspaceFilesInput
+        Tool input (optional subdirectory, glob pattern, recursion flag).
+    config : MCPConfig
+        Server configuration (read allowlist).
+
+    Returns
+    -------
+    ListWorkspaceFilesOutput
+        Listed files (path + size), capped and flagged if truncated.
+
+    Raises
+    ------
+    MCPSecurityError
+        If a requested subdirectory is outside the read allowlist.
+
+    """
+    roots = [Path(d) for d in (config.read_allowlist or [])]
+    if not roots:
+        raise ValueError("No read folders are configured.")
+
+    if input_data.subdirectory:
+        resolved = resolve_workspace_path(input_data.subdirectory, config.read_allowlist, must_exist=True)
+        if resolved is None or not resolved.is_dir():
+            raise MCPSecurityError(
+                f"Subdirectory not found in workspace: {input_data.subdirectory!r}", path=input_data.subdirectory
+            )
+        resolved = resolved.resolve()
+        if not any(_is_within(resolved, r.resolve()) for r in roots):
+            raise MCPSecurityError(
+                f"Subdirectory is outside the read allowlist: {input_data.subdirectory!r}",
+                path=input_data.subdirectory,
+            )
+        search_roots = [resolved]
+    else:
+        search_roots = [r.resolve() for r in roots if r.exists()]
+
+    pattern = input_data.pattern or "*"
+    entries: dict[str, int] = {}
+    truncated = False
+    for root in search_roots:
+        globber = root.rglob if input_data.recursive else root.glob
+        try:
+            for path in globber(pattern):
+                if not path.is_file():
+                    continue
+                resolved_file = path.resolve()
+                key = str(resolved_file)
+                if key in entries:
+                    continue
+                try:
+                    size = resolved_file.stat().st_size
+                except OSError:
+                    continue
+                entries[key] = size
+                if len(entries) >= _LIST_FILES_CAP:
+                    truncated = True
+                    break
+        except OSError as e:
+            logger.warning(f"Error listing {root}: {e}")
+            continue
+        if truncated:
+            break
+
+    files = [{"path": key, "size_bytes": size} for key, size in sorted(entries.items())]
+    logger.info(f"list_workspace_files returned {len(files)} file(s) (truncated={truncated})")
+    return ListWorkspaceFilesOutput(
+        files=files,
+        total=len(files),
+        truncated=truncated,
+        read_dirs=[str(r) for r in roots],
+    )

--- a/src/all2md/mcp/schemas.py
+++ b/src/all2md/mcp/schemas.py
@@ -153,6 +153,7 @@ class EditOperation:
     ----------
     action : EditDocumentAction
         Operation to perform. One of:
+
         - "list-sections": list all sections with metadata (read-only)
         - "extract": get a single section by heading or index (read-only)
         - "add:before" / "add:after": add a new section relative to target

--- a/src/all2md/mcp/schemas.py
+++ b/src/all2md/mcp/schemas.py
@@ -9,8 +9,12 @@ Classes
 - ReadDocumentAsMarkdownInput: Input schema for read_document_as_markdown tool
 - SaveDocumentFromMarkdownInput: Input schema for save_document_from_markdown tool
 - SaveDocumentFromMarkdownOutput: Output schema for save_document_from_markdown tool
-- EditDocumentSimpleInput: Input schema for edit_document tool (simplified)
-- EditDocumentSimpleOutput: Output schema for edit_document tool (simplified)
+- EditOperation: A single edit within an edit_document batch
+- EditDocumentInput: Input schema for edit_document tool (batch, in-place)
+- EditResultItem: Per-edit result entry for edit_document tool
+- EditDocumentOutput: Output schema for edit_document tool
+- ListWorkspaceFilesInput: Input schema for list_workspace_files tool
+- ListWorkspaceFilesOutput: Output schema for list_workspace_files tool
 - SearchDocumentsInput: Input schema for search_documents tool
 - SearchResultItem: Single result entry for search_documents tool
 - SearchDocumentsOutput: Output schema for search_documents tool
@@ -142,80 +146,128 @@ EditDocumentAction = Literal[
 
 
 @dataclass
-class EditDocumentSimpleInput:
-    """Input schema for edit_document tool (simplified LLM-friendly interface).
-
-    This is a simplified wrapper around the powerful AST-based document
-    manipulation functionality. It uses sensible defaults and a streamlined
-    interface designed for LLM usage.
+class EditOperation:
+    """A single edit within an edit_document batch.
 
     Attributes
     ----------
     action : EditDocumentAction
-        Operation to perform on the document. One of:
-        - "list-sections": List all sections with metadata
-        - "extract": Get a single section by heading or index
-        - "add:before": Add new section before target
-        - "add:after": Add new section after target
-        - "remove": Remove a section
-        - "replace": Replace section content
-        - "insert:start": Insert content at start of section
-        - "insert:end": Insert content at end of section
-        - "insert:after_heading": Insert content right after heading
-    doc : str
-        File path to the document (must be in read allowlist).
-        Only file paths are supported (no inline content).
+        Operation to perform. One of:
+        - "list-sections": list all sections with metadata (read-only)
+        - "extract": get a single section by heading or index (read-only)
+        - "add:before" / "add:after": add a new section relative to target
+        - "remove": remove a section
+        - "replace": replace a section's content
+        - "insert:start" / "insert:end" / "insert:after_heading": insert content
+          within the target section
     target : str | None
-        Section to target for operations. Can be:
-        - Heading text (case-insensitive): "Introduction"
-        - Index notation: "#0", "#1", "#2", etc. (zero-based)
-        Required for all operations except "list-sections".
+        Section to target. Either heading text (case-insensitive), e.g.
+        "Introduction", or zero-based index notation, e.g. "#0", "#1".
+        Required for every action except "list-sections". Heading text is
+        recommended in multi-edit batches, since indices can shift as earlier
+        edits in the batch add or remove sections.
     content : str | None
-        Markdown content to add/replace/insert.
-        Required for add/replace/insert operations.
-        Ignored for list-sections/extract/remove.
-
-    Notes
-    -----
-    Defaults (not configurable in simplified interface):
-
-    - Format: markdown only (no AST JSON)
-    - Case sensitivity: case-insensitive heading matching
-    - Flavor: "gfm" (GitHub Flavored Markdown)
-    - Output: always returned in response (no file writing)
+        Markdown content to add/replace/insert. Required for the add/replace/
+        insert actions; ignored for list-sections/extract/remove.
 
     """
 
     action: EditDocumentAction
-    doc: str
     target: str | None = None
     content: str | None = None
 
 
 @dataclass
-class EditDocumentSimpleOutput:
+class EditDocumentInput:
+    """Input schema for edit_document tool (batch, in-place editing).
+
+    Applies one or more edits to a single document. Edits are applied in order
+    to one parse of the document and the whole batch is atomic: if any edit
+    fails, none are applied and nothing is written. When the batch contains a
+    mutating action, the modified document is written back to disk in its
+    original format (the file must be within the write allowlist).
+
+    Attributes
+    ----------
+    doc : str
+        Path to the document (absolute or workspace-relative). For mutating
+        edits it must be within the write allowlist.
+    edits : list[EditOperation]
+        Ordered list of edits to apply.
+
+    Notes
+    -----
+    - Source format is auto-detected (Markdown, DOCX, HTML, RST, EPUB, ...), so
+      the tool is not Markdown-only.
+    - Non-Markdown formats are re-rendered on write-back; for binary formats this
+      can lose some fine-grained formatting (a warning is returned). DOCX uses
+      the original file as a template to preserve styles where possible.
+    - Mutating responses echo only the edited region, not the whole document, to
+      keep responses small.
+
+    """
+
+    doc: str
+    edits: list[EditOperation] = field(default_factory=list)
+
+
+@dataclass
+class EditResultItem:
+    """Result of a single edit within a batch.
+
+    Attributes
+    ----------
+    index : int
+        Zero-based position of this edit in the request batch.
+    action : str
+        The action that was requested.
+    target : str | None
+        The target that was requested (if any).
+    success : bool
+        Whether this individual edit applied successfully.
+    message : str
+        Human-readable result or error message.
+    edited_region : str | None
+        For mutating edits, the markdown of just the affected section after the
+        edit (not the whole document). For "list-sections"/"extract", the
+        requested listing/section content. None when not applicable.
+
+    """
+
+    index: int
+    action: str
+    target: str | None
+    success: bool
+    message: str
+    edited_region: str | None = None
+
+
+@dataclass
+class EditDocumentOutput:
     """Output schema for edit_document tool.
 
     Attributes
     ----------
     success : bool
-        Whether the operation succeeded
-    message : str
-        Human-readable message describing the result.
-        For errors, contains clear error description.
-        For success, contains confirmation message.
-    content : str | None
-        Content returned by the operation (when applicable).
-        - For "list-sections": formatted list of sections with metadata
-        - For "extract": markdown content of the extracted section
-        - For add/remove/replace/insert operations: updated markdown content
-        - None otherwise
+        True only if every edit in the batch applied successfully.
+    disk_written : bool
+        Whether the modified document was persisted to disk. False for read-only
+        batches (list-sections/extract only) and for any failed/atomically
+        aborted batch.
+    output_path : str | None
+        Path written to, when disk_written is True.
+    results : list[EditResultItem]
+        Per-edit results, in request order.
+    warnings : list[str]
+        Non-fatal warnings (e.g. potential fidelity loss on a binary round-trip).
 
     """
 
     success: bool
-    message: str
-    content: str | None = None
+    disk_written: bool = False
+    output_path: str | None = None
+    results: list[EditResultItem] = field(default_factory=list)
+    warnings: list[str] = field(default_factory=list)
 
 
 # search_documents tool schemas
@@ -408,3 +460,55 @@ class GetDocumentOutlineOutput:
 
     sections: list[dict] = field(default_factory=list)
     total: int = 0
+
+
+# list_workspace_files tool schemas
+@dataclass
+class ListWorkspaceFilesInput:
+    """Input schema for list_workspace_files tool.
+
+    Lists files the server is allowed to read, so an agent can orient itself
+    before reading or editing. Results are confined to the read allowlist
+    (workspace folder plus any additional read-only folders).
+
+    Attributes
+    ----------
+    subdirectory : str | None
+        Optional workspace-relative subdirectory to list. When omitted, all read
+        allowlist roots are listed. Must resolve to a location inside the read
+        allowlist.
+    pattern : str | None
+        Optional glob filter applied to file names, e.g. "*.pdf" or "*.docx".
+    recursive : bool
+        Recurse into subdirectories (default: True).
+
+    """
+
+    subdirectory: str | None = None
+    pattern: str | None = None
+    recursive: bool = True
+
+
+@dataclass
+class ListWorkspaceFilesOutput:
+    """Output schema for list_workspace_files tool.
+
+    Attributes
+    ----------
+    files : list[dict]
+        Listed files, each ``{"path": str, "size_bytes": int}`` where ``path`` is
+        absolute. Sorted by path.
+    total : int
+        Number of files returned.
+    truncated : bool
+        True if the listing was capped and more files exist than were returned.
+    read_dirs : list[str]
+        The read allowlist roots that were searched (helps the agent understand
+        what it can access).
+
+    """
+
+    files: list[dict] = field(default_factory=list)
+    total: int = 0
+    truncated: bool = False
+    read_dirs: list[str] = field(default_factory=list)

--- a/src/all2md/mcp/security.py
+++ b/src/all2md/mcp/security.py
@@ -207,6 +207,68 @@ def validate_write_path(path: str | Path, write_allowlist_dirs: list[str | Path]
     return final_path
 
 
+def resolve_workspace_path(
+    raw: str | Path,
+    allowlist_dirs: list[str | Path] | None,
+    *,
+    must_exist: bool,
+) -> Path | None:
+    """Resolve a possibly-relative path against the workspace (allowlist) dirs.
+
+    The first allowlist directory acts as the working directory, so agents can
+    refer to files by a bare name or workspace-relative path instead of always
+    supplying an absolute path.
+
+    Parameters
+    ----------
+    raw : str | Path
+        Path supplied by the caller. May be absolute, workspace-relative, or a
+        bare filename.
+    allowlist_dirs : list[str | Path] | None
+        Allowed directories (strings or resolved Paths). Used as candidate bases
+        for relative paths, in order.
+    must_exist : bool
+        When True (reads), each candidate is probed and the first that exists is
+        returned, or None if none exist. When False (writes), the path is simply
+        anchored to the first allowlist directory (or CWD) without probing.
+
+    Returns
+    -------
+    Path | None
+        The resolved path, or None when ``must_exist`` is True and no candidate
+        exists. Absolute inputs are returned unchanged.
+
+    """
+    path_obj = Path(raw)
+
+    if path_obj.is_absolute():
+        if not must_exist:
+            return path_obj
+        return path_obj if path_obj.exists() else None
+
+    bases = [Path(d) for d in allowlist_dirs] if allowlist_dirs else []
+
+    if not must_exist:
+        # Writes: anchor a relative filename to the first workspace directory.
+        base = bases[0] if bases else Path.cwd()
+        return base / path_obj
+
+    # Reads: try each workspace directory, then fall back to the current dir.
+    for base in bases:
+        candidate = base / path_obj
+        try:
+            if candidate.exists():
+                return candidate
+        except OSError:
+            continue
+    try:
+        if path_obj.exists():
+            return path_obj
+    except OSError:
+        pass
+    return None
+
+
 def prepare_allowlist_dirs(paths: list[str | Path] | None) -> list[Path] | None:
     """Validate allowlist directory paths.
 

--- a/src/all2md/mcp/security.py
+++ b/src/all2md/mcp/security.py
@@ -264,8 +264,8 @@ def resolve_workspace_path(
     try:
         if path_obj.exists():
             return path_obj
-    except OSError:
-        pass
+    except OSError as exc:
+        logger.debug("Failed to probe path existence for %s: %s", path_obj, exc, exc_info=exc)
     return None
 
 

--- a/src/all2md/mcp/server.py
+++ b/src/all2md/mcp/server.py
@@ -12,10 +12,12 @@ Functions
 
 #  Copyright (c) 2025 Tom Villani, Ph.D.
 
+import contextlib
 import logging
 import os
 import sys
-from collections.abc import Callable
+import threading
+from collections.abc import Callable, Iterator
 from typing import TYPE_CHECKING, Annotated, Any, cast
 
 from all2md import DependencyError
@@ -30,11 +32,13 @@ from all2md.mcp.schemas import (
     DiffDocumentsOutput,
     DiffFormat,
     DiffGranularity,
-    EditDocumentAction,
-    EditDocumentSimpleInput,
-    EditDocumentSimpleOutput,
+    EditDocumentInput,
+    EditDocumentOutput,
+    EditOperation,
     GetDocumentOutlineInput,
     GetDocumentOutlineOutput,
+    ListWorkspaceFilesInput,
+    ListWorkspaceFilesOutput,
     ReadDocumentAsMarkdownInput,
     SaveDocumentFromMarkdownInput,
     SaveDocumentFromMarkdownOutput,
@@ -48,15 +52,44 @@ from all2md.mcp.security import MCPSecurityError, prepare_allowlist_dirs
 
 logger = logging.getLogger(__name__)
 
+# Serialize the brief stdout->stderr redirect below across any concurrent tool
+# calls so they never clobber each other's saved file descriptor.
+_stdout_guard_lock = threading.Lock()
+
+
+@contextlib.contextmanager
+def protect_stdout() -> Iterator[None]:
+    """Redirect OS-level stdout (fd 1) to stderr for the duration.
+
+    The MCP stdio transport uses stdout for its JSON-RPC messages. Some
+    libraries in the conversion pipeline (notably PyMuPDF) print advisories
+    straight to stdout, which corrupts that channel and breaks the client
+    connection. We point fd 1 at stderr while running conversion code, then
+    restore it before FastMCP serializes the response. This catches both
+    Python-level ``print`` and C-level writes.
+    """
+    with _stdout_guard_lock:
+        sys.stdout.flush()
+        sys.stderr.flush()
+        saved_fd = os.dup(1)
+        try:
+            os.dup2(2, 1)
+            yield
+        finally:
+            sys.stdout.flush()
+            os.dup2(saved_fd, 1)
+            os.close(saved_fd)
+
 
 def create_server(
     config: MCPConfig,
     read_impl: Callable[[ReadDocumentAsMarkdownInput, MCPConfig], list[Any]],
     save_impl: Callable[[SaveDocumentFromMarkdownInput, MCPConfig], SaveDocumentFromMarkdownOutput],
-    edit_doc_impl: Callable[[EditDocumentSimpleInput, MCPConfig], EditDocumentSimpleOutput],
+    edit_doc_impl: Callable[[EditDocumentInput, MCPConfig], EditDocumentOutput],
     search_impl: Callable[[SearchDocumentsInput, MCPConfig], SearchDocumentsOutput],
     diff_impl: Callable[[DiffDocumentsInput, MCPConfig], DiffDocumentsOutput],
     outline_impl: Callable[[GetDocumentOutlineInput, MCPConfig], GetDocumentOutlineOutput],
+    list_files_impl: Callable[[ListWorkspaceFilesInput, MCPConfig], ListWorkspaceFilesOutput],
 ) -> "FastMCP":
     """Create and configure FastMCP server with tools.
 
@@ -76,6 +109,8 @@ def create_server(
         Implementation function for diff_documents tool
     outline_impl : callable
         Implementation function for get_document_outline tool
+    list_files_impl : callable
+        Implementation function for list_workspace_files tool
 
     Returns
     -------
@@ -149,7 +184,8 @@ def create_server(
             )
 
             # Return list directly - FastMCP converts to content blocks
-            return read_impl(input_obj, config)
+            with protect_stdout():
+                return read_impl(input_obj, config)
 
         logger.info("Registered tool: read_document_as_markdown")
 
@@ -184,7 +220,8 @@ def create_server(
                 format=cast(TargetFormat, format), source=source, filename=filename
             )
 
-            result = save_impl(input_obj, config)
+            with protect_stdout():
+                result = save_impl(input_obj, config)
 
             return {"output_path": result.output_path, "warnings": result.warnings}
 
@@ -195,59 +232,72 @@ def create_server(
 
         @mcp.tool(name="edit_document")
         def edit_document(
-            action: Annotated[
+            doc: Annotated[
                 str,
-                "Action to perform: list-sections, extract, add:before, add:after, remove, replace, "
-                "insert:start, insert:end, insert:after_heading. REQUIRED.",
+                "Path to the document (absolute or workspace-relative). For mutating edits it must be "
+                "within the write allowlist. REQUIRED.",
             ],
-            doc: Annotated[str, "File path to the document (must be within read allowlist). REQUIRED."],
-            target: Annotated[
-                str | None,
-                "Section to target. Either heading text (case-insensitive) like 'Introduction', or "
-                "index notation like '#0', '#1', '#2' (zero-based). Required for all actions except "
-                "list-sections.",
-            ] = None,
-            content: Annotated[
-                str | None,
-                "Markdown content to add/replace/insert. Required for add:before, add:after, replace, "
-                "insert:start, insert:end, and insert:after_heading actions.",
-            ] = None,
+            edits: Annotated[
+                list[EditOperation],
+                "Ordered list of edits to apply atomically. Each edit is an object with: "
+                "'action' (one of list-sections, extract, add:before, add:after, remove, replace, "
+                "insert:start, insert:end, insert:after_heading); 'target' (heading text like "
+                "'Introduction', or index like '#0' — required for every action except list-sections; "
+                "prefer heading text in multi-edit batches since indices can shift); and 'content' "
+                "(markdown, required for add/replace/insert actions). REQUIRED.",
+            ],
         ) -> dict:
-            """Edit markdown documents by manipulating their structure.
+            """Apply a batch of structural edits to a document, in place.
 
-            This tool provides a simplified interface for document manipulation with sensible
-            LLM-friendly defaults (markdown only, case-insensitive heading matching, GFM flavor).
+            Source format is auto-detected (Markdown, DOCX, HTML, RST, EPUB, ...), so this is
+            not Markdown-only. The whole batch is atomic: if any edit fails, none are applied
+            and nothing is written. When the batch contains a mutating action, the modified
+            document is written back to disk in its original format (the file must be within the
+            write allowlist). Heading matching is case-insensitive.
 
-            Available actions:
-            - list-sections: List all sections with metadata (returns formatted section list)
-            - extract: Get a specific section by heading or index (returns section content)
-            - add:before: Add new section before the target section
-            - add:after: Add new section after the target section
-            - remove: Remove a section from the document
-            - replace: Replace section content with new content
-            - insert:start: Insert content at the start of a section
-            - insert:end: Insert content at the end of a section
-            - insert:after_heading: Insert content right after the section heading
+            Actions:
+            - list-sections: list all sections with metadata (read-only)
+            - extract: get a section by heading or index (read-only)
+            - add:before / add:after: add a new section relative to target
+            - remove: remove a section
+            - replace: replace a section's content
+            - insert:start / insert:end / insert:after_heading: insert within a section
 
-            Target format:
-            - Heading text: "Introduction", "Methods and Results", etc. (case-insensitive)
-            - Index notation: "#0" (first section), "#1" (second section), etc.
+            In-place write-back is supported for .md, .html, .docx, .pptx, .rst, .epub. For other
+            formats (e.g. .pdf), use save_document_from_markdown to export instead.
 
             Requires --enable-doc-edit flag (disabled by default for security).
 
             Returns a dictionary with:
-            - success: Boolean indicating if operation succeeded
-            - message: Human-readable result or error message
-            - content: Content from operation (for list-sections and extract actions)
+            - success: True only if every edit applied
+            - disk_written: whether the file was persisted to disk
+            - output_path: path written to (when disk_written is True)
+            - results: per-edit {index, action, target, success, message, edited_region}
+              where edited_region is only the affected section, not the whole document
+            - warnings: non-fatal notes (e.g. potential formatting loss on a binary round-trip)
             """
-            # Cast to proper Literal type (FastMCP validates at the boundary)
-            input_obj = EditDocumentSimpleInput(
-                action=cast(EditDocumentAction, action), doc=doc, target=target, content=content
-            )
+            input_obj = EditDocumentInput(doc=doc, edits=list(edits))
 
-            result = edit_doc_impl(input_obj, config)
+            with protect_stdout():
+                result = edit_doc_impl(input_obj, config)
 
-            return {"success": result.success, "message": result.message, "content": result.content}
+            return {
+                "success": result.success,
+                "disk_written": result.disk_written,
+                "output_path": result.output_path,
+                "results": [
+                    {
+                        "index": item.index,
+                        "action": item.action,
+                        "target": item.target,
+                        "success": item.success,
+                        "message": item.message,
+                        "edited_region": item.edited_region,
+                    }
+                    for item in result.results
+                ],
+                "warnings": result.warnings,
+            }
 
         logger.info("Registered tool: edit_document")
 
@@ -303,7 +353,8 @@ def create_server(
                 regex=regex,
                 recursive=recursive,
             )
-            result = search_impl(input_obj, config)
+            with protect_stdout():
+                result = search_impl(input_obj, config)
             return {
                 "results": [
                     {
@@ -359,7 +410,8 @@ def create_server(
                 granularity=cast(DiffGranularity, granularity),
                 ignore_whitespace=ignore_whitespace,
             )
-            result = diff_impl(input_obj, config)
+            with protect_stdout():
+                result = diff_impl(input_obj, config)
             return {"diff": result.diff, "has_changes": result.has_changes}
 
         logger.info("Registered tool: diff_documents")
@@ -393,10 +445,51 @@ def create_server(
             input_obj = GetDocumentOutlineInput(
                 doc=doc, max_level=max_level, format_hint=cast(SourceFormat | None, format_hint)
             )
-            result = outline_impl(input_obj, config)
+            with protect_stdout():
+                result = outline_impl(input_obj, config)
             return {"sections": result.sections, "total": result.total}
 
         logger.info("Registered tool: get_document_outline")
+
+    # Conditionally register list_workspace_files tool (read-only)
+    if config.enable_list_files:
+
+        @mcp.tool(name="list_workspace_files")
+        def list_workspace_files(
+            subdirectory: Annotated[
+                str | None,
+                "Optional workspace-relative subdirectory to list. If omitted, all read folders are listed.",
+            ] = None,
+            pattern: Annotated[
+                str | None,
+                "Optional glob filter on file names, e.g. '*.pdf' or '*.docx'. Default: all files.",
+            ] = None,
+            recursive: Annotated[bool, "Recurse into subdirectories. Default: true."] = True,
+        ) -> dict:
+            """List files the server is allowed to read.
+
+            Use this to discover what is available before reading or editing. Results
+            are confined to the read allowlist (the workspace folder plus any additional
+            read-only folders). Paths returned here can be passed directly to the other
+            tools.
+
+            Returns a dictionary with:
+            - files: list of {path, size_bytes} (absolute paths, sorted)
+            - total: number of files returned
+            - truncated: true if more files exist than were returned (capped)
+            - read_dirs: the read folders that were searched
+            """
+            input_obj = ListWorkspaceFilesInput(subdirectory=subdirectory, pattern=pattern, recursive=recursive)
+            with protect_stdout():
+                result = list_files_impl(input_obj, config)
+            return {
+                "files": result.files,
+                "total": result.total,
+                "truncated": result.truncated,
+                "read_dirs": result.read_dirs,
+            }
+
+        logger.info("Registered tool: list_workspace_files")
 
     return mcp
 
@@ -409,6 +502,12 @@ def configure_logging(level: str) -> None:
 def main() -> int:
     """Run all2md-mcp server."""
     try:
+        # Route PyMuPDF's advisory messages to stderr (fd 2) instead of stdout,
+        # which the stdio transport reserves for JSON-RPC. Must be set before
+        # PyMuPDF is imported. protect_stdout() is the runtime backstop, but this
+        # keeps even import-time advisories off the protocol channel.
+        os.environ.setdefault("PYMUPDF_MESSAGE", "fd:2")
+
         # Configure logging with default level first (will be reconfigured if needed)
         configure_logging("INFO")
 
@@ -424,7 +523,7 @@ def main() -> int:
             f"Configuration: enable_to_md={config.enable_to_md}, "
             f"enable_from_md={config.enable_from_md}, enable_doc_edit={config.enable_doc_edit}, "
             f"enable_search={config.enable_search}, enable_diff={config.enable_diff}, "
-            f"enable_outline={config.enable_outline}"
+            f"enable_outline={config.enable_outline}, enable_list_files={config.enable_list_files}"
         )
         logger.info(f"Include images: {config.include_images}")
         if config.search_index_dir:
@@ -464,6 +563,7 @@ def main() -> int:
         from all2md.mcp.query_tools import (
             diff_documents_impl,
             get_document_outline_impl,
+            list_workspace_files_impl,
             search_documents_impl,
         )
         from all2md.mcp.tools import read_document_as_markdown_impl, save_document_from_markdown_impl
@@ -477,6 +577,7 @@ def main() -> int:
             search_documents_impl,
             diff_documents_impl,
             get_document_outline_impl,
+            list_workspace_files_impl,
         )
 
         logger.info("Server ready, listening on stdio")

--- a/src/all2md/mcp/tools.py
+++ b/src/all2md/mcp/tools.py
@@ -32,7 +32,13 @@ from all2md.mcp.schemas import (
     SaveDocumentFromMarkdownOutput,
     SourceFormat,
 )
-from all2md.mcp.security import secure_open_for_write, validate_read_path, validate_write_path
+from all2md.mcp.security import (
+    MCPSecurityError,
+    resolve_workspace_path,
+    secure_open_for_write,
+    validate_read_path,
+    validate_write_path,
+)
 
 FastMCPImage: type | None
 try:
@@ -93,6 +99,35 @@ def _extract_images_from_ast(doc: Any) -> list[Any]:
     return fastmcp_images
 
 
+# Path-like detection heuristics for the unified ``source`` parameter. Base64's
+# alphabet has no '.', so requiring a trailing file extension cleanly separates
+# real file references (which we error on when missing) from base64/inline text.
+_EXTENSION_RE = re.compile(r"\.[A-Za-z0-9]{1,8}$")
+
+
+def _path_candidate(source: str) -> bool:
+    """Return True if ``source`` is worth attempting to resolve as a file path."""
+    s = source.strip()
+    if not s or "\n" in s or "\r" in s or len(s) > 512:
+        return False
+    if s.startswith("<") or s.lower().startswith("data:") or "://" in s:
+        return False
+    if "/" in s or "\\" in s:  # has a path separator
+        return True
+    # No separator: only a bare, space-free filename with an extension qualifies.
+    return _EXTENSION_RE.search(s) is not None and " " not in s
+
+
+def _is_definite_path(source: str) -> bool:
+    """Return True if ``source`` is unambiguously a file reference.
+
+    Used to decide whether a missing file should raise (definite path) rather
+    than fall through to inline-content handling. Requires a trailing file
+    extension, which base64 and most prose never have.
+    """
+    return _path_candidate(source) and _EXTENSION_RE.search(source.strip()) is not None
+
+
 def _detect_source_type(source: str, config: MCPConfig) -> tuple[Path | bytes, str]:
     """Detect and prepare source from unified source parameter.
 
@@ -115,29 +150,25 @@ def _detect_source_type(source: str, config: MCPConfig) -> tuple[Path | bytes, s
         If path validation fails
 
     """
-    # Quick checks to skip path detection for obvious content types
-    if source.startswith("<") or "<" in source[:100]:  # HTML/XML content
-        logger.debug("Skipping path detection: appears to be HTML/XML content")
-    elif source.startswith("data:"):  # Data URI
-        logger.debug("Skipping path detection: appears to be data URI")
-    # 1. Try to resolve as file path (if looks plausible and not HTML/JSON/etc)
-    elif (
-        "/" in source or "\\" in source or ("." in source and len(source) < 500)  # Has path separators
-    ):  # Or has dot and reasonable length
-        try:
-            path_obj = Path(source)
-            # Only validate if the path actually exists on the filesystem
-            # This prevents false positives when text happens to contain path-like strings
-            if path_obj.exists():
-                validated_path = validate_read_path(path_obj, config.read_allowlist)
-                logger.info(f"Detected as file path: {validated_path}")
-                return validated_path, "path"
-            else:
-                # Path doesn't exist, continue to other detection methods
-                logger.debug(f"Path does not exist: {path_obj}, treating as content")
-        except (OSError, ValueError):
-            # Not a valid path, continue to other detection methods
-            pass
+    # 1. Try to resolve as a file path (workspace-relative or absolute), unless
+    #    the source is obviously inline content (HTML/XML or a data URI).
+    is_inline = source.startswith("<") or "<" in source[:100] or source.startswith("data:")
+    if not is_inline and _path_candidate(source):
+        resolved = resolve_workspace_path(source, config.read_allowlist, must_exist=True)
+        if resolved is not None:
+            validated_path = validate_read_path(resolved, config.read_allowlist)
+            logger.info(f"Detected as file path: {validated_path}")
+            return validated_path, "path"
+        # Looks unmistakably like a file reference but we couldn't find it. Fail
+        # loudly instead of silently treating the path string as document text.
+        if _is_definite_path(source):
+            searched = ", ".join(str(d) for d in (config.read_allowlist or [])) or "(no read folders configured)"
+            raise MCPSecurityError(
+                f"File not found: {source!r}. Looked relative to the workspace folder(s): {searched}. "
+                "Provide a path inside an allowed folder, or pass the document content directly.",
+                path=source,
+            )
+        logger.debug(f"Path candidate {source!r} not found; treating as content")
 
     # 2. Check for data URI format (data:...)
     if source.startswith("data:"):
@@ -344,8 +375,10 @@ def save_document_from_markdown_impl(
     """
     warnings: list[str] = []
 
-    # Validate write access for output file
-    validated_output = validate_write_path(input_data.filename, config.write_allowlist)
+    # Anchor a relative filename to the workspace (write allowlist acts as cwd),
+    # then validate write access for the output file.
+    target = resolve_workspace_path(input_data.filename, config.write_allowlist, must_exist=False)
+    validated_output = validate_write_path(target or input_data.filename, config.write_allowlist)
     output_path = str(validated_output)
     logger.info(f"Writing output to: {validated_output}")
 

--- a/tests/integration/mcp/test_mcp_document_tools.py
+++ b/tests/integration/mcp/test_mcp_document_tools.py
@@ -1,504 +1,322 @@
 #  Copyright (c) 2025 Tom Villani, Ph.D.
 #
 # tests/integration/test_mcp_document_tools.py
-"""Integration tests for MCP document manipulation tool (simplified interface).
+"""Integration tests for the MCP edit_document tool (batch, in-place).
 
-Tests cover all 9 supported actions:
-- list-sections
-- extract
-- add:before
-- add:after
-- remove
-- replace
-- insert:start
-- insert:end
-- insert:after_heading
+edit_document applies an ordered batch of edits to a single parse of a document
+and, when the batch mutates the document, writes it back to disk in its original
+format. The batch is atomic. Mutating responses echo only the edited region.
 
+Actions covered: list-sections, extract, add:before, add:after, remove, replace,
+insert:start, insert:end, insert:after_heading.
 """
 
 import pytest
 
 from all2md.mcp.config import MCPConfig
 from all2md.mcp.document_tools import edit_document_impl
-from all2md.mcp.schemas import EditDocumentSimpleInput
+from all2md.mcp.schemas import EditDocumentInput, EditOperation
+
+
+def _edit(doc, ops, config):
+    """Run edit_document_impl with a list of EditOperation."""
+    return edit_document_impl(EditDocumentInput(doc=str(doc), edits=ops), config)
+
+
+def _rw_config(tmp_path):
+    """Config allowing both reads and writes within tmp_path."""
+    return MCPConfig(read_allowlist=[str(tmp_path)], write_allowlist=[str(tmp_path)])
 
 
 @pytest.mark.integration
-class TestMCPDocumentToolListSections:
-    """Tests for list-sections action."""
+class TestListSectionsAndExtract:
+    """Read-only actions: list-sections and extract (no disk writes)."""
 
     def test_list_sections_from_file(self, tmp_path):
-        """Test listing sections from markdown file."""
         md_file = tmp_path / "doc.md"
-        md_file.write_text("""# Chapter 1
-
-Content for chapter 1.
-
-## Section 1.1
-
-Content for section 1.1.
-
-# Chapter 2
-
-Content for chapter 2.
-""")
-
+        md_file.write_text(
+            "# Chapter 1\n\nContent for chapter 1.\n\n"
+            "## Section 1.1\n\nContent for section 1.1.\n\n"
+            "# Chapter 2\n\nContent for chapter 2.\n"
+        )
         config = MCPConfig(read_allowlist=[str(tmp_path)])
-        input_data = EditDocumentSimpleInput(action="list-sections", doc=str(md_file))
 
-        result = edit_document_impl(input_data, config)
+        result = _edit(md_file, [EditOperation(action="list-sections")], config)
 
         assert result.success is True
-        assert "3 section(s)" in result.message
-        assert result.content is not None
-        assert "Chapter 1" in result.content
-        assert "Section 1.1" in result.content
-        assert "Chapter 2" in result.content
-        assert "[#0]" in result.content
-        assert "[#1]" in result.content
-        assert "[#2]" in result.content
-
-
-@pytest.mark.integration
-class TestMCPDocumentToolExtract:
-    """Tests for extract action."""
-
-    def test_extract_by_heading_text(self, tmp_path):
-        """Test extracting section by heading text (case-insensitive)."""
-        md_file = tmp_path / "doc.md"
-        md_file.write_text("""# Introduction
-
-Intro content.
-
-# Methods
-
-Methods content.
-
-# Results
-
-Results content.
-""")
-
-        config = MCPConfig(read_allowlist=[str(tmp_path)])
-        input_data = EditDocumentSimpleInput(action="extract", doc=str(md_file), target="Methods")  # Case-insensitive
-
-        result = edit_document_impl(input_data, config)
-
-        assert result.success is True
-        assert "extracted" in result.message.lower()
-        assert "Methods" in result.message
-        assert result.content is not None
-        assert "Methods" in result.content
-        assert "Methods content" in result.content
-        assert "Introduction" not in result.content
-        assert "Results" not in result.content
+        assert result.disk_written is False
+        region = result.results[0].edited_region
+        assert region is not None
+        assert "Chapter 1" in region
+        assert "Section 1.1" in region
+        assert "[#0]" in region and "[#1]" in region and "[#2]" in region
 
     def test_extract_by_heading_case_insensitive(self, tmp_path):
-        """Test that heading matching is case-insensitive."""
         md_file = tmp_path / "doc.md"
-        md_file.write_text("""# Introduction
-
-Content here.
-""")
-
+        md_file.write_text("# Introduction\n\nIntro content.\n\n# Methods\n\nMethods content.\n")
         config = MCPConfig(read_allowlist=[str(tmp_path)])
-        input_data = EditDocumentSimpleInput(action="extract", doc=str(md_file), target="introduction")  # Lowercase
 
-        result = edit_document_impl(input_data, config)
+        result = _edit(md_file, [EditOperation(action="extract", target="methods")], config)
 
         assert result.success is True
-        assert result.content is not None
-        assert "Introduction" in result.content
+        assert result.disk_written is False
+        region = result.results[0].edited_region
+        assert region is not None
+        assert "Methods content" in region
+        assert "Introduction" not in region
 
     def test_extract_by_index_notation(self, tmp_path):
-        """Test extracting section by index notation (#0, #1, etc.)."""
         md_file = tmp_path / "doc.md"
-        md_file.write_text("""# First
-
-Content.
-
-# Second
-
-Content.
-
-# Third
-
-Content.
-""")
-
+        md_file.write_text("# First\n\nA.\n\n# Second\n\nB.\n\n# Third\n\nC.\n")
         config = MCPConfig(read_allowlist=[str(tmp_path)])
-        input_data = EditDocumentSimpleInput(
-            action="extract",
-            doc=str(md_file),
-            target="#1",  # Second section (zero-based)
-        )
 
-        result = edit_document_impl(input_data, config)
+        result = _edit(md_file, [EditOperation(action="extract", target="#1")], config)
 
         assert result.success is True
-        assert "#1" in result.message
-        assert result.content is not None
-        assert "Second" in result.content
-        assert "First" not in result.content
-        assert "Third" not in result.content
+        region = result.results[0].edited_region
+        assert region is not None
+        assert "Second" in region
+        assert "First" not in region and "Third" not in region
 
-    def test_extract_missing_section_returns_error(self, tmp_path):
-        """Test that extracting nonexistent section returns error."""
+    def test_extract_missing_section_fails(self, tmp_path):
         md_file = tmp_path / "doc.md"
-        md_file.write_text("""# Existing
-
-Content.
-""")
-
+        md_file.write_text("# Existing\n\nContent.\n")
         config = MCPConfig(read_allowlist=[str(tmp_path)])
-        input_data = EditDocumentSimpleInput(action="extract", doc=str(md_file), target="Nonexistent")
 
-        result = edit_document_impl(input_data, config)
+        result = _edit(md_file, [EditOperation(action="extract", target="Nonexistent")], config)
 
         assert result.success is False
-        assert "[ERROR]" in result.message
-        assert "no sections match pattern: nonexistent" in result.message.lower()
+        assert "nonexistent" in result.results[0].message.lower()
 
 
 @pytest.mark.integration
-class TestMCPDocumentToolAddSection:
-    """Tests for add:before and add:after actions."""
+class TestMutatingEditsPersist:
+    """Mutating actions write back to disk in the source format."""
 
-    def test_add_section_after(self, tmp_path):
-        """Test adding section after target."""
+    def test_add_section_after_persists(self, tmp_path):
         md_file = tmp_path / "doc.md"
-        md_file.write_text("""# First
+        md_file.write_text("# First\n\nContent 1.\n\n# Third\n\nContent 3.\n")
+        config = _rw_config(tmp_path)
 
-Content 1.
-
-# Third
-
-Content 3.
-""")
-
-        config = MCPConfig(read_allowlist=[str(tmp_path)])
-        input_data = EditDocumentSimpleInput(
-            action="add:after", doc=str(md_file), target="First", content="# Second\n\nContent 2."
+        result = _edit(
+            md_file,
+            [EditOperation(action="add:after", target="First", content="# Second\n\nContent 2.")],
+            config,
         )
 
-        result = edit_document_impl(input_data, config)
+        assert result.success is True
+        assert result.disk_written is True
+        assert result.output_path == str(md_file.resolve())
+        saved = md_file.read_text()
+        assert "Second" in saved
+        assert saved.index("First") < saved.index("Second") < saved.index("Third")
+        # Region echoes only the added section, not the whole document.
+        assert "Second" in (result.results[0].edited_region or "")
+        assert "Third" not in (result.results[0].edited_region or "")
+
+    def test_remove_section_persists(self, tmp_path):
+        md_file = tmp_path / "doc.md"
+        md_file.write_text("# Keep\n\nA.\n\n# Drop\n\nB.\n\n# KeepToo\n\nC.\n")
+        config = _rw_config(tmp_path)
+
+        result = _edit(md_file, [EditOperation(action="remove", target="Drop")], config)
 
         assert result.success is True
-        assert "added" in result.message.lower()
-        assert "First" in result.message
-        assert result.content is not None
-        assert "# Second" in result.content
-        # Verify ordering
-        first_pos = result.content.index("First")
-        second_pos = result.content.index("Second")
-        third_pos = result.content.index("Third")
-        assert first_pos < second_pos < third_pos
+        assert result.disk_written is True
+        saved = md_file.read_text()
+        assert "Drop" not in saved
+        assert "Keep" in saved and "KeepToo" in saved
 
-    def test_add_section_before(self, tmp_path):
-        """Test adding section before target."""
+    def test_replace_section_persists(self, tmp_path):
         md_file = tmp_path / "doc.md"
-        md_file.write_text("""# Second
+        md_file.write_text("# Intro\n\nOld intro.\n\n# Methods\n\nMethods.\n")
+        config = _rw_config(tmp_path)
 
-Content 2.
-
-# Third
-
-Content 3.
-""")
-
-        config = MCPConfig(read_allowlist=[str(tmp_path)])
-        input_data = EditDocumentSimpleInput(
-            action="add:before", doc=str(md_file), target="Second", content="# First\n\nContent 1."
+        result = _edit(
+            md_file,
+            [EditOperation(action="replace", target="Intro", content="# Intro\n\nBrand new intro.")],
+            config,
         )
 
-        result = edit_document_impl(input_data, config)
-
         assert result.success is True
-        assert "added" in result.message.lower()
-        assert "before" in result.message
-        assert result.content is not None
-        assert "# First" in result.content
-        # Verify ordering
-        first_pos = result.content.index("First")
-        second_pos = result.content.index("Second")
-        assert first_pos < second_pos
+        assert result.disk_written is True
+        saved = md_file.read_text()
+        assert "Brand new intro" in saved
+        assert "Old intro" not in saved
+        assert "Methods" in saved
 
-    def test_add_section_using_index_notation(self, tmp_path):
-        """Test adding section using index notation for target."""
+    def test_insert_end_persists(self, tmp_path):
         md_file = tmp_path / "doc.md"
-        md_file.write_text("""# Section 1
+        md_file.write_text("# Section\n\nExisting content.\n")
+        config = _rw_config(tmp_path)
 
-Content 1.
-
-# Section 2
-
-Content 2.
-""")
-
-        config = MCPConfig(read_allowlist=[str(tmp_path)])
-        input_data = EditDocumentSimpleInput(
-            action="add:after",
-            doc=str(md_file),
-            target="#0",  # After first section
-            content="# New Section\n\nNew content.",
+        result = _edit(
+            md_file,
+            [EditOperation(action="insert:end", target="Section", content="Appended paragraph.")],
+            config,
         )
 
-        result = edit_document_impl(input_data, config)
-
         assert result.success is True
-        assert "#0" in result.message
-        assert result.content is not None
-        assert "New Section" in result.content
+        assert result.disk_written is True
+        saved = md_file.read_text()
+        assert "Existing content" in saved
+        assert "Appended paragraph" in saved
 
 
 @pytest.mark.integration
-class TestMCPDocumentToolRemoveSection:
-    """Tests for remove action."""
+class TestBatchSemantics:
+    """Batch ordering, persistence across edits, and atomicity."""
 
-    def test_remove_section_by_heading(self, tmp_path):
-        """Test removing section by heading text."""
+    def test_multiple_edits_in_one_call_all_persist(self, tmp_path):
+        """Sequential edits in a batch all land (the stale-state fix)."""
         md_file = tmp_path / "doc.md"
-        md_file.write_text("""# Keep This
+        md_file.write_text("# Section\n\nStart.\n")
+        config = _rw_config(tmp_path)
 
-Content.
-
-# Remove This
-
-Content to remove.
-
-# Keep This Too
-
-More content.
-""")
-
-        config = MCPConfig(read_allowlist=[str(tmp_path)])
-        input_data = EditDocumentSimpleInput(action="remove", doc=str(md_file), target="Remove This")
-
-        result = edit_document_impl(input_data, config)
+        result = _edit(
+            md_file,
+            [
+                EditOperation(action="insert:end", target="Section", content="First addition."),
+                EditOperation(action="insert:end", target="Section", content="Second addition."),
+            ],
+            config,
+        )
 
         assert result.success is True
-        assert "removed" in result.message.lower()
-        assert "Remove This" in result.message
-        assert result.content is not None
-        assert "Remove This" not in result.content
-        assert "Keep This" in result.content
-        assert "Keep This Too" in result.content
+        assert result.disk_written is True
+        assert len(result.results) == 2
+        saved = md_file.read_text()
+        assert "First addition" in saved
+        assert "Second addition" in saved
 
-    def test_remove_section_by_index(self, tmp_path):
-        """Test removing section by index notation."""
+    def test_atomic_abort_writes_nothing(self, tmp_path):
+        """If any edit fails, none are persisted."""
         md_file = tmp_path / "doc.md"
-        md_file.write_text("""# First
+        original = "# Section\n\nStart.\n"
+        md_file.write_text(original)
+        config = _rw_config(tmp_path)
 
-Content.
+        result = _edit(
+            md_file,
+            [
+                EditOperation(action="insert:end", target="Section", content="Would-be addition."),
+                EditOperation(action="replace", target="Nonexistent", content="# X\n\nY."),
+            ],
+            config,
+        )
 
-# Second
-
-Content.
-
-# Third
-
-Content.
-""")
-
-        config = MCPConfig(read_allowlist=[str(tmp_path)])
-        input_data = EditDocumentSimpleInput(action="remove", doc=str(md_file), target="#1")  # Remove middle section
-
-        result = edit_document_impl(input_data, config)
-
-        assert result.success is True
-        assert "#1" in result.message
-        assert result.content is not None
-        assert "Second" not in result.content
-        assert "First" in result.content
-        assert "Third" in result.content
+        assert result.success is False
+        assert result.disk_written is False
+        assert result.results[1].success is False
+        # Nothing was written to disk.
+        assert "Would-be addition" not in md_file.read_text()
 
 
 @pytest.mark.integration
-class TestMCPDocumentToolReplaceSection:
-    """Tests for replace action."""
+class TestWriteBackBoundaries:
+    """Format and allowlist boundaries for in-place writes."""
 
-    def test_replace_section_content(self, tmp_path):
-        """Test replacing section with new content."""
-        md_file = tmp_path / "doc.md"
-        md_file.write_text("""# Introduction
+    def test_unsupported_format_for_inplace_write(self, tmp_path):
+        """A format with no in-place renderer (e.g. .csv) is rejected clearly."""
+        csv_file = tmp_path / "data.csv"
+        csv_file.write_text("a,b\n1,2\n")
+        config = _rw_config(tmp_path)
 
-Old introduction content.
+        result = _edit(csv_file, [EditOperation(action="insert:end", target="#0", content="x")], config)
 
-# Methods
+        assert result.success is False
+        assert result.disk_written is False
+        assert any("cannot write" in w.lower() for w in result.warnings)
 
-Methods content.
-""")
+    def test_read_only_folder_cannot_be_edited(self, tmp_path):
+        """A file readable but not writable cannot be mutated in place."""
+        read_dir = tmp_path / "readonly"
+        write_dir = tmp_path / "writable"
+        read_dir.mkdir()
+        write_dir.mkdir()
+        md_file = read_dir / "doc.md"
+        md_file.write_text("# Section\n\nContent.\n")
+        config = MCPConfig(read_allowlist=[str(read_dir)], write_allowlist=[str(write_dir)])
 
-        config = MCPConfig(read_allowlist=[str(tmp_path)])
-        input_data = EditDocumentSimpleInput(
-            action="replace",
-            doc=str(md_file),
-            target="Introduction",
-            content="# Introduction\n\nNew introduction content with more details.",
-        )
+        result = _edit(md_file, [EditOperation(action="insert:end", target="Section", content="x")], config)
 
-        result = edit_document_impl(input_data, config)
-
-        assert result.success is True
-        assert "replaced" in result.message.lower()
-        assert "Introduction" in result.message
-        assert result.content is not None
-        assert "New introduction content" in result.content
-        assert "Old introduction content" not in result.content
-        assert "Methods" in result.content  # Other sections preserved
+        assert result.success is False
+        assert result.disk_written is False
+        assert result.warnings
 
 
 @pytest.mark.integration
-class TestMCPDocumentToolInsertContent:
-    """Tests for insert:start, insert:end, and insert:after_heading actions."""
+class TestEditValidation:
+    """Input validation and access errors."""
 
-    def test_insert_content_at_end(self, tmp_path):
-        """Test inserting content at end of section."""
-        md_file = tmp_path / "doc.md"
-        md_file.write_text("""# Section
-
-Existing content.
-""")
-
-        config = MCPConfig(read_allowlist=[str(tmp_path)])
-        input_data = EditDocumentSimpleInput(
-            action="insert:end", doc=str(md_file), target="Section", content="Additional paragraph at the end."
-        )
-
-        result = edit_document_impl(input_data, config)
-
-        assert result.success is True
-        assert "inserted" in result.message.lower()
-        assert result.content is not None
-        assert "Existing content" in result.content
-        assert "Additional paragraph" in result.content
-
-    def test_insert_content_at_start(self, tmp_path):
-        """Test inserting content at start of section."""
-        md_file = tmp_path / "doc.md"
-        md_file.write_text("""# Section
-
-Existing content.
-""")
-
-        config = MCPConfig(read_allowlist=[str(tmp_path)])
-        input_data = EditDocumentSimpleInput(
-            action="insert:start", doc=str(md_file), target="Section", content="New first paragraph."
-        )
-
-        result = edit_document_impl(input_data, config)
-
-        assert result.success is True
-        assert "inserted" in result.message.lower()
-        assert result.content is not None
-        assert "New first paragraph" in result.content
-        assert "Existing content" in result.content
-
-    def test_insert_content_after_heading(self, tmp_path):
-        """Test inserting content right after heading."""
-        md_file = tmp_path / "doc.md"
-        md_file.write_text("""# Section
-
-Existing content.
-""")
-
-        config = MCPConfig(read_allowlist=[str(tmp_path)])
-        input_data = EditDocumentSimpleInput(
-            action="insert:after_heading", doc=str(md_file), target="Section", content="Inserted right after heading."
-        )
-
-        result = edit_document_impl(input_data, config)
-
-        assert result.success is True
-        assert "inserted" in result.message.lower()
-        assert result.content is not None
-        assert "Inserted right after heading" in result.content
-
-
-@pytest.mark.integration
-class TestMCPDocumentToolErrorHandling:
-    """Tests for error handling and validation."""
-
-    def test_missing_target_for_extract_returns_error(self, tmp_path):
-        """Test that extract without target returns error."""
+    def test_missing_target_for_extract(self, tmp_path):
         md_file = tmp_path / "doc.md"
         md_file.write_text("# Content\n\nText.")
-
         config = MCPConfig(read_allowlist=[str(tmp_path)])
-        input_data = EditDocumentSimpleInput(
-            action="extract",
-            doc=str(md_file),
-            # Missing target parameter
-        )
 
-        result = edit_document_impl(input_data, config)
+        result = _edit(md_file, [EditOperation(action="extract")], config)
 
         assert result.success is False
-        assert "[ERROR]" in result.message
-        assert "requires a target" in result.message
+        assert "requires a target" in result.results[0].message
 
-    def test_missing_content_for_add_returns_error(self, tmp_path):
-        """Test that add without content returns error."""
+    def test_missing_content_for_add(self, tmp_path):
         md_file = tmp_path / "doc.md"
         md_file.write_text("# Section\n\nContent.")
+        config = _rw_config(tmp_path)
 
-        config = MCPConfig(read_allowlist=[str(tmp_path)])
-        input_data = EditDocumentSimpleInput(
-            action="add:after",
-            doc=str(md_file),
-            target="Section",
-            # Missing content parameter
-        )
-
-        result = edit_document_impl(input_data, config)
+        result = _edit(md_file, [EditOperation(action="add:after", target="Section")], config)
 
         assert result.success is False
-        assert "[ERROR]" in result.message
-        assert "requires content" in result.message
+        assert "requires a content" in result.results[0].message
 
-    def test_invalid_index_notation_returns_error(self, tmp_path):
-        """Test that invalid index notation returns error."""
+    def test_invalid_index_notation(self, tmp_path):
         md_file = tmp_path / "doc.md"
         md_file.write_text("# Section\n\nContent.")
-
         config = MCPConfig(read_allowlist=[str(tmp_path)])
-        input_data = EditDocumentSimpleInput(
-            action="extract",
-            doc=str(md_file),
-            target="#abc",  # Invalid - not a number
-        )
 
-        result = edit_document_impl(input_data, config)
+        result = _edit(md_file, [EditOperation(action="extract", target="#abc")], config)
 
         assert result.success is False
-        assert "[ERROR]" in result.message
-        assert "Invalid target index format" in result.message
+        assert "Invalid target index format" in result.results[0].message
 
-    def test_path_not_in_allowlist_returns_error(self, tmp_path):
-        """Test that path outside allowlist returns error."""
-        allowed_dir = tmp_path / "allowed"
-        forbidden_dir = tmp_path / "forbidden"
-        allowed_dir.mkdir()
-        forbidden_dir.mkdir()
+    def test_invalid_action(self, tmp_path):
+        md_file = tmp_path / "doc.md"
+        md_file.write_text("# Section\n\nContent.")
+        config = MCPConfig(read_allowlist=[str(tmp_path)])
 
-        forbidden_file = forbidden_dir / "doc.md"
+        result = _edit(md_file, [EditOperation(action="frobnicate", target="Section")], config)
+
+        assert result.success is False
+        assert "invalid action" in result.results[0].message.lower()
+
+    def test_path_not_in_allowlist(self, tmp_path):
+        allowed = tmp_path / "allowed"
+        forbidden = tmp_path / "forbidden"
+        allowed.mkdir()
+        forbidden.mkdir()
+        forbidden_file = forbidden / "doc.md"
         forbidden_file.write_text("# Secret\n\nContent.")
+        config = MCPConfig(read_allowlist=[str(allowed)])
 
-        config = MCPConfig(read_allowlist=[str(allowed_dir)])
-        input_data = EditDocumentSimpleInput(action="list-sections", doc=str(forbidden_file))
-
-        result = edit_document_impl(input_data, config)
+        result = _edit(forbidden_file, [EditOperation(action="list-sections")], config)
 
         assert result.success is False
-        assert "[ERROR]" in result.message
-        assert "access denied" in result.message.lower()
+        # File is outside the read allowlist, so it isn't found relative to it.
+        assert result.warnings
 
-    def test_nonexistent_file_returns_error(self, tmp_path):
-        """Test that nonexistent file returns error."""
+    def test_nonexistent_file(self, tmp_path):
         config = MCPConfig(read_allowlist=[str(tmp_path)])
-        input_data = EditDocumentSimpleInput(action="list-sections", doc=str(tmp_path / "nonexistent.md"))
 
-        result = edit_document_impl(input_data, config)
+        result = _edit(tmp_path / "nope.md", [EditOperation(action="list-sections")], config)
 
         assert result.success is False
-        assert "[ERROR]" in result.message
+        assert any("not found" in w.lower() for w in result.warnings)
+
+    def test_no_edits(self, tmp_path):
+        md_file = tmp_path / "doc.md"
+        md_file.write_text("# Section\n\nContent.")
+        config = MCPConfig(read_allowlist=[str(tmp_path)])
+
+        result = _edit(md_file, [], config)
+
+        assert result.success is False

--- a/tests/unit/test_mcp/test_mcp_config.py
+++ b/tests/unit/test_mcp/test_mcp_config.py
@@ -74,7 +74,7 @@ class TestMCPConfig:
         assert config.log_level == "INFO"
 
     def test_config_validate_no_tools_enabled(self):
-        """Test that at least one tool must be enabled (all six disabled)."""
+        """Test that at least one tool must be enabled (all disabled)."""
         config = MCPConfig(
             enable_to_md=False,
             enable_from_md=False,
@@ -82,6 +82,7 @@ class TestMCPConfig:
             enable_search=False,
             enable_diff=False,
             enable_outline=False,
+            enable_list_files=False,
         )
         with pytest.raises(ValueError, match="At least one tool must be enabled"):
             config.validate()

--- a/tests/unit/test_mcp/test_mcp_new_features.py
+++ b/tests/unit/test_mcp/test_mcp_new_features.py
@@ -1,0 +1,166 @@
+#  Copyright (c) 2025 Tom Villani, Ph.D.
+"""Unit tests for MCP path resolution, list_workspace_files, and config additions."""
+
+from pathlib import Path
+
+import pytest
+
+from all2md.mcp.config import MCPConfig, _parse_dir_list, load_config_from_env
+from all2md.mcp.query_tools import list_workspace_files_impl
+from all2md.mcp.schemas import ListWorkspaceFilesInput
+from all2md.mcp.security import MCPSecurityError, prepare_allowlist_dirs, resolve_workspace_path
+from all2md.mcp.tools import _detect_source_type
+
+
+def _read_cfg(*dirs):
+    return MCPConfig(read_allowlist=prepare_allowlist_dirs([str(d) for d in dirs]))
+
+
+@pytest.mark.unit
+class TestWorkspaceRelativeResolution:
+    """resolve_workspace_path and path detection treat the workspace as cwd."""
+
+    def test_resolve_relative_against_workspace(self, tmp_path):
+        (tmp_path / "report.md").write_text("# Hi")
+        resolved = resolve_workspace_path("report.md", [tmp_path], must_exist=True)
+        assert resolved is not None
+        assert resolved.resolve() == (tmp_path / "report.md").resolve()
+
+    def test_resolve_missing_returns_none(self, tmp_path):
+        assert resolve_workspace_path("nope.md", [tmp_path], must_exist=True) is None
+
+    def test_resolve_write_anchors_to_first_dir(self, tmp_path):
+        resolved = resolve_workspace_path("out.docx", [tmp_path], must_exist=False)
+        assert resolved == tmp_path / "out.docx"
+
+    def test_bare_filename_detected_as_path(self, tmp_path):
+        target = tmp_path / "doc.md"
+        target.write_text("# Title\n\nBody.")
+        source, kind = _detect_source_type("doc.md", _read_cfg(tmp_path))
+        assert kind == "path"
+        assert Path(source).resolve() == target.resolve()
+
+    def test_workspace_relative_subpath_detected(self, tmp_path):
+        sub = tmp_path / "sub"
+        sub.mkdir()
+        target = sub / "doc.md"
+        target.write_text("# Title")
+        source, kind = _detect_source_type("sub/doc.md", _read_cfg(tmp_path))
+        assert kind == "path"
+        assert Path(source).resolve() == target.resolve()
+
+
+@pytest.mark.unit
+class TestSilentFailureFix:
+    """A definite-but-missing path raises instead of being treated as text."""
+
+    def test_missing_bare_filename_raises(self, tmp_path):
+        with pytest.raises(MCPSecurityError, match="File not found"):
+            _detect_source_type("missing.pdf", _read_cfg(tmp_path))
+
+    def test_missing_relative_path_raises(self, tmp_path):
+        with pytest.raises(MCPSecurityError, match="File not found"):
+            _detect_source_type("subdir/missing.docx", _read_cfg(tmp_path))
+
+    def test_inline_markdown_not_treated_as_path(self, tmp_path):
+        # Prose with a dotted token but spaces is content, not a path.
+        source, kind = _detect_source_type("See section 1.2 for details.", _read_cfg(tmp_path))
+        assert kind == "plain_text"
+
+    def test_inline_heading_not_treated_as_path(self, tmp_path):
+        source, kind = _detect_source_type("# Title\n\nSome body text.", _read_cfg(tmp_path))
+        assert kind == "plain_text"
+
+    def test_html_still_inline(self, tmp_path):
+        source, kind = _detect_source_type("<h1>Hi</h1>", _read_cfg(tmp_path))
+        assert kind == "plain_text"
+
+
+@pytest.mark.unit
+class TestListWorkspaceFiles:
+    """list_workspace_files lists only allowed files."""
+
+    def test_lists_files_recursively(self, tmp_path):
+        (tmp_path / "a.md").write_text("a")
+        (tmp_path / "b.pdf").write_text("b")
+        sub = tmp_path / "sub"
+        sub.mkdir()
+        (sub / "c.docx").write_text("c")
+        out = list_workspace_files_impl(ListWorkspaceFilesInput(), _read_cfg(tmp_path))
+        names = {Path(f["path"]).name for f in out.files}
+        assert names == {"a.md", "b.pdf", "c.docx"}
+        assert out.total == 3
+        assert out.truncated is False
+        assert all("size_bytes" in f for f in out.files)
+
+    def test_pattern_filter(self, tmp_path):
+        (tmp_path / "a.md").write_text("a")
+        (tmp_path / "b.pdf").write_text("b")
+        out = list_workspace_files_impl(ListWorkspaceFilesInput(pattern="*.pdf"), _read_cfg(tmp_path))
+        names = {Path(f["path"]).name for f in out.files}
+        assert names == {"b.pdf"}
+
+    def test_non_recursive(self, tmp_path):
+        (tmp_path / "a.md").write_text("a")
+        sub = tmp_path / "sub"
+        sub.mkdir()
+        (sub / "c.md").write_text("c")
+        out = list_workspace_files_impl(ListWorkspaceFilesInput(recursive=False), _read_cfg(tmp_path))
+        names = {Path(f["path"]).name for f in out.files}
+        assert names == {"a.md"}
+
+    def test_subdirectory_scope(self, tmp_path):
+        (tmp_path / "a.md").write_text("a")
+        sub = tmp_path / "sub"
+        sub.mkdir()
+        (sub / "c.md").write_text("c")
+        out = list_workspace_files_impl(ListWorkspaceFilesInput(subdirectory="sub"), _read_cfg(tmp_path))
+        names = {Path(f["path"]).name for f in out.files}
+        assert names == {"c.md"}
+
+    def test_subdirectory_outside_allowlist_raises(self, tmp_path):
+        allowed = tmp_path / "allowed"
+        outside = tmp_path / "outside"
+        allowed.mkdir()
+        outside.mkdir()
+        with pytest.raises(MCPSecurityError):
+            list_workspace_files_impl(ListWorkspaceFilesInput(subdirectory=str(outside)), _read_cfg(allowed))
+
+    def test_reports_read_dirs(self, tmp_path):
+        out = list_workspace_files_impl(ListWorkspaceFilesInput(), _read_cfg(tmp_path))
+        assert any(str(tmp_path.resolve()) == str(Path(d).resolve()) for d in out.read_dirs)
+
+
+@pytest.mark.unit
+class TestConfigAdditions:
+    """Additional read dirs and the list-files toggle."""
+
+    def test_parse_dir_list_separators(self):
+        assert _parse_dir_list("a;b") == ["a", "b"]
+        assert _parse_dir_list("a\nb\nc") == ["a", "b", "c"]
+        assert _parse_dir_list("  ") is None
+        assert _parse_dir_list(None) is None
+
+    def test_parse_dir_list_ignores_unsubstituted_placeholder(self):
+        # Hosts that leave an optional config blank may pass the raw placeholder.
+        assert _parse_dir_list("${user_config.additional_read_dirs}") is None
+
+    def test_additional_read_dirs_appended(self, tmp_path, monkeypatch):
+        ws = tmp_path / "ws"
+        extra = tmp_path / "extra"
+        ws.mkdir()
+        extra.mkdir()
+        monkeypatch.setenv("ALL2MD_MCP_ALLOWED_READ_DIRS", str(ws))
+        monkeypatch.setenv("ALL2MD_MCP_ALLOWED_WRITE_DIRS", str(ws))
+        monkeypatch.setenv("ALL2MD_MCP_ADDITIONAL_READ_DIRS", str(extra))
+        cfg = load_config_from_env()
+        read = [str(p) for p in cfg.read_allowlist]
+        write = [str(p) for p in cfg.write_allowlist]
+        assert str(ws) in read and str(extra) in read
+        # Additional dirs are read-only: never added to the write allowlist.
+        assert str(extra) not in write
+
+    def test_enable_list_files_env_toggle(self, monkeypatch):
+        monkeypatch.setenv("ALL2MD_MCP_ENABLE_LIST_FILES", "false")
+        cfg = load_config_from_env()
+        assert cfg.enable_list_files is False

--- a/tests/unit/test_mcp/test_mcp_query_tools.py
+++ b/tests/unit/test_mcp/test_mcp_query_tools.py
@@ -271,6 +271,7 @@ class TestConfigFlags:
             enable_search=False,
             enable_diff=False,
             enable_outline=False,
+            enable_list_files=False,
         )
         with pytest.raises(ValueError):
             config.validate()


### PR DESCRIPTION
## Summary

Fixes a set of MCP server issues surfaced while using the bundle in Claude Desktop. Net new tool count: **7** (adds `list_workspace_files`).

### `edit_document` — batch, in-place, format-aware
- **Auto-detects source format** instead of hardcoding markdown. Previously a `.docx` was parsed as markdown → 0 sections → cryptic `index out of range (0--1)`. This also restores index coherence with `get_document_outline` (both parse identically).
- **Batch** of edits applied to one parse, **atomic** (any failure → nothing written).
- **Writes back to disk in place** in the source format. DOCX uses the original file as a template (`preserve_formatting`) to keep styles; a fidelity warning is returned for binary round-trips. Responses report `disk_written`/`output_path` and echo **only the edited region**, not the whole document (token-friendly). In-place write-back covers `.md/.html/.docx/.pptx/.rst/.epub`; unsupported formats (e.g. `.pdf`) and read-only-folder targets fail with clear messages.

### Path handling
- Relative paths and bare filenames now resolve against the workspace (the read/write allowlist acts as cwd) across read/edit/outline/diff/save.
- A source that is unmistakably a file path but can't be found now **raises a clear error listing the searched folders**, instead of silently returning the path string as document content.

### New capabilities
- **`list_workspace_files`** tool so an agent can discover what it can read (`path` + `size_bytes`, `truncated` flag, glob + subdirectory scoping, `read_dirs`).
- **Additional read-only folders** via `ALL2MD_MCP_ADDITIONAL_READ_DIRS` / `--additional-read-dirs`, appended to the read allowlist only and exposed in the MCPB manifest.

### Stability — stdio JSON-RPC corruption
PyMuPDF prints `Consider using the pymupdf_layout package…` to **stdout** when processing PDFs, corrupting the JSON-RPC stream and crashing the connection for any PDF (manifested as a hang + `Unexpected token 'C', "Consider u"... is not valid JSON`). Fixed with an fd-level `protect_stdout()` guard wrapping every tool's conversion work, plus `PYMUPDF_MESSAGE=fd:2` as an import-time backstop.

## Testing
- Rewrote `edit_document` integration tests for the batch/in-place API (atomicity, persistence across edits, format/allowlist boundaries).
- Added `test_mcp_new_features.py` covering path resolution, the silent-failure fix, `list_workspace_files`, and the new config.
- `ruff` + `mypy` clean; full unit suite passes; end-to-end DOCX in-place edit verified on a real document.

## Notes for reviewers
- Version not bumped and `.mcpb` not rebuilt — that's the release step (CI rebuilds the bundle on a `v*` tag).
- PDF is intentionally excluded from in-place write-back (re-rendering reflows the whole document).

🤖 Generated with [Claude Code](https://claude.com/claude-code)