### PR TITLE
docs(examples): refresh cookbook and examples to current API

### DIFF
--- a/docs/source/recipes.rst
+++ b/docs/source/recipes.rst
@@ -89,7 +89,7 @@ View and Publish
 
    all2md view report.pdf            # render to HTML and open in a browser
    all2md serve docs/ --recursive    # live-reloading local server
-   all2md generate-site docs/        # build a static HTML site
+   all2md generate-site docs/ --generator hugo --output-dir ./site   # build a static site
 
 .. note::
 
@@ -137,78 +137,33 @@ Converting Directory of Mixed Documents
 
 **Python equivalent:**
 
+The CLI batch above is the recommended way to convert a directory -- it already
+runs in parallel (``--parallel``), mirrors the tree (``--preserve-structure``),
+and continues past failures (``--skip-errors``). Reach for Python only when you
+need custom per-file logic; convert each file with ``to_markdown``:
+
 .. code-block:: python
 
-   import os
    from pathlib import Path
-   from concurrent.futures import ThreadPoolExecutor
    from all2md import to_markdown, PdfOptions, HtmlOptions, PptxOptions, MarkdownRendererOptions
 
-   def convert_documents_parallel(source_dir: str, output_dir: str):
-       # Create shared markdown options
-       md_options = MarkdownRendererOptions(
-           emphasis_symbol="_",
-           bullet_symbols="•◦▪",
-           escape_special=False,
-           use_hash_headings=True,
-       )
+   md_options = MarkdownRendererOptions(emphasis_symbol="_", escape_special=False, use_hash_headings=True)
+   options_by_ext = {
+       "pdf": PdfOptions(detect_columns=True),
+       "html": HtmlOptions(strip_dangerous_elements=True),
+       "pptx": PptxOptions(include_slide_numbers=True),
+   }
 
-       # Define format-specific options
-       options_map = {
-           'pdf': PdfOptions(
-               attachment_mode="save",
-               attachment_output_dir="./extracted_media",
-               detect_columns=True,
-           ),
-           'html': HtmlOptions(
-               attachment_mode="save",
-               attachment_output_dir="./extracted_media",
-               strip_dangerous_elements=True,
-           ),
-           'pptx': PptxOptions(
-               attachment_mode="save",
-               attachment_output_dir="./extracted_media",
-               include_slide_numbers=True,
-           )
-       }
-
-       def convert_file(file_path):
-           try:
-               # Get file extension to determine options
-               ext = file_path.suffix.lower().lstrip('.')
-               options = options_map.get(ext)
-
-               # Convert to markdown
-               markdown_content = to_markdown(
-                   file_path,
-                   parser_options=options,
-                   renderer_options=md_options,
-               )
-
-               # Create output path preserving structure
-               relative_path = file_path.relative_to(source_dir)
-               output_path = Path(output_dir) / relative_path.with_suffix('.md')
-               output_path.parent.mkdir(parents=True, exist_ok=True)
-
-               # Write markdown file
-               output_path.write_text(markdown_content, encoding='utf-8')
-               print(f"Converted: {file_path} -> {output_path}")
-
-           except Exception as e:
-               print(f"Error converting {file_path}: {e}")
-
-       # Find all supported files
-       source_path = Path(source_dir)
-       supported_extensions = {'.pdf', '.docx', '.pptx', '.html', '.eml', '.epub'}
-       files = [f for f in source_path.rglob('*')
-                if f.suffix.lower() in supported_extensions and f.is_file()]
-
-       # Process in parallel
-       with ThreadPoolExecutor(max_workers=4) as executor:
-           executor.map(convert_file, files)
-
-   # Usage
-   convert_documents_parallel('./documents', './markdown_output')
+   source, output = Path("./documents"), Path("./markdown_output")
+   for src in source.rglob("*"):
+       ext = src.suffix.lower().lstrip(".")
+       if ext not in options_by_ext or not src.is_file():
+           continue
+       markdown = to_markdown(src, parser_options=options_by_ext[ext], renderer_options=md_options)
+       dest = output / src.relative_to(source).with_suffix(".md")
+       dest.parent.mkdir(parents=True, exist_ok=True)
+       dest.write_text(markdown, encoding="utf-8")
+       print(f"Converted: {src} -> {dest}")
 
 Creating Text-Only Archive from Website
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -237,64 +192,28 @@ Creating Text-Only Archive from Website
        --collate \
        --out website_archive.md
 
-**Python solution with metadata preservation:**
+**Python equivalent:**
+
+The ``--collate`` flag above already merges a glob of files into one document.
+Use Python when you want to interleave custom per-page headers or metadata:
 
 .. code-block:: python
 
-   from pathlib import Path
    from datetime import datetime
+   from pathlib import Path
    from all2md import to_markdown, HtmlOptions, MarkdownRendererOptions
 
-   def create_website_archive(html_dir: str, output_file: str):
-       md_options = MarkdownRendererOptions(
-           escape_special=False,  # Keep text readable
-           use_hash_headings=True
-       )
+   html_options = HtmlOptions(attachment_mode="skip", extract_title=True,
+                              strip_dangerous_elements=True, convert_nbsp=True)
+   md_options = MarkdownRendererOptions(escape_special=False, use_hash_headings=True)
 
-       html_options = HtmlOptions(
-           attachment_mode="skip",
-           extract_title=True,
-           strip_dangerous_elements=True,
-           convert_nbsp=True,
-       )
+   pages = sorted(Path("./scraped_website").glob("*.html"))
+   parts = [f"# Website Archive\n\nGenerated: {datetime.now().isoformat()}  ·  {len(pages)} pages\n"]
+   for i, page in enumerate(pages, 1):
+       markdown = to_markdown(page, parser_options=html_options, renderer_options=md_options)
+       parts.append(f"\n\n{'=' * 80}\nPage {i}: {page.name}\n{'=' * 80}\n\n{markdown}")
 
