### PR TITLE
feat(lint): curated --profile bundles for the document linter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Lint profiles: `all2md lint --profile NAME`.** Curated, named rule bundles
+  built entirely from the existing 47 rules — ``prose`` (typographic polish for
+  long-form writing, ideal for a converted DOCX), ``accessibility`` (alt text,
+  link/table semantics, heading hierarchy at error severity), and
+  ``technical-docs`` (structure and links enforced, prose typography relaxed).
+  ``--list-profiles`` prints them with descriptions. Profiles are a base layer:
+  config files and CLI flags layer on top in precedence ``profile`` < config file
+  < CLI flags. Exposed from Python via ``all2md.linter.get_profile_config`` /
+  ``available_profiles``. New "Linting & Enforcing a Style Guide" how-to guide in
+  the docs walks the full convert → lint → fix → profile workflow.
 - **`--extract` is now repeatable and understands tables and figures.** In
   addition to sections (by name/pattern or ``#:`` index) and ``line:`` ranges,
   ``--extract`` now selects tables (``table:2``, ``table:1-3``, ``table:*``) and

--- a/docs/source/cli.rst
+++ b/docs/source/cli.rst
@@ -731,9 +731,16 @@ applies in place — see :ref:`auto-fix` below.
    # Preview --fix without writing the file
    all2md lint --fix --dry-run README.md
 
+   # Start from a curated rule bundle (see --list-profiles)
+   all2md lint --profile prose report.md
+   all2md lint --list-profiles
+
 Common options:
 
 * ``-R`` / ``--recursive`` – recurse into directories when collecting inputs
+* ``--profile NAME`` – start from a curated rule bundle, then layer config-file
+  and CLI settings on top (see :ref:`lint-profiles` below)
+* ``--list-profiles`` – print the available profiles with descriptions and exit
 * ``--format`` – ``text`` (default, human-readable) or ``json`` (CI-friendly)
 * ``--output`` – write the report to this file instead of stdout
 * ``--config`` – explicit path to an ``.all2md.toml`` or ``pyproject.toml``
@@ -742,6 +749,30 @@ Common options:
 * ``--severity`` – minimum severity to report: ``info`` (default), ``warning``, or ``error``
 * ``--fix`` – apply safe auto-fixes in place (file inputs only)
 * ``--dry-run`` – with ``--fix``, report what would be changed without writing
+
+.. _lint-profiles:
+
+Profiles
+~~~~~~~~
+
+A **profile** packages a coherent set of rules and severities behind a single
+flag, so you can opt into a house style without hand-assembling a long
+``--rule`` / ``--disable`` / ``--severity`` invocation. Three ship built in:
+
+* ``prose`` – polished long-form writing: typographic niceties, consistent
+  heading style, and quality link text (curly-quote / em-dash / ellipsis rules
+  promoted to *warning*). Ideal for a converted DOCX bound for publication.
+* ``accessibility`` – alt text, descriptive link text, table headers, and a
+  clean heading hierarchy enforced at *error*; stylistic typography omitted.
+* ``technical-docs`` – enforce structure, valid links, and resolvable images,
+  but relax prose-typography rules that fight code and reference-style writing.
+
+Configuration layers on top of a profile in a fixed precedence — lowest to
+highest: the ``--profile`` bundle, then ``[tool.all2md.lint]`` from the config
+file, then explicit CLI flags. So ``--profile prose --disable TYP003`` adopts
+the ``prose`` bundle but silences one rule. ``--disable`` lists are unioned
+across layers; ``severity`` and per-rule options merge with the more specific
+layer winning. For a worked DOCX example and CI patterns, see :doc:`lint_guide`.
 
 The ``--severity`` flag filters **both** the displayed output and the process
 exit code. With ``--severity warning``, info-level violations are dropped and

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -123,6 +123,7 @@ Guides & References
 
    python_api
    cli
+   lint_guide
    options
    batch
    attachments

--- a/docs/source/lint_guide.rst
+++ b/docs/source/lint_guide.rst
@@ -1,0 +1,210 @@
+Linting & Enforcing a Style Guide
+=================================
+
+Converting a document is only half the job. A ``.docx`` that looks tidy in Word
+routinely carries straight quotes, ``--`` where an em-dash belongs, double
+spaces left over from manual justification, heading levels that skip because
+someone styled an *H3* to "look like" an *H2*, and figures with no alt text.
+None of that is visible until you publish — and then it is everywhere.
+
+The **all2md linter** turns those latent problems into a checklist you can read,
+gate CI on, and in many cases fix automatically. Because it runs on the parsed
+AST, the *same* rules apply whether the document started life as DOCX, PDF,
+HTML, EPUB, or Markdown.
+
+This guide walks the end-to-end workflow — convert, inspect, fix, and lock in a
+house style with a **profile**. For the exhaustive rule reference (all 47 codes
+and their severities) and the full CLI flag list, see the "Lint Command" section
+of the :doc:`CLI reference <cli>`.
+
+.. contents:: On this page
+   :local:
+   :depth: 2
+
+The four-step workflow
+----------------------
+
+Cleaning up a converted document is always the same loop: **convert → inspect →
+preview fixes → apply**, then optionally pin a profile so every future document
+gets the same treatment.
+
+.. code-block:: bash
+
+   # 1. Convert the source document to Markdown
+   all2md report.docx --out report.md
+
+   # 2. Inspect — what's wrong, and where?
+   all2md lint report.md
+
+   # 3. Preview the automatic fixes without touching the file
+   all2md lint --fix --dry-run report.md
+
+   # 4. Apply the safe fixes in place
+   all2md lint --fix report.md
+
+Step 2 prints a report like this:
+
+.. code-block:: text
+
+   report.md:1:1: STR003 error: Heading level skips from H1 to H3
+       suggestion: Use H2 for this heading, or promote the preceding section
+   report.md:12:1: TYP003 info: Text uses straight quotes around a word
+       suggestion: Replace with curly quotes (“” or ‘’)
+   report.md:12:40: TYP004 info: Text contains '--' (should be em-dash)
+   report.md:31:1: IMG001 warning: Image is missing alt text
+   Found 4 violations (1 error, 1 warning, 2 info) in 1 file
+
+Why this matters for DOCX in particular
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Word is a reliable source of exactly the issues the typography and structure
+rules catch. A converted DOCX is the linter's ideal first customer:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 45 55
+
+   * - Symptom Word leaves behind
+     - Rule that catches it
+   * - Straight ``"`` / ``'`` quotes
+     - ``TYP003`` (``straight-quotes``)
+   * - ``--`` instead of an em-dash
+     - ``TYP004`` (``double-hyphens``)
+   * - ``...`` instead of ``…``
+     - ``TYP006`` (``ellipsis-character``) — auto-fixable
+   * - Double spaces after periods
+     - ``TYP002`` (``multiple-spaces``)
+   * - Trailing spaces on lines
+     - ``TYP001`` (``trailing-spaces``)
+   * - Visually-styled heading levels
+     - ``STR003`` (``heading-hierarchy``)
+   * - Inconsistent heading capitalization
+     - ``HDG004`` (``heading-capitalization``)
+   * - Pasted images with no description
+     - ``IMG001`` (``missing-alt-text``)
+
+Several of these — ``TYP006``, ``TYP007``, and a handful of others — carry
+**safe auto-fixes**, so ``--fix`` resolves them with no manual editing. Run
+``all2md lint --fix --dry-run`` first to see exactly which violations will be
+rewritten; only fixes classified ``SAFE`` are ever applied.
+
+Profiles: a named house style
+-----------------------------
+
+Hand-assembling a long ``--rule`` / ``--disable`` / ``--severity`` invocation
+gets old fast, and it does not travel between projects. A **profile** packages a
+coherent set of rules and severities behind a single flag:
+
+.. code-block:: bash
+
+   all2md lint --profile prose report.md
+
+List the built-in profiles and what each one is for:
+
+.. code-block:: bash
+
+   all2md lint --list-profiles
+
+.. list-table::
+   :header-rows: 1
+   :widths: 25 75
+
+   * - Profile
+     - Use it when…
+   * - ``prose``
+     - Polishing long-form writing (articles, reports, a converted DOCX bound
+       for publication). Enforces typographic niceties, consistent heading
+       style, and high-quality link text; promotes the curly-quote / em-dash /
+       ellipsis rules to *warning*.
+   * - ``accessibility``
+     - Accessibility is the priority. Enforces image alt text, descriptive link
+       text, table headers, and a clean heading hierarchy at *error* severity,
+       and deliberately skips purely stylistic typography.
+   * - ``technical-docs``
+     - Engineering / API documentation. Enforces structure, valid links, and
+       resolvable images, but relaxes the prose-typography rules that fight
+       code, CLI flags (``--foo``), identifiers, and reference-style writing.
+
+Profiles ship as data, built entirely from the existing rules — they are a
+convenience, not a separate engine. The same three are available from Python:
+
+.. code-block:: python
+
+   from all2md.linter import (
+       LintConfig,
+       available_profiles,
+       get_profile_config,
+       lint_document,
+   )
+   from all2md import to_ast
+
+   print(available_profiles())            # ['accessibility', 'prose', 'technical-docs']
+
+   config = LintConfig.from_dict(get_profile_config("prose"))
+   result = lint_document(to_ast("report.docx"), config=config)
+   print(result.total, "violations")
+
+Tuning a profile
+~~~~~~~~~~~~~~~~~
+
+A profile is a *base*, not a straitjacket. Configuration layers on top of it in
+a fixed precedence — lowest to highest:
+
+1. ``--profile`` bundle
+2. the project's ``[tool.all2md.lint]`` config file
+3. explicit CLI flags (``--rule`` / ``--disable`` / ``--severity``)
+
+So you can adopt ``prose`` wholesale but silence one rule you disagree with, and
+the flag wins:
+
+.. code-block:: bash
+
+   # Everything prose enforces, minus the curly-quote rule
+   all2md lint --profile prose --disable TYP003 report.md
+
+Or bake the same idea into ``pyproject.toml`` so every contributor and CI run
+inherits it. The config file refines the profile; ``--disable`` lists are
+**unioned**, while ``severity`` and per-rule options are merged with the more
+specific layer winning:
+
+.. code-block:: toml
+
+   [tool.all2md.lint]
+   # Layered on top of `--profile prose`
+   disable = ["TYP003"]          # added to anything the profile already disables
+
+   [tool.all2md.lint.severity]
+   IMG001 = "error"              # stricter than the profile's default
+
+Gating CI on a clean document
+-----------------------------
+
+``all2md lint`` is built to gate a pipeline. It exits non-zero when violations
+remain after the severity filter, so a CI step needs no extra glue:
+
+.. code-block:: bash
+
+   # Fail the build on any warning-or-worse, machine-readable report for logs
+   all2md lint --profile accessibility --severity warning \
+       --format json --output lint-report.json docs/
+
+Exit codes:
+
+* ``0`` — no violations remain after the severity filter
+* ``3`` — one or more violations remain (``EXIT_VALIDATION_ERROR``)
+* ``4`` — an input file was not found
+
+``--severity`` filters **both** the printed report and the exit code, so the
+mental model is "what you see is what fails CI." Pair a profile with a severity
+threshold to express a precise gate: ``--profile accessibility --severity error``
+fails only on genuine accessibility blockers, while ``--severity warning`` holds
+the line on style too.
+
+See also
+--------
+
+* :doc:`CLI reference <cli>` ("Lint Command") — every flag and the full 47-rule
+  table with default severities.
+* :ref:`lint-configuration` — the ``[tool.all2md.lint]`` schema in depth.
+* :doc:`python_api` ("Document Linting") — the runner, rule registry, and how to
+  ship your own rules via the ``all2md.lint_rules`` entry point.

--- a/src/all2md/cli/commands/lint.py
+++ b/src/all2md/cli/commands/lint.py
@@ -12,6 +12,7 @@ from all2md.cli.builder import EXIT_ERROR, EXIT_FILE_ERROR, EXIT_SUCCESS, EXIT_V
 from all2md.cli.commands.shared import collect_input_files
 from all2md.cli.config import load_config_with_priority
 from all2md.linter import FixSafety, LintConfig, LintRunner, Severity
+from all2md.linter.profiles import available_profiles, describe_profiles, get_profile_config, merge_profile_dicts
 from all2md.linter.reporters import ReportableResult, get_reporter
 from all2md.linter.runner import LintFixResult, LintResult
 
@@ -37,6 +38,14 @@ def handle_lint_command(args: list[str] | None = None) -> int:
         parsed = parser.parse_args(args or [])
     except SystemExit as exc:
         return exc.code if isinstance(exc.code, int) else EXIT_ERROR
+
+    if parsed.list_profiles:
+        print(describe_profiles())
+        return EXIT_SUCCESS
+
+    if not parsed.inputs:
+        print("Error: No input files given", file=sys.stderr)
+        return EXIT_FILE_ERROR
 
     if parsed.dry_run and not parsed.fix:
         print("Error: --dry-run requires --fix", file=sys.stderr)
@@ -136,12 +145,27 @@ def _build_parser() -> argparse.ArgumentParser:
             "Use --fix to apply safe auto-fixes in place."
         ),
     )
