### PR TITLE
fix(markdown): parse GFM tables nested in list items and blockquotes

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -37,7 +37,7 @@ if str(SCRIPTS_PATH) not in sys.path:
 project = "all2md"
 copyright = "2025, Tom Villani, Ph.D."
 author = "Tom Villani, Ph.D."
-release = "1.7.0"
+release = "1.7.1"
 
 # -- General configuration ---------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration

--- a/mcpb/manifest.json
+++ b/mcpb/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": "0.4",
   "name": "all2md",
   "display_name": "all2md",
-  "version": "1.7.0",
+  "version": "1.7.1",
   "description": "Convert PDFs, Office files, HTML, email, and 40+ formats to Markdown and back, directly inside Claude.",
   "long_description": "all2md's built-in MCP server, packaged for one-click install. Lets AI assistants read and convert documents across 40+ formats via an AST-based conversion pipeline, render Markdown back out to PDF/DOCX/PPTX/EPUB/HTML/RST, and edit documents section-by-section. Read-only query tools let assistants search across a corpus (grep + keyword/BM25), diff two documents, and outline a document's headings. Includes smart source auto-detection (file path, data URI, base64, plain text), section extraction, and security controls (a user-chosen workspace folder, network off by default, and path validation).",
   "author": {

--- a/mcpb/pyproject.toml
+++ b/mcpb/pyproject.toml
@@ -7,10 +7,10 @@
 # [tool.bumpversion] config — do NOT hand-edit the version strings below.
 [project]
 name = "all2md-mcpb"
-version = "1.7.0"
+version = "1.7.1"
 requires-python = ">=3.10"
 dependencies = [
-    "all2md[mcp,pdf,pdf_render,docx,html,xlsx,pptx,epub,rst,markdown,odf]>=1.7.0",
+    "all2md[mcp,pdf,pdf_render,docx,html,xlsx,pptx,epub,rst,markdown,odf]>=1.7.1",
     # The search_documents MCP tool defaults to keyword (BM25) mode, which needs
     # rank-bm25. Depend on it directly rather than via the `search` extra: that
     # extra also pulls faiss-cpu and sentence-transformers for vector/hybrid

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "all2md"
-version = "1.7.0"
+version = "1.7.1"
 description = "Rapid, lightweight conversion of various document formats to markdown for LLMs"
 readme = "README.md"
 authors = [
@@ -457,7 +457,7 @@ skips = [
 ]
 
 [tool.bumpversion]
-current_version = "1.7.0"
+current_version = "1.7.1"
 parse = "(?P<major>\\d+)\\.(?P<minor>\\d+)\\.(?P<patch>\\d+)"
 serialize = ["{major}.{minor}.{patch}"]
 commit = true

--- a/src/all2md/__init__.py
+++ b/src/all2md/__init__.py
@@ -86,7 +86,7 @@ if sys.version_info < (3, 10):
         f"You are using Python {sys.version_info.major}.{sys.version_info.minor}."
     )
 
-__version__ = "1.7.0"
+__version__ = "1.7.1"
 
 from typing import TYPE_CHECKING, Any
 

--- a/src/all2md/parsers/markdown.py
+++ b/src/all2md/parsers/markdown.py
@@ -251,7 +251,15 @@ class MarkdownToAstConverter(BaseParser):
         if self.options.parse_strikethrough:
             plugins.append("strikethrough")
         if self.options.parse_tables:
-            plugins.append("table")
+            # The base "table" plugin only recognizes tables at the document
+            # root. table_in_list/table_in_quote extend the table block rule into
+            # list items and blockquotes so GFM tables nested there (e.g. a table
+            # inside a numbered list item) are parsed as tables rather than
+            # falling back to literal paragraph text. These ship with mistune but
+            # are not registered under string names, so import the callables.
+            from mistune.plugins.table import table_in_list, table_in_quote
+
+            plugins.extend(["table", table_in_list, table_in_quote])
         if self.options.parse_footnotes:
             plugins.append("footnotes")
         if self.options.parse_task_lists:

--- a/tests/unit/ast/test_markdown2ast.py
+++ b/tests/unit/ast/test_markdown2ast.py
@@ -320,6 +320,44 @@ class TestTables:
         # Alignments should be captured
         assert len(table.alignments) == 3
 
+    def test_table_nested_in_list_item(self) -> None:
+        """Tables indented inside a list item must parse as tables, not text.
+
+        Regression: mistune's base ``table`` plugin only matches tables at the
+        document root, so a GFM table nested in a list item used to fall back to
+        literal paragraph text (visible pipes instead of a rendered table).
+        """
+        markdown = """1. **Intro** with a table:
+
+   | File | Count |
+   |------|------:|
+   | A    | 1     |
+   | B    | 2     |
+
+   Trailing text.
+"""
+        doc = markdown_to_ast(markdown)
+
+        item = doc.children[0].items[0]
+        assert isinstance(item, ListItem)
+
+        tables = [child for child in item.children if isinstance(child, Table)]
+        assert len(tables) == 1
+        assert len(tables[0].rows) == 2
+
+    def test_table_nested_in_blockquote(self) -> None:
+        """Tables inside a blockquote must parse as tables, not text."""
+        markdown = """> | File | Count |
+> |------|------:|
+> | A    | 1     |
+"""
+        doc = markdown_to_ast(markdown)
+
+        quote = doc.children[0]
+        tables = [child for child in quote.children if isinstance(child, Table)]
+        assert len(tables) == 1
+        assert len(tables[0].rows) == 1
+
 
 class TestMiscellaneous:
     """Test miscellaneous elements."""

--- a/uv.lock
+++ b/uv.lock
@@ -19,7 +19,7 @@ wheels = [
 
 [[package]]
 name = "all2md"
-version = "1.6.0"
+version = "1.7.1"
 source = { editable = "." }
 dependencies = [
     { name = "pyyaml" },


### PR DESCRIPTION
## Problem

`all2md view` rendered some tables as raw pipe syntax (`| File | ... |`) instead of an HTML table, specifically when the table was indented inside a list item or blockquote. Reproduced from a real `SUMMARY.md` where a table under a numbered list item showed up as literal text.

## Root cause

The Markdown parser (`src/all2md/parsers/markdown.py`) registered only mistune's base `table` plugin. That plugin matches tables **solely at the document root** — its block rule is never inserted into the list-item or blockquote sub-parsers. A nested GFM table therefore fell back to literal paragraph text.

## Fix

When `parse_tables` is enabled, also register mistune's companion `table_in_list` and `table_in_quote` plugins. These ship with mistune but aren't registered under string names, so they're imported as callables.

After the fix, the example document renders all 4 tables (previously 3 — the nested one was dropped to text).

## Tests

Added two regression tests in `tests/unit/ast/test_markdown2ast.py`:
- `test_table_nested_in_list_item`
- `test_table_nested_in_blockquote`

Full markdown parser/renderer suites pass; `ruff` and `mypy` clean.

## Release

Patch version bump to **1.7.1** (via `bump-my-version`, syncing `pyproject.toml`, `__init__.py`, `docs/source/conf.py`, `mcpb/manifest.json`, `mcpb/pyproject.toml`, and `uv.lock`). Tag `v1.7.1` to be pushed after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)