-       html_files = list(Path(html_dir).glob('*.html'))
-       archive_content = []
-
-       # Add archive header
-       archive_content.append(f"""# Website Archive
-   Generated on: {datetime.now().isoformat()}
-   Total pages: {len(html_files)}
-   Source directory: {html_dir}
-
-   """)
-
-       for i, html_file in enumerate(html_files, 1):
-           try:
-               # Convert HTML to markdown
-               markdown = to_markdown(
-                   html_file,
-                   parser_options=html_options,
-                   renderer_options=md_options,
-               )
-
-               # Add page separator with metadata
-               separator = "=" * 80
-               header = f"\n{separator}\nPage {i}: {html_file.name}\n{separator}\n\n"
-
-               archive_content.append(header + markdown)
-               print(f"Processed: {html_file.name}")
-
-           except Exception as e:
-               print(f"Error processing {html_file}: {e}")
-               continue
-
-       # Write combined archive
-       Path(output_file).write_text('\n\n'.join(archive_content), encoding='utf-8')
-       print(f"Archive created: {output_file}")
-
-   # Usage
-   create_website_archive('./scraped_website', 'company_website_archive.md')
+   Path("company_website_archive.md").write_text("\n".join(parts), encoding="utf-8")
 
 Feeding Documents to an LLM (RAG)
 ---------------------------------
@@ -519,188 +438,64 @@ Directory Processing with Progress Tracking
 
 **Solution:**
 
+The CLI batch engine already runs in parallel, shows a progress bar, and reports
+failures -- use it for plain bulk conversion:
+
+.. code-block:: bash
+
+   all2md ./source_documents \
+       --recursive \
+       --parallel 6 \
+       --output-dir ./converted_docs \
+       --preserve-structure \
+       --progress \
+       --skip-errors
+
+When you need a *structured* report (timings, word counts, a JSON summary), wrap
+the single-file API in your own pool. ``ThreadPoolExecutor`` is convenient, but
+note that most parsers are pure-Python and GIL-bound, so ``ProcessPoolExecutor``
+often scales better:
+
 .. code-block:: python
 
    import json
    import time
-   from pathlib import Path
    from concurrent.futures import ThreadPoolExecutor, as_completed
-   from dataclasses import dataclass, asdict
-   from typing import List, Dict, Optional
-   from all2md import to_markdown, PdfOptions, DocxOptions, MarkdownRendererOptions
+   from pathlib import Path
+   from all2md import to_markdown
 
-   @dataclass
-   class ProcessingResult:
-       file_path: str
-       success: bool
-       output_path: Optional[str] = None
-       error: Optional[str] = None
-       processing_time: float = 0.0
-       content_length: int = 0
-       word_count: int = 0
+   def convert_one(root: Path, out_dir: Path, src: Path) -> dict:
+       start = time.time()
+       try:
+           markdown = to_markdown(src)
+           dest = out_dir / src.relative_to(root).with_suffix(".md")  # mirror the input tree
+           dest.parent.mkdir(parents=True, exist_ok=True)
+           dest.write_text(markdown, encoding="utf-8")
+           return {"file": str(src), "ok": True, "words": len(markdown.split()), "secs": time.time() - start}
+       except Exception as exc:
+           return {"file": str(src), "ok": False, "error": str(exc), "secs": time.time() - start}
 
-   class BatchProcessor:
-       """Advanced batch processor with progress tracking."""
+   root, out_dir = Path("./source_documents"), Path("./converted_docs")
+   files = [f for f in root.rglob("*") if f.suffix.lower() in {".pdf", ".docx"} and f.is_file()]
 
-       def __init__(self, output_dir: str, max_workers: int = 4):
-           self.output_dir = Path(output_dir)
-           self.output_dir.mkdir(parents=True, exist_ok=True)
-           self.max_workers = max_workers
+   results = []
+   with ThreadPoolExecutor(max_workers=6) as pool:
+       futures = {pool.submit(convert_one, root, out_dir, f): f for f in files}
+       for n, future in enumerate(as_completed(futures), 1):
+           res = future.result()
+           results.append(res)
+           print(f"[{n}/{len(files)}] {'OK ' if res['ok'] else 'FAIL'} {Path(res['file']).name}")
 
