### PR TITLE
feat(cli): richer --extract, --slice paging, and line-window flags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,30 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- **`--extract` is now repeatable and understands tables and figures.** In
+  addition to sections (by name/pattern or ``#:`` index) and ``line:`` ranges,
+  ``--extract`` now selects tables (``table:2``, ``table:1-3``, ``table:*``) and
+  figures/images (``figure:1``, ``image:*``). Pass ``--extract`` multiple times to
+  pull several pieces at once; results are emitted in the order the flags appear,
+  separated by ``---``. A single ``line:`` range still cannot be mixed with other
+  selectors.
+- **`--extract … ::N` word limit.** Append ``::N`` to a selector to cap its output
+  at roughly ``N`` words, cut at node boundaries so the result stays valid (e.g.
+  ``--extract "Introduction::500"``).
+- **`--slice X/Y` paging.** Return the Xth of Y semantic slices of a document to
+  stdout/file without writing split files. The document is divided into exactly
+  ``Y`` balanced slices at section boundaries, and the chosen slice is emitted with
+  a footer hint pointing at the next slice. Mutually exclusive with
+  ``--extract``/``--outline``/``--split-by``/``--collate``.
+- **`--head [N]`, `--tail [N]`, and `--lines START:END`.** Simple windows over the
+  rendered Markdown output (1-based, inclusive), mirroring ``head``/``tail`` and the
+  existing ``--extract line:`` range. ``--head``/``--tail`` default to 10 lines and
+  honor ``--line-numbers``.
+
 ## [1.7.0] - 2026-06-24
 
 ### Changed

--- a/docs/source/cli.rst
+++ b/docs/source/cli.rst
@@ -2042,6 +2042,84 @@ conversion:
 
    all2md report.pdf --extract line:42-87 --out excerpt.html
 
+Tables, Figures, and Multiple Extracts
+--------------------------------------
+
+``--extract`` selects more than sections. Use a typed prefix to pull tables or
+figures by their 1-based position in the document, and pass ``--extract`` more
+than once to gather several pieces at a time:
+
+.. code-block:: bash
+
+   # The second table in the document
+   all2md report.docx --extract table:2
+
+   # A range or all of them
+   all2md report.docx --extract table:1-3
+   all2md report.docx --extract table:*
+
+   # Figures/images (the two prefixes are aliases)
+   all2md paper.pdf --extract figure:1
+   all2md paper.pdf --extract image:*
+
+   # Several selectors at once -- emitted in the order given, separated by '---'
+   all2md paper.pdf --extract "Methods" --extract table:1 --extract figure:1
+
+When ``--extract`` is repeated, results are concatenated in **flag order** (not
+document order), so you control the sequence. A single ``line:`` range cannot be
+combined with other selectors.
+
+Capping length with ``::N``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Append ``::N`` to any selector to cap its output at roughly ``N`` words. The cut
+happens at node boundaries, so the returned content is always a valid document
+(it never slices a paragraph or table in half):
+
+.. code-block:: bash
+
+   # The Introduction, trimmed to about 500 words
+   all2md paper.pdf --extract "Introduction::500"
+
+   # Works with index and typed selectors too
+   all2md paper.pdf --extract "#:1::200"
+
+Paging with ``--slice``
+-----------------------
+
+``--slice X/Y`` returns the **Xth of Y** semantic slices of a document to stdout
+(or ``--out``) without writing a pile of split files. The document is divided
+into exactly ``Y`` balanced parts at section boundaries, and only slice ``X`` is
+emitted, followed by a footer hint pointing at the next slice:
+
+.. code-block:: bash
+
+   all2md long-report.pdf --slice 1/5
+   all2md long-report.pdf --slice 2/5    # ... up to 5/5
+
+This is handy for feeding a large document to a tool with a context limit one
+page at a time. ``--slice`` cannot be combined with
+``--extract``/``--outline``/``--split-by``/``--collate``.
+
+Line Windows: ``--head``, ``--tail``, ``--lines``
+-------------------------------------------------
+
+For quick windows over the rendered output, three shorthand flags mirror the
+familiar ``head``/``tail`` tools and the ``--extract line:`` range. All operate
+on 1-based output lines and honor ``--line-numbers``:
+
+.. code-block:: bash
+
+   all2md document.pdf --head        # first 10 lines (default)
+   all2md document.pdf --head 40     # first 40 lines
+   all2md document.pdf --tail 20     # last 20 lines
+   all2md document.pdf --lines 10:25 # lines 10-25 (inclusive)
+   all2md document.pdf --lines :25   # through line 25
+   all2md document.pdf --lines 40:   # from line 40 to the end
+
+These are mutually exclusive with each other and with
+``--extract``/``--outline``/``--split-by``/``--slice``.
+
 Document Serving
 ----------------
 

--- a/src/all2md/ast/extraction.py
+++ b/src/all2md/ast/extraction.py
@@ -1,0 +1,270 @@
+#  Copyright (c) 2025 Tom Villani, Ph.D.
+#
+# src/all2md/ast/extraction.py
+"""Typed ``--extract`` selectors: sections, tables, and figures.
+
+This module backs the CLI ``--extract`` flag. It parses a single selector
+string into a typed :class:`ExtractSelector`, resolves it against a document's
+AST, and assembles one or more selectors into a combined :class:`Document`.
+
+Selector grammar (one per ``--extract``)::
+
+    <body>[::<word-limit>]
+
+where ``<body>`` is one of:
+
+- ``Introduction`` / ``Chapter*`` -- section by heading name or wildcard pattern
+- ``#:1`` / ``#:1-3`` / ``#:1,3,5`` / ``#:3-`` -- section(s) by 1-based index
+- ``table:2`` / ``table:1-3`` / ``table:*`` -- table(s) by 1-based position
+- ``figure:1`` / ``image:1`` / ``figure:*`` -- figure(s)/image(s) by position
+
+The optional ``::N`` suffix truncates the selector's output to roughly ``N``
+words, cutting only at node boundaries so the result stays a valid AST.
+
+``line:`` ranges are intentionally *not* handled here -- they select by rendered
+output line and are resolved in the CLI layer where the Markdown rendering is
+available.
+
+Examples
+--------
+>>> doc = build_extracted_document(source, ["Introduction::500", "table:1"])
+
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Iterator, Literal, Optional
+
+from all2md.ast.nodes import (
+    Document,
+    Image,
+    Node,
+    Paragraph,
+    Table,
+    ThematicBreak,
+    get_node_children,
+)
+from all2md.ast.sections import get_all_sections, parse_section_ranges, resolve_section_indices
+from all2md.ast.utils import extract_text
+
+# Separator between a selector body and its optional word limit (``Intro::500``).
+WORD_LIMIT_SEP = "::"
+
+# Reserved prefixes that switch a selector away from section name/index matching.
+_TABLE_PREFIX = "table:"
+_FIGURE_PREFIXES = ("figure:", "image:")
+
+SelectorKind = Literal["section", "table", "figure"]
+
+
+@dataclass(frozen=True)
+class ExtractSelector:
+    """A parsed ``--extract`` selector.
+
+    Attributes
+    ----------
+    kind : {"section", "table", "figure"}
+        What the selector targets.
+    spec : str
+        The selector body with any ``kind:`` prefix and ``::N`` suffix removed
+        (e.g. ``"Introduction"``, ``"#:1-3"``, ``"2"``, ``"*"``).
+    word_limit : int or None
+        Optional cap on the number of words in the selector's output.
+    raw : str
+        The original, unparsed selector string (used in error messages).
+
+    """
+
+    kind: SelectorKind
+    spec: str
+    word_limit: Optional[int]
+    raw: str
+
+
+def parse_extract_selector(raw: str) -> ExtractSelector:
+    """Parse a single ``--extract`` selector string.
+
+    Parameters
+    ----------
+    raw : str
+        Selector string, e.g. ``"Introduction::500"`` or ``"table:2"``.
+
+    Returns
+    -------
+    ExtractSelector
+        The parsed selector.
+
+    Raises
+    ------
+    ValueError
+        If the selector is empty or the ``::N`` word limit is not a positive
+        integer.
+
+    """
+    text = raw.strip()
+
+    word_limit: Optional[int] = None
+    body = text
+    if WORD_LIMIT_SEP in text:
+        body, _, limit_str = text.rpartition(WORD_LIMIT_SEP)
+        body = body.strip()
+        limit_str = limit_str.strip()
+        if not limit_str.isdigit() or int(limit_str) < 1:
+            raise ValueError(
+                f"Invalid word limit in --extract '{raw}': expected a positive integer after '{WORD_LIMIT_SEP}'."
+            )
+        word_limit = int(limit_str)
+
+    if not body:
+        raise ValueError(f"Empty --extract selector: '{raw}'.")
+
+    lower = body.lower()
+    if lower.startswith(_TABLE_PREFIX):
+        return ExtractSelector("table", body[len(_TABLE_PREFIX) :].strip(), word_limit, raw)
+    for prefix in _FIGURE_PREFIXES:
+        if lower.startswith(prefix):
+            return ExtractSelector("figure", body[len(prefix) :].strip(), word_limit, raw)
+
+    return ExtractSelector("section", body, word_limit, raw)
+
+
+def _walk(nodes: list[Node]) -> Iterator[Node]:
+    """Yield every node in ``nodes`` and all of their descendants (pre-order)."""
+    for node in nodes:
+        yield node
+        yield from _walk(get_node_children(node))
+
+
+def collect_tables(doc: Document) -> list[Table]:
+    """Return every :class:`Table` in the document, in document order."""
+    return [node for node in _walk(doc.children) if isinstance(node, Table)]
+
+
+def collect_figures(doc: Document) -> list[Image]:
+    """Return every :class:`Image` in the document, in document order."""
+    return [node for node in _walk(doc.children) if isinstance(node, Image)]
+
+
+def _resolve_indexed(count: int, spec: str, what: str) -> list[int]:
+    """Resolve a 1-based positional spec (``2``, ``1-3``, ``*``) to 0-based indices."""
+    if count == 0:
+        raise ValueError(f"Document contains no {what}s to extract")
+
+    normalized = spec.strip().lower()
+    if normalized in ("", "*", "all"):
+        return list(range(count))
+
+    indices = parse_section_ranges(spec, count)
+    if not indices:
+        raise ValueError(f"No {what}s selected by '{spec}' (document has {count} {what}{'s' if count != 1 else ''})")
+    return indices
+
+
+def _join_groups(groups: list[list[Node]]) -> list[Node]:
+    """Flatten node groups, inserting a :class:`ThematicBreak` between groups."""
+    out: list[Node] = []
+    for i, group in enumerate(groups):
+        if i:
+            out.append(ThematicBreak())
+        out.extend(group)
+    return out
+
+
+def _section_nodes(doc: Document, spec: str) -> list[Node]:
+    """Resolve a section selector to a node sequence (matching ``extract_sections``)."""
+    sections = get_all_sections(doc)
+    if not sections:
+        raise ValueError("Document contains no sections (headings)")
+
+    indices = resolve_section_indices(sections, spec, case_sensitive=False)
+    groups = [[sections[i].heading, *sections[i].content] for i in indices]
+    return _join_groups(groups)
+
+
+def _figure_groups(figures: list[Image], indices: list[int]) -> list[list[Node]]:
+    """Wrap selected inline images in paragraphs so they render at block level."""
+    return [[Paragraph(content=[figures[i]])] for i in indices]
+
+
+def _truncate_words(nodes: list[Node], limit: int) -> list[Node]:
+    """Keep whole nodes until ``limit`` words are reached (never splits a node).
+
+    Always returns at least the first node so a selector never yields nothing
+    just because its opening node already exceeds the budget.
+    """
+    kept: list[Node] = []
+    used = 0
+    for node in nodes:
+        if used >= limit:
+            break
+        kept.append(node)
+        used += len(extract_text(node).split())
+    return kept or nodes[:1]
+
+
+def selector_nodes(doc: Document, selector: ExtractSelector) -> list[Node]:
+    """Resolve a single selector to its node sequence (before word-limit trimming)."""
+    if selector.kind == "section":
+        return _section_nodes(doc, selector.spec)
+
+    if selector.kind == "table":
+        tables = collect_tables(doc)
+        indices = _resolve_indexed(len(tables), selector.spec, "table")
+        return _join_groups([[tables[i]] for i in indices])
+
+    figures = collect_figures(doc)
+    indices = _resolve_indexed(len(figures), selector.spec, "figure")
+    return _join_groups(_figure_groups(figures, indices))
+
+
+def build_extracted_document(doc: Document, raw_specs: list[str]) -> Document:
+    """Build a document from one or more ``--extract`` selectors, in spec order.
+
+    Each selector's output is appended in the order the selectors were given,
+    separated by a :class:`ThematicBreak`. Word limits are applied per selector.
+
+    Parameters
+    ----------
+    doc : Document
+        Source document.
+    raw_specs : list of str
+        Raw ``--extract`` selector strings (excluding ``line:`` ranges).
+
+    Returns
+    -------
+    Document
+        New document containing the selected content.
+
+    Raises
+    ------
+    ValueError
+        If a selector is malformed or matches nothing.
+
+    """
+    selectors = [parse_extract_selector(raw) for raw in raw_specs]
+
+    parts: list[list[Node]] = []
+    for selector in selectors:
+        nodes = selector_nodes(doc, selector)
+        if selector.word_limit is not None:
+            nodes = _truncate_words(nodes, selector.word_limit)
+        if nodes:
+            parts.append(nodes)
+
+    if not parts:
+        raise ValueError("No content matched the --extract selector(s)")
+
+    children = _join_groups(parts)
+    return Document(children=children, metadata=doc.metadata.copy(), source_location=doc.source_location)
+
+
+__all__ = [
+    "ExtractSelector",
+    "WORD_LIMIT_SEP",
+    "parse_extract_selector",
+    "collect_tables",
+    "collect_figures",
+    "selector_nodes",
+    "build_extracted_document",
+]

--- a/src/all2md/ast/splitting.py
+++ b/src/all2md/ast/splitting.py
@@ -364,6 +364,90 @@ class DocumentSplitter:
         return DocumentSplitter.split_by_word_count(doc, target_words=target_words_per_part)
 
     @staticmethod
+    def split_into_slices(doc: Document, num_slices: int) -> list[SplitResult]:
+        """Divide a document into exactly ``num_slices`` balanced, contiguous slices.
+
+        Unlike :meth:`split_by_parts` (which targets a word count and may yield a
+        different number of parts), this guarantees exactly ``num_slices`` slices
+        whenever the document has at least that many semantic "atoms" (sections,
+        or word-count blocks for heading-light documents). When the document has
+        fewer atoms than requested, it returns one slice per atom.
+
+        This powers the ``--slice X/Y`` paging flag, where a deterministic ``Y``
+        matters so callers can page ``1/Y, 2/Y, ... Y/Y``.
+
+        Parameters
+        ----------
+        doc : Document
+            Document to slice.
+        num_slices : int
+            Desired number of slices (``Y``). Must be >= 1.
+
+        Returns
+        -------
+        list of SplitResult
+            ``min(num_slices, num_atoms)`` contiguous slices in document order.
+
+        Raises
+        ------
+        ValueError
+            If ``num_slices`` is less than 1.
+
+        """
+        if num_slices < 1:
+            raise ValueError(f"num_slices must be at least 1, got {num_slices}")
+
+        atoms = DocumentSplitter.split_by_sections(doc, include_preamble=True)
+
+        # Heading-light documents yield too few section atoms to page deeply;
+        # fall back to word-count blocks so Y can still be honored.
+        if len(atoms) < num_slices:
+            total_words = len(extract_text(doc.children, joiner=" ").split())
+            if total_words > 0:
+                target = max(1, total_words // num_slices)
+                wc_atoms = DocumentSplitter.split_by_word_count(doc, target_words=target)
+                if len(wc_atoms) > len(atoms):
+                    atoms = wc_atoms
+
+        if not atoms:
+            return [
+                SplitResult(
+                    document=doc,
+                    index=1,
+                    title=None,
+                    word_count=len(extract_text(doc.children, joiner=" ").split()),
+                )
+            ]
+
+        n = min(num_slices, len(atoms))
+        weights = [max(1, atom.word_count) for atom in atoms]
+        bounds = _balanced_partition(weights, n)
+
+        slices: list[SplitResult] = []
+        for slice_index, (start, end) in enumerate(bounds, start=1):
+            children: list[Node] = []
+            title: Optional[str] = None
+            word_count = 0
+            for atom in atoms[start:end]:
+                children.extend(atom.document.children)
+                word_count += atom.word_count
+                if title is None:
+                    title = atom.title
+            slices.append(
+                SplitResult(
+                    document=Document(
+                        children=children,
+                        metadata=doc.metadata.copy(),
+                        source_location=doc.source_location,
+                    ),
+                    index=slice_index,
+                    title=title,
+                    word_count=word_count,
+                )
+            )
+        return slices
+
+    @staticmethod
     def split_by_break(doc: Document) -> list[SplitResult]:
         """Split document at thematic breaks (horizontal rules).
 
@@ -697,6 +781,49 @@ class DocumentSplitter:
             index += 1
 
         return splits
+
+
+def _balanced_partition(weights: list[int], n: int) -> list[tuple[int, int]]:
+    """Partition ``weights`` into exactly ``n`` contiguous, non-empty groups.
+
+    Greedily closes a group once its accumulated weight meets the running target
+    (total of remaining weight divided by remaining groups), while guaranteeing
+    that enough atoms are left to fill every remaining group. The result is a
+    list of ``(start, end)`` index pairs covering ``range(len(weights))``.
+
+    Assumes ``1 <= n <= len(weights)``.
+    """
+    count = len(weights)
+    total = sum(weights)
+    bounds: list[tuple[int, int]] = []
+
+    start = 0
+    acc = 0
+    remaining = n
+    consumed = 0
+    target = total / n
+
+    for i, w in enumerate(weights):
+        acc += w
+        groups_left_after = remaining - 1
+        atoms_left_after = count - (i + 1)
+
+        if remaining > 1:
+            # Must close now if every remaining atom is needed to fill the
+            # remaining groups; otherwise close once we've met the target and
+            # still have enough atoms left over.
+            must_close = atoms_left_after == groups_left_after
+            can_close = acc >= target and atoms_left_after >= groups_left_after
+            if must_close or can_close:
+                bounds.append((start, i + 1))
+                consumed += acc
+                start = i + 1
+                acc = 0
+                remaining -= 1
+                target = (total - consumed) / remaining
+
+    bounds.append((start, count))
+    return bounds
 
 
 def parse_split_spec(spec: str) -> tuple[str, Any]:

--- a/src/all2md/cli/builder.py
+++ b/src/all2md/cli/builder.py
@@ -1106,6 +1106,18 @@ Examples:
   all2md document.pdf --extract "Materials and Methods"
   all2md document.pdf --extract "#:3"
 
+  # Cap a section at ~500 words, or pull tables/figures (repeatable, spec order)
+  all2md document.pdf --extract "Introduction::500"
+  all2md report.docx --extract "table:1-2" --extract "figure:1"
+
+  # Paging: return the 2nd of 5 semantic slices, with a 'next slice' hint
+  all2md long-report.pdf --slice 2/5
+
+  # Simple line windows over the rendered output
+  all2md document.pdf --head 40
+  all2md document.pdf --tail 20
+  all2md document.pdf --lines 10:25
+
   # Line-numbered navigation (handy for LLMs/agents picking a range)
   all2md document.pdf --outline --line-numbers
   all2md document.pdf --extract line:42-87
@@ -1167,15 +1179,62 @@ Examples:
         # Section extraction option
         parser.add_argument(
             "--extract",
+            action="append",
             type=str,
             metavar="SPEC",
-            help="Extract specific section(s) from document. "
-            "Supports: name pattern ('Introduction', 'Chapter*'), "
-            "single index ('#:1'), range ('#:1-3'), "
-            "multiple ('#:1,3,5'), or open-ended ('#:3-'). "
+            help="Extract specific content from a document. May be given multiple times; "
+            "results are emitted in the order the flags appear, separated by '---'. "
+            "Supports: section by name/pattern ('Introduction', 'Chapter*'), "
+            "section index ('#:1', '#:1-3', '#:1,3,5', '#:3-'), "
+            "tables ('table:2', 'table:1-3', 'table:*'), "
+            "figures/images ('figure:1', 'image:*'). "
+            "Append '::N' to cap output at ~N words at node boundaries (e.g. 'Introduction::500'). "
             "Also supports output line ranges: 'line:10-25', 'line:10-', 'line:5,8-12' "
-            "(1-based, inclusive; numbers as reported by --line-numbers). "
-            "Sections are 1-indexed. Pattern matching is case-insensitive with wildcard support.",
+            "(1-based, inclusive; numbers as reported by --line-numbers); a line: range "
+            "cannot be combined with other --extract selectors. "
+            "Sections/tables/figures are 1-indexed; name matching is case-insensitive with wildcards.",
+        )
+
+        # Single-slice paging: return one of N semantic slices to stdout/file
+        parser.add_argument(
+            "--slice",
+            type=str,
+            metavar="X/Y",
+            dest="slice_spec",
+            help="Return the Xth of Y semantic slices of the document (1-based, e.g. '2/5'). "
+            "The document is divided into Y roughly equal parts at section boundaries (like "
+            "--split-by parts=Y) but only slice X is emitted, with a footer hint pointing at the "
+            "next slice. Cannot be combined with --extract/--outline/--split-by/--collate.",
+        )
+
+        # Simple line-range selectors (operate on the rendered Markdown output)
+        parser.add_argument(
+            "--lines",
+            type=str,
+            metavar="START:END",
+            help="Return a range of output lines (1-based, inclusive), e.g. '10:25', ':25', '40:'. "
+            "Operates on the rendered Markdown (the numbers shown by --line-numbers). "
+            "Cannot be combined with --extract/--outline/--split-by/--slice.",
+        )
+        parser.add_argument(
+            "--head",
+            type=int,
+            nargs="?",
+            const=10,
+            default=None,
+            metavar="N",
+            help="Return the first N output lines (default 10). Like 'head -n'. "
+            "Cannot be combined with --extract/--outline/--split-by/--slice/--lines/--tail.",
+        )
+        parser.add_argument(
+            "--tail",
+            type=int,
+            nargs="?",
+            const=10,
+            default=None,
+            metavar="N",
+            help="Return the last N output lines (default 10). Like 'tail -n'. "
+            "Cannot be combined with --extract/--outline/--split-by/--slice/--lines/--head.",
         )
 
         # Outline extraction option
@@ -1831,6 +1890,10 @@ Examples:
             "outline",
             "outline_max_level",
             "line_numbers",
+            "slice_spec",
+            "lines",
+            "head",
+            "tail",
         } | global_attachment_fields  # Union with global attachment fields
 
         # Process each argument

