### PR TITLE
chore: resolve CodeQL Security & Quality findings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -119,19 +119,13 @@ jobs:
         uses: semgrep/semgrep-action@v1
         with:
           config: auto
-          # Exclude false-positive rules:
-          # - non-literal-import: Our imports use hardcoded internal mappings, not user input
-          # - render-template-string: Example file uses constant template, not user input
-          # - direct-use-of-jinja2: Renderers output Markdown (no XSS) or use proper autoescape
-          # Note: `--exclude-rule` via `semgrepArgs` is not honored by
-          # `semgrep-action@v1`'s `config: auto` mode (cloud rules ignore the
-          # local arg). Per-line suppression with `# nosemgrep: <rule-id>` is
-          # the reliable mechanism — see `benchmarks/corpus/download.py:55`
-          # for the urllib false-positive suppression.
-          semgrepArgs: >-
-            --exclude-rule python.lang.security.audit.non-literal-import.non-literal-import
-            --exclude-rule python.flask.security.audit.render-template-string.render-template-string
-            --exclude-rule python.flask.security.xss.audit.direct-use-of-jinja2.direct-use-of-jinja2
+          # Rule exclusions are intentionally NOT configured here: `--exclude-rule`
+          # is not honored by semgrep-action@v1's `config: auto` mode — the cloud
+          # ruleset ignores locally-passed args (and the action has no
+          # `semgrepArgs` input anyway). False positives are suppressed per-line
+          # with `# nosemgrep: <rule-id>` instead — see
+          # `benchmarks/corpus/download.py:55` for the non-literal-import
+          # suppression in the manifest generator.
         env:
           SEMGREP_APP_TOKEN: ${{ secrets.SEMGREP_APP_TOKEN }}
 

--- a/benchmarks/corpus/report.py
+++ b/benchmarks/corpus/report.py
@@ -156,6 +156,7 @@ def render_report(results_path: Path) -> str:
         try:
             ts = datetime.fromisoformat(ts).strftime("%Y-%m-%d %H:%M UTC")
         except Exception:
