### PR TITLE
fix(ci): unbreak CI from dependency drift (mistune 3.3, mypy 2.x)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -169,7 +169,7 @@ xlsx = [
     "chardet>=5.2.0",
 ]
 markdown = [
-    "mistune>=3.0.0",
+    "mistune>=3.3.1",  # 3.3 fixes single-line $$...$$ block-math parsing
     "chardet>=5.2.0",
 ]
 pdf_render = [
@@ -230,7 +230,7 @@ all = [
     "fastmcp>=2.0.0",
     "httpx>=0.28.1",
     "jinja2>=3.1.0",
-    "mistune>=3.0.0",
+    "mistune>=3.3.1",  # 3.3 fixes single-line $$...$$ block-math parsing
     "odfpy>=1.4.1",
     "openpyxl>=3.1.5",
     "orgparse>=0.4.20250520",
@@ -412,6 +412,15 @@ cache_dir = ".mypy_cache"
 [[tool.mypy.overrides]]
 module = "docx.*"
 ignore_missing_imports = false
+
+# numpy (a transitive dep via rank-bm25) ships PEP 695 `type` statements in its
+# bundled stubs as of 2.5.0. mypy rejects those under python_version=3.10
+# ("Type statement is only supported in Python 3.12+"), halting the run. We
+# don't rely on numpy's types, so skip following its imports entirely.
+[[tool.mypy.overrides]]
+module = "numpy.*"
+follow_imports = "skip"
+follow_imports_for_stubs = true
 
 # context_menu.py is Windows-only (winreg registry plumbing). The CI type check
 # runs on Linux, where the stdlib `winreg` module exposes no attributes

--- a/src/all2md/parsers/markdown.py
+++ b/src/all2md/parsers/markdown.py
@@ -978,6 +978,11 @@ class MarkdownToAstConverter(BaseParser):
         nodes: list[Node] = []
 
         for token in tokens:
+            # mistune >=3.3 emits spurious empty text tokens around nested
+            # inline elements (e.g. inside **bold *italic***). Drop them so
+            # they don't pollute the AST or downstream rendering.
+            if token.get("type") == "text" and not token.get("raw"):
+                continue
             node = self._process_inline_token(token)
             if node is not None:
                 if isinstance(node, list):

--- a/tests/golden/__snapshots__/test_other_formats_golden.ambr
+++ b/tests/golden/__snapshots__/test_other_formats_golden.ambr
@@ -222,7 +222,9 @@
   
   Here is a displayed equation:
   
-  $$\int_0^1 x^2\,dx = \frac{1}{3}$$
+  $$
+  \int_0^1 x^2\,dx = \frac{1}{3}
+  $$
   
   We also mention inline Greek letters like $\alpha$ and $\beta$ for completeness.
   '''

--- a/uv.lock
+++ b/uv.lock
@@ -19,7 +19,7 @@ wheels = [
 
 [[package]]
 name = "all2md"
-version = "1.4.0"
+version = "1.6.0"
 source = { editable = "." }
 dependencies = [
     { name = "pyyaml" },
@@ -281,8 +281,8 @@ requires-dist = [
     { name = "jinja2", marker = "extra == 'templates'", specifier = ">=3.1.0" },
     { name = "langdetect", marker = "extra == 'all'", specifier = ">=1.0.9" },
     { name = "langdetect", marker = "extra == 'langdetect'", specifier = ">=1.0.9" },
-    { name = "mistune", marker = "extra == 'all'", specifier = ">=3.0.0" },
-    { name = "mistune", marker = "extra == 'markdown'", specifier = ">=3.0.0" },
+    { name = "mistune", marker = "extra == 'all'", specifier = ">=3.3.1" },
+    { name = "mistune", marker = "extra == 'markdown'", specifier = ">=3.3.1" },
     { name = "mwparserfromhell", marker = "extra == 'all'", specifier = ">=0.7.2" },
     { name = "mwparserfromhell", marker = "extra == 'wiki'", specifier = ">=0.7.2" },
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.18.2" },
@@ -1839,14 +1839,14 @@ wheels = [
 
 [[package]]
 name = "mistune"
-version = "3.1.4"
+version = "3.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/d7/02/a7fb8b21d4d55ac93cdcde9d3638da5dd0ebdd3a4fed76c7725e10b81cbe/mistune-3.1.4.tar.gz", hash = "sha256:b5a7f801d389f724ec702840c11d8fc48f2b33519102fc7ee739e8177b672164", size = 94588, upload-time = "2025-08-29T07:20:43.594Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/10/55/ede164a9ff68694455bf42217e9e75b174e4048436688cfff7b382ae486c/mistune-3.3.1.tar.gz", hash = "sha256:7d2108b532850ab81d3e92a5566abe1168f4f27c0c9dbe914e02d1d06e2a0288", size = 111268, upload-time = "2026-06-22T01:32:05.843Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/7a/f0/8282d9641415e9e33df173516226b404d367a0fc55e1a60424a152913abc/mistune-3.1.4-py3-none-any.whl", hash = "sha256:93691da911e5d9d2e23bc54472892aff676df27a75274962ff9edc210364266d", size = 53481, upload-time = "2025-08-29T07:20:42.218Z" },
+    { url = "https://files.pythonhosted.org/packages/af/f4/c8951ccd856f56b5300b6c716f645f526b92012983bec84487eea786cf78/mistune-3.3.1-py3-none-any.whl", hash = "sha256:61c4ca5f8c1e0f4622e85bdec00ebf93942a742123bb26440a737bac0edce5c6", size = 61542, upload-time = "2026-06-22T01:32:04.375Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Why

PR #35 (Dependabot `actions/checkout` 6→7) failed CI, but the bump is innocent. CI installs deps with unpinned floors, so recent upstream releases broke the build independent of any source change. The last green run on `main` was Jun 19; re-running today reproduces these failures.

## Failures & fixes

**Lint/Type Check — numpy 2.5.0 stubs**
numpy ≥2.5.0 ships PEP 695 `type` statements in its bundled stubs; mypy rejects them under our `python_version = "3.10"` (*"Type statement is only supported in Python 3.12 and greater"*), halting the run. This affects **both mypy 1.x and 2.x** — it's a numpy change, not a mypy regression. numpy is a transitive dep (via `rank-bm25`) whose types we don't use. → Add a mypy override skipping `numpy.*` imports. Verified clean against numpy 2.5.0 with both mypy 1.20.2 and 2.1.0.

**Tests — mistune 3.3.1** (`mistune>=3.0.0`)
- `test_markdown_roundtrip_with_math`: mistune 3.3 **fixed** single-line `$$…$$` parsing (old 3.1.4 mis-tokenized it as `inline_math` with a stray leading `$`; 3.3 produces a clean `block_math`). New output is correct multi-line block math. → Bump floor to `>=3.3.1`, refresh snapshot.
- `test_combined_formatting`: mistune 3.3 emits spurious empty text tokens around nested inline elements (`strong.content` → 5 nodes vs 3). → Filter empty text tokens in `_process_inline_tokens`.

## Validation
- `mypy src/` clean against numpy 2.5.0 (mypy 1.20.2 and 2.1.0).
- AST / golden / parser / renderer test suites pass locally on mistune 3.3.1.

Once merged, PR #35 will be rebased and should go green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)