-           # Setup options
-           self.md_options = MarkdownRendererOptions(
-               emphasis_symbol="_",
-               use_hash_headings=True
-           )
-
-           self.options_map = {
-               '.pdf': PdfOptions(
-                   attachment_mode="save",
-                   attachment_output_dir=str(self.output_dir / "media"),
-               ),
-               '.docx': DocxOptions(
-                   attachment_mode="save",
-                   attachment_output_dir=str(self.output_dir / "media"),
-               )
-           }
-
-       def process_file(self, file_path: Path) -> ProcessingResult:
-           """Process a single file with timing and error handling."""
-           start_time = time.time()
-
-           try:
-               # Get appropriate options
-               ext = file_path.suffix.lower()
-               options = self.options_map.get(ext)
-
-               # Convert to markdown
-               content = to_markdown(
-                   file_path,
-                   parser_options=options,
-                   renderer_options=self.md_options,
-               )
-
-               # Create output path
-               relative_path = file_path.relative_to(file_path.parent)
-               output_path = self.output_dir / relative_path.with_suffix('.md')
-               output_path.parent.mkdir(parents=True, exist_ok=True)
-
-               # Write output
-               output_path.write_text(content, encoding='utf-8')
-
-               processing_time = time.time() - start_time
-               word_count = len(content.split())
-
-               return ProcessingResult(
-                   file_path=str(file_path),
-                   success=True,
-                   output_path=str(output_path),
-                   processing_time=processing_time,
-                   content_length=len(content),
-                   word_count=word_count
-               )
-
-           except Exception as e:
-               processing_time = time.time() - start_time
-               return ProcessingResult(
-                   file_path=str(file_path),
-                   success=False,
-                   error=str(e),
-                   processing_time=processing_time
-               )
-
-       def process_batch(self, input_paths: List[Path],
-                        progress_callback=None) -> List[ProcessingResult]:
-           """Process multiple files with progress tracking."""
-           results = []
-           completed = 0
-           total = len(input_paths)
-
-           with ThreadPoolExecutor(max_workers=self.max_workers) as executor:
-               # Submit all tasks
-               future_to_path = {
-                   executor.submit(self.process_file, path): path
-                   for path in input_paths
-               }
-
-               # Process completed tasks
-               for future in as_completed(future_to_path):
-                   result = future.result()
-                   results.append(result)
-                   completed += 1
-
-                   # Progress callback
-                   if progress_callback:
-                       progress_callback(completed, total, result)
-
-                   # Simple progress logging
-                   status = "✓" if result.success else "✗"
-                   print(f"{status} [{completed:4d}/{total:4d}] {Path(result.file_path).name}")
-
-           return results
-
-       def generate_report(self, results: List[ProcessingResult]) -> Dict:
-           """Generate processing report."""
-           successful = [r for r in results if r.success]
-           failed = [r for r in results if not r.success]
-
-           report = {
-               "summary": {
-                   "total_files": len(results),
-                   "successful": len(successful),
-                   "failed": len(failed),
-                   "success_rate": len(successful) / len(results) * 100 if results else 0,
-                   "total_processing_time": sum(r.processing_time for r in results),
-                   "total_words": sum(r.word_count for r in successful),
-                   "average_processing_time": sum(r.processing_time for r in results) / len(results) if results else 0
-               },
-               "successful_files": [asdict(r) for r in successful],
-               "failed_files": [asdict(r) for r in failed]
-           }
-
-           return report
-
-   # Usage example with progress tracking
-   def process_documents_with_progress():
-       processor = BatchProcessor("./converted_docs", max_workers=6)
-
-       # Find all files to process
-       input_dir = Path("./source_documents")
-       file_patterns = ["*.pdf", "*.docx"]
-       input_files = []
-
-       for pattern in file_patterns:
-           input_files.extend(input_dir.rglob(pattern))
-
-       print(f"Found {len(input_files)} files to process")
-
-       # Custom progress callback
-       def progress_callback(completed, total, result):
-           if result.success:
-               print(f"  → Converted {result.word_count:,} words in {result.processing_time:.2f}s")
-           else:
-               print(f"  → Error: {result.error}")
-
-       # Process files
-       results = processor.process_batch(input_files, progress_callback)
-
-       # Generate and save report
-       report = processor.generate_report(results)
-       report_path = Path("./converted_docs/processing_report.json")
-       report_path.write_text(json.dumps(report, indent=2))
-
-       # Print summary
-       summary = report["summary"]
-       print(f"\nProcessing Complete:")
-       print(f"  Files processed: {summary['total_files']}")
-       print(f"  Successful: {summary['successful']} ({summary['success_rate']:.1f}%)")
-       print(f"  Failed: {summary['failed']}")
-       print(f"  Total words: {summary['total_words']:,}")
-       print(f"  Total time: {summary['total_processing_time']:.2f}s")
-       print(f"  Report saved: {report_path}")
-
-   # Run the batch processing
-   process_documents_with_progress()
+   ok = [r for r in results if r["ok"]]
+   report = {
+       "total": len(results),
+       "succeeded": len(ok),
+       "failed": len(results) - len(ok),
+       "total_words": sum(r["words"] for r in ok),
+       "total_secs": round(sum(r["secs"] for r in results), 2),
+   }
+   Path("./converted_docs/processing_report.json").write_text(json.dumps(report, indent=2))
+   print(report)
 
 Real-Time Progress Monitoring
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -760,6 +555,7 @@ Use the built-in progress callback system for fine-grained progress tracking:
 
    class ConverterGUI:
        def __init__(self, root):
+           self.root = root
            self.progress = ttk.Progressbar(root, length=400, mode='determinate')
            self.progress.pack(pady=20)
            self.status = tk.Label(root, text="Ready")

--- a/examples/cli/README.md
+++ b/examples/cli/README.md
@@ -15,7 +15,7 @@ for feeding documents to LLMs. Every concept ships as a **bash** (`.sh`) and a
 | Script | What it shows |
 | ------ | ------------- |
 | `convert-and-pipe` | Convert to stdout, any-to-any (`--to`), stdin with `-`, attachment modes, piping into other tools |
-| `batch-convert` | Whole-folder conversion: built-in batch (`--recursive --skip-errors --preserve-structure`), `--collate`, and parallel `find`/`xargs` (bash) / `ForEach-Object -Parallel` (PowerShell) |
+| `batch-convert` | Whole-folder conversion: built-in batch (`--recursive --skip-errors --preserve-structure`), `--collate`, and the built-in parallel worker pool (`--parallel N`) |
 | `extract-and-navigate` | Cheap reading of big docs: `--outline`, `--line-numbers`, `--extract "Section"`, `--extract "line:A-B"` |
 | `grep-binary-docs` | `all2md grep` *inside* PDF/DOCX/PPTX that plain grep can't read |
 | `search-corpus` | Ranked `all2md search --json` over a corpus, post-processed with `jq` / `ConvertFrom-Json`; provenance per hit |

--- a/examples/cli/batch-convert.ps1
+++ b/examples/cli/batch-convert.ps1
@@ -20,10 +20,13 @@ Write-Output "Converted tree into $OutputDir/"
 all2md $InputDir --recursive --collate --out "$OutputDir/combined.md"
 Write-Output "Wrote combined corpus to $OutputDir/combined.md"
 
-# 3. Hand-rolled parallel fan-out with ForEach-Object -Parallel (PowerShell 7+),
-#    when you want control over per-file flags or concurrency.
-Get-ChildItem $InputDir -Recurse -File -Include *.pdf, *.docx, *.html |
-    ForEach-Object -Parallel {
-        all2md $_.FullName --out "$($_.FullName).md"
-    } -ThrottleLimit 4
-Write-Output "Parallel conversion complete (one .md next to each source)."
+# 3. Parallel conversion with the built-in worker pool. --parallel N spins up N
+#    workers; no need to hand-roll ForEach-Object -Parallel (which also re-resolves
+#    all2md in each runspace). With --output-dir the tree structure is mirrored.
+all2md $InputDir --output-dir $OutputDir --recursive --parallel 4 --skip-errors --preserve-structure
+Write-Output "Parallel conversion complete (mirrored under $OutputDir/)."
+
+# 3b. Only reach for a hand-rolled fan-out when you need per-file flags that the
+#     batch engine can't express uniformly:
+#   Get-ChildItem $InputDir -Recurse -File -Include *.pdf, *.docx, *.html |
+#       ForEach-Object -Parallel { all2md $_.FullName --out "$($_.FullName).md" } -ThrottleLimit 4