-    parser.add_argument("inputs", nargs="+", help="Files, directories, or globs to lint")
+    parser.add_argument("inputs", nargs="*", help="Files, directories, or globs to lint")
     parser.add_argument(
         "-R",
         "--recursive",
         action="store_true",
         help="Recurse into directories",
+    )
+    parser.add_argument(
+        "--profile",
+        choices=available_profiles(),
+        metavar="NAME",
+        help=(
+            "Start from a curated rule bundle, then layer config-file and CLI "
+            "settings on top. Choices: " + ", ".join(available_profiles()) + ". "
+            "Run --list-profiles for descriptions."
+        ),
+    )
+    parser.add_argument(
+        "--list-profiles",
+        action="store_true",
+        help="List the available lint profiles and exit.",
     )
     parser.add_argument(
         "--format",
@@ -196,11 +220,18 @@ def _build_parser() -> argparse.ArgumentParser:
 
 
 def _build_lint_config(parsed: argparse.Namespace) -> LintConfig:
-    """Merge the config file and CLI flags into a single :class:`LintConfig`."""
+    """Merge the profile, config file, and CLI flags into a single :class:`LintConfig`.
+
+    Precedence, lowest to highest: ``--profile`` bundle < ``[tool.all2md.lint]``
+    config file < explicit CLI flags (``--rule`` / ``--disable`` / ``--severity``).
+    """
     config_dict: dict[str, Any] = {}
+    if parsed.profile:
+        config_dict = get_profile_config(parsed.profile)
+
     raw = load_config_with_priority(explicit_path=parsed.config)
     if isinstance(raw, dict) and isinstance(raw.get("lint"), dict):
-        config_dict = dict(raw["lint"])
+        config_dict = merge_profile_dicts(config_dict, dict(raw["lint"]))
 
     config = LintConfig.from_dict(config_dict)
 

--- a/src/all2md/linter/__init__.py
+++ b/src/all2md/linter/__init__.py
@@ -21,6 +21,14 @@ from __future__ import annotations
 
 from all2md.linter.config import LintConfig
 from all2md.linter.fixes import AppliedFix, FixContext, FixSafety, LintFix, apply_fixes
+from all2md.linter.profiles import (
+    LINT_PROFILES,
+    available_profiles,
+    describe_profiles,
+    get_profile_config,
+    merge_profile_dicts,
+    profile_description,
+)
 from all2md.linter.registry import RuleRegistry, rule_registry
 from all2md.linter.rule import LintContext, LintRule
 from all2md.linter.runner import (
@@ -35,6 +43,7 @@ from all2md.linter.runner import (
 from all2md.linter.violations import Severity, Violation
 
 __all__ = [
+    "LINT_PROFILES",
     "AppliedFix",
     "FixContext",
     "FixSafety",
@@ -49,9 +58,14 @@ __all__ = [
     "Severity",
     "Violation",
     "apply_fixes",
+    "available_profiles",
+    "describe_profiles",
+    "get_profile_config",
     "lint_and_fix_document",
     "lint_and_fix_file",
     "lint_document",
     "lint_file",
+    "merge_profile_dicts",
+    "profile_description",
     "rule_registry",
 ]

--- a/src/all2md/linter/profiles.py
+++ b/src/all2md/linter/profiles.py
@@ -1,0 +1,233 @@
+"""Named lint profiles — curated bundles of the built-in rules.
+
+A *profile* is a pre-baked :class:`~all2md.linter.config.LintConfig` expressed
+as a plain dict (the same shape :meth:`LintConfig.from_dict` accepts). It lets a
+user opt into a coherent style policy with a single flag —
+``all2md lint --profile accessibility`` — instead of hand-assembling a long
+``--rule`` / ``--disable`` / ``[tool.all2md.lint]`` configuration.
+
+Profiles ship as data only: every profile here is built exclusively from the
+47 built-in rule codes, so adding one is config, not code. They mirror the
+conversion-side presets in :mod:`all2md.cli.presets`.
+
+Resolution precedence when the CLI builds a config is::
+
+    profile  <  config file ([tool.all2md.lint])  <  explicit CLI flags
+
+so a profile is a *base* a project file and ad-hoc flags can both refine.
+:func:`merge_profile_dicts` implements the merge policy used for that layering.
+"""
+
+from __future__ import annotations
+
+import copy
+from typing import Any, Dict, List
+
+# Canonical config keys understood by ``LintConfig.from_dict``. ``enable`` and
+# ``disable`` also accept the ``enabled_rules`` / ``disabled_rules`` aliases; we
+# normalise to the short forms before merging so the policy below is simple.
+_SCALAR_KEYS = ("severity_threshold",)
+
+_ALIASES = {
+    "enabled_rules": "enable",
+    "disabled_rules": "disable",
+}
+
+
+LINT_PROFILES: Dict[str, Dict[str, Any]] = {
+    "accessibility": {
+        "description": (
+            "Accessibility-first: enforce alt text, descriptive link text, "
+            "table headers, and a clean heading hierarchy. Stylistic typography "
+            "is left out so the report stays focused on a11y blockers."
+        ),
+        "config": {
+            "enable": [
+                "STR001",  # document has a title / H1 landmark
+                "STR003",  # heading hierarchy must not skip levels
+                "STR004",  # no empty headings
+                "HDG004",  # consistent heading capitalization
+                "HDG005",  # heading not wrapped entirely in emphasis
+                "IMG001",  # images need alt text
+                "IMG005",  # alt text must be descriptive, not "image"
+                "LNK001",  # links need visible text
+                "LNK005",  # link text must not be "click here"
+                "LNK007",  # link text must not just be the URL
+                "TBL001",  # tables need a header row
+            ],
+            "severity": {
+                "IMG001": "error",
+                "LNK001": "error",
+                "LNK005": "error",
+                "TBL001": "error",
+                "STR003": "error",
+                "STR004": "error",
+            },
+        },
+    },
+    "technical-docs": {
+        "description": (
+            "Engineering / API documentation: enforce structure, valid links, "
+            "and resolvable images, but relax prose-typography rules that fight "
+            "code, identifiers, and reference-style writing."
+        ),
+        "config": {
+            "disable": [
+                "TYP003",  # straight quotes are correct in code-heavy docs
+                "TYP004",  # double hyphens often appear in CLI flags (--foo)
+                "TYP006",  # literal "..." is common in code and output
+                "HDG006",  # reference headings legitimately read as phrases
+                "STR006",  # stub/reference sections are intentionally short
+                "LST001",  # single-item lists are common in step docs
+                "TBL003",  # single-column tables are valid reference layouts
+            ],
+            "severity": {
+                "STR003": "error",
+                "LNK002": "error",
+                "IMG002": "error",
+                "LNK006": "warning",
+                "TBL001": "warning",
+            },
+        },
+    },
+    "prose": {
+        "description": (
+            "Polished long-form prose (articles, blog posts, reports): typographic "
+            "niceties, consistent heading style, and high-quality link text. Ideal "
+            "for cleaning up a converted DOCX before publishing."
+        ),
+        "config": {
+            "enable": [
+                "STR001",
+                "STR003",
+                "HDG001",  # no trailing punctuation in headings
+                "HDG003",  # no duplicate headings
+                "HDG004",  # consistent heading capitalization
+                "HDG006",  # headings should not read as full sentences
+                "TYP001",  # no trailing whitespace
+                "TYP002",  # no double spaces
+                "TYP003",  # curly quotes
+                "TYP004",  # em-dashes
+                "TYP006",  # ellipsis character
+                "TYP007",  # no space before punctuation
+                "TYP008",  # no repeated punctuation
+                "LNK004",  # wrap bare URLs
+                "LNK005",  # quality link text
+                "LNK007",  # link text is not the URL
+                "IMG001",  # images need alt text
+            ],
+            "severity": {
+                "TYP003": "warning",
+                "TYP004": "warning",
+                "TYP006": "warning",
+                "HDG004": "warning",
+            },
+        },
+    },
+}
+
+
+def available_profiles() -> List[str]:
+    """Return the sorted names of every built-in lint profile."""
+    return sorted(LINT_PROFILES.keys())
+
+
+def profile_description(name: str) -> str:
+    """Return the one-line description for ``name`` (raises ``KeyError`` if unknown)."""
+    return str(LINT_PROFILES[name]["description"])
+
+
+def get_profile_config(name: str) -> Dict[str, Any]:
+    """Return a deep copy of the config dict for profile ``name``.
+
+    Parameters
+    ----------
+    name : str
+        A profile name (see :func:`available_profiles`).
+
+    Returns
+    -------
+    dict
+        A fresh, normalised config dict ready to feed to
+        :meth:`LintConfig.from_dict` or :func:`merge_profile_dicts`. The copy is
+        deep so callers can mutate it without corrupting the shared definition.
+
+    Raises
+    ------
+    KeyError
+        If ``name`` is not a known profile.
+
+    """
+    if name not in LINT_PROFILES:
+        raise KeyError(name)
+    return _normalize(LINT_PROFILES[name]["config"])
+
+
+def describe_profiles() -> str:
+    """Render a human-readable ``name — description`` listing for ``--list-profiles``."""
+    width = max((len(n) for n in LINT_PROFILES), default=0)
+    lines = [f"  {name.ljust(width)}  {profile_description(name)}" for name in available_profiles()]
+    return "Available lint profiles:\n" + "\n".join(lines)
+
+
+def _normalize(config: Dict[str, Any]) -> Dict[str, Any]:
+    """Return a deep copy of ``config`` with alias keys folded to canonical names."""
+    out: Dict[str, Any] = {}
+    for key, value in copy.deepcopy(config).items():
+        out[_ALIASES.get(key, key)] = value
+    return out
+
+
+def merge_profile_dicts(base: Dict[str, Any], override: Dict[str, Any]) -> Dict[str, Any]:
+    """Layer ``override`` on top of ``base`` and return a new merged config dict.
+
+    The merge policy is chosen so layering reads intuitively:
+
+    - ``disable`` lists are **unioned** — disabling more rules is always additive.
+    - ``enable`` whitelists are **replaced** when ``override`` supplies one;
+      intersecting two independent whitelists almost never matches intent.
+    - ``severity`` and ``rules`` tables are **shallow-merged per rule code**, with
+      ``override`` winning on conflicts (``rules`` option dicts merge one level deep).
+    - ``severity_threshold`` is **replaced** when present in ``override``.
+
+    Both inputs are treated as read-only; alias keys (``enabled_rules`` /
+    ``disabled_rules``) are accepted and normalised.
+    """
+    merged = _normalize(base)
+    incoming = _normalize(override)
+
+    # disable: union, order-stable
+    if "disable" in incoming:
+        union = list(merged.get("disable", []))
+        seen = set(union)
+        for code in incoming["disable"]:
+            if code not in seen:
+                union.append(code)
+                seen.add(code)
+        merged["disable"] = union
+
+    # enable: replace
+    if "enable" in incoming:
+        merged["enable"] = list(incoming["enable"])
+
+    # severity: per-code merge, override wins
+    if "severity" in incoming:
+        sev = dict(merged.get("severity", {}))
+        sev.update(incoming["severity"])
+        merged["severity"] = sev
+
+    # rules: per-code merge, option dicts merged one level deep
+    if "rules" in incoming:
+        rules = {code: dict(opts) for code, opts in merged.get("rules", {}).items()}
+        for code, opts in incoming["rules"].items():
+            existing = dict(rules.get(code, {}))
+            existing.update(opts)
+            rules[code] = existing
+        merged["rules"] = rules
+
+    # severity_threshold: replace
+    for key in _SCALAR_KEYS:
+        if key in incoming:
+            merged[key] = incoming[key]
+
+    return merged

--- a/tests/unit/linter/test_cli_lint.py
+++ b/tests/unit/linter/test_cli_lint.py
@@ -127,3 +127,52 @@ class TestLintCliFix:
         handle_lint_command(["--fix", str(path)])
         second = path.read_text(encoding="utf-8")
         assert first == second, "running --fix twice should be a no-op the second time"
+
+
+class TestLintCliProfiles:
+    """Coverage for --profile and --list-profiles."""
+
+    def _write(self, tmp_path: Path) -> Path:
+        path = tmp_path / "doc.md"
+        path.write_text(
+            '# Title\n\nSee [click here](http://x.com) for "stuff" -- really...\n',
+            encoding="utf-8",
+        )
+        return path
+
+    def test_list_profiles_without_inputs(self, capsys):
+        exit_code = handle_lint_command(["--list-profiles"])
+        captured = capsys.readouterr()
+        assert exit_code == EXIT_SUCCESS
+        assert "accessibility" in captured.out
+        assert "technical-docs" in captured.out
+        assert "prose" in captured.out
+
+    def test_no_inputs_without_list_profiles_errors(self, capsys):
+        exit_code = handle_lint_command([])
+        captured = capsys.readouterr()
+        assert exit_code != EXIT_SUCCESS
+        assert "No input files" in captured.err
+
+    def test_prose_profile_elevates_typography(self, tmp_path, capsys):
+        path = self._write(tmp_path)
+        exit_code = handle_lint_command(["--profile", "prose", str(path)])
+        captured = capsys.readouterr()
+        assert exit_code == EXIT_VALIDATION_ERROR
+        # prose bumps straight-quotes/em-dash/ellipsis from info to warning.
+        assert "TYP003 warning" in captured.out
+        assert "TYP004 warning" in captured.out
+
+    def test_profile_disable_flag_unions(self, tmp_path, capsys):
+        path = self._write(tmp_path)
+        exit_code = handle_lint_command(["--profile", "prose", "--disable", "TYP003", str(path)])
+        captured = capsys.readouterr()
+        # CLI --disable layers on top of the profile and suppresses the rule.
+        assert "TYP003" not in captured.out
+        # Other profile rules still fire.
+        assert "TYP004" in captured.out
+        assert exit_code == EXIT_VALIDATION_ERROR
+
+    def test_unknown_profile_rejected(self, capsys):
+        exit_code = handle_lint_command(["--profile", "nope", "x.md"])
+        assert exit_code != EXIT_SUCCESS

--- a/tests/unit/linter/test_profiles.py
+++ b/tests/unit/linter/test_profiles.py
@@ -1,0 +1,140 @@
+"""Unit tests for the lint profile bundles and their merge policy."""
+
+from __future__ import annotations
+
+import pytest
+
+from all2md.linter import LintConfig, Severity, rule_registry
+from all2md.linter.profiles import (
+    LINT_PROFILES,
+    available_profiles,
+    describe_profiles,
+    get_profile_config,
+    merge_profile_dicts,
+    profile_description,
+)
+
+pytestmark = pytest.mark.unit
+
+
+class TestProfileCatalog:
+    def test_available_profiles_sorted(self):
+        names = available_profiles()
+        assert names == sorted(names)
+        assert set(names) == set(LINT_PROFILES)
+        # The three profiles we ship.
+        assert {"accessibility", "technical-docs", "prose"} <= set(names)
+
+    def test_every_profile_references_real_rule_codes(self):
+        """A profile must never name a rule code that isn't registered."""
+        known = set(rule_registry.list_rules())
+        for name in available_profiles():
+            cfg = get_profile_config(name)
+            referenced: set[str] = set()
+            referenced.update(cfg.get("enable", []))
+            referenced.update(cfg.get("disable", []))
+            referenced.update(cfg.get("severity", {}).keys())
+            referenced.update(cfg.get("rules", {}).keys())
+            unknown = referenced - known
+            assert not unknown, f"profile {name!r} references unknown rules: {sorted(unknown)}"
+
+    def test_every_profile_loads_as_lintconfig(self):
+        for name in available_profiles():
+            config = LintConfig.from_dict(get_profile_config(name))
+            assert isinstance(config, LintConfig)
+
+    def test_profile_description_present(self):
+        for name in available_profiles():
+            assert profile_description(name).strip()
+
+    def test_describe_profiles_lists_all(self):
+        text = describe_profiles()
+        for name in available_profiles():
+            assert name in text
+
+    def test_unknown_profile_raises(self):
+        with pytest.raises(KeyError):
+            get_profile_config("does-not-exist")
+
+    def test_get_profile_config_returns_isolated_copy(self):
+        first = get_profile_config("prose")
+        first.setdefault("enable", []).append("ZZZ999")
+        first.setdefault("severity", {})["ZZZ999"] = "error"
+        second = get_profile_config("prose")
+        assert "ZZZ999" not in second.get("enable", [])
+        assert "ZZZ999" not in second.get("severity", {})
+
+
+class TestProfileSemantics:
+    def test_prose_elevates_typography_to_warning(self):
+        config = LintConfig.from_dict(get_profile_config("prose"))
+        assert config.severity_overrides["TYP003"] == Severity.WARNING
+        # Whitelist mode: a rule outside the bundle is disabled.
+        assert config.is_rule_enabled("TYP003")
+        assert not config.is_rule_enabled("LST004")
+
+    def test_accessibility_marks_alt_text_error(self):
+        config = LintConfig.from_dict(get_profile_config("accessibility"))
+        assert config.severity_overrides["IMG001"] == Severity.ERROR
+        assert config.is_rule_enabled("IMG001")
+        # Typography niceties are intentionally excluded from the a11y bundle.
+        assert not config.is_rule_enabled("TYP003")
+
+    def test_technical_docs_disables_prose_typography(self):
+        config = LintConfig.from_dict(get_profile_config("technical-docs"))
+        # Disable list (no whitelist), so unrelated rules stay enabled.
+        assert not config.is_rule_enabled("TYP003")
+        assert config.is_rule_enabled("STR001")
+
+
+class TestMergePolicy:
+    def test_disable_unions(self):
+        merged = merge_profile_dicts({"disable": ["TYP003"]}, {"disable": ["TYP004"]})
+        assert merged["disable"] == ["TYP003", "TYP004"]
+
+    def test_disable_union_dedupes_and_preserves_order(self):
+        merged = merge_profile_dicts({"disable": ["A", "B"]}, {"disable": ["B", "C"]})
+        assert merged["disable"] == ["A", "B", "C"]
+
+    def test_enable_replaces(self):
+        merged = merge_profile_dicts({"enable": ["STR001", "STR002"]}, {"enable": ["TYP003"]})
+        assert merged["enable"] == ["TYP003"]
+
+    def test_severity_merges_override_wins(self):
+        merged = merge_profile_dicts(
+            {"severity": {"TYP003": "info", "STR001": "error"}},
+            {"severity": {"TYP003": "warning"}},
+        )
+        assert merged["severity"] == {"TYP003": "warning", "STR001": "error"}
+
+    def test_rules_options_merge_one_level_deep(self):
+        merged = merge_profile_dicts(
+            {"rules": {"HDG002": {"max_length": 80}}},
+            {"rules": {"HDG002": {"foo": 1}, "STR006": {"min_words": 5}}},
+        )
+        assert merged["rules"]["HDG002"] == {"max_length": 80, "foo": 1}
+        assert merged["rules"]["STR006"] == {"min_words": 5}
+
+    def test_severity_threshold_replaces(self):
+        merged = merge_profile_dicts({"severity_threshold": "info"}, {"severity_threshold": "warning"})
+        assert merged["severity_threshold"] == "warning"
+
+    def test_alias_keys_normalized(self):
+        merged = merge_profile_dicts(
+            {"enabled_rules": ["STR001"]},
+            {"disabled_rules": ["TYP003"]},
+        )
+        assert merged["enable"] == ["STR001"]
+        assert merged["disable"] == ["TYP003"]
+
+    def test_inputs_not_mutated(self):
+        base = {"disable": ["TYP003"]}
+        override = {"disable": ["TYP004"]}
+        merge_profile_dicts(base, override)
+        assert base == {"disable": ["TYP003"]}
+        assert override == {"disable": ["TYP004"]}
+
+    def test_empty_override_is_identity(self):
+        merged = merge_profile_dicts({"enable": ["STR001"], "disable": ["TYP003"]}, {})
+        assert merged["enable"] == ["STR001"]
+        assert merged["disable"] == ["TYP003"]


### PR DESCRIPTION
## Summary

Adds **named lint profiles** so users can opt into a coherent style policy with a single flag instead of hand-assembling a long `--rule` / `--disable` / `--severity` invocation. Built entirely from the existing 47 rules — this is config packaging, not a new engine.

Three profiles ship built in:

| Profile | For |
|---|---|
| `prose` | Polished long-form writing; typographic niceties + heading/link quality, curly-quote/em-dash/ellipsis promoted to *warning*. Ideal for a converted DOCX bound for publication. |
| `accessibility` | Alt text, descriptive link text, table headers, and clean heading hierarchy enforced at *error*; stylistic typography omitted. |
| `technical-docs` | Structure + valid links + resolvable images enforced; prose-typography rules that fight code/CLI-flags relaxed. |

## CLI

```bash
all2md lint --profile prose report.md
all2md lint --list-profiles
all2md lint --profile prose --disable TYP003 report.md   # layer a flag on top
```

Precedence, lowest → highest: **`--profile` bundle < `[tool.all2md.lint]` config file < CLI flags**. `--disable` lists union across layers; `severity` and per-rule options merge with the more specific layer winning (`merge_profile_dicts`).

## Python API

```python
from all2md.linter import available_profiles, get_profile_config, LintConfig
config = LintConfig.from_dict(get_profile_config("prose"))
```

New exports: `LINT_PROFILES`, `available_profiles`, `get_profile_config`, `merge_profile_dicts`, `describe_profiles`, `profile_description`.

## Docs

- New **"Linting & Enforcing a Style Guide"** how-to (`docs/source/lint_guide.rst`) walking the full convert → lint → fix → profile workflow, with a DOCX-symptom→rule table and CI patterns. Linked into the toctree.
- `--profile` / `--list-profiles` documented in the CLI reference, with a new "Profiles" subsection.
- CHANGELOG entry.

## Tests

- New `tests/unit/linter/test_profiles.py` — catalog integrity (every profile references only registered rule codes), config-load, copy isolation, and full merge-policy coverage.
- Extended `tests/unit/linter/test_cli_lint.py` — `--list-profiles`, profile severity elevation, profile + `--disable` union, unknown-profile rejection.
- **177 linter tests pass**; mypy clean on changed files; pre-commit (black/ruff/bandit) green; Sphinx build clean for changed pages.

> Note: an unrelated, pre-existing Windows-only flake in `test_cli_watch.py::test_watch_mode_real_file_modification` (an `os.replace` file-locking race) is **not** touched by this branch — changes are isolated to `linter/` + `docs/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)