### PR TITLE
chore: issue/PR templates + discoverability keywords

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,55 @@
+name: Bug report
+description: Report a conversion error, crash, or incorrect output
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to file a bug! Please fill out the sections below so we can reproduce it quickly.
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened?
+      description: A clear description of the bug, including what you expected instead.
+      placeholder: Converting a DOCX dropped all table borders / raised an exception / produced garbled text...
+    validations:
+      required: true
+  - type: input
+    id: format
+    attributes:
+      label: Source format(s)
+      description: Which input/output format(s) are involved?
+      placeholder: "pdf -> markdown, docx, mbox, etc."
+    validations:
+      required: true
+  - type: textarea
+    id: repro
+    attributes:
+      label: How to reproduce
+      description: The exact command or Python snippet. Attach a minimal sample file if you can.
+      placeholder: |
+        all2md report.pdf --pdf-pages "1-3"
+        # or
+        from all2md import to_markdown
+        to_markdown("report.pdf")
+      render: shell
+    validations:
+      required: true
+  - type: textarea
+    id: output
+    attributes:
+      label: Actual output / traceback
+      description: Paste the incorrect output or full traceback.
+      render: shell
+  - type: textarea
+    id: env
+    attributes:
+      label: Environment
+      description: Run `all2md --version` and `all2md check-deps`, plus your OS and Python version.
+      placeholder: |
+        all2md 1.7.0
+        Python 3.12 on Windows 11
+        Installed extras: pdf, docx, html
+      render: shell
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Documentation
+    url: https://all2md.readthedocs.io/
+    about: Browse the full docs, format reference, and examples before filing.
+  - name: Question or usage help
+    url: https://github.com/thomas-villani/all2md/discussions
+    about: Ask how-to questions and share ideas in Discussions.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,38 @@
+name: Feature request
+description: Suggest a new format, transform, CLI flag, or capability
+labels: ["enhancement"]
+body:
+  - type: textarea
+    id: problem
+    attributes:
+      label: What problem would this solve?
+      description: Describe the use case or pain point, not just the solution.
+      placeholder: "I need to convert .pages files / extract footnotes / output AsciiDoc..."
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed solution
+      description: What would the feature look like? A CLI flag, a new converter, a Python API, a transform?
+    validations:
+      required: true
+  - type: dropdown
+    id: area
+    attributes:
+      label: Area
+      options:
+        - New input format (parser)
+        - New output format (renderer)
+        - New transform
+        - CLI / UX
+        - Python API
+        - MCP server / AI integration
+        - Other
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Existing flags, other tools, or workarounds you've tried.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,29 @@
+<!-- Thanks for contributing to all2md! Please fill out the checklist below. -->
+
+## Summary
+
+<!-- What does this PR do and why? Link any related issue: "Closes #123" -->
+
+## Type of change
+
+- [ ] Bug fix
+- [ ] New input format (parser)
+- [ ] New output format (renderer)
+- [ ] New transform
+- [ ] CLI / UX change
+- [ ] Documentation
+- [ ] Other
+
+## Checklist
+
+- [ ] Tests added or updated for the change
+- [ ] `ruff check` and `ruff format` pass
+- [ ] `mypy src/` passes
+- [ ] `pytest` passes locally
+- [ ] Docs/README/CHANGELOG updated if user-facing
+- [ ] If a parser/renderer was added or changed, regenerated the converter manifest
+      (`scripts/generate_converter_manifest.py --update`)
+
+## Notes for reviewers
+
+<!-- Anything reviewers should focus on, trade-offs, or follow-ups. -->

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,16 +11,25 @@ keywords = [
     "markdown",
     "converter",
     "pdf",
+    "pdf-to-markdown",
     "docx",
     "html",
+    "html-to-markdown",
     "document-conversion",
+    "text-extraction",
     "llm",
+    "rag",
+    "mcp",
+    "model-context-protocol",
     "ai",
+    "ocr",
     "parsing",
     "bidirectional",
     "pptx",
     "epub",
-    "pandoc-alternative"
+    "cli",
+    "pandoc-alternative",
+    "markitdown-alternative"
 ]
 
 requires-python = ">=3.10"


### PR DESCRIPTION
Community & discoverability quick wins.

## What's here
- **Issue forms** (`.github/ISSUE_TEMPLATE/`): structured bug-report and feature-request forms, plus a `config.yml` that disables blank issues and routes questions to the docs and Discussions.
- **PR template**: contributor checklist (tests, ruff, mypy, converter-manifest regen).
- **PyPI keywords**: added high-intent terms (`pdf-to-markdown`, `html-to-markdown`, `text-extraction`, `rag`, `mcp`, `model-context-protocol`, `ocr`, `cli`, `markitdown-alternative`).

## Already applied directly on GitHub (not in this diff)
For the record, these were set via the API and are already live: repo topics (20), repo description, homepage URL, and Discussions enabled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)