--- a/examples/cli/batch-convert.sh
+++ b/examples/cli/batch-convert.sh
@@ -20,8 +20,13 @@ echo "Converted tree into $OUT/"
 all2md "$IN" --recursive --collate --out "$OUT/combined.md"
 echo "Wrote combined corpus to $OUT/combined.md"
 
-# 3. Hand-rolled parallel fan-out with find + xargs, when you want control over
-#    per-file flags or concurrency. -P sets the number of parallel workers.
-find "$IN" -type f \( -name '*.pdf' -o -name '*.docx' -o -name '*.html' \) -print0 \
-  | xargs -0 -P 4 -I {} sh -c 'all2md "$1" --out "$1.md"' _ {}
-echo "Parallel conversion complete (one .md next to each source)."
+# 3. Parallel conversion with the built-in worker pool. --parallel N spins up N
+#    workers; no need to hand-roll find + xargs. With --output-dir the tree
+#    structure is mirrored; without it, a .md is written next to each source.
+all2md "$IN" --output-dir "$OUT" --recursive --parallel 4 --skip-errors --preserve-structure
+echo "Parallel conversion complete (mirrored under $OUT/)."
+
+# 3b. Only reach for a hand-rolled fan-out when you need per-file flags that the
+#     batch engine can't express uniformly:
+#   find "$IN" -type f \( -name '*.pdf' -o -name '*.docx' -o -name '*.html' \) -print0 \
+#     | xargs -0 -P 4 -I {} sh -c 'all2md "$1" --out "$1.md"' _ {}

--- a/examples/cli/diff-in-ci.ps1
+++ b/examples/cli/diff-in-ci.ps1
@@ -26,7 +26,10 @@ if ([string]::IsNullOrWhiteSpace($json)) {
 }
 Write-Output "Change hunks: $hunks"
 if ($hunks -gt 0) {
-    Write-Error "Documents differ -- failing CI gate."
+    # Write-Warning, not Write-Error: under $ErrorActionPreference="Stop" a
+    # Write-Error would throw before `exit 1` runs, dying with a stack trace
+    # instead of a clean CI failure code.
+    Write-Warning "Documents differ -- failing CI gate."
     exit 1
 }
 Write-Output "Documents are equivalent."

--- a/examples/cli/grep-binary-docs.ps1
+++ b/examples/cli/grep-binary-docs.ps1
@@ -16,7 +16,7 @@ $ErrorActionPreference = "Stop"
 all2md grep $Pattern @Paths -i -n -C 2
 
 # 2. Recurse a directory tree (every supported document under it):
-#    all2md grep -r $Pattern ./docs
+#    all2md grep --recursive $Pattern ./docs
 
 # 3. Treat the pattern as a regular expression:
 #    all2md grep --regex "TODO|FIXME" @Paths -n

--- a/examples/cli/grep-binary-docs.sh
+++ b/examples/cli/grep-binary-docs.sh
@@ -18,7 +18,7 @@ PATHS=("$@")
 all2md grep "$PATTERN" "${PATHS[@]}" -i -n -C 2
 
 # 2. Recurse a directory tree (every supported document under it).
-#    all2md grep -r "$PATTERN" docs/
+#    all2md grep --recursive "$PATTERN" docs/
 
 # 3. Treat the pattern as a regular expression.
 #    all2md grep --regex "TODO|FIXME" "${PATHS[@]}" -n

--- a/examples/cli/rag-ingest.ps1
+++ b/examples/cli/rag-ingest.ps1
@@ -23,7 +23,8 @@ $context = ($hits | ForEach-Object {
     $i++
     $loc = $_.chunk_metadata.document_path
     if ($_.chunk_metadata.section_heading) { $loc += " -> " + $_.chunk_metadata.section_heading }
-    "[$i] ($loc)`n$($_.text)`n"
+    # Strip the <<...>> match-highlight markers so they don't leak into the prompt.
+    "[$i] ($loc)`n$($_.text -replace '<<|>>','')`n"
 }) -join "`n"
 
 # 2. Build the final grounded prompt.

--- a/examples/cli/rag-ingest.sh
+++ b/examples/cli/rag-ingest.sh
@@ -20,9 +20,11 @@ PATHS=("$@")
 
 # 1. Retrieve top-k chunks as JSON and format them into a citation-numbered
 #    context block. Each passage keeps its source path and section heading.