+            # Unparseable timestamp; keep the raw string as-is.
             pass
     lines += [
         "# all2md corpus benchmark",

--- a/benchmarks/corpus/run.py
+++ b/benchmarks/corpus/run.py
@@ -126,6 +126,7 @@ def _dir_size_bytes(path: Path) -> int:
             try:
                 total += p.stat().st_size
             except OSError:
+                # File unreadable or vanished mid-walk; skip it in the tally.
                 pass
     return total
 

--- a/src/all2md/cli/commands/edit.py
+++ b/src/all2md/cli/commands/edit.py
@@ -460,6 +460,8 @@ def handle_edit_command(args: list[str] | None = None) -> int:  # noqa: C901
                 try:
                     webbrowser.open(url)
                 except Exception:
+                    # Best-effort convenience; the URL is printed above if the
+                    # browser can't be launched.
                     pass
             try:
                 httpd.serve_forever()

--- a/src/all2md/cli/commands/server.py
+++ b/src/all2md/cli/commands/server.py
@@ -260,6 +260,8 @@ def _compute_directory_state(
             stat = file.stat()
             signature.add((str(file), stat.st_size, stat.st_mtime))
         except OSError:
+            # File vanished or became unreadable between listing and stat;
+            # omit it from the change signature.
             pass
     return files, subdirs, mapping, signature
 

--- a/src/all2md/cli/commands/skills.py
+++ b/src/all2md/cli/commands/skills.py
@@ -389,8 +389,10 @@ def _build_llm_help_guide(skill_dir: Path, topics: list[str]) -> str:
     parts: list[str] = [
         "# all2md - CLI guide for LLMs and agents",
         "",
-        "all2md converts between 40+ document formats and Markdown from the command line. "
-        "This guide leads with an overview, then concatenates the per-task references listed below.",
+        (
+            "all2md converts between 40+ document formats and Markdown from the command line. "
+            "This guide leads with an overview, then concatenates the per-task references listed below."
+        ),
         "",
         f"Topics: {', '.join(topics)}",
         "  - Print one topic:      all2md llm-help <topic>",

--- a/src/all2md/cli/processors.py
+++ b/src/all2md/cli/processors.py
@@ -2395,6 +2395,8 @@ def _detect_renderer_hint(target_format: str, output_path: Optional[Path]) -> st
         if detected_target and detected_target != "txt":
             return detected_target
     except Exception:
+        # Format detection is best-effort; fall through to the caller's
+        # default target on any error.
         pass
 
     return "auto"

--- a/src/all2md/dependencies.py
+++ b/src/all2md/dependencies.py
@@ -726,4 +726,4 @@ def main(argv: Optional[List[str]] = None) -> int:
 
 
 if __name__ == "__main__":
-    exit(main())
+    sys.exit(main())

--- a/src/all2md/parsers/docx.py
+++ b/src/all2md/parsers/docx.py
@@ -1514,6 +1514,8 @@ def _get_paragraph_indent_level(paragraph: "Paragraph") -> int:
         if indent:
             return int(indent.pt / DEFAULT_INDENTATION_PT_PER_LEVEL)
     except AttributeError:
+        # Paragraph lacks indentation formatting; treat it as top level
+        # (falls through to the default return below).
         pass
     return 0
 

--- a/src/all2md/parsers/html.py
+++ b/src/all2md/parsers/html.py
@@ -546,6 +546,8 @@ class HtmlToAstConverter(BaseParser):
                     continue
                 json_ld_data.append(json.loads(script_content))
             except Exception:
+                # Malformed JSON-LD block; skip it rather than failing the
+                # whole HTML parse.
                 pass
         return json_ld_data
 

--- a/src/all2md/parsers/org.py
+++ b/src/all2md/parsers/org.py
@@ -502,6 +502,8 @@ class OrgParser(BaseParser):
                 try:
                     entry["duration"] = str(clock.duration)
                 except Exception:
+                    # orgparse may raise computing duration for malformed
+                    # clock entries; omit the duration field.
                     pass
             if entry:
                 clock_entries.append(entry)

--- a/src/all2md/parsers/pdf.py
+++ b/src/all2md/parsers/pdf.py
@@ -2723,6 +2723,8 @@ class PdfToAstConverter(BaseParser):
             if tabs.tables:
                 return self._process_table_to_ast(tabs.tables[0], page, page_num)
         except Exception:
+            # PyMuPDF table detection is best-effort; fall through to the
+            # caller's fallback handling on any error.
             pass
 
         # Fallback: extract raw text from the region as a simple table

--- a/src/all2md/renderers/pptx.py
+++ b/src/all2md/renderers/pptx.py
@@ -681,11 +681,15 @@ class PptxRenderer(NodeVisitor, BaseRenderer):
                 if shape.placeholder_format.idx == 0:
                     continue
             except Exception:
+                # Shape has no usable placeholder_format.idx; treat it as a
+                # non-title placeholder and keep checking.
                 pass
             try:
                 if hasattr(shape.placeholder_format, "type") and shape.placeholder_format.type == 2:
                     return shape
             except Exception:
+                # placeholder_format.type unavailable; fall through to the
+                # generic text-frame check below.
                 pass
             if content_ph is None and shape.has_text_frame:
                 content_ph = shape
@@ -750,6 +754,8 @@ class PptxRenderer(NodeVisitor, BaseRenderer):
             try:
                 keep_idx = content_ph.placeholder_format.idx
             except Exception:
+                # Placeholder index unavailable; leave keep_idx unset so no
+                # placeholder is preserved by index.
                 pass
 
         # Remove other content placeholders (keep the one we'll reuse)


### PR DESCRIPTION
Triage of the open GitHub code-scanning (CodeQL) alerts. Companion to #36 (which fixed CI).

## Fixed in code (14 alerts)
- **`py/use-of-exit-or-quit`** (`dependencies.py`): `exit()` → `sys.exit()` (the `exit` builtin is injected by `site` and may be absent under `python -S`).
- **`py/implicit-string-concatenation-in-list`** (`skills.py`): parenthesized the intentional multi-line guide string so the concatenation reads as deliberate.
- **`py/empty-except` ×12**: added explanatory comments to best-effort `except: pass` blocks across `cli/`, `parsers/`, `renderers/`, and `benchmarks/`, matching the convention already used elsewhere (e.g. the context-menu uninstall path).

## Dismissed as false positives (8 alerts, via API)
- **`py/path-injection` (high) ×5** — `edit.py` (393/395/404) and `server.py` (219/857): every flagged sink is guarded by an explicit `Path.is_relative_to(...)` containment check that rejects escapes (HTTP 403 / `None`). CodeQL does not model `is_relative_to` as a sanitizer.
- **`py/unsafe-cyclic-import` / `py/cyclic-import` / `py/unused-import`** — `linter/fixes.py:48`, `robots_txt.py:21`, `linter/rule.py:20`: all are `if TYPE_CHECKING:` imports (no runtime cycle); `LintFix` is used in the `Optional["LintFix"]` annotation.

## Validation
- `ruff check`, `black --check`, and `py_compile` clean on all changed files.
- Changes are behavior-inert (comments, `sys.exit`, paren-wrapped literal); smoke-tested the `skills` and `dependencies` modules.

🤖 Generated with [Claude Code](https://claude.com/claude-code)