--- a/src/all2md/cli/processors.py
+++ b/src/all2md/cli/processors.py
@@ -216,27 +216,41 @@ def _outline_output(
 
 def _extraction_output(
     doc: Document,
-    extract_spec: str,
+    extract_specs: List[str],
     render_target: str,
     line_numbers: bool,
     effective_options: Dict[str, Any],
     transforms: Optional[list],
 ) -> Any:
-    """Produce extraction output for a name/index spec or a ``line:`` range.
+    """Produce extraction output for one or more ``--extract`` selectors.
 
-    Returns a str (text targets) or bytes (binary targets). Line numbering is
-    only meaningful for Markdown output and references the full Markdown render.
+    ``extract_specs`` is the list of raw selector strings (sections, tables,
+    figures, or a single ``line:`` range). Multiple selectors are assembled in
+    spec order, separated by ``---``. Returns a str (text targets) or bytes
+    (binary targets). Line numbering is only meaningful for Markdown output and
+    references the full Markdown render.
     """
-    if is_line_extract_spec(extract_spec):
-        return _extract_by_lines(doc, extract_spec, render_target, line_numbers, effective_options, transforms)
+    from all2md.ast.extraction import build_extracted_document, parse_extract_selector
 
-    if line_numbers and render_target == "markdown":
+    line_specs = [spec for spec in extract_specs if is_line_extract_spec(spec)]
+    if line_specs:
+        if len(extract_specs) > 1:
+            raise ValueError("A 'line:' --extract range cannot be combined with other --extract selectors.")
+        return _extract_by_lines(doc, extract_specs[0], render_target, line_numbers, effective_options, transforms)
+
+    if (
+        len(extract_specs) == 1
+        and line_numbers
+        and render_target == "markdown"
+        and parse_extract_selector(extract_specs[0]).kind == "section"
+    ):
         # Slice the original rendered lines for each selected section so the
         # reported numbers are the document's true line numbers (matching what
-        # --outline -ln and full -ln report), not extract-relative ones.
-        return _extract_sections_with_line_numbers(doc, extract_spec, effective_options)
+        # --outline -ln and full -ln report), not extract-relative ones. Only
+        # plain section selectors carry meaningful per-line numbers.
+        return _extract_sections_with_line_numbers(doc, extract_specs[0], effective_options)
 
-    extracted = extract_sections_from_document(doc, extract_spec)
+    extracted = build_extracted_document(doc, extract_specs)
     if transforms:
         for transform in transforms:
             extracted = transform.transform(extracted)
@@ -274,22 +288,16 @@ def _gather_selected_lines(md_lines: List[str], indices: List[int]) -> Tuple[Lis
     return out_lines, out_numbers
 
 
-def _extract_by_lines(
-    doc: Document,
-    extract_spec: str,
+def _emit_line_selection(
+    md_lines: List[str],
+    indices: List[int],
     render_target: str,
     line_numbers: bool,
     effective_options: Dict[str, Any],
     transforms: Optional[list],
 ) -> Any:
-    """Extract content by output line range (``line:X-Y``)."""
+    """Render a set of 0-based output-line indices to the requested target."""
     from all2md.ast.line_map import number_text_lines
-
-    rendered_markdown = _render_reference_markdown(doc, effective_options)
-    md_lines = rendered_markdown.split("\n")
-
-    spec_body = extract_spec.strip()[len(LINE_EXTRACT_PREFIX) :].strip()
-    indices = _parse_line_indices(spec_body, len(md_lines), extract_spec)
 
     out_lines, out_numbers = _gather_selected_lines(md_lines, indices)
     selected_text = "\n".join(out_lines)
@@ -305,6 +313,165 @@ def _extract_by_lines(
         for transform in transforms:
             reparsed = transform.transform(reparsed)
     return from_ast(reparsed, cast(DocumentFormat, render_target), **effective_options)
+
+
+def _extract_by_lines(
+    doc: Document,
+    extract_spec: str,
+    render_target: str,
+    line_numbers: bool,
+    effective_options: Dict[str, Any],
+    transforms: Optional[list],
+) -> Any:
+    """Extract content by output line range (``line:X-Y``)."""
+    rendered_markdown = _render_reference_markdown(doc, effective_options)
+    md_lines = rendered_markdown.split("\n")
+
+    spec_body = extract_spec.strip()[len(LINE_EXTRACT_PREFIX) :].strip()
+    indices = _parse_line_indices(spec_body, len(md_lines), extract_spec)
+
+    return _emit_line_selection(md_lines, indices, render_target, line_numbers, effective_options, transforms)
+
+
+def _line_indices_for_selection(line_select: str, total_lines: int) -> List[int]:
+    """Resolve a normalized ``--head``/``--tail``/``--lines`` spec to 0-based indices.
+
+    ``line_select`` is one of ``head:N``, ``tail:N``, or ``lines:<range>`` where
+    ``<range>`` uses the same 1-based, inclusive grammar as ``line:`` (e.g.
+    ``10-25``, ``-25``, ``40-``).
+    """
+    kind, _, body = line_select.partition(":")
+    body = body.strip()
+
+    if kind == "head":
+        n = max(0, int(body))
+        return list(range(0, min(n, total_lines)))
+
+    if kind == "tail":
+        n = max(0, int(body))
+        return list(range(max(0, total_lines - n), total_lines))
+
+    if kind == "lines":
+        indices = _parse_line_indices(body, total_lines, f"--lines {body}")
+        return indices
+
+    raise ValueError(f"Unknown line selection: {line_select}")
+
+
+def _line_range_output(
+    doc: Document,
+    line_select: str,
+    render_target: str,
+    line_numbers: bool,
+    effective_options: Dict[str, Any],
+    transforms: Optional[list],
+) -> Any:
+    """Produce output for the ``--head``/``--tail``/``--lines`` flags."""
+    rendered_markdown = _render_reference_markdown(doc, effective_options)
+    md_lines = rendered_markdown.split("\n")
+    indices = _line_indices_for_selection(line_select, len(md_lines))
+    return _emit_line_selection(md_lines, indices, render_target, line_numbers, effective_options, transforms)
+
+
+def _slice_footer(x: int, y: int, word_count: int) -> str:
+    """Build the trailing hint that points at the next slice (Markdown comment)."""
+    if x < y:
+        nxt = f"next: --slice {x + 1}/{y}"
+    else:
+        nxt = "last slice"
+    return f"<!-- slice {x}/{y} · ~{word_count} words · {nxt} -->"
+
+
+def _slice_output(
+    doc: Document,
+    slice_spec: str,
+    render_target: str,
+    effective_options: Dict[str, Any],
+    transforms: Optional[list],
+) -> Any:
+    """Return the Xth of Y semantic slices, with a 'next slice' footer hint.
+
+    The document is divided into Y roughly equal parts at section boundaries
+    (reusing :meth:`DocumentSplitter.split_by_parts`). Only Markdown output gets
+    the footer comment; other text/binary targets are rendered without it.
+    """
+    from all2md.ast.splitting import DocumentSplitter
+
+    x, y = parse_slice_spec(slice_spec)
+    splits = DocumentSplitter.split_into_slices(doc, num_slices=y)
+
+    if x > len(splits):
+        raise ValueError(
+            f"--slice {x}/{y}: document only divides into {len(splits)} slice"
+            f"{'s' if len(splits) != 1 else ''} at section boundaries; pick X within 1-{len(splits)}."
+        )
+
+    chosen = splits[x - 1]
+    sliced_doc = chosen.document
+    if transforms:
+        for transform in transforms:
+            sliced_doc = transform.transform(sliced_doc)
+
+    result = from_ast(sliced_doc, cast(DocumentFormat, render_target), **effective_options)
+
+    if render_target == "markdown" and isinstance(result, str):
+        footer = _slice_footer(x, len(splits), chosen.word_count)
+        result = f"{result.rstrip()}\n\n{footer}\n"
+
+    return result
+
+
+def parse_slice_spec(spec: str) -> Tuple[int, int]:
+    """Parse a ``--slice X/Y`` spec into 1-based ``(x, y)``.
+
+    Raises
+    ------
+    ValueError
+        If the spec is malformed or out of the ``1 <= x <= y`` range.
+
+    """
+    text = spec.strip()
+    if "/" not in text:
+        raise ValueError(f"Invalid --slice spec '{spec}': expected 'X/Y' (e.g. '2/5').")
+
+    x_str, _, y_str = text.partition("/")
+    x_str, y_str = x_str.strip(), y_str.strip()
+    if not (x_str.isdigit() and y_str.isdigit()):
+        raise ValueError(f"Invalid --slice spec '{spec}': X and Y must be positive integers (e.g. '2/5').")
+
+    x, y = int(x_str), int(y_str)
+    if y < 1:
+        raise ValueError(f"Invalid --slice spec '{spec}': Y (number of slices) must be at least 1.")
+    if not 1 <= x <= y:
+        raise ValueError(f"Invalid --slice spec '{spec}': X must satisfy 1 <= X <= Y (got X={x}, Y={y}).")
+
+    return x, y
+
+
+def line_selection_from_args(args: argparse.Namespace) -> Optional[str]:
+    """Derive a normalized line-selection string from ``--head``/``--tail``/``--lines``.
+
+    Returns ``None`` when none of the flags are set. Only one is expected to be
+    set at a time (enforced by validation); if several are present, the first of
+    head/tail/lines wins.
+    """
+    head = getattr(args, "head", None)
+    if head is not None:
+        return f"head:{head}"
+
+    tail = getattr(args, "tail", None)
+    if tail is not None:
+        return f"tail:{tail}"
+
+    lines = getattr(args, "lines", None)
+    if lines:
+        body = lines.strip()
+        if ":" in body:
+            start, _, end = body.partition(":")
+            body = f"{start.strip()}-{end.strip()}"
+        return f"lines:{body}"
+
+    return None
 
 
 def _extract_sections_with_line_numbers(
@@ -2559,7 +2726,7 @@ def _handle_extraction_conversion(
     progress_callback: Optional[Any],
     output_path: Optional[Path],
     target_format: str,
-    extract_spec: str,
+    extract_specs: List[str],
     local_transforms: Optional[list],
     display_name: str,
     line_numbers: bool = False,
@@ -2581,7 +2748,69 @@ def _handle_extraction_conversion(
 
     render_target = target_format if target_format != "auto" else "markdown"
     line_numbers = _line_numbers_for_target(line_numbers, render_target)
-    result = _extraction_output(doc, extract_spec, render_target, line_numbers, effective_options, local_transforms)
+    result = _extraction_output(doc, extract_specs, render_target, line_numbers, effective_options, local_transforms)
+
+    if output_path is not None:
+        _write_result_to_path(result, output_path)
+    else:
+        _output_result_to_stdout(result)
+
+    return EXIT_SUCCESS, display_name, None
+
+
+def _handle_slice_conversion(
+    source_value: Any,
+    format_arg: str,
+    effective_options: Dict[str, Any],
+    progress_callback: Optional[Any],
+    output_path: Optional[Path],
+    target_format: str,
+    slice_spec: str,
+    local_transforms: Optional[list],
+    display_name: str,
+) -> Tuple[int, str, Optional[str]]:
+    """Handle ``--slice X/Y`` mode conversion."""
+    doc = to_ast(
+        source_value,
+        source_format=cast(DocumentFormat, format_arg),
+        progress_callback=progress_callback,
+        **effective_options,
+    )
+
+    render_target = target_format if target_format != "auto" else "markdown"
+    result = _slice_output(doc, slice_spec, render_target, effective_options, local_transforms)
+
+    if output_path is not None:
+        _write_result_to_path(result, output_path)
+    else:
+        _output_result_to_stdout(result)
+
+    return EXIT_SUCCESS, display_name, None
+
+
+def _handle_line_range_conversion(
+    source_value: Any,
+    format_arg: str,
+    effective_options: Dict[str, Any],
+    progress_callback: Optional[Any],
+    output_path: Optional[Path],
+    target_format: str,
+    line_select: str,
+    local_transforms: Optional[list],
+    display_name: str,
+    line_numbers: bool = False,
+) -> Tuple[int, str, Optional[str]]:
+    """Handle ``--head``/``--tail``/``--lines`` mode conversion."""
+    doc = to_ast(
+        source_value,
+        source_format=cast(DocumentFormat, format_arg),
+        progress_callback=progress_callback,
+        **effective_options,
+    )
+
+    render_target = target_format if target_format != "auto" else "markdown"
+    line_numbers = _line_numbers_for_target(line_numbers, render_target)
+    result = _line_range_output(doc, line_select, render_target, line_numbers, effective_options, local_transforms)
 
     if output_path is not None:
         _write_result_to_path(result, output_path)
@@ -2657,10 +2886,12 @@ def convert_single_file(
     target_format: str = "markdown",
     transform_specs: Optional[list[TransformSpec]] = None,
     progress_callback: Optional[Any] = None,
-    extract_spec: Optional[str] = None,
+    extract_specs: Optional[List[str]] = None,
     outline: bool = False,
     outline_max_level: int = 6,
     line_numbers: bool = False,
+    slice_spec: Optional[str] = None,
+    line_select: Optional[str] = None,
 ) -> Tuple[int, str, Optional[str]]:
     """Convert a single file to the specified target format.
 
@@ -2684,8 +2915,9 @@ def convert_single_file(
         Serializable transform specifications to rebuild in worker processes
     progress_callback : ProgressCallback, optional
         Optional callback for progress updates
-    extract_spec : str, optional
-        Section extraction specification (e.g., "Introduction", "#:1-3")
+    extract_specs : list[str], optional
+        One or more extraction selectors (e.g., ["Introduction", "table:1"]).
+        See :func:`_extraction_output` for the supported grammar.
     outline : bool, default False
         Whether to output document outline instead of full content
     outline_max_level : int, default 6
@@ -2693,6 +2925,10 @@ def convert_single_file(
     line_numbers : bool, default False
         Whether to annotate Markdown output with line numbers (outline headings,
         extracted lines, or every line of a full conversion)
+    slice_spec : str, optional
+        ``--slice X/Y`` specification; emit the Xth of Y semantic slices.
+    line_select : str, optional
+        Normalized ``--head``/``--tail``/``--lines`` selection (e.g. "head:10").
 
     Returns
     -------
@@ -2727,7 +2963,34 @@ def convert_single_file(
                 line_numbers,
             )
 
-        if extract_spec:
+        if slice_spec:
+            return _handle_slice_conversion(
+                source_value,
+                format_arg,
+                effective_options,
+                progress_callback,
+                output_path,
+                renderer_hint,
+                slice_spec,
+                local_transforms,
+                input_item.display_name,
+            )
+
+        if line_select:
+            return _handle_line_range_conversion(
+                source_value,
+                format_arg,
+                effective_options,
+                progress_callback,
+                output_path,
+                renderer_hint,
+                line_select,
+                local_transforms,
+                input_item.display_name,
+                line_numbers,
+            )
+
+        if extract_specs:
             return _handle_extraction_conversion(
                 source_value,
                 format_arg,
@@ -2735,7 +2998,7 @@ def convert_single_file(
                 progress_callback,
                 output_path,
                 renderer_hint,
-                extract_spec,
+                extract_specs,
                 local_transforms,
                 input_item.display_name,
                 line_numbers,
@@ -2916,10 +3179,12 @@ def _execute_tasks_parallel(
     failures: List[Tuple[CLIInputItem, Optional[str], int]] = []
     max_exit_code = EXIT_SUCCESS
 
-    extract_spec = getattr(args, "extract", None)
+    extract_specs = getattr(args, "extract", None)
     outline = getattr(args, "outline", False)
     outline_max_level = getattr(args, "outline_max_level", 6)
     line_numbers = getattr(args, "line_numbers", False)
+    slice_spec = getattr(args, "slice_spec", None)
+    line_select = line_selection_from_args(args)
     max_workers = args.parallel if args.parallel else os.cpu_count()
 
     with ProgressContext(use_rich, show_progress, len(planned_tasks), "Converting inputs") as progress:
@@ -2936,10 +3201,12 @@ def _execute_tasks_parallel(
                     target_format,
                     transform_specs,
                     None,
-                    extract_spec,
+                    extract_specs,
                     outline,
                     outline_max_level,
                     line_numbers,
+                    slice_spec,
+                    line_select,
                 ): (item, output_path)
                 for item, output_path, target_format, _ in planned_tasks
             }
@@ -2988,10 +3255,12 @@ def _execute_tasks_sequential(
     failures: List[Tuple[CLIInputItem, Optional[str], int]] = []
     max_exit_code = EXIT_SUCCESS
 
-    extract_spec = getattr(args, "extract", None)
+    extract_specs = getattr(args, "extract", None)
     outline = getattr(args, "outline", False)
     outline_max_level = getattr(args, "outline_max_level", 6)
     line_numbers = getattr(args, "line_numbers", False)
+    slice_spec = getattr(args, "slice_spec", None)
+    line_select = line_selection_from_args(args)
 
     with ProgressContext(use_rich, show_progress, len(planned_tasks), "Converting inputs") as progress:
         progress_callback = create_progress_context_callback(progress) if show_progress else None
@@ -3009,10 +3278,12 @@ def _execute_tasks_sequential(
                 target_format,
                 transform_specs,
                 progress_callback,
-                extract_spec,
+                extract_specs,
                 outline,
                 outline_max_level,
                 line_numbers,
+                slice_spec,
+                line_select,
             )
 
             _log_task_result(progress, item, output_path, exit_code, error)
@@ -3132,14 +3403,73 @@ def _convert_with_extraction(
     item: CLIInputItem,
     effective_options: Dict[str, Any],
     format_arg: str,
-    extract_spec: str,
+    extract_specs: List[str],
     transforms: Optional[list],
     render_target: str,
     line_numbers: bool = False,
 ) -> Any:
-    """Convert with section extraction (name/index or ``line:`` range)."""
+    """Convert with content extraction (sections/tables/figures or ``line:``)."""
     doc = to_ast(item.raw_input, source_format=cast(DocumentFormat, format_arg), **effective_options)
-    return _extraction_output(doc, extract_spec, render_target, line_numbers, effective_options, transforms)
+    return _extraction_output(doc, extract_specs, render_target, line_numbers, effective_options, transforms)
+
+
+def _emit_result_to_stdout(
+    result: Any,
+    args: argparse.Namespace,
+    should_use_rich: bool,
+    render_target: str,
+) -> int:
+    """Emit a conversion result (str or bytes) to stdout with rich/pager handling."""
+    if isinstance(result, bytes):
+        sys.stdout.buffer.write(result)
+        sys.stdout.buffer.flush()
+        return EXIT_SUCCESS
+
+    text_output = result if isinstance(result, str) else ""
+
+    if render_target == "markdown":
+        _apply_formatting_and_output(text_output, args, should_use_rich)
+        return EXIT_SUCCESS
+
+    rendered = False
+    if should_use_rich and args.rich and text_output:
+        rendered = _render_rich_text_output(text_output, args, render_target)
+    if not rendered:
+        _output_text_with_options(text_output, args, is_rich=False)
+    return EXIT_SUCCESS
+
+
+def _render_slice_mode(
+    item: CLIInputItem,
+    args: argparse.Namespace,
+    effective_options: Dict[str, Any],
+    format_arg: str,
+    transforms: Optional[list],
+    should_use_rich: bool,
+    render_target: str,
+    slice_spec: str,
+) -> int:
+    """Handle ``--slice X/Y`` rendering to stdout."""
+    doc = to_ast(item.raw_input, source_format=cast(DocumentFormat, format_arg), **effective_options)
+    result = _slice_output(doc, slice_spec, render_target, effective_options, transforms)
+    return _emit_result_to_stdout(result, args, should_use_rich, render_target)
+
+
+def _render_line_range_mode(
+    item: CLIInputItem,
+    args: argparse.Namespace,
+    effective_options: Dict[str, Any],
+    format_arg: str,
+    transforms: Optional[list],
+    should_use_rich: bool,
+    render_target: str,
+    line_select: str,
+) -> int:
+    """Handle ``--head``/``--tail``/``--lines`` rendering to stdout."""
+    line_numbers = _line_numbers_for_target(getattr(args, "line_numbers", False), render_target)
+    doc = to_ast(item.raw_input, source_format=cast(DocumentFormat, format_arg), **effective_options)
+    result = _line_range_output(doc, line_select, render_target, line_numbers, effective_options, transforms)
+    return _emit_result_to_stdout(result, args, should_use_rich, render_target)
 
 
 def _render_markdown_mode(
@@ -3149,13 +3479,13 @@ def _render_markdown_mode(
     format_arg: str,
     transforms: Optional[list],
     should_use_rich: bool,
-    extract_spec: Optional[str],
+    extract_specs: Optional[List[str]],
 ) -> int:
     """Handle markdown format rendering."""
     line_numbers = getattr(args, "line_numbers", False)
-    if extract_spec:
+    if extract_specs:
         markdown_content = _convert_with_extraction(
-            item, effective_options, format_arg, extract_spec, transforms, "markdown", line_numbers
+            item, effective_options, format_arg, extract_specs, transforms, "markdown", line_numbers
         )
     else:
         markdown_content = to_markdown(
@@ -3181,15 +3511,15 @@ def _render_other_format_mode(
     transforms: Optional[list],
     should_use_rich: bool,
     render_target: str,
-    extract_spec: Optional[str],
+    extract_specs: Optional[List[str]],
 ) -> int:
     """Handle non-markdown format rendering."""
     # Line numbers reference the Markdown rendering, so they do not apply to
     # other targets; warn once if requested (selection by line: still works).
     _line_numbers_for_target(getattr(args, "line_numbers", False), render_target)
 
-    if extract_spec:
-        result = _convert_with_extraction(item, effective_options, format_arg, extract_spec, transforms, render_target)
+    if extract_specs:
+        result = _convert_with_extraction(item, effective_options, format_arg, extract_specs, transforms, render_target)
     else:
         result = convert(
             item.raw_input,
@@ -3230,19 +3560,33 @@ def _render_single_item_to_stdout(
     try:
         render_target = target_format if target_format != "auto" else "markdown"
         effective_options = prepare_options_for_execution(options, item.best_path(), format_arg, render_target)
-        extract_spec = getattr(args, "extract", None)
+        extract_specs = getattr(args, "extract", None)
+        slice_spec = getattr(args, "slice_spec", None)
+        line_select = line_selection_from_args(args)
 
         # Handle outline mode
         if getattr(args, "outline", False):
             return _render_outline_mode(item, args, effective_options, format_arg, should_use_rich)
 
+        # Handle single-slice paging
+        if slice_spec:
+            return _render_slice_mode(
+                item, args, effective_options, format_arg, transforms, should_use_rich, render_target, slice_spec
+            )
+
+        # Handle simple line windows (--head/--tail/--lines)
+        if line_select:
+            return _render_line_range_mode(
+                item, args, effective_options, format_arg, transforms, should_use_rich, render_target, line_select
+            )
+
         # Handle markdown vs other formats
         if render_target == "markdown":
             return _render_markdown_mode(
-                item, args, effective_options, format_arg, transforms, should_use_rich, extract_spec
+                item, args, effective_options, format_arg, transforms, should_use_rich, extract_specs
             )
         return _render_other_format_mode(
-            item, args, effective_options, format_arg, transforms, should_use_rich, render_target, extract_spec
+            item, args, effective_options, format_arg, transforms, should_use_rich, render_target, extract_specs
         )
     except Exception as exc:
         exit_code = get_exit_code_for_exception(exc)

--- a/src/all2md/cli/validation.py
+++ b/src/all2md/cli/validation.py
@@ -46,7 +46,7 @@ def collect_argument_problems(
     if attachment_dir and attachment_mode and attachment_mode != "save":
         problems.append(
             ValidationProblem(
-                "--attachment-output-dir specified but attachment mode is " f"'{attachment_mode}' (expected 'save')",
+                f"--attachment-output-dir specified but attachment mode is '{attachment_mode}' (expected 'save')",
                 ValidationSeverity.WARNING,
             )
         )
@@ -158,6 +158,68 @@ def collect_argument_problems(
                 ValidationProblem(
                     "--split-by and --outline cannot be used together. "
                     "Use --outline to view document structure or --split-by to split the document.",
+                    ValidationSeverity.ERROR,
+                )
+            )
+
+    # Single-document selection modes (--slice, --lines, --head, --tail) each pick
+    # one window of a single document. They are mutually exclusive with each other
+    # and with the other content-selection modes.
+    slice_spec = getattr(parsed_args, "slice_spec", None)
+    lines = getattr(parsed_args, "lines", None)
+    head = getattr(parsed_args, "head", None)
+    tail = getattr(parsed_args, "tail", None)
+
+    active_windows = [
+        name
+        for name, present in (
+            ("--slice", bool(slice_spec)),
+            ("--lines", bool(lines)),
+            ("--head", head is not None),
+            ("--tail", tail is not None),
+        )
+        if present
+    ]
+
+    if len(active_windows) > 1:
+        problems.append(
+            ValidationProblem(
+                f"{' and '.join(active_windows)} cannot be used together. "
+                "These select content in different ways; use one at a time.",
+                ValidationSeverity.ERROR,
+            )
+        )
+
+    if active_windows:
+        joined = " / ".join(active_windows)
+        if outline:
+            problems.append(
+                ValidationProblem(
+                    f"--outline cannot be combined with {joined}. "
+                    "Use --outline for document structure, or a window selector for content.",
+                    ValidationSeverity.ERROR,
+                )
+            )
+        if extract:
+            problems.append(
+                ValidationProblem(
+                    f"--extract cannot be combined with {joined}. "
+                    "Use --extract for sections/tables/figures, or a window selector for output lines/slices.",
+                    ValidationSeverity.ERROR,
+                )
+            )
+        if split_by:
+            problems.append(
+                ValidationProblem(
+                    f"--split-by cannot be combined with {joined}.",
+                    ValidationSeverity.ERROR,
+                )
+            )
+        if collate:
+            problems.append(
+                ValidationProblem(
+                    f"--collate cannot be combined with {joined}. "
+                    "Collation merges many inputs into one document; window selectors pick from a single document.",
                     ValidationSeverity.ERROR,
                 )
             )

--- a/tests/e2e/test_slice_lines_cli.py
+++ b/tests/e2e/test_slice_lines_cli.py
@@ -1,0 +1,166 @@
+"""End-to-end tests for all2md CLI paging/windowing flags.
+
+Covers the quality-of-life selectors added alongside --extract:
+- --slice X/Y       (semantic paging)
+- --head / --tail   (output-line windows)
+- --lines START:END (output-line range)
+- multi --extract, ::N word limits, table:/figure: selectors
+"""
+
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+from utils import cleanup_test_dir, create_test_temp_dir
+
+
+@pytest.mark.e2e
+@pytest.mark.cli
+class TestSliceLinesCLI:
+    """End-to-end tests for --slice, --head, --tail, --lines, and rich --extract."""
+
+    def setup_method(self):
+        self.temp_dir = create_test_temp_dir()
+        self.cli_path = Path(__file__).parent.parent.parent / "src" / "all2md" / "cli.py"
+
+    def teardown_method(self):
+        cleanup_test_dir(self.temp_dir)
+
+    def _run_cli(self, args: list[str]) -> subprocess.CompletedProcess:
+        cmd = [sys.executable, "-m", "all2md"] + args
+        return subprocess.run(
+            cmd,
+            cwd=self.cli_path.parent.parent.parent,
+            capture_output=True,
+            text=True,
+        )
+
+    def _doc(self) -> Path:
+        md = """# Introduction
+
+Intro paragraph one with several words here for counting purposes today.
+
+## Background
+
+Background details go here with more words to push the count up nicely.
+
+# Methods
+
+We used a careful method.
+
+| Name | Value |
+| ---- | ----- |
+| a    | 1     |
+| b    | 2     |
+
+![A figure](fig1.png)
+
+# Results
+
+Findings appear here.
+
+| R1 | R2 |
+| -- | -- |
+| x  | y  |
+
+# Conclusion
+
+Final thoughts here.
+"""
+        path = self.temp_dir / "doc.md"
+        path.write_text(md, encoding="utf-8")
+        return path
+
+    # --- --slice -----------------------------------------------------------
+
+    def test_slice_returns_one_of_y(self):
+        result = self._run_cli([str(self._doc()), "--slice", "1/3"])
+        assert result.returncode == 0, result.stderr
+        assert "# Introduction" in result.stdout
+        # Footer hint points at the next slice and honors Y.
+        assert "slice 1/3" in result.stdout
+        assert "next: --slice 2/3" in result.stdout
+
+    def test_slice_last_has_no_next_hint(self):
+        result = self._run_cli([str(self._doc()), "--slice", "3/3"])
+        assert result.returncode == 0, result.stderr
+        assert "last slice" in result.stdout
+        assert "next:" not in result.stdout
+
+    def test_slice_out_of_range_errors(self):
+        result = self._run_cli([str(self._doc()), "--slice", "99/99"])
+        assert result.returncode != 0
+        assert "only divides into" in result.stderr.lower() or "slice" in result.stderr.lower()
+
+    def test_slice_invalid_spec_errors(self):
+        result = self._run_cli([str(self._doc()), "--slice", "2"])
+        assert result.returncode != 0
+
+    # --- --head / --tail ---------------------------------------------------
+
+    def test_head_default_and_n(self):
+        result = self._run_cli([str(self._doc()), "--head", "3"])
+        assert result.returncode == 0, result.stderr
+        assert result.stdout.splitlines()[0] == "# Introduction"
+        # Only the first lines; later sections excluded.
+        assert "# Conclusion" not in result.stdout
+
+    def test_tail(self):
+        result = self._run_cli([str(self._doc()), "--tail", "2"])
+        assert result.returncode == 0, result.stderr
+        assert "Final thoughts here." in result.stdout
+        assert "# Introduction" not in result.stdout
+
+    def test_lines_range(self):
+        result = self._run_cli([str(self._doc()), "--lines", "5:8"])
+        assert result.returncode == 0, result.stderr
+        assert "## Background" in result.stdout
+        assert "# Introduction" not in result.stdout
+
+    def test_lines_with_line_numbers(self):
+        result = self._run_cli([str(self._doc()), "--lines", "1:1", "--line-numbers"])
+        assert result.returncode == 0, result.stderr
+        assert result.stdout.strip().startswith("1: # Introduction")
+
+    # --- rich --extract ----------------------------------------------------
+
+    def test_extract_word_limit(self):
+        result = self._run_cli([str(self._doc()), "--extract", "Introduction::6"])
+        assert result.returncode == 0, result.stderr
+        assert "# Introduction" in result.stdout
+        # Background heading is past the word budget.
+        assert "## Background" not in result.stdout
+
+    def test_extract_table_selector(self):
+        result = self._run_cli([str(self._doc()), "--extract", "table:2"])
+        assert result.returncode == 0, result.stderr
+        assert "R1" in result.stdout and "R2" in result.stdout
+        assert "Name" not in result.stdout
+
+    def test_extract_figure_selector(self):
+        result = self._run_cli([str(self._doc()), "--extract", "figure:1"])
+        assert result.returncode == 0, result.stderr
+        assert "fig1.png" in result.stdout
+
+    def test_multiple_extract_spec_order(self):
+        result = self._run_cli([str(self._doc()), "--extract", "table:2", "--extract", "figure:1"])
+        assert result.returncode == 0, result.stderr
+        # Spec order: table first, figure second, separated by ---.
+        table_pos = result.stdout.find("R1")
+        fig_pos = result.stdout.find("fig1.png")
+        sep_pos = result.stdout.find("---")
+        assert table_pos != -1 and fig_pos != -1
+        assert table_pos < sep_pos < fig_pos
+
+    # --- mutual exclusion --------------------------------------------------
+
+    def test_extract_and_head_conflict(self):
+        result = self._run_cli([str(self._doc()), "--extract", "Methods", "--head", "3"])
+        assert result.returncode != 0
+        assert "cannot be combined" in result.stderr.lower()
+
+    def test_slice_and_lines_conflict(self):
+        result = self._run_cli([str(self._doc()), "--slice", "1/2", "--lines", "1:3"])
+        assert result.returncode != 0
+        assert "cannot be used together" in result.stderr.lower()

--- a/tests/unit/ast/test_extraction.py
+++ b/tests/unit/ast/test_extraction.py
@@ -1,0 +1,157 @@
+#  Copyright (c) 2025 Tom Villani, Ph.D.
+"""Tests for typed --extract selectors (sections, tables, figures, word limits)."""
+
+import pytest
+
+from all2md.ast.extraction import (
+    build_extracted_document,
+    collect_figures,
+    collect_tables,
+    parse_extract_selector,
+)
+from all2md.ast.nodes import (
+    Document,
+    Heading,
+    Image,
+    Paragraph,
+    Table,
+    TableCell,
+    TableRow,
+    Text,
+    ThematicBreak,
+)
+from all2md.ast.utils import extract_text
+
+
+def _cell(text: str) -> TableCell:
+    return TableCell(content=[Text(content=text)])
+
+
+def _table(tag: str) -> Table:
+    return Table(
+        header=TableRow(cells=[_cell(f"{tag}-h1"), _cell(f"{tag}-h2")]),
+        rows=[TableRow(cells=[_cell(f"{tag}-a"), _cell(f"{tag}-b")])],
+    )
+
+
+@pytest.fixture
+def doc():
+    """A document with two sections, two tables, and one figure."""
+    return Document(
+        children=[
+            Heading(level=1, content=[Text(content="Introduction")]),
+            Paragraph(content=[Text(content="one two three four five six seven eight")]),
+            _table("T1"),
+            Heading(level=1, content=[Text(content="Methods")]),
+            Paragraph(content=[Text(content="alpha beta gamma")]),
+            Paragraph(content=[Image(url="fig1.png", alt_text="Figure one")]),
+            _table("T2"),
+        ]
+    )
+
+
+@pytest.mark.unit
+class TestParseExtractSelector:
+    def test_section_name(self):
+        sel = parse_extract_selector("Introduction")
+        assert (sel.kind, sel.spec, sel.word_limit) == ("section", "Introduction", None)
+
+    def test_section_index(self):
+        sel = parse_extract_selector("#:1-3")
+        assert sel.kind == "section"
+        assert sel.spec == "#:1-3"
+
+    def test_word_limit_suffix(self):
+        sel = parse_extract_selector("Introduction::500")
+        assert sel.kind == "section"
+        assert sel.spec == "Introduction"
+        assert sel.word_limit == 500
+
+    def test_table_selector(self):
+        sel = parse_extract_selector("table:2")
+        assert (sel.kind, sel.spec) == ("table", "2")
+
+    def test_figure_and_image_alias(self):
+        assert parse_extract_selector("figure:1").kind == "figure"
+        assert parse_extract_selector("image:1").kind == "figure"
+
+    def test_table_with_word_limit(self):
+        sel = parse_extract_selector("table:1::20")
+        assert (sel.kind, sel.spec, sel.word_limit) == ("table", "1", 20)
+
+    def test_invalid_word_limit_raises(self):
+        with pytest.raises(ValueError, match="word limit"):
+            parse_extract_selector("Intro::0")
+        with pytest.raises(ValueError, match="word limit"):
+            parse_extract_selector("Intro::abc")
+
+    def test_empty_selector_raises(self):
+        with pytest.raises(ValueError, match="Empty"):
+            parse_extract_selector("::500")
+
+
+@pytest.mark.unit
+class TestCollectors:
+    def test_collect_tables_in_order(self, doc):
+        tables = collect_tables(doc)
+        assert len(tables) == 2
+        assert extract_text(tables[0]).startswith("T1")
+        assert extract_text(tables[1]).startswith("T2")
+
+    def test_collect_figures(self, doc):
+        figures = collect_figures(doc)
+        assert len(figures) == 1
+        assert figures[0].url == "fig1.png"
+
+
+@pytest.mark.unit
+class TestBuildExtractedDocument:
+    def test_single_section(self, doc):
+        out = build_extracted_document(doc, ["Introduction"])
+        assert isinstance(out.children[0], Heading)
+        assert extract_text(out.children[0]) == "Introduction"
+        # Introduction's table is part of the section content.
+        assert any(isinstance(n, Table) for n in out.children)
+        # Methods must not appear.
+        assert "Methods" not in extract_text(out.children)
+
+    def test_table_selector(self, doc):
+        out = build_extracted_document(doc, ["table:2"])
+        tables = [n for n in out.children if isinstance(n, Table)]
+        assert len(tables) == 1
+        assert extract_text(tables[0]).startswith("T2")
+
+    def test_figure_wrapped_in_paragraph(self, doc):
+        out = build_extracted_document(doc, ["figure:1"])
+        assert len(out.children) == 1
+        assert isinstance(out.children[0], Paragraph)
+        assert isinstance(out.children[0].content[0], Image)
+
+    def test_multiple_specs_in_spec_order_separated(self, doc):
+        # table:2 first, then figure:1 -- order follows the spec list, not the doc.
+        out = build_extracted_document(doc, ["table:2", "figure:1"])
+        kinds = [type(n).__name__ for n in out.children]
+        assert kinds == ["Table", "ThematicBreak", "Paragraph"]
+        assert isinstance(out.children[1], ThematicBreak)
+
+    def test_word_limit_truncates_at_node_boundary(self, doc):
+        # Heading (1 word) + first paragraph (8 words) = 9; the table that follows
+        # should be dropped once the 5-word budget is exceeded.
+        out = build_extracted_document(doc, ["Introduction::5"])
+        assert isinstance(out.children[0], Heading)
+        assert isinstance(out.children[1], Paragraph)
+        assert not any(isinstance(n, Table) for n in out.children)
+
+    def test_word_limit_keeps_at_least_first_node(self, doc):
+        out = build_extracted_document(doc, ["Introduction::1"])
+        assert len(out.children) >= 1
+        assert isinstance(out.children[0], Heading)
+
+    def test_no_match_raises(self, doc):
+        with pytest.raises(ValueError):
+            build_extracted_document(doc, ["table:99"])
+
+    def test_no_tables_raises(self):
+        bare = Document(children=[Heading(level=1, content=[Text(content="x")])])
+        with pytest.raises(ValueError, match="no table"):
+            build_extracted_document(bare, ["table:1"])

--- a/tests/unit/ast/test_splitting.py
+++ b/tests/unit/ast/test_splitting.py
@@ -497,3 +497,72 @@ class TestSplitAuto:
         splits = splitter.split_auto(doc, target_words=200)
 
         assert len(splits) >= 1
+
+
+@pytest.mark.unit
+class TestSplitIntoSlices:
+    """Tests for DocumentSplitter.split_into_slices (the --slice X/Y engine)."""
+
+    def test_honors_exact_slice_count(self, long_doc):
+        """With enough section atoms, exactly Y slices are produced."""
+        splits = DocumentSplitter.split_into_slices(long_doc, num_slices=3)
+        assert len(splits) == 3
+        # Slices are 1-indexed and contiguous.
+        assert [s.index for s in splits] == [1, 2, 3]
+
+    def test_slices_cover_all_content(self, long_doc):
+        """The concatenated slices contain every section heading, in order."""
+        splits = DocumentSplitter.split_into_slices(long_doc, num_slices=4)
+        combined = " ".join(extract_text(s.document.children) for s in splits)
+        for i in range(10):
+            assert f"Section {i + 1}" in combined
+
+    def test_balanced_word_counts(self, long_doc):
+        """Slices are roughly balanced by word count."""
+        splits = DocumentSplitter.split_into_slices(long_doc, num_slices=5)
+        counts = [s.word_count for s in splits]
+        # Each section is ~101 words; 10 sections / 5 slices => ~2 sections each.
+        assert max(counts) - min(counts) <= max(counts)  # no wildly empty slice
+        assert all(c > 0 for c in counts)
+
+    def test_fewer_atoms_than_requested(self, simple_doc):
+        """A document with few sections yields at most that many slices."""
+        splits = DocumentSplitter.split_into_slices(simple_doc, num_slices=20)
+        assert 1 <= len(splits) <= 20
+
+    def test_single_slice_returns_whole_document(self, simple_doc):
+        splits = DocumentSplitter.split_into_slices(simple_doc, num_slices=1)
+        assert len(splits) == 1
+
+    def test_invalid_count_raises(self, simple_doc):
+        with pytest.raises(ValueError):
+            DocumentSplitter.split_into_slices(simple_doc, num_slices=0)
+
+
+@pytest.mark.unit
+class TestBalancedPartition:
+    """Tests for the internal contiguous balanced-partition helper."""
+
+    def test_exact_n_groups(self):
+        from all2md.ast.splitting import _balanced_partition
+
+        bounds = _balanced_partition([1, 1, 1, 1, 1, 1], 3)
+        assert len(bounds) == 3
+        # Contiguous and covering.
+        assert bounds[0][0] == 0
+        assert bounds[-1][1] == 6
+        for (_s, e), (ns, _ne) in zip(bounds, bounds[1:], strict=False):
+            assert e == ns
+
+    def test_n_equals_len(self):
+        from all2md.ast.splitting import _balanced_partition
+
+        bounds = _balanced_partition([5, 2, 9], 3)
+        assert bounds == [(0, 1), (1, 2), (2, 3)]
+
+    def test_lumpy_weights_still_n_groups(self):
+        from all2md.ast.splitting import _balanced_partition
+
+        bounds = _balanced_partition([100, 1, 1, 1, 1], 3)
+        assert len(bounds) == 3
+        assert all(e > s for s, e in bounds)

--- a/tests/unit/cli/test_cli_builder.py
+++ b/tests/unit/cli/test_cli_builder.py
@@ -555,7 +555,7 @@ class TestCLIParser:
         parser = create_parser()
 
         args = parser.parse_args(["test.pdf", "--extract", "line:10-25"])
-        assert args.extract == "line:10-25"
+        assert args.extract == ["line:10-25"]
 
     def test_parser_output_format_is_tracked(self):
         """An explicit --to/--output-format is recorded in _provided_args.

--- a/tests/unit/cli/test_cli_processors.py
+++ b/tests/unit/cli/test_cli_processors.py
@@ -522,7 +522,7 @@ def test_extract_by_line_range_markdown() -> None:
     """--extract line:X-Y slices the rendered Markdown by line range."""
     from all2md.cli.processors import _extraction_output
 
-    result = _extraction_output(_outline_doc(), "line:9-11", "markdown", False, {}, None)
+    result = _extraction_output(_outline_doc(), ["line:9-11"], "markdown", False, {}, None)
 
     assert result == "# Methods\n\nMethods body."
 
@@ -532,7 +532,7 @@ def test_extract_by_line_range_with_line_numbers() -> None:
     """line: extraction with --line-numbers keeps the original line numbers."""
     from all2md.cli.processors import _extraction_output
 
-    result = _extraction_output(_outline_doc(), "line:9-11", "markdown", True, {}, None)
+    result = _extraction_output(_outline_doc(), ["line:9-11"], "markdown", True, {}, None)
 
     assert result == " 9: # Methods\n10: \n11: Methods body."
 
@@ -542,7 +542,7 @@ def test_extract_by_line_range_noncontiguous() -> None:
     """A non-contiguous line: selection is separated by an unnumbered blank line."""
     from all2md.cli.processors import _extraction_output
 
-    result = _extraction_output(_outline_doc(), "line:1,9", "markdown", True, {}, None)
+    result = _extraction_output(_outline_doc(), ["line:1,9"], "markdown", True, {}, None)
 
     assert result == "1: # Introduction\n\n9: # Methods"
 
@@ -553,7 +553,7 @@ def test_extract_by_lines_out_of_range_raises() -> None:
     from all2md.cli.processors import _extraction_output
 
     with pytest.raises(ValueError, match="No lines selected"):
-        _extraction_output(_outline_doc(), "line:500-600", "markdown", False, {}, None)
+        _extraction_output(_outline_doc(), ["line:500-600"], "markdown", False, {}, None)
 
 
 @pytest.mark.unit
@@ -561,7 +561,7 @@ def test_extract_name_with_line_numbers_uses_original_lines() -> None:
     """Name extraction with --line-numbers reports the document's true line numbers."""
     from all2md.cli.processors import _extraction_output
 
-    result = _extraction_output(_outline_doc(), "Methods", "markdown", True, {}, None)
+    result = _extraction_output(_outline_doc(), ["Methods"], "markdown", True, {}, None)
 
     # The Methods section starts at line 9 in the full render (width 2: lines 9-11).
     assert result.splitlines()[0] == " 9: # Methods"


### PR DESCRIPTION
## Summary

Four quality-of-life features for the converter CLI's content-selection surface:

- **`--extract` is now repeatable and understands tables and figures.** Adds `table:N` / `table:1-3` / `table:*` and `figure:N` / `image:*` selectors alongside the existing section (name/`#:`-index) and `line:` selectors. Pass `--extract` multiple times to gather several pieces at once — results are emitted in **flag order**, separated by `---`. A single `line:` range still can't be mixed with other selectors.
- **`--extract "<sel>::N"` word limit.** Caps a selector's output at ~N words, cut at node boundaries so the result stays a valid document (never slices a paragraph/table in half), e.g. `--extract "Introduction::500"`.
- **`--slice X/Y` paging.** Returns the Xth of Y semantic slices to stdout/file with a next-slice footer hint. A new `DocumentSplitter.split_into_slices` divides the document into **exactly Y** balanced, contiguous slices at section boundaries (falling back to word-count blocks for heading-light docs), so `Y` is deterministic for paging `1/Y … Y/Y`.
- **`--head [N]`, `--tail [N]`, `--lines START:END`.** Simple windows over the rendered Markdown output (1-based inclusive; default 10 lines; honor `--line-numbers`), mirroring `head`/`tail` and the existing `--extract line:` range.

New selection modes are mutually exclusive with each other and with `--extract`/`--outline`/`--split-by`/`--collate`, enforced in `validation.py`.

## Design notes

- Selector parsing/resolution lives in a new `src/all2md/ast/extraction.py` module (`parse_extract_selector`, `build_extracted_document`, table/figure collectors). A single section selector renders identically to the old `extract_sections` path, so existing behavior is preserved.
- `--extract` changed from a single string to `action="append"` (list). Internal `_extraction_output` and `convert_single_file` updated accordingly; the `view` subcommand keeps its own single-valued `-x/--extract`.
- `--head`/`--tail`/`--lines` reuse the existing line-selection machinery via a shared `_emit_line_selection` core.

## Testing

- New: `tests/unit/ast/test_extraction.py`, slice/partition tests in `tests/unit/ast/test_splitting.py`, e2e `tests/e2e/test_slice_lines_cli.py`.
- Updated existing line-extract/builder unit tests for the list-based `--extract` API.
- `pre-commit run` (black/ruff/bandit/file hooks) ✅, `mypy src/` ✅ (only pre-existing `bleach`-stub errors), full `pytest tests/` ✅ (0 failures).

🤖 Generated with [Claude Code](https://claude.com/claude-code)