+#    The `gsub` strips the `<<...>>` match-highlight markers so they don't leak
+#    into the LLM prompt.
 CONTEXT=$(all2md search "$QUESTION" "${PATHS[@]}" --keyword --json --top-k 5 \
   | jq -r 'to_entries | .[] |
-      "[\(.key + 1)] (\(.value.chunk_metadata.document_path)\(if .value.chunk_metadata.section_heading then " -> " + .value.chunk_metadata.section_heading else "" end))\n\(.value.text)\n"')
+      "[\(.key + 1)] (\(.value.chunk_metadata.document_path)\(if .value.chunk_metadata.section_heading then " -> " + .value.chunk_metadata.section_heading else "" end))\n\(.value.text | gsub("<<|>>";""))\n"')
 
 # 2. Build the final grounded prompt.
 PROMPT="Context passages:

--- a/examples/cli/vcs-converter/COMMANDS.md
+++ b/examples/cli/vcs-converter/COMMANDS.md
@@ -66,7 +66,7 @@ bash setup.sh
 ### Manual Setup Steps
 ```bash
 # 1. Copy example to your repo
-cp -r examples/vcs-converter /path/to/repo/.vcs-converter
+cp -r examples/cli/vcs-converter /path/to/repo/.vcs-converter
 
 # 2. Install hook
 python .vcs-converter/install_hook.py
@@ -183,8 +183,7 @@ cat > vcs-converter.config.json << EOF
 {
   "markdown_dir": ".vcs-docs",
   "track_metadata": true,
-  "preserve_images": true,
-  "line_width": 80
+  "store_ast": false
 }
 EOF
 ```

--- a/examples/cli/vcs-converter/CONTRIBUTING.md
+++ b/examples/cli/vcs-converter/CONTRIBUTING.md
@@ -1,0 +1,55 @@
+# Contributing to the VCS Document Converter
+
+This directory is an **example** shipped with [all2md](https://github.com/thomas-villani/all2md).
+It shows how to make binary documents (DOCX, PPTX, PDF) git-friendly by keeping
+parallel Markdown versions under version control. Improvements are welcome.
+
+## Development setup
+
+```bash
+# From an all2md checkout
+pip install -e .            # install all2md itself
+pip install all2md[all]     # optional: all format support (PDF, DOCX, PPTX, ...)
+
+# Run the example directly from this directory
+python vcs_converter.py scan
+python vcs_converter.py to-md path/to/document.docx
+python vcs_converter.py to-binary .vcs-docs/document.vcs.md
+```
+
+The script has no third-party dependencies of its own beyond `all2md`; it uses
+only the public API (`all2md.to_ast`, `all2md.from_ast`, `all2md.from_markdown`)
+plus the standard library.
+
+## How it is organized
+
+- `vcs_converter.py` — the converter and its CLI (`to-md`, `to-binary`, `batch`, `scan`, `clean`).
+- `pre-commit-hook.sh` / `install_hook.py` — git pre-commit integration.
+- `vcs-converter.config.json` — example configuration (`markdown_dir`, `track_metadata`, `store_ast`, `exclude_patterns`).
+- `README.md` / `QUICKSTART.md` / `COMMANDS.md` / `OVERVIEW.md` / `INDEX.md` — documentation.
+- `demo.py` — a self-contained demonstration.
+
+## Enhancement ideas
+
+These are deliberately left out of the example to keep it small, and make good
+starting points for contributions:
+
+- **PPTX round-trip** — `to-binary` currently raises `NotImplementedError` for
+  `.pptx`/`.ppt`. Wire up `from_markdown(..., "pptx", ...)` once slide layout
+  fidelity is acceptable.
+- **Image preservation** — extract attachments with `--attachment-mode save`
+  and store them alongside the Markdown so round-trips keep images.
+- **Configurable rendering** — expose `MarkdownRendererOptions` (line wrapping,
+  emphasis symbols, etc.) through the config file.
+- **Git LFS / large files** — guidance and helpers for very large binaries.
+
+## Guidelines
+
+1. Keep the example dependency-light and use only all2md's **public** API.
+2. Match the existing code style (run `ruff format` / `ruff check`).
+3. If you add a config key, make sure the code actually reads it and document it
+   in `README.md` — an advertised-but-ignored option is worse than no option.
+4. Verify a full round-trip (`to-md` then `to-binary`) before submitting.
+
+File issues and pull requests in the main
+[all2md repository](https://github.com/thomas-villani/all2md).

--- a/examples/cli/vcs-converter/QUICKSTART.md
+++ b/examples/cli/vcs-converter/QUICKSTART.md
@@ -9,7 +9,7 @@ Get up and running with VCS Document Converter in 5 minutes.
 pip install all2md
 
 # Clone or copy this example to your repository
-cp -r examples/vcs-converter /path/to/your/repo/.vcs-converter
+cp -r examples/cli/vcs-converter /path/to/your/repo/.vcs-converter
 cd /path/to/your/repo
 ```
 

--- a/examples/cli/vcs-converter/README.md
+++ b/examples/cli/vcs-converter/README.md
@@ -23,7 +23,7 @@ This tool solves these problems by maintaining parallel markdown versions of you
 - Track document changes in text format
 - Bidirectional sync (markdown <-> binary)
 - Preserve formatting metadata
-- Diff-friendly output with configurable line width
+- Diff-friendly markdown output
 - Batch processing for entire repositories
 - Configurable behavior via JSON config file
 
@@ -47,7 +47,7 @@ pip install all2md
 
 1. Copy the example to your repository:
 ```bash
-cp -r examples/vcs-converter /path/to/your/repo/.vcs-converter
+cp -r examples/cli/vcs-converter /path/to/your/repo/.vcs-converter
 cd /path/to/your/repo
 ```
 
@@ -132,17 +132,13 @@ Create a `vcs-converter.config.json` file in your repository root:
 {
   "markdown_dir": ".vcs-docs",
   "track_metadata": true,
-  "preserve_images": true,
-  "line_width": 80,
   "store_ast": false,
   "exclude_patterns": [
     "*.tmp.docx",
     "~$*.docx",
     "**/build/**",
     "**/dist/**"
-  ],
-  "auto_commit_markdown": false,
-  "diff_friendly": true
+  ]
 }
 ```
 
@@ -150,12 +146,8 @@ Create a `vcs-converter.config.json` file in your repository root:
 
 - `markdown_dir`: Directory for generated markdown (default: `.vcs-docs`)
 - `track_metadata`: Store metadata for reconstruction (default: `true`)
-- `preserve_images`: Extract and preserve images (default: `true`)
-- `line_width`: Maximum line width for markdown (default: `80`)
 - `store_ast`: Store full AST for perfect reconstruction (default: `false`)
-- `exclude_patterns`: Glob patterns for files to exclude
-- `auto_commit_markdown`: Automatically stage markdown files (default: `false`)
-- `diff_friendly`: Optimize output for git diff (default: `true`)
+- `exclude_patterns`: Glob patterns (matched against file name and full path) for files to skip during `batch`/`scan`
 
 ## Workflows
 
@@ -293,7 +285,7 @@ jobs:
   check-docs:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Install dependencies
         run: pip install all2md
       - name: Convert documents
@@ -369,9 +361,7 @@ For large documents, consider:
 
 ```json
 {
-  "store_ast": false,
-  "preserve_images": false,
-  "line_width": 120
+  "store_ast": false
 }
 ```
 

--- a/examples/cli/vcs-converter/pre-commit-hook.sh
+++ b/examples/cli/vcs-converter/pre-commit-hook.sh
@@ -11,7 +11,7 @@
 set -e
 
 # Configuration
-CONVERTER_SCRIPT="examples/vcs-converter/vcs_converter.py"
+CONVERTER_SCRIPT=".vcs-converter/vcs_converter.py"
 PYTHON="${PYTHON:-python}"
 BINARY_EXTENSIONS=("docx" "pptx" "pdf" "doc" "ppt")
 

--- a/examples/cli/vcs-converter/vcs-converter.config.json
+++ b/examples/cli/vcs-converter/vcs-converter.config.json
@@ -1,15 +1,11 @@
 {
   "markdown_dir": ".vcs-docs",
   "track_metadata": true,
-  "preserve_images": true,
-  "line_width": 80,
   "store_ast": false,
   "exclude_patterns": [
     "*.tmp.docx",
     "~$*.docx",
     "**/build/**",
     "**/dist/**"
-  ],
-  "auto_commit_markdown": false,
-  "diff_friendly": true
+  ]
 }

--- a/examples/cli/vcs-converter/vcs_converter.py
+++ b/examples/cli/vcs-converter/vcs_converter.py
@@ -12,6 +12,7 @@ Features:
 """
 
 import argparse
+import fnmatch
 import json
 import logging
 import shutil
@@ -34,6 +35,7 @@ class VCSConverter:
     ----------
     config_path : Path, optional
         Path to configuration file
+
     """
 
     BINARY_FORMATS = {".docx", ".pptx", ".pdf", ".doc", ".ppt"}
@@ -44,8 +46,6 @@ class VCSConverter:
         self.config = self._load_config(config_path)
         self.markdown_dir = Path(self.config.get("markdown_dir", ".vcs-docs"))
         self.track_metadata = self.config.get("track_metadata", True)
-        self.preserve_images = self.config.get("preserve_images", True)
-        self.line_width = self.config.get("line_width", 80)
 
     def _load_config(self, config_path: Path | None) -> dict[str, Any]:
         """Load configuration from file.
@@ -59,6 +59,7 @@ class VCSConverter:
         -------
         dict[str, Any]
             Configuration dictionary
+
         """
         if config_path and config_path.exists():
             with open(config_path, encoding="utf-8") as f:
@@ -77,10 +78,33 @@ class VCSConverter:
         -------
         Path
             Path where markdown should be stored
+
         """
         relative = binary_path.relative_to(Path.cwd()) if binary_path.is_absolute() else binary_path
         md_path = self.markdown_dir / relative.parent / (relative.stem + self.MARKDOWN_SUFFIX)
         return md_path
+
+    def _metadata_path_for(self, md_path: Path) -> Path:
+        """Metadata path for a generated markdown path.
+
+        Swaps the markdown suffix (``.vcs.md``) for the metadata suffix
+        (``.vcs.json``). Using ``Path.with_suffix`` here would only replace the
+        trailing ``.md`` and yield ``*.vcs.vcs.json``.
+
+        Parameters
+        ----------
+        md_path : Path
+            Path to the generated markdown file
+
+        Returns
+        -------
+        Path
+            Path where metadata should be stored
+
+        """
+        if md_path.name.endswith(self.MARKDOWN_SUFFIX):
+            return md_path.with_name(md_path.name[: -len(self.MARKDOWN_SUFFIX)] + self.METADATA_SUFFIX)
+        return md_path.with_suffix(".json")
 
     def _get_metadata_path(self, binary_path: Path) -> Path:
         """Get the metadata path for a binary document.
@@ -94,9 +118,9 @@ class VCSConverter:
         -------
         Path
             Path where metadata should be stored
+
         """
-        md_path = self._get_markdown_path(binary_path)
-        return md_path.with_suffix(self.METADATA_SUFFIX)
+        return self._metadata_path_for(self._get_markdown_path(binary_path))
 
     def convert_to_markdown(self, binary_path: Path) -> tuple[Path, Path | None]:
         """Convert a binary document to markdown.
@@ -110,6 +134,7 @@ class VCSConverter:
         -------
         tuple[Path, Path | None]
             Paths to created markdown and metadata files
+
         """
         logger.info(f"Converting {binary_path} to markdown...")
 
@@ -161,6 +186,7 @@ class VCSConverter:
         -------
         dict[str, Any]
             Document metadata
+
         """
         metadata = {
             "source_file": str(binary_path),
@@ -192,9 +218,10 @@ class VCSConverter:
         -------
         Path
             Path to created binary document
+
         """
         # Load metadata to determine target format
-        metadata_path = markdown_path.with_suffix(self.METADATA_SUFFIX)
+        metadata_path = self._metadata_path_for(markdown_path)
         if not metadata_path.exists():
             raise ValueError(f"No metadata found for {markdown_path}")
 
@@ -239,6 +266,7 @@ class VCSConverter:
             Output path for DOCX file
         metadata : dict[str, Any]
             Document metadata
+
         """
         # Render markdown straight to DOCX (parse + render in one call).
         output_path.parent.mkdir(parents=True, exist_ok=True)
@@ -255,6 +283,7 @@ class VCSConverter:
             Output path for PDF file
         metadata : dict[str, Any]
             Document metadata
+
         """
         # Render markdown straight to PDF (parse + render in one call).
         output_path.parent.mkdir(parents=True, exist_ok=True)
@@ -272,15 +301,22 @@ class VCSConverter:
         -------
         list[Path]
             List of binary document paths
+
         """
         if root_dir is None:
             root_dir = Path.cwd()
 
         binary_docs = []
         exclude_dirs = {".git", ".vcs-docs", "venv", ".venv", "node_modules", "__pycache__"}
+        exclude_patterns = self.config.get("exclude_patterns", [])
 
         for path in root_dir.rglob("*"):
             if any(excluded in path.parts for excluded in exclude_dirs):
+                continue
+            # Honour user-supplied glob patterns (match the bare name and the
+            # full path, so both "~$*.docx" and "**/build/**" work).
+            posix_path = path.as_posix()
+            if any(fnmatch.fnmatch(path.name, pat) or fnmatch.fnmatch(posix_path, pat) for pat in exclude_patterns):
                 continue
             if path.suffix.lower() in self.BINARY_FORMATS and path.is_file():
                 binary_docs.append(path)
@@ -296,6 +332,7 @@ class VCSConverter:
             Root directory to scan
         force : bool
             Force reconversion even if markdown exists
+
         """
         binary_docs = self.scan_repository(root_dir)
 
@@ -322,6 +359,7 @@ class VCSConverter:
         ----------
         root_dir : Path, optional
             Root directory
+
         """
         if root_dir is None:
             root_dir = Path.cwd()
@@ -342,6 +380,7 @@ def main() -> int:
     -------
     int
         Exit code
+
     """
     parser = argparse.ArgumentParser(
         description="Make binary documents version control friendly",

--- a/examples/plugins/simpledoc-plugin/README.md
+++ b/examples/plugins/simpledoc-plugin/README.md
@@ -65,7 +65,7 @@ Or for development:
 
 ```bash
 git clone https://github.com/thomas-villani/all2md.git
-cd all2md/examples/simpledoc-plugin
+cd all2md/examples/plugins/simpledoc-plugin
 pip install -e .
 ```
 
@@ -87,7 +87,7 @@ all2md document.md --out output.sdoc
 
 ```python
 from all2md import to_markdown, from_markdown
-from all2md_simpledoc.options import SimpleDocOptions
+from all2md_simpledoc import SimpleDocOptions
 
 # Parse SimpleDoc to Markdown
 markdown_output = to_markdown("document.sdoc")
@@ -266,4 +266,4 @@ Contributions welcome! Please open an issue or PR on GitHub.
 ## Related Projects
 
 - [all2md](https://github.com/thomas-villani/all2md) - Universal document converter
-- [all2md-watermark](https://github.com/thomas-villani/all2md/tree/main/examples/watermark-plugin) - Transform plugin example
+- [all2md-watermark](https://github.com/thomas-villani/all2md/tree/main/examples/plugins/watermark-plugin) - Transform plugin example

--- a/examples/plugins/simpledoc-plugin/pyproject.toml
+++ b/examples/plugins/simpledoc-plugin/pyproject.toml
@@ -26,7 +26,7 @@ dependencies = [
 ]
 
 [project.urls]
-Homepage = "https://github.com/thomas-villani/all2md/tree/main/examples/simpledoc-plugin"
+Homepage = "https://github.com/thomas-villani/all2md/tree/main/examples/plugins/simpledoc-plugin"
 Repository = "https://github.com/thomas-villani/all2md.git"
 Issues = "https://github.com/thomas-villani/all2md/issues"
 

--- a/examples/plugins/simpledoc-plugin/src/all2md_simpledoc/__init__.py
+++ b/examples/plugins/simpledoc-plugin/src/all2md_simpledoc/__init__.py
@@ -15,13 +15,12 @@ SimpleDoc is a lightweight markup format with:
 Example usage:
 
     from all2md import to_markdown
-    from all2md.converter_registry import get_registry
+    from all2md.converter_registry import registry
 
     # Parse SimpleDoc to Markdown
     markdown = to_markdown("document.sdoc")
 
     # Convert Markdown to SimpleDoc
-    registry = get_registry()
     parser = registry.get_parser("markdown")()
     ast_doc = parser.parse("document.md")
 

--- a/examples/plugins/watermark-plugin/README.md
+++ b/examples/plugins/watermark-plugin/README.md
@@ -1,6 +1,6 @@
 # all2md-watermark
 
-A watermark transform plugin for [all2md](https://github.com/thomas.villani/all2md) that embeds a visual watermark into images when their bytes are available (base64 or downloaded attachments). For other images it still records watermark metadata for downstream tools.
+A watermark transform plugin for [all2md](https://github.com/thomas-villani/all2md) that embeds a visual watermark into images when their bytes are available (base64 or downloaded attachments). For other images it still records watermark metadata for downstream tools.
 
 ## Installation
 
@@ -31,8 +31,8 @@ markdown = to_markdown('document.pdf', transforms=[transform])
 # Default watermark (embed watermark into inline image data)
 all2md document.pdf --attachment-mode base64 --transform watermark
 
-# Custom watermark text while embedding into downloaded attachments
-all2md document.pdf --attachment-mode download --transform watermark --watermark-text "DRAFT"
+# Custom watermark text while embedding into saved (on-disk) attachments
+all2md document.pdf --attachment-mode save --transform watermark --watermark-text "DRAFT"
 ```
 
 ### Using Transform Names
@@ -62,13 +62,10 @@ When either flag is present the plugin decodes the image with [Pillow](https://p
 ```bash
 # Clone the repository
 git clone https://github.com/thomas-villani/all2md.git
-cd all2md/examples/watermark-plugin
+cd all2md/examples/plugins/watermark-plugin
 
-# Install in development mode
+# Install in development mode (Pillow is a hard dependency, so this is all you need)
 pip install -e .
-
-# Install with all2md development dependencies (includes Pillow for watermarking)
-pip install -e ".[dev]"
 ```
 
 ### Testing

--- a/examples/plugins/watermark-plugin/pyproject.toml
+++ b/examples/plugins/watermark-plugin/pyproject.toml
@@ -27,7 +27,7 @@ dependencies = [
 ]
 
 [project.urls]
-Homepage = "https://github.com/thomas-villani/all2md/tree/main/examples/watermark-plugin"
+Homepage = "https://github.com/thomas-villani/all2md/tree/main/examples/plugins/watermark-plugin"
 Repository = "https://github.com/thomas-villani/all2md.git"
 Issues = "https://github.com/thomas-villani/all2md/issues"
 

--- a/examples/templates/jinja-templates/README.md
+++ b/examples/templates/jinja-templates/README.md
@@ -10,12 +10,12 @@ Converts documents to DocBook XML format, suitable for technical documentation.
 
 **Usage:**
 ```python
-from all2md import Document
+from all2md.ast import Document
 from all2md.renderers.jinja import JinjaRenderer
 from all2md.options.jinja import JinjaRendererOptions
 
 options = JinjaRendererOptions(
-    template_file="examples/jinja-templates/docbook.xml.jinja2",
+    template_file="examples/templates/jinja-templates/docbook.xml.jinja2",
     escape_strategy="xml",
     enable_escape_filters=True,
     enable_traversal_helpers=True
@@ -32,7 +32,7 @@ Extracts document structure and metadata as YAML.
 **Usage:**
 ```python
 options = JinjaRendererOptions(
-    template_file="examples/jinja-templates/metadata.yaml.jinja2",
+    template_file="examples/templates/jinja-templates/metadata.yaml.jinja2",
     escape_strategy="yaml",
     enable_escape_filters=True,
     enable_traversal_helpers=True
@@ -49,7 +49,7 @@ Generates a human-readable document outline with table of contents.
 **Usage:**
 ```python
 options = JinjaRendererOptions(
-    template_file="examples/jinja-templates/custom-outline.txt.jinja2",
+    template_file="examples/templates/jinja-templates/custom-outline.txt.jinja2",
     enable_traversal_helpers=True
 )
 

--- a/examples/templates/jinja_template_demo.py
+++ b/examples/templates/jinja_template_demo.py
@@ -6,10 +6,10 @@ documents to various custom formats using templates.
 """
 
 import sys
+from pathlib import Path
 
 # Fix Windows console encoding for Unicode box characters
 if sys.platform == "win32":
-    import codecs
 
     sys.stdout.reconfigure(encoding="utf-8")
 
@@ -25,6 +25,10 @@ from all2md.ast import (
 )
 from all2md.options.jinja import JinjaRendererOptions
 from all2md.renderers.jinja import JinjaRenderer
+
+# Templates live alongside this script, so resolve them relative to it rather
+# than relying on the current working directory.
+TEMPLATE_DIR = Path(__file__).parent / "jinja-templates"
 
 
 def create_sample_document() -> Document:
@@ -83,7 +87,7 @@ def demo_docbook_xml():
     doc = create_sample_document()
 
     options = JinjaRendererOptions(
-        template_file="examples/jinja-templates/docbook.xml.jinja2",
+        template_file=str(TEMPLATE_DIR / "docbook.xml.jinja2"),
         escape_strategy="xml",
         enable_escape_filters=True,
         enable_traversal_helpers=True,
@@ -105,7 +109,7 @@ def demo_yaml_metadata():
     doc = create_sample_document()
 
     options = JinjaRendererOptions(
-        template_file="examples/jinja-templates/metadata.yaml.jinja2",
+        template_file=str(TEMPLATE_DIR / "metadata.yaml.jinja2"),
         escape_strategy="yaml",
         enable_escape_filters=True,
         enable_traversal_helpers=True,
@@ -127,7 +131,7 @@ def demo_custom_outline():
     doc = create_sample_document()
 
     options = JinjaRendererOptions(
-        template_file="examples/jinja-templates/custom-outline.txt.jinja2",
+        template_file=str(TEMPLATE_DIR / "custom-outline.txt.jinja2"),
         enable_traversal_helpers=True,
     )
 
@@ -185,7 +189,7 @@ def demo_ansi_terminal():
     doc = create_sample_document()
 
     options = JinjaRendererOptions(
-        template_file="examples/jinja-templates/ansi-terminal.txt.jinja2",
+        template_file=str(TEMPLATE_DIR / "ansi-terminal.txt.jinja2"),
         enable_traversal_helpers=True,
     )
 


### PR DESCRIPTION
## Summary

A review pass over the docs cookbook (`docs/source/recipes.rst`) and the `examples/` tree to remove stale "bad advice" (patterns written before features existed) and fix examples that no longer run against the current API. Driven by four parallel audits; every claim was verified against the installed library and CLI.

`examples/python/` and `examples/llm/` were audited and found fully current (imports, kwargs, AST fields, Anthropic model IDs) — **no changes needed there**.

## Stale "bad advice"
- **`batch-convert.{sh,ps1}`** — use the built-in `--parallel` worker pool instead of hand-rolled `find|xargs` / `ForEach-Object -Parallel` (kept as a commented fallback for custom per-file flags); updated the `cli/README.md` row.
- **`recipes.rst`** — trimmed three `ThreadPoolExecutor` recipes (Mixed-Directory, Website-Archive, Progress-Tracking) to lead with the CLI batch engine, plus a compact Python snippet. Also fixed the `relative_to(file_path.parent)` bug that silently flattened the output tree, and added a GIL/`ProcessPoolExecutor` note. (~371 lines of hand-rolled orchestration removed.)

## Broken examples (HIGH)
- `grep-binary-docs.{sh,ps1}`: `grep -r` → `grep --recursive` (short flag doesn't exist).
- `recipes.rst`: `generate-site` now requires `--generator`/`--output-dir`; fixed `ConverterGUI` snippet missing `self.root`.
- `jinja_template_demo.py` + `jinja-templates/README.md`: corrected template paths and `from all2md import Document` → `from all2md.ast import Document`.
- `simpledoc-plugin/__init__.py`: nonexistent `get_registry()` → `registry` singleton.
- `watermark-plugin/README.md`: invalid `--attachment-mode download` → `save`.
- `vcs-converter`: fixed metadata filename (`*.vcs.vcs.json` → documented `*.vcs.json`), hook script path, `cp -r` source paths; wired up the previously-ignored `exclude_patterns`; dropped never-implemented config keys; added missing `CONTRIBUTING.md`; bumped `checkout@v4`.

## Cleanups (LOW)
- `rag-ingest.{sh,ps1}`: strip `<<...>>` match-highlight markers from prompt context.
- `diff-in-ci.ps1`: `Write-Warning` before `exit 1` so the CI gate exits cleanly.
- Stale plugin homepage paths.

## Verification
- Jinja demo runs end-to-end.
- vcs-converter round-trips (`to-md` → `to-binary`) with the corrected filename.
- All 17 Python code-blocks in `recipes.rst` parse.
- Pre-commit hooks (black/ruff/bandit) pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)