### PR TITLE
feat: provenance-aware `all2md chunk` command for RAG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,12 +22,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   ``--token-counter {auto,tiktoken,whitespace}`` selects the tokenizer. Real BPE
   token counting uses ``tiktoken`` (new optional extra: ``pip install all2md[chunk]``);
   count-only strategies fall back to a whitespace approximation when it is absent.
-  Element handling: ``--avoid-table-split`` keeps each table whole (one atomic chunk
-  rather than fragmenting it mid-row), ``--drop-elements image,table,…`` strips noisy
-  node types before chunking, and ``--attachment-mode {skip,alt_text,save,base64}``
-  (plus any ``[pdf]``/``[html]``/top-level converter keys in a config file) controls
-  how the underlying conversion handles images — so base64 blobs need never reach a
-  chunk. Exposed from Python via ``all2md.chunking.chunk_ast`` returning
+  Element handling: ``--avoid-table-split`` and ``--avoid-code-split`` keep each table
+  or fenced code block whole (one atomic chunk rather than fragmenting it),
+  ``--drop-elements image,table,…`` strips noisy node types before chunking,
+  ``--elide-data-uris`` (on by default) replaces long base64 ``data:`` URIs with a short
+  placeholder so embedded images never inflate token counts or shred into noise, and
+  ``--attachment-mode {skip,alt_text,save,base64}`` (plus any ``[pdf]``/``[html]``/
+  top-level converter keys in a config file) controls how the underlying conversion
+  handles images — so base64 blobs need never reach a chunk. Exposed from Python via ``all2md.chunking.chunk_ast`` returning
   ``ProvenanceChunk`` records. The fine-grained chunkers are vendored from the
   ``localvectordb`` sister project.
 - **Lint profiles: `all2md lint --profile NAME`.** Curated, named rule bundles

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,8 +29,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   placeholder so embedded images never inflate token counts or shred into noise, and
   ``--attachment-mode {skip,alt_text,save,base64}`` (plus any ``[pdf]``/``[html]``/
   top-level converter keys in a config file) controls how the underlying conversion
-  handles images — so base64 blobs need never reach a chunk. Exposed from Python via ``all2md.chunking.chunk_ast`` returning
-  ``ProvenanceChunk`` records. The fine-grained chunkers are vendored from the
+  handles images — so base64 blobs need never reach a chunk. Exposed from Python as a
+  one-call ``all2md.chunk(source, …)`` (mirrors ``to_markdown``: converts and chunks in a
+  single step, deriving ``document_id``/path from the source and forwarding converter
+  kwargs), with ``all2md.chunking.chunk_ast(doc, …)`` for an AST you already hold; both
+  return ``ProvenanceChunk`` records. The fine-grained chunkers are vendored from the
   ``localvectordb`` sister project.
 - **Lint profiles: `all2md lint --profile NAME`.** Curated, named rule bundles
   built entirely from the existing 47 rules — ``prose`` (typographic polish for

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **`all2md chunk`: provenance-aware document chunking for RAG/LLM pipelines.**
+  Splits any supported document into chunks and emits them as JSONL (one object
+  per line) — or ``--format json``/``pretty``. Unlike flat-text chunkers, every
+  chunk carries AST-derived provenance: its section heading/level, and the source
+  page span where the parser tracks it (PDF and friends). Eleven strategies:
+  ``semantic`` (default; section-bounded real-token windows), ``heading``,
+  ``section``, ``auto`` (coarse, one chunk per boundary), and ``token``,
+  ``sentence``, ``paragraph``, ``word``, ``line``, ``char``, ``code`` (fine).
+  ``--max-tokens``/``--overlap``/``--min-tokens`` bound size; ``--max-heading-level``,
+  ``--include-preamble``/``--heading-merge`` toggles control structure;
+  ``--token-counter {auto,tiktoken,whitespace}`` selects the tokenizer. Real BPE
+  token counting uses ``tiktoken`` (new optional extra: ``pip install all2md[chunk]``);
+  count-only strategies fall back to a whitespace approximation when it is absent.
+  Element handling: ``--avoid-table-split`` keeps each table whole (one atomic chunk
+  rather than fragmenting it mid-row), ``--drop-elements image,table,…`` strips noisy
+  node types before chunking, and ``--attachment-mode {skip,alt_text,save,base64}``
+  (plus any ``[pdf]``/``[html]``/top-level converter keys in a config file) controls
+  how the underlying conversion handles images — so base64 blobs need never reach a
+  chunk. Exposed from Python via ``all2md.chunking.chunk_ast`` returning
+  ``ProvenanceChunk`` records. The fine-grained chunkers are vendored from the
+  ``localvectordb`` sister project.
 - **Lint profiles: `all2md lint --profile NAME`.** Curated, named rule bundles
   built entirely from the existing 47 rules — ``prose`` (typographic polish for
   long-form writing, ideal for a converted DOCX), ``accessibility`` (alt text,

--- a/README.md
+++ b/README.md
@@ -79,6 +79,9 @@ all2md grep -i "case insensitive" report.docx
 all2md search "machine learning" ./research_papers/
 all2md search "project timeline" --semantic ./docs/
 
+# Chunk documents for RAG/LLM pipelines (JSONL with section + page provenance)
+all2md chunk report.pdf --strategy semantic --max-tokens 512 --overlap 64
+
 # Pipe and chain commands with stdin/stdout support (use '-' for stdin)
 curl https://example.com/doc.pdf | all2md - | grep "important"
 cat report.html | all2md - --format html --rich
@@ -163,6 +166,7 @@ Unlike direct format-to-format converters, all2md uses an intermediate Abstract 
 Designed for embedding in applications, not just CLI usage:
 
 - Clean, typed API with comprehensive options classes for every format
+- One-call helpers — `to_markdown()`, `to_ast()`, `convert()`, and `chunk()` for RAG-ready chunks
 - Progress callbacks for long-running conversions
 - Bidirectional conversion between any supported formats
 - AST manipulation for advanced document processing
@@ -184,6 +188,13 @@ Beyond basic conversion, the CLI includes advanced features for production workf
 
 ### 4. AI-Native Integration
 
+**RAG-Native Chunking** — Split any document into chunks ready for retrieval-augmented generation, with provenance most chunkers throw away.
+
+- `all2md chunk doc.pdf --strategy semantic --max-tokens 512 --overlap 64` → JSONL, one chunk per line
+- Every chunk carries its **section heading/level** and the **source page span** (where the format records it), so answers can cite where they came from
+- 11 strategies (semantic/heading/section/token/sentence/paragraph/word/line/char/code/auto); keep tables and code blocks whole; strip or elide noisy elements
+- One-call Python API: `chunks = all2md.chunk("doc.pdf", strategy="semantic", max_tokens=512)`
+
 **MCP Server** — Built-in Model Context Protocol server enables direct integration with AI assistants like Claude Desktop. No wrapper scripts or external tools needed.
 
 - Direct document reading in Claude Desktop and other MCP-compatible AI tools
@@ -194,7 +205,7 @@ Beyond basic conversion, the CLI includes advanced features for production workf
 
 **Agent Skills** — Pre-built skill files that teach AI coding assistants how to use all2md effectively.
 
-- 6 focused skills covering reading, conversion, generation, grep, search, and diff
+- 7 focused skills covering reading, conversion, generation, grep, search, diff, and chunking
 - Works with Claude Code, Cursor, Windsurf, and other skill-aware agents
 - Install with one command: `all2md install-skills`
 - Customizable — edit the installed skill files to match your project's needs
@@ -703,6 +714,37 @@ markdown_output = render(
     ]
 )
 ```
+
+**Chunking for RAG**
+
+`all2md.chunk()` converts and splits a document in one call, returning chunks that
+carry their section context and source page span — provenance most chunkers drop.
+
+```python
+import all2md
+
+# Semantic, token-bounded chunks straight from a file
+chunks = all2md.chunk("report.pdf", strategy="semantic", max_tokens=512, overlap=64)
+
+for c in chunks:
+    print(c.chunk_id, c.section_heading, c.page, c.token_count)
+    record = c.to_dict()  # flat dict — the same object emitted as JSONL by the CLI
+
+# Shape the output: keep tables whole, drop images, set a floor, pass converter options
+chunks = all2md.chunk(
+    "report.pdf",
+    strategy="paragraph",
+    max_tokens=256,
+    min_tokens=20,
+    avoid_table_split=True,
+    drop_elements=["image"],
+    attachment_mode="skip",   # forwarded to the converter
+)
+```
+
+Real BPE token counting uses `tiktoken` (`pip install all2md[chunk]`); count-only
+strategies fall back to a whitespace approximation. For an AST you already hold, call
+`all2md.chunking.chunk_ast(doc, ...)` directly.
 
 ## Extensibility: The Plugin System
 

--- a/docs/source/cli.rst
+++ b/docs/source/cli.rst
@@ -699,11 +699,14 @@ budget and can otherwise cut a table mid-row; these flags give you control:
 
 .. code-block:: bash
 
-   # Keep each table whole (emitted as its own chunk, may exceed --max-tokens)
-   all2md chunk report.pdf --avoid-table-split
+   # Keep each table or fenced code block whole (its own chunk, may exceed --max-tokens)
+   all2md chunk report.pdf --avoid-table-split --avoid-code-split
 
    # Strip noisy elements before chunking (aliases like images/tables accepted)
    all2md chunk report.pdf --drop-elements image,table
+
+   # Long base64 data: URIs are elided to a placeholder by default; opt out with:
+   all2md chunk report.pdf --no-elide-data-uris
 
    # Control how the converter handles images (avoids huge base64 blobs in chunks)
    all2md chunk report.pdf --attachment-mode skip

--- a/docs/source/cli.rst
+++ b/docs/source/cli.rst
@@ -643,6 +643,103 @@ Configuration sources are applied in this order (highest to lowest priority):
    # 5. Use it (auto-discovered)
    all2md document.pdf
 
+Chunk Command
+-------------
+
+``all2md chunk`` splits a document into chunks for retrieval-augmented generation
+(RAG) and other LLM pipelines, emitting JSONL by default (one chunk per line).
+Unlike flat-text chunkers, every chunk carries AST-derived **provenance**: the
+section heading/level it came from and, where the source format records it, the
+originating page span. This lets a downstream answer cite *where* a passage came
+from.
+
+Basic Usage
+~~~~~~~~~~~
+
+.. code-block:: bash
+
+   # Semantic chunks (section-bounded, real-token windows) as JSONL
+   all2md chunk report.pdf --strategy semantic --max-tokens 512 --overlap 64
+
+   # One chunk per section, written to a file
+   all2md chunk handbook.docx --strategy section --out chunks.jsonl
+
+   # Read from stdin
+   cat page.html | all2md chunk - --strategy paragraph
+
+Strategies
+~~~~~~~~~~
+
+Coarse (one chunk per semantic boundary): ``heading``, ``section``, ``auto``.
+
+Fine (windowed within each section, up to ``--max-tokens``): ``semantic``
+(default), ``token``, ``sentence``, ``paragraph``, ``word``, ``line``, ``char``,
+``code``.
+
+Key Options
+~~~~~~~~~~~
+
+.. code-block:: bash
+
+   # Bound chunk size and overlap (overlap is coerced to 0 for coarse strategies)
+   all2md chunk doc.md --max-tokens 256 --overlap 32 --min-tokens 20
+
+   # Limit how deep section detection descends, and control structure
+   all2md chunk doc.md --max-heading-level 2 --no-include-preamble --no-heading-merge
+
+   # Output formats: jsonl (default), json (array), pretty (human-readable)
+   all2md chunk doc.md --format pretty
+
+Element & Attachment Handling
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The chunkers run on each section's rendered Markdown, so tables, images, and code
+blocks appear in chunk text as their Markdown form. Fine strategies split by token
+budget and can otherwise cut a table mid-row; these flags give you control:
+
+.. code-block:: bash
+
+   # Keep each table whole (emitted as its own chunk, may exceed --max-tokens)
+   all2md chunk report.pdf --avoid-table-split
+
+   # Strip noisy elements before chunking (aliases like images/tables accepted)
+   all2md chunk report.pdf --drop-elements image,table
+
+   # Control how the converter handles images (avoids huge base64 blobs in chunks)
+   all2md chunk report.pdf --attachment-mode skip
+
+``all2md chunk`` also reads converter settings from a config file (the same ``[pdf]``,
+``[html]``, and top-level keys used by ``all2md``/``view``/``serve``), honoring
+``--config``/``--no-config``. ``--attachment-mode`` overrides the config value.
+
+Tokenizer
+~~~~~~~~~
+
+Real BPE token counting (and the ``semantic``/``token``/``char`` strategies that
+split *on* token boundaries) uses ``tiktoken``:
+
+.. code-block:: bash
+
+   pip install all2md[chunk]
+
+Count-only strategies (``sentence``/``word``/``line``/``paragraph``/``section``/
+``heading``/``auto``) fall back to a whitespace approximation when ``tiktoken`` is
+not installed. Force a backend with ``--token-counter {auto,tiktoken,whitespace}``.
+
+JSONL Schema
+~~~~~~~~~~~~
+
+Each line is a flat object: ``chunk_id``, ``index``, ``text``, ``token_count``,
+``token_counter``, ``strategy``, ``document_id``, ``document_path``,
+``section_heading``, ``section_level``, ``section_index``, ``page``, ``page_end``,
+``source_line_start``, ``source_line_end``, ``char_start``, ``char_end``,
+``char_basis``, ``prev_chunk_id``, ``next_chunk_id``. Character spans index into
+the chunk's rendered section text (``char_basis="section_text"``), and ``page``
+fields are populated only for formats that track pages.
+
+From Python, ``all2md.chunking.chunk_ast(doc, strategy=..., max_tokens=...)``
+returns a list of ``ProvenanceChunk`` records.
+
 Lint Command
 ------------
 

--- a/docs/source/cli.rst
+++ b/docs/source/cli.rst
@@ -740,8 +740,28 @@ Each line is a flat object: ``chunk_id``, ``index``, ``text``, ``token_count``,
 the chunk's rendered section text (``char_basis="section_text"``), and ``page``
 fields are populated only for formats that track pages.
 
-From Python, ``all2md.chunking.chunk_ast(doc, strategy=..., max_tokens=...)``
-returns a list of ``ProvenanceChunk`` records.
+Python API
+~~~~~~~~~~
+
+The one-call ``all2md.chunk()`` mirrors ``to_markdown`` — convert and chunk a source
+in a single step, returning ``ProvenanceChunk`` records:
+
+.. code-block:: python
+
+   import all2md
+
+   chunks = all2md.chunk("report.pdf", strategy="semantic", max_tokens=512, overlap=64)
+   for c in chunks:
+       print(c.chunk_id, c.section_heading, c.page, c.token_count)
+       record = c.to_dict()  # the same flat object emitted as JSONL
+
+It accepts the same shaping options as the CLI (``min_tokens``, ``avoid_table_split``,
+``avoid_code_split``, ``drop_elements=[...]``, ``elide_data_uris``, …) and forwards any
+extra keyword arguments to the converter (e.g. ``attachment_mode="skip"``).
+``document_id``/``document_path`` are derived from the source automatically.
+
+For lower-level control over an AST you already hold, call
+``all2md.chunking.chunk_ast(doc, strategy=..., max_tokens=...)`` directly.
 
 Lint Command
 ------------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -136,6 +136,11 @@ search = [
     "faiss-cpu>=1.7.4",
     "sentence-transformers>=2.2.2",
 ]
+chunk = [
+    # Real BPE token counting/splitting for `all2md chunk` (token/semantic/char
+    # strategies). Count-only strategies fall back to a whitespace approximation.
+    "tiktoken>=0.7.0",
+]
 chm = [
     "pychm>=0.8.6"
 ]
@@ -258,6 +263,7 @@ all = [
     "reportlab>=4.0.0",
     "rich>=14.2.0",
     "textile>=4.0.1",
+    "tiktoken>=0.7.0",
     "tqdm>=4.66.0",
     "watchdog>=4.0.0",
     "defusedxml>=0.7.1",

--- a/src/all2md/__init__.py
+++ b/src/all2md/__init__.py
@@ -82,8 +82,7 @@ import sys
 
 if sys.version_info < (3, 10):
     raise ImportError(
-        "all2md requires Python 3.10 or later. "
-        f"You are using Python {sys.version_info.major}.{sys.version_info.minor}."
+        f"all2md requires Python 3.10 or later. You are using Python {sys.version_info.major}.{sys.version_info.minor}."
     )
 
 __version__ = "1.7.1"
@@ -123,6 +122,7 @@ if TYPE_CHECKING:
     from all2md.utils.input_sources import RemoteInputOptions  # noqa: F401
 
 from all2md.api import (
+    chunk,
     convert,
     from_ast,
     from_markdown,
@@ -200,6 +200,7 @@ __all__ = [
     "from_ast",
     "from_markdown",
     "convert",
+    "chunk",
     # Registry system
     "registry",
     # Type definitions

--- a/src/all2md/api.py
+++ b/src/all2md/api.py
@@ -6,7 +6,7 @@ import logging
 import warnings
 from dataclasses import fields, is_dataclass
 from pathlib import Path
-from typing import IO, Any, Optional, TypeVar, Union, cast, get_type_hints
+from typing import IO, TYPE_CHECKING, Any, Optional, TypeVar, Union, cast, get_type_hints
 
 from all2md.ast.nodes import Document
 from all2md.constants import DocumentFormat
@@ -23,6 +23,9 @@ from all2md.utils.input_sources import (
     default_loader,
 )
 from all2md.utils.io_utils import write_content
+
+if TYPE_CHECKING:
+    from all2md.chunking import ProvenanceChunk
 
 logger = logging.getLogger(__name__)
 
@@ -745,6 +748,118 @@ def to_ast(
         raise
     except Exception as e:
         raise ParsingError(f"AST conversion failed: {e!r}", parsing_stage="ast_conversion", original_error=e) from e
+
+
+def _derive_chunk_identity(source: Any, ast_doc: "Document", document_id: Optional[str]) -> tuple[str, Optional[str]]:
+    """Derive ``(document_id, document_path)`` for chunking from the source.
+
+    Reuses the ``source_path`` ``to_ast`` stashes for file inputs; falls back to a
+    generic id (or the caller-supplied ``document_id``) for streams/bytes.
+    """
+    source_path = ast_doc.metadata.get("source_path") if ast_doc.metadata else None
+    if source_path:
+        path = Path(source_path)
+        return document_id or path.stem, path.as_posix()
+    return document_id or "document", None
+
+
+def chunk(
+    source: Union[str, Path, IO[bytes], bytes],
+    *,
+    strategy: str = "semantic",
+    max_tokens: int = 512,
+    overlap: int = 0,
+    min_tokens: int = 0,
+    include_preamble: bool = True,
+    heading_merge: bool = True,
+    max_heading_level: Optional[int] = None,
+    avoid_table_split: bool = False,
+    avoid_code_split: bool = False,
+    elide_data_uris: bool = True,
+    drop_elements: Optional[list[str]] = None,
+    token_counter: str = "auto",
+    document_id: Optional[str] = None,
+    source_format: DocumentFormat = "auto",
+    **converter_options: Any,
+) -> "list[ProvenanceChunk]":
+    """Convert a document and split it into provenance-carrying chunks in one call.
+
+    The one-call equivalent of ``to_ast`` + ``all2md.chunking.chunk_ast``: convert
+    ``source`` (a path, bytes, or file-like object) to an AST, optionally strip node
+    types, and return chunks each carrying its section heading/level and — where the
+    source format records it — the originating page span. Ideal for RAG / LLM
+    pipelines.
+
+    Parameters
+    ----------
+    source : str, Path, IO[bytes], or bytes
+        Document to chunk (any supported format).
+    strategy : str
+        Chunking strategy; see ``all2md.chunking.STRATEGIES`` (``semantic`` default).
+    max_tokens, overlap, min_tokens : int
+        Size controls — token budget per chunk, window overlap, and a floor below
+        which chunks are dropped.
+    include_preamble, heading_merge : bool
+        Structure toggles (emit pre-heading content; prepend each heading to its
+        section's chunks).
+    max_heading_level : int, optional
+        For fine strategies, only descend into sections at or above this level.
+    avoid_table_split, avoid_code_split : bool
+        Keep tables / fenced code blocks whole (one atomic chunk each).
+    elide_data_uris : bool
+        Replace long base64 ``data:`` URIs with a short placeholder (default True).
+    drop_elements : list of str, optional
+        AST node types to strip before chunking (e.g. ``["image", "table"]``).
+    token_counter : {"auto", "tiktoken", "whitespace"}
+        Token-counting backend.
+    document_id : str, optional
+        Identifier woven into chunk ids; defaults to the file stem (or ``"document"``).
+    source_format : DocumentFormat, default "auto"
+        Explicit source format, or auto-detect.
+    converter_options : Any
+        Extra options forwarded to :func:`to_ast` (e.g. ``attachment_mode="skip"``,
+        ``pages=[1, 2]``).
+
+    Returns
+    -------
+    list of ProvenanceChunk
+        Chunks in reading order, with ``prev``/``next`` ids linked. Call
+        ``chunk.to_dict()`` for a JSON-serializable record.
+
+    Examples
+    --------
+    >>> import all2md
+    >>> chunks = all2md.chunk("report.pdf", strategy="semantic", max_tokens=512, overlap=64)
+    >>> chunks[0].section_heading, chunks[0].page, chunks[0].token_count  # doctest: +SKIP
+
+    """
+    from all2md.chunking import chunk_ast
+
+    doc = to_ast(source, source_format=source_format, **converter_options)
+
+    if drop_elements:
+        from all2md.transforms.builtin import RemoveNodesTransform
+
+        doc = cast("Document", RemoveNodesTransform(node_types=list(drop_elements)).transform(doc))
+
+    doc_id, doc_path = _derive_chunk_identity(source, doc, document_id)
+
+    return chunk_ast(
+        doc,
+        strategy=strategy,
+        max_tokens=max_tokens,
+        overlap=overlap,
+        min_tokens=min_tokens,
+        include_preamble=include_preamble,
+        heading_merge=heading_merge,
+        max_heading_level=max_heading_level,
+        avoid_table_split=avoid_table_split,
+        avoid_code_split=avoid_code_split,
+        elide_data_uris=elide_data_uris,
+        token_counter=token_counter,
+        document_id=doc_id,
+        document_path=doc_path,
+    )
 
 
 def _record_source_path(ast_doc: "Document", source: Any) -> None:

--- a/src/all2md/chunking/__init__.py
+++ b/src/all2md/chunking/__init__.py
@@ -1,0 +1,28 @@
+#  Copyright (c) 2025 Tom Villani, Ph.D.
+#
+# src/all2md/chunking/__init__.py
+"""Provenance-aware document chunking for RAG workflows.
+
+Public API:
+
+- :func:`chunk_ast` — turn a parsed :class:`~all2md.ast.nodes.Document` into a
+  list of :class:`ProvenanceChunk` records (the entry point for ``all2md chunk``).
+- :data:`STRATEGIES` — the available chunking strategy names.
+- :class:`ProvenanceChunk` — the output record, with section + page/line provenance.
+- :func:`get_counter` — resolve a token-counting backend.
+
+Example:
+-------
+    >>> from all2md import to_ast
+    >>> from all2md.chunking import chunk_ast
+    >>> doc = to_ast("README.md")
+    >>> chunks = chunk_ast(doc, strategy="semantic", max_tokens=256, overlap=32)
+    >>> chunks[0].section_heading, chunks[0].token_count  # doctest: +SKIP
+
+"""
+
+from all2md.chunking.provenance import STRATEGIES, chunk_ast
+from all2md.chunking.records import ProvenanceChunk
+from all2md.chunking.tokenization import TokenCounter, get_counter
+
+__all__ = ["chunk_ast", "STRATEGIES", "ProvenanceChunk", "TokenCounter", "get_counter"]

--- a/src/all2md/chunking/primitives.py
+++ b/src/all2md/chunking/primitives.py
@@ -1,0 +1,967 @@
+#  Copyright (c) 2025 Tom Villani, Ph.D.
+#
+# src/all2md/chunking/primitives.py
+"""Position-tracking text chunkers.
+
+These chunkers split raw text into windows bounded by a token budget, tracking
+each window's exact character and line/column span so the original document can
+be reconstructed or highlighted. They are format-agnostic and operate on plain
+strings; the AST bridge in :mod:`all2md.chunking.provenance` runs them within
+section boundaries and attaches document provenance.
+
+Ported from the ``localvectordb`` sister project (same author) and adapted to
+inject an :class:`~all2md.chunking.tokenization.TokenCounter` rather than
+constructing a ``tiktoken`` encoder directly, so count-only strategies work
+without ``tiktoken`` installed.
+
+Classes
+-------
+PositionTrackingChunker : Abstract base with position + token-limit machinery
+SentenceChunker, TokenChunker, WordChunker, LineChunker, CharChunker,
+ParagraphChunker, SectionChunker, CodeBlockChunker : Concrete strategies
+ChunkerFactory : Name -> chunker construction
+
+Functions
+---------
+reconstruct_document : Reassemble original text from its chunks
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
+from typing import Any, Dict, List, Optional, Tuple, Type, Union
+
+from all2md.chunking.tokenization import TokenCounter
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class ChunkPosition:
+    """Exact position of a chunk within the text it was split from.
+
+    ``start``/``end`` are character offsets; ``line``/``column`` and
+    ``end_line``/``end_column`` are 1-based.
+    """
+
+    start: int
+    end: int
+    line: int
+    column: int
+    end_line: int
+    end_column: int
+
+
+@dataclass
+class TextChunk:
+    """A position-tracked text window produced by a chunker."""
+
+    content: str
+    position: ChunkPosition
+    tokens: int
+    index: int
+
+
+class PositionTrackingChunker(ABC):
+    """Base class for chunkers that track exact positions.
+
+    Parameters
+    ----------
+    max_tokens : int
+        Maximum tokens per chunk.
+    overlap : int
+        Strategy-specific overlap (units depend on the concrete chunker).
+    counter : TokenCounter
+        Backend used to count tokens. Token-boundary chunkers additionally
+        require ``counter.encoding`` (a ``tiktoken`` encoding).
+
+    """
+
+    def __init__(self, max_tokens: int = 500, overlap: int = 0, *, counter: TokenCounter) -> None:
+        """Store the token budget, overlap, and counter for this chunker."""
+        self.max_tokens = max_tokens
+        self.overlap = overlap
+        self.counter = counter
+
+    @abstractmethod
+    def chunk(self, text: str) -> List[TextChunk]:
+        """Split ``text`` into position-tracked chunks."""
+        ...
+
+    def count_tokens(self, text: str) -> int:
+        """Count tokens in ``text`` using the injected counter."""
+        return self.counter.count(text)
+
+    def _calculate_line_column(self, text: str, position: int) -> Tuple[int, int]:
+        """Calculate 1-based line and column for a character position."""
+        if position > len(text):
+            position = len(text)
+
+        before = text[:position]
+        lines = before.split("\n")
+        line = len(lines)
+
+        last_line = lines[-1]
+        column = len(last_line) + 1 if last_line else 1
+        return line, column
+
+    def _create_chunk(self, text: str, start: int, end: int, index: int) -> TextChunk:
+        """Create a chunk with position tracking."""
+        content = text[start:end]
+        line, column = self._calculate_line_column(text, start)
+        end_line, end_column = self._calculate_line_column(text, end)
+
+        position = ChunkPosition(
+            start=start, end=end, line=line, column=column, end_line=end_line, end_column=end_column
+        )
+        return TextChunk(content=content, position=position, tokens=self.count_tokens(content), index=index)
+
+    def _ensure_chunks_within_limit(self, chunks: List[TextChunk], text: str) -> List[TextChunk]:
+        """Split any oversized chunk with :class:`CharChunker`, then renumber."""
+        result: List[TextChunk] = []
+        for chunk in chunks:
+            if chunk.tokens <= self.max_tokens:
+                result.append(chunk)
+                continue
+
+            logger.warning(
+                "Chunk %d exceeds max_tokens (%d > %d). Splitting with CharChunker.",
+                chunk.index,
+                chunk.tokens,
+                self.max_tokens,
+            )
+            char_chunker = CharChunker(self.max_tokens, overlap=0, counter=self.counter)
+            sub_chunks = char_chunker.chunk(chunk.content)
+
+            base_start = chunk.position.start
+            base_index = chunk.index
+            for i, sub_chunk in enumerate(sub_chunks):
+                new_start = base_start + sub_chunk.position.start
+                new_end = base_start + sub_chunk.position.end
+                line, column = self._calculate_line_column(text, new_start)
+                end_line, end_column = self._calculate_line_column(text, new_end)
+                sub_chunk.position = ChunkPosition(
+                    start=new_start, end=new_end, line=line, column=column, end_line=end_line, end_column=end_column
+                )
+                sub_chunk.index = base_index + i
+            result.extend(sub_chunks)
+
+        for i, chunk in enumerate(result):
+            chunk.index = i
+        return result
+
+
+class SentenceChunker(PositionTrackingChunker):
+    """Chunk by sentences while preserving boundaries."""
+
+    sentence_pattern = re.compile(r'(?<=[.!?])\s+|(?<=[.!?]")(?=\s+[A-Z])|(?<=[.!?])\n+', re.MULTILINE)
+
+    def chunk(self, text: str) -> List[TextChunk]:
+        """Split ``text`` by sentences, packing up to the token budget."""
+        if not text.strip():
+            return []
+
+        sentences = self._split_into_sentences(text)
+        if not sentences:
+            return [self._create_chunk(text, 0, len(text), 0)]
+
+        # Fast path: the whole sentence span fits in one chunk.
+        single = self._create_chunk(text, sentences[0][0], sentences[-1][1], 0)
+        if single.tokens <= self.max_tokens:
+            return [single]
+
+        # Pre-count once; the overlap rewind below can revisit sentences.
+        sentence_token_counts = [self.count_tokens(s[2]) for s in sentences]
+
+        chunks: List[TextChunk] = []
+        chunk_index = 0
+        i = 0
+
+        while i < len(sentences):
+            chunk_sentences: list[tuple[int, int, str]] = []
+            chunk_tokens = 0
+            start_idx = i
+
+            while i < len(sentences):
+                sentence_start, sentence_end, sentence_text = sentences[i]
+                sentence_tokens = sentence_token_counts[i]
+
+                if sentence_tokens > self.max_tokens and not chunk_sentences:
+                    word_chunks = self._split_sentence_by_words(text, sentence_start, sentence_end, chunk_index)
+                    chunks.extend(word_chunks)
+                    chunk_index += len(word_chunks)
+                    i += 1
+                    break
+
+                if chunk_tokens + sentence_tokens > self.max_tokens and chunk_sentences:
+                    break
+
+                chunk_sentences.append((sentence_start, sentence_end, sentence_text))
+                chunk_tokens += sentence_tokens
+                i += 1
+
+            if chunk_sentences:
+                start_pos = chunk_sentences[0][0]
+                end_pos = chunk_sentences[-1][1]
+                chunks.append(self._create_chunk(text, start_pos, end_pos, chunk_index))
+                chunk_index += 1
+
+                if self.overlap > 0 and i < len(sentences):
+                    sentences_processed = i - start_idx
+                    overlap_count = min(self.overlap, sentences_processed - 1)
+                    i = start_idx + max(1, sentences_processed - overlap_count)
+
+        return self._ensure_chunks_within_limit(chunks, text)
+
+    def _split_into_sentences(self, text: str) -> List[Tuple[int, int, str]]:
+        """Split text into ``(start, end, text)`` sentence tuples."""
+        sentences = []
+        last_end = 0
+        for match in self.sentence_pattern.finditer(text):
+            start = last_end
+            end = match.start()
+            if start < end:
+                sentence_text = text[start:end].strip()
+                if sentence_text:
+                    sentences.append((start, end, sentence_text))
+            last_end = match.end()
+        if last_end < len(text):
+            final_text = text[last_end:].strip()
+            if final_text:
+                sentences.append((last_end, len(text), final_text))
+        return sentences
+
+    def _split_sentence_by_words(self, text: str, start: int, end: int, base_index: int) -> List[TextChunk]:
+        """Split a single over-long sentence by words."""
+        sentence_text = text[start:end]
+        word_pattern = re.compile(r"\S+")
+        words = [(start + m.start(), start + m.end(), m.group()) for m in word_pattern.finditer(sentence_text)]
+        if not words:
+            return [self._create_chunk(text, start, end, base_index)]
+
+        chunks: List[TextChunk] = []
+        chunk_index = base_index
+        i = 0
+        while i < len(words):
+            chunk_words: list[tuple[int, int, str]] = []
+            while i < len(words):
+                word_start, word_end, word_text = words[i]
+                test_start = chunk_words[0][0] if chunk_words else word_start
+                test_end = words[i + 1][0] if i + 1 < len(words) else end
+                test_tokens = self.count_tokens(text[test_start:test_end])
+                if test_tokens > self.max_tokens and chunk_words:
+                    break
+                chunk_words.append((word_start, word_end, word_text))
+                i += 1
+            if chunk_words:
+                chunk_start = chunk_words[0][0]
+                chunk_end = words[i][0] if i < len(words) else end
+                chunks.append(self._create_chunk(text, chunk_start, chunk_end, chunk_index))
+                chunk_index += 1
+        return chunks
+
+
+class TokenChunker(PositionTrackingChunker):
+    """Chunk on token boundaries with position tracking.
+
+    Requires ``counter.encoding`` (a ``tiktoken`` encoding) for the
+    ``encode``/``decode`` round-trip.
+    """
+
+    def __init__(self, max_tokens: int = 500, overlap: int = 0, *, counter: TokenCounter) -> None:
+        """Require a tiktoken-backed counter and cache its encoding."""
+        super().__init__(max_tokens, overlap, counter=counter)
+        encoding = getattr(counter, "encoding", None)
+        if encoding is None:
+            raise ValueError(
+                "TokenChunker requires a tiktoken-backed token counter; "
+                "use --token-counter tiktoken (pip install all2md[chunk])."
+            )
+        self.encoding = encoding
+
+    def chunk(self, text: str) -> List[TextChunk]:
+        """Split ``text`` by token boundaries with sliding overlap."""
+        if not text.strip():
+            return []
+
+        tokens = self.encoding.encode(text)
+        if len(tokens) <= self.max_tokens:
+            return [self._create_chunk(text, 0, len(text), 0)]
+
+        chunks: List[TextChunk] = []
+        chunk_index = 0
+        stride = max(1, self.max_tokens - self.overlap)
+
+        for i in range(0, len(tokens), stride):
+            chunk_tokens = tokens[i : i + self.max_tokens]
+            chunk_text = self.encoding.decode(chunk_tokens)
+            start_pos = self._estimate_position(text, tokens, i)
+            end_pos = min(start_pos + len(chunk_text), len(text))
+            chunks.append(self._create_chunk(text, start_pos, end_pos, chunk_index))
+            chunk_index += 1
+            if end_pos >= len(text):
+                break
+
+        return self._ensure_chunks_within_limit(chunks, text)
+
+    def _estimate_position(self, text: str, all_tokens: List[int], token_index: int) -> int:
+        """Estimate a character position from a token index via decode length."""
+        if token_index == 0:
+            return 0
+        prefix_text = self.encoding.decode(all_tokens[:token_index])
+        return min(len(prefix_text), len(text))
+
+
+class WordChunker(PositionTrackingChunker):
+    """Chunk by word boundaries while preserving whitespace."""
+
+    def chunk(self, text: str) -> List[TextChunk]:
+        """Split ``text`` by words, packing up to the token budget."""
+        if not text.strip():
+            return []
+
+        word_pattern = re.compile(r"\S+")
+        words = [(m.start(), m.end(), m.group()) for m in word_pattern.finditer(text)]
+        if not words:
+            return [self._create_chunk(text, 0, len(text), 0)]
+
+        chunks: List[TextChunk] = []
+        chunk_index = 0
+        i = 0
+        while i < len(words):
+            chunk_words: list[tuple[int, int, str]] = []
+            start_idx = i
+            while i < len(words):
+                word_start, word_end, word_text = words[i]
+                test_start = chunk_words[0][0] if chunk_words else word_start
+                test_end = words[i + 1][0] if i + 1 < len(words) else len(text)
+                if self.count_tokens(text[test_start:test_end]) > self.max_tokens and chunk_words:
+                    break
+                chunk_words.append((word_start, word_end, word_text))
+                i += 1
+            if chunk_words:
+                start_pos = chunk_words[0][0]
+                end_pos = words[i][0] if i < len(words) else len(text)
+                chunks.append(self._create_chunk(text, start_pos, end_pos, chunk_index))
+                chunk_index += 1
+                if self.overlap > 0 and i < len(words):
+                    words_processed = i - start_idx
+                    overlap_count = min(self.overlap, words_processed - 1)
+                    i = start_idx + max(1, words_processed - overlap_count)
+
+        return self._ensure_chunks_within_limit(chunks, text)
+
+
+class LineChunker(PositionTrackingChunker):
+    """Chunk by line boundaries."""
+
+    def chunk(self, text: str) -> List[TextChunk]:
+        """Split ``text`` by lines, packing up to the token budget."""
+        if not text.strip():
+            return []
+
+        lines = text.splitlines(keepends=True)
+        line_positions = []
+        current_pos = 0
+        for line in lines:
+            line_positions.append((current_pos, current_pos + len(line), line))
+            current_pos += len(line)
+        if not line_positions:
+            return [self._create_chunk(text, 0, len(text), 0)]
+
+        chunks: List[TextChunk] = []
+        chunk_index = 0
+        i = 0
+        while i < len(line_positions):
+            chunk_lines: list[tuple[int, int, str]] = []
+            chunk_tokens = 0
+            start_idx = i
+            while i < len(line_positions):
+                line_start, line_end, line_text = line_positions[i]
+                line_tokens = self.count_tokens(line_text)
+                if line_tokens > self.max_tokens and not chunk_lines:
+                    word_chunks = self._split_line_by_words(text, line_start, line_end, chunk_index)
+                    chunks.extend(word_chunks)
+                    chunk_index += len(word_chunks)
+                    i += 1
+                    break
+                if chunk_tokens + line_tokens > self.max_tokens and chunk_lines:
+                    break
+                chunk_lines.append((line_start, line_end, line_text))
+                chunk_tokens += line_tokens
+                i += 1
+            if chunk_lines:
+                start_pos = chunk_lines[0][0]
+                end_pos = chunk_lines[-1][1]
+                chunks.append(self._create_chunk(text, start_pos, end_pos, chunk_index))
+                chunk_index += 1
+                if self.overlap > 0 and i < len(line_positions):
+                    lines_processed = i - start_idx
+                    overlap_count = min(self.overlap, lines_processed - 1)
+                    i = start_idx + max(1, lines_processed - overlap_count)
+
+        return self._ensure_chunks_within_limit(chunks, text)
+
+    def _split_line_by_words(self, text: str, start: int, end: int, base_index: int) -> List[TextChunk]:
+        """Split an over-long line by words, rebasing positions to ``text``."""
+        line_text = text[start:end]
+        word_chunker = WordChunker(self.max_tokens, self.overlap, counter=self.counter)
+        word_chunks = word_chunker.chunk(line_text)
+        for chunk in word_chunks:
+            chunk.position.start += start
+            chunk.position.end += start
+            chunk.index = base_index
+            base_index += 1
+        return word_chunks
+
+
+class CharChunker(PositionTrackingChunker):
+    """Chunk by character boundaries with exact position tracking."""
+
+    def chunk(self, text: str) -> List[TextChunk]:
+        """Grow chunks character-by-character up to the token budget."""
+        if not text.strip():
+            return []
+
+        chunks: List[TextChunk] = []
+        chunk_index = 0
+        start_pos = 0
+        while start_pos < len(text):
+            end_pos = start_pos
+            current_chunk = ""
+            while end_pos < len(text):
+                test_chunk = current_chunk + text[end_pos]
+                if self.count_tokens(test_chunk) > self.max_tokens and current_chunk:
+                    break
+                current_chunk = test_chunk
+                end_pos += 1
+            if end_pos == start_pos:
+                end_pos = start_pos + 1
+            chunks.append(self._create_chunk(text, start_pos, end_pos, chunk_index))
+            chunk_index += 1
+            if end_pos >= len(text):
+                break
+            chunk_length = end_pos - start_pos
+            start_pos += max(1, chunk_length - self.overlap)
+
+        return chunks
+
+
+class ParagraphChunker(PositionTrackingChunker):
+    """Chunk by paragraph (blank-line) boundaries."""
+
+    paragraph_pattern = re.compile(r"\n\s*\n", re.MULTILINE)
+
+    def chunk(self, text: str) -> List[TextChunk]:
+        """Split ``text`` by paragraphs, packing up to the token budget."""
+        if not text.strip():
+            return []
+
+        paragraphs = self._split_into_paragraphs(text)
+        if not paragraphs:
+            return [self._create_chunk(text, 0, len(text), 0)]
+
+        chunks: List[TextChunk] = []
+        chunk_index = 0
+        i = 0
+        while i < len(paragraphs):
+            chunk_paragraphs: list[tuple[int, int, str]] = []
+            chunk_tokens = 0
+            start_idx = i
+            while i < len(paragraphs):
+                para_start, para_end, para_text = paragraphs[i]
+                para_tokens = self.count_tokens(para_text)
+                if para_tokens > self.max_tokens and not chunk_paragraphs:
+                    sentence_chunks = self._split_paragraph_by_sentences(text, para_start, para_end, chunk_index)
+                    chunks.extend(sentence_chunks)
+                    chunk_index += len(sentence_chunks)
+                    i += 1
+                    break
+                if chunk_tokens + para_tokens > self.max_tokens and chunk_paragraphs:
+                    break
+                chunk_paragraphs.append((para_start, para_end, para_text))
+                chunk_tokens += para_tokens
+                i += 1
+            if chunk_paragraphs:
+                start_pos = chunk_paragraphs[0][0]
+                end_pos = chunk_paragraphs[-1][1]
+                chunks.append(self._create_chunk(text, start_pos, end_pos, chunk_index))
+                chunk_index += 1
+                if self.overlap > 0 and i < len(paragraphs):
+                    paragraphs_processed = i - start_idx
+                    overlap_count = min(self.overlap, paragraphs_processed - 1)
+                    i = start_idx + max(1, paragraphs_processed - overlap_count)
+
+        return self._ensure_chunks_within_limit(chunks, text)
+
+    def _split_into_paragraphs(self, text: str) -> List[Tuple[int, int, str]]:
+        """Split text into ``(start, end, text)`` paragraph tuples."""
+        paragraphs = []
+        last_end = 0
+        for match in self.paragraph_pattern.finditer(text):
+            start = last_end
+            end = match.start()
+            if start < end:
+                para_text = text[start:end].strip()
+                if para_text:
+                    paragraphs.append((start, end, para_text))
+            last_end = match.end()
+        if last_end < len(text):
+            final_text = text[last_end:].strip()
+            if final_text:
+                paragraphs.append((last_end, len(text), final_text))
+        return paragraphs
+
+    def _split_paragraph_by_sentences(self, text: str, start: int, end: int, base_index: int) -> List[TextChunk]:
+        """Split an over-long paragraph by sentences, rebasing positions."""
+        para_text = text[start:end]
+        sentence_chunker = SentenceChunker(self.max_tokens, self.overlap, counter=self.counter)
+        sentence_chunks = sentence_chunker.chunk(para_text)
+        for chunk in sentence_chunks:
+            chunk.position.start += start
+            chunk.position.end += start
+            chunk.index = base_index
+            base_index += 1
+        return sentence_chunks
+
+
+class SectionChunker(PositionTrackingChunker):
+    """Chunk by markdown-style section headers, avoiding orphaned headings."""
+
+    header_pattern = re.compile(r"^(#{1,6})\s+(.+)$", re.MULTILINE)
+
+    def __init__(self, max_tokens: int = 500, overlap: int = 0, *, counter: TokenCounter) -> None:
+        """Construct a section chunker; ``overlap`` must be 0 (sections are logical units)."""
+        if overlap != 0:
+            raise ValueError("`overlap` must be 0 for SectionChunker")
+        super().__init__(max_tokens, 0, counter=counter)
+
+    def chunk(self, text: str) -> List[TextChunk]:
+        """Split ``text`` at header boundaries, keeping whole sections when they fit."""
+        if not text.strip():
+            return []
+
+        headers = list(self.header_pattern.finditer(text))
+        header_positions = {h.start() for h in headers}
+
+        if not headers:
+            if self.count_tokens(text) <= self.max_tokens:
+                return [self._create_chunk(text, 0, len(text), 0)]
+            return ParagraphChunker(self.max_tokens, 0, counter=self.counter).chunk(text)
+
+        chunks: List[TextChunk] = []
+        chunk_index = 0
+        current_pos = 0
+
+        while current_pos < len(text):
+            chunk_start = current_pos
+            chunk_end = current_pos
+            chunk_tokens = 0
+            last_good_break = current_pos
+
+            while chunk_end < len(text):
+                next_newline = text.find("\n", chunk_end + 1)
+                next_break = len(text) if next_newline == -1 else next_newline + 1
+
+                test_tokens = self.count_tokens(text[chunk_start:next_break])
+                if test_tokens > self.max_tokens:
+                    if chunk_tokens == 0:
+                        chunk_end = self._break_oversized_segment(
+                            text, chunk_start, chunk_end, next_break, header_positions
+                        )
+                    elif chunk_end in header_positions and last_good_break > chunk_start:
+                        chunk_end = last_good_break
+                    else:
+                        chunk_end = last_good_break
+                    break
+
+                chunk_tokens = test_tokens
+                last_good_break = next_break
+                chunk_end = next_break
+
+                if chunk_end in header_positions:
+                    next_header_pos = next((h.start() for h in headers if h.start() > chunk_end), len(text))
+                    section_text = text[chunk_end:next_header_pos]
+                    if chunk_tokens + self.count_tokens(section_text) <= self.max_tokens:
+                        chunk_end = next_header_pos
+                        chunk_tokens = self.count_tokens(text[chunk_start:chunk_end])
+                    else:
+                        break
+
+            if chunk_end > chunk_start:
+                chunks.append(self._create_chunk(text, chunk_start, chunk_end, chunk_index))
+                chunk_index += 1
+                current_pos = chunk_end
+            else:
+                current_pos = min(current_pos + 1, len(text))
+
+        return self._ensure_chunks_within_limit(chunks, text)
+
+    def _break_oversized_segment(
+        self, text: str, chunk_start: int, chunk_end: int, next_break: int, header_positions: set[int]
+    ) -> int:
+        """Find a break point inside a first segment that already exceeds the budget."""
+        if chunk_end in header_positions:
+            header_end_nl = text.find("\n", chunk_end)
+            header_end = len(text) if header_end_nl == -1 else header_end_nl + 1
+            search_start = header_end
+            new_end = chunk_start
+            while search_start < len(text):
+                search_end_nl = text.find("\n", search_start)
+                search_end = len(text) if search_end_nl == -1 else search_end_nl + 1
+                if self.count_tokens(text[chunk_start:search_end]) <= self.max_tokens:
+                    new_end = search_end
+                    search_start = search_end
+                else:
+                    break
+            return new_end if new_end != chunk_start else header_end
+
+        words = text[chunk_start:next_break].split()
+        accumulated: list[str] = []
+        for word in words:
+            accumulated.append(word)
+            if self.count_tokens(" ".join(accumulated)) > self.max_tokens:
+                accumulated.pop()
+                break
+        if accumulated:
+            return chunk_start + len(" ".join(accumulated))
+        return next_break
+
+
+class CodeBlockChunker(PositionTrackingChunker):
+    """Chunk code while preserving logical (function/class/bracket) blocks."""
+
+    def __init__(
+        self, max_tokens: int = 500, overlap: int = 0, *, counter: TokenCounter, language: Optional[str] = None
+    ) -> None:
+        """Construct a code chunker, optionally pinning the language (else auto-detected)."""
+        super().__init__(max_tokens, overlap, counter=counter)
+        self.language = language
+
+    def chunk(self, text: str) -> List[TextChunk]:
+        """Split code into chunks that respect detected block boundaries."""
+        if not text.strip():
+            return []
+        if self.count_tokens(text) <= self.max_tokens:
+            return [self._create_chunk(text, 0, len(text), 0)]
+
+        if not self.language:
+            self.language = self._detect_language(text)
+
+        lines = text.splitlines()
+        start_patterns, end_patterns = self._get_language_patterns(self.language)
+        blocks = self._identify_code_blocks(lines, self.language, start_patterns, end_patterns)
+        chunks = self._create_chunks_from_blocks(text, lines, blocks)
+        return self._ensure_chunks_within_limit(chunks, text)
+
+    def _detect_language(self, text: str) -> str:
+        """Heuristically detect the programming language from a sample."""
+        sample = text[:1000]
+        signatures: Dict[str, Dict[str, List[str]]] = {
+            "python": {
+                "patterns": [
+                    r"^\s*def\s+\w+\s*\(.*\):",
+                    r"^\s*class\s+\w+(\s*\(.*\))?:",
+                    r"^\s*import\s+\w+",
+                    r"^\s*from\s+[\w\.]+\s+import",
+                    r"^\s*@\w+",
+                ],
+                "keywords": ["def", "class", "import", "from", "with", "as", "if", "elif", "else", "for", "while"],
+            },
+            "javascript": {
+                "patterns": [
+                    r"function\s+\w+\s*\(.*\)\s*{",
+                    r"const\s+\w+\s*=",
+                    r"let\s+\w+\s*=",
+                    r"var\s+\w+\s*=",
+                    r"import\s+.*\s+from",
+                    r"=>",
+                ],
+                "keywords": ["function", "const", "let", "var", "import", "export", "class", "return"],
+            },
+            "java": {
+                "patterns": [
+                    r"public\s+class",
+                    r"private\s+\w+[\s\w]*\(.*\)\s*{",
+                    r"protected\s+\w+[\s\w]*\(.*\)\s*{",
+                    r"import\s+[\w\.]+;",
+                ],
+                "keywords": ["public", "private", "protected", "class", "interface", "extends", "implements"],
+            },
+            "generic": {"patterns": [], "keywords": []},
+        }
+
+        scores = dict.fromkeys(signatures, 0)
+        for lang, sig in signatures.items():
+            for pattern in sig["patterns"]:
+                scores[lang] += len(re.findall(pattern, sample, re.MULTILINE)) * 2
+            for keyword in sig.get("keywords", []):
+                scores[lang] += len(re.findall(r"\b" + keyword + r"\b", sample))
+
+        if "    " in sample and "{" not in sample[:100]:
+            scores["python"] += 5
+        if "{" in sample and "}" in sample:
+            for lang in ("javascript", "java"):
+                scores[lang] += 2
+
+        best_lang = max(scores.items(), key=lambda x: x[1])
+        return "generic" if best_lang[1] < 3 else best_lang[0]
+
+    def _get_language_patterns(self, language: str) -> Tuple[List[str], List[str]]:
+        """Return ``(start_patterns, end_patterns)`` for ``language``."""
+        patterns = {
+            "python": {
+                "starts": [
+                    r"^\s*def\s+\w+\s*\(.*\):",
+                    r"^\s*class\s+\w+(\s*\(.*\))?:",
+                    r"^\s*if\s+.*:",
+                    r"^\s*while\s+.*:",
+                    r"^\s*for\s+.*:",
+                    r"^\s*try:",
+                    r"^\s*except.*:",
+                    r"^\s*with.*:",
+                ],
+                "ends": [],
+            },
+            "javascript": {
+                "starts": [
+                    r"function\s+\w+\s*\(.*\)\s*{",
+                    r"class\s+\w+(\s+extends\s+\w+)?\s*{",
+                    r"if\s*\(.*\)\s*{",
+                    r"for\s*\(.*\)\s*{",
+                    r"while\s*\(.*\)\s*{",
+                ],
+                "ends": [r"^(\s*)\}"],
+            },
+            "java": {
+                "starts": [
+                    r"(public|private|protected)?\s*\w+(\s+\w+)?\s*\(.*\)\s*{",
+                    r"class\s+\w+(\s+extends\s+\w+)?(\s+implements\s+[\w,\s]+)?\s*{",
+                    r"interface\s+\w+\s*{",
+                    r"if\s*\(.*\)\s*{",
+                    r"for\s*\(.*\)\s*{",
+                    r"while\s*\(.*\)\s*{",
+                ],
+                "ends": [r"^(\s*)\}"],
+            },
+            "generic": {
+                "starts": [
+                    r"^\s*\w+\s*\(.*\)\s*{",
+                    r"^\s*class\s+\w+\s*{",
+                    r"^\s*if\s*\(.*\)\s*{",
+                    r"^\s*for\s*\(.*\)\s*{",
+                    r"^\s*while\s*\(.*\)\s*{",
+                ],
+                "ends": [r"^(\s*)\}", r"^(\s*)end"],
+            },
+        }
+        lang_patterns = patterns.get(language, patterns["generic"])
+        return lang_patterns["starts"], lang_patterns["ends"]
+
+    @staticmethod
+    def _identify_code_blocks(
+        lines: List[str], language: str, start_patterns: List[str], end_patterns: List[str]
+    ) -> List[Dict[str, Any]]:
+        """Identify code blocks via indentation (Python) or bracket depth."""
+        blocks: List[Dict[str, Any]] = []
+        i = 0
+
+        if language == "python":
+            while i < len(lines):
+                block_start = None
+                for pattern in start_patterns:
+                    if re.match(pattern, lines[i]):
+                        block_start = i
+                        break
+                if block_start is not None:
+                    indent_match = re.match(r"^(\s*)", lines[i])
+                    start_indent = indent_match.group(1) if indent_match else ""
+                    j = i + 1
+                    while j < len(lines):
+                        if not lines[j].strip() or lines[j].strip().startswith("#"):
+                            j += 1
+                            continue
+                        indent_match = re.match(r"^(\s*)", lines[j])
+                        current_indent = indent_match.group(1) if indent_match else ""
+                        if len(current_indent) <= len(start_indent) and j > i + 1:
+                            blocks.append({"start": block_start, "end": j - 1, "type": "block"})
+                            i = j - 1
+                            break
+                        j += 1
+                    if j == len(lines):
+                        blocks.append({"start": block_start, "end": j - 1, "type": "block"})
+                        i = j - 1
+                i += 1
+        else:
+            bracket_stack: list[int] = []
+            while i < len(lines):
+                line = lines[i]
+                opening_brackets = line.count("{")
+                closing_brackets = line.count("}")
+                is_block_start = False
+                for pattern in start_patterns:
+                    if re.search(pattern, line):
+                        is_block_start = True
+                        if not bracket_stack:
+                            blocks.append({"start": i, "end": None, "bracket_depth": 1, "type": "block"})
+                            bracket_stack.append(len(blocks) - 1)
+                        break
+                if opening_brackets > 0 and not is_block_start:
+                    if not bracket_stack:
+                        blocks.append({"start": i, "end": None, "bracket_depth": opening_brackets, "type": "block"})
+                        bracket_stack.append(len(blocks) - 1)
+                    else:
+                        blocks[bracket_stack[-1]]["bracket_depth"] += opening_brackets
+                if closing_brackets > 0 and bracket_stack:
+                    block_idx = bracket_stack[-1]
+                    blocks[block_idx]["bracket_depth"] -= closing_brackets
+                    if blocks[block_idx]["bracket_depth"] <= 0:
+                        blocks[block_idx]["end"] = i
+                        bracket_stack.pop()
+                i += 1
+            for block_idx in bracket_stack:
+                if blocks[block_idx]["end"] is None:
+                    blocks[block_idx]["end"] = len(lines) - 1
+
+        covered_lines = set()
+        for block in blocks:
+            for j in range(block["start"], block["end"] + 1):
+                covered_lines.add(j)
+        i = 0
+        while i < len(lines):
+            if i not in covered_lines:
+                start = i
+                while i < len(lines) and i not in covered_lines:
+                    i += 1
+                if any(line.strip() for line in lines[start:i]):
+                    blocks.append({"start": start, "end": i - 1, "type": "non-block"})
+                continue
+            i += 1
+
+        blocks.sort(key=lambda x: x["start"])
+        return blocks
+
+    def _create_chunks_from_blocks(self, text: str, lines: List[str], blocks: List[Dict[str, Any]]) -> List[TextChunk]:
+        """Pack identified blocks into chunks under the token budget."""
+        if not blocks:
+            return []
+
+        chunks: List[TextChunk] = []
+        chunk_index = 0
+        current_chunk_lines: list[Dict[str, Any]] = []
+        current_tokens = 0
+
+        line_positions = []
+        current_pos = 0
+        for line in lines:
+            line_positions.append(current_pos)
+            current_pos += len(line) + 1
+
+        def _finalize(chunk_lines: list[Dict[str, Any]], index: int) -> TextChunk:
+            start_pos = line_positions[chunk_lines[0]["line_idx"]]
+            end_pos = line_positions[chunk_lines[-1]["line_idx"]] + len(chunk_lines[-1]["line"])
+            return self._create_chunk(text, start_pos, end_pos, index)
+
+        for block in blocks:
+            block_lines = lines[block["start"] : block["end"] + 1]
+            block_text = "\n".join(block_lines)
+            block_tokens = self.count_tokens(block_text)
+
+            if block_tokens > self.max_tokens:
+                if current_chunk_lines:
+                    chunks.append(_finalize(current_chunk_lines, chunk_index))
+                    chunk_index += 1
+                    current_chunk_lines = []
+                    current_tokens = 0
+                block_start_pos = line_positions[block["start"]]
+                block_end_pos = line_positions[block["end"]] + len(lines[block["end"]])
+                large_block_text = text[block_start_pos:block_end_pos]
+                line_chunker = LineChunker(self.max_tokens, self.overlap, counter=self.counter)
+                for line_chunk in line_chunker.chunk(large_block_text):
+                    chunk_start = block_start_pos + large_block_text.index(line_chunk.content)
+                    chunk_end = chunk_start + len(line_chunk.content)
+                    chunks.append(self._create_chunk(text, chunk_start, chunk_end, chunk_index))
+                    chunk_index += 1
+                continue
+
+            if current_tokens + block_tokens > self.max_tokens and current_chunk_lines:
+                chunks.append(_finalize(current_chunk_lines, chunk_index))
+                chunk_index += 1
+                if self.overlap > 0 and current_chunk_lines:
+                    overlap_lines = min(self.overlap, len(current_chunk_lines))
+                    current_chunk_lines = current_chunk_lines[-overlap_lines:]
+                    current_tokens = self.count_tokens("\n".join(ln["line"] for ln in current_chunk_lines))
+                else:
+                    current_chunk_lines = []
+                    current_tokens = 0
+
+            for offset, line in enumerate(block_lines):
+                current_chunk_lines.append({"line": line, "line_idx": block["start"] + offset})
+            current_tokens = self.count_tokens("\n".join(ln["line"] for ln in current_chunk_lines))
+
+        if current_chunk_lines:
+            chunks.append(_finalize(current_chunk_lines, chunk_index))
+
+        return [chunk for chunk in chunks if chunk.content.strip()]
+
+
+class ChunkerFactory:
+    """Construct chunkers by name."""
+
+    CHUNKERS: dict[str, Type[PositionTrackingChunker]] = {
+        "sentences": SentenceChunker,
+        "tokens": TokenChunker,
+        "words": WordChunker,
+        "lines": LineChunker,
+        "characters": CharChunker,
+        "paragraphs": ParagraphChunker,
+        "sections": SectionChunker,
+        "code-blocks": CodeBlockChunker,
+    }
+
+    @classmethod
+    def create_chunker(
+        cls,
+        method: Union[str, Type[PositionTrackingChunker]],
+        max_tokens: int = 500,
+        overlap: int = 0,
+        *,
+        counter: TokenCounter,
+        **kwargs: Any,
+    ) -> PositionTrackingChunker:
+        """Create a chunker instance for ``method`` with the given counter."""
+        if isinstance(method, type) and issubclass(method, PositionTrackingChunker):
+            return method(max_tokens, overlap=overlap, counter=counter, **kwargs)
+        if not isinstance(method, str):
+            raise TypeError(f"`method` must be str or PositionTrackingChunker, found: {type(method)}")
+        if method not in cls.CHUNKERS:
+            raise ValueError(f"Unknown chunking method: {method}. Available: {', '.join(cls.CHUNKERS)}")
+        if not isinstance(max_tokens, int) or max_tokens <= 0:
+            raise ValueError(f"`max_tokens` must be a positive integer, found: {max_tokens}")
+
+        chunker_class = cls.CHUNKERS[method]
+        if method == "sections":
+            return chunker_class(max_tokens, overlap=0, counter=counter, **kwargs)
+        return chunker_class(max_tokens, overlap=overlap, counter=counter, **kwargs)
+
+    @classmethod
+    def list_methods(cls) -> List[str]:
+        """List available chunking method names."""
+        return list(cls.CHUNKERS.keys())
+
+
+def reconstruct_document(chunks: List[TextChunk], original_length: int) -> str:
+    """Reassemble the original text from non-overlapping ``chunks``."""
+    if not chunks:
+        return ""
+    sorted_chunks = sorted(chunks, key=lambda c: c.position.start)
+    result = [""] * original_length
+    for chunk in sorted_chunks:
+        start = chunk.position.start
+        end = min(chunk.position.end, original_length)
+        if start < original_length:
+            result[start:end] = list(chunk.content[: end - start])
+    return "".join(result)

--- a/src/all2md/chunking/primitives.py
+++ b/src/all2md/chunking/primitives.py
@@ -89,7 +89,7 @@ class PositionTrackingChunker(ABC):
     @abstractmethod
     def chunk(self, text: str) -> List[TextChunk]:
         """Split ``text`` into position-tracked chunks."""
-        ...
+        raise NotImplementedError
 
     def count_tokens(self, text: str) -> int:
         """Count tokens in ``text`` using the injected counter."""
@@ -890,16 +890,15 @@ class CodeBlockChunker(PositionTrackingChunker):
             if current_tokens + block_tokens > self.max_tokens and current_chunk_lines:
                 chunks.append(_finalize(current_chunk_lines, chunk_index))
                 chunk_index += 1
-                if self.overlap > 0 and current_chunk_lines:
+                if self.overlap > 0:
                     overlap_lines = min(self.overlap, len(current_chunk_lines))
                     current_chunk_lines = current_chunk_lines[-overlap_lines:]
-                    current_tokens = self.count_tokens("\n".join(ln["line"] for ln in current_chunk_lines))
                 else:
                     current_chunk_lines = []
-                    current_tokens = 0
 
             for offset, line in enumerate(block_lines):
                 current_chunk_lines.append({"line": line, "line_idx": block["start"] + offset})
+            # Recomputed over the full window each time, so no need to track it above.
             current_tokens = self.count_tokens("\n".join(ln["line"] for ln in current_chunk_lines))
 
         if current_chunk_lines:

--- a/src/all2md/chunking/provenance.py
+++ b/src/all2md/chunking/provenance.py
@@ -109,6 +109,7 @@ def chunk_ast(
     avoid_table_split: bool = False,
     avoid_code_split: bool = False,
     elide_data_uris: bool = True,
+    min_tokens: int = 0,
     token_counter: str = "auto",
     counter: Optional[TokenCounter] = None,
 ) -> list[ProvenanceChunk]:
@@ -147,6 +148,9 @@ def chunk_ast(
         Replace long ``data:…;base64,…`` payloads in chunk text with a short
         placeholder (default True), so an embedded image never inflates token
         counts or shreds into base64 noise.
+    min_tokens : int
+        Drop chunks smaller than this many tokens (default 0, keep all). Filtering
+        happens after chunking; remaining chunks are re-indexed and re-linked.
     token_counter : {"auto", "tiktoken", "whitespace"}
         Token-counting backend (ignored when ``counter`` is provided).
     counter : TokenCounter, optional
@@ -200,7 +204,9 @@ def chunk_ast(
             opts=opts,
         )
 
-    _link_neighbors(chunks)
+    if min_tokens > 0:
+        chunks = [c for c in chunks if c.token_count >= min_tokens]
+    _finalize_sequence(chunks)
     return chunks
 
 
@@ -536,9 +542,14 @@ def _first_heading_level(nodes: list[Node]) -> Optional[int]:
     return None
 
 
-def _link_neighbors(chunks: list[ProvenanceChunk]) -> None:
-    """Populate ``prev_chunk_id``/``next_chunk_id`` across the sequence."""
+def _finalize_sequence(chunks: list[ProvenanceChunk]) -> None:
+    """Assign 0-based ``index`` and link ``prev``/``next`` ids across the sequence.
+
+    Idempotent for an unfiltered list (indices already match), and corrects the
+    numbering after ``min_tokens`` filtering removes chunks.
+    """
     for i, chunk in enumerate(chunks):
+        chunk.index = i
         chunk.prev_chunk_id = chunks[i - 1].chunk_id if i > 0 else None
         chunk.next_chunk_id = chunks[i + 1].chunk_id if i + 1 < len(chunks) else None
 

--- a/src/all2md/chunking/provenance.py
+++ b/src/all2md/chunking/provenance.py
@@ -27,9 +27,11 @@ not the original binary.
 
 from __future__ import annotations
 
+import re
+from dataclasses import dataclass
 from typing import Iterable, Optional, cast
 
-from all2md.ast.nodes import Document, Node, Table, get_node_children
+from all2md.ast.nodes import CodeBlock, Document, Node, Table, get_node_children
 from all2md.ast.sections import get_all_sections, get_preamble
 from all2md.ast.splitting import DocumentSplitter
 from all2md.chunking.primitives import ChunkerFactory, PositionTrackingChunker
@@ -66,6 +68,32 @@ STRATEGIES = (
     "auto",
 )
 
+#: A ``data:<mime>;base64,<payload>`` URI. The payload is elided when long.
+_DATA_URI_RE = re.compile(r"data:(?P<mime>[^,;)\s]*);base64,(?P<data>[A-Za-z0-9+/=]+)")
+
+#: Base64 payloads longer than this are elided (short ones are harmless and
+#: likely not real embedded assets).
+_DATA_URI_ELIDE_THRESHOLD = 64
+
+
+@dataclass(frozen=True)
+class _UnitOpts:
+    """Per-unit rendering/segmentation options threaded through the bridge.
+
+    Attributes
+    ----------
+    atomic_types : tuple of type
+        Node classes (e.g. ``Table``, ``CodeBlock``) emitted as their own
+        un-split chunk in the fine path. Empty disables segmentation.
+    elide_data_uris : bool
+        Replace long ``data:…;base64,…`` payloads with a short placeholder in
+        rendered Markdown so embedded blobs never pollute (or shred) chunks.
+
+    """
+
+    atomic_types: tuple[type, ...]
+    elide_data_uris: bool
+
 
 def chunk_ast(
     doc: Document,
@@ -79,6 +107,8 @@ def chunk_ast(
     heading_merge: bool = True,
     max_heading_level: Optional[int] = None,
     avoid_table_split: bool = False,
+    avoid_code_split: bool = False,
+    elide_data_uris: bool = True,
     token_counter: str = "auto",
     counter: Optional[TokenCounter] = None,
 ) -> list[ProvenanceChunk]:
@@ -110,6 +140,13 @@ def chunk_ast(
         For fine strategies, emit each table as its own atomic chunk so a table is
         never split mid-row (it may exceed ``max_tokens``). Coarse strategies never
         split tables regardless.
+    avoid_code_split : bool
+        Like ``avoid_table_split`` but for fenced code blocks: each code block is
+        emitted as one atomic chunk (may exceed ``max_tokens``).
+    elide_data_uris : bool
+        Replace long ``data:…;base64,…`` payloads in chunk text with a short
+        placeholder (default True), so an embedded image never inflates token
+        counts or shreds into base64 noise.
     token_counter : {"auto", "tiktoken", "whitespace"}
         Token-counting backend (ignored when ``counter`` is provided).
     counter : TokenCounter, optional
@@ -129,7 +166,14 @@ def chunk_ast(
     if counter is None:
         counter = get_counter(token_counter, strategy=strategy)
 
+    atomic_types: tuple[type, ...] = tuple(
+        cls for cls, on in ((Table, avoid_table_split), (CodeBlock, avoid_code_split)) if on
+    )
+
     if strategy in _COARSE_STRATEGIES:
+        # Coarse strategies emit one chunk per split, so no atomic segmentation is
+        # needed; data-URI elision still applies.
+        opts = _UnitOpts(atomic_types=(), elide_data_uris=elide_data_uris)
         chunks = _chunk_coarse(
             doc,
             strategy=strategy,
@@ -138,8 +182,10 @@ def chunk_ast(
             document_id=document_id,
             document_path=document_path,
             counter=counter,
+            opts=opts,
         )
     else:
+        opts = _UnitOpts(atomic_types=atomic_types, elide_data_uris=elide_data_uris)
         chunks = _chunk_fine(
             doc,
             strategy=strategy,
@@ -148,10 +194,10 @@ def chunk_ast(
             include_preamble=include_preamble,
             heading_merge=heading_merge,
             max_heading_level=max_heading_level,
-            avoid_table_split=avoid_table_split,
             document_id=document_id,
             document_path=document_path,
             counter=counter,
+            opts=opts,
         )
 
     _link_neighbors(chunks)
@@ -172,10 +218,10 @@ def _chunk_fine(
     include_preamble: bool,
     heading_merge: bool,
     max_heading_level: Optional[int],
-    avoid_table_split: bool,
     document_id: str,
     document_path: Optional[str],
     counter: TokenCounter,
+    opts: _UnitOpts,
 ) -> list[ProvenanceChunk]:
     method = _FINE_METHOD[strategy]
     chunker = ChunkerFactory.create_chunker(method, max_tokens, overlap, counter=counter)
@@ -201,7 +247,7 @@ def _chunk_fine(
             section_heading=None,
             section_level=None,
             section_index=-1,
-            avoid_table_split=avoid_table_split,
+            opts=opts,
         )
         return chunks
 
@@ -221,7 +267,7 @@ def _chunk_fine(
                 section_heading=None,
                 section_level=None,
                 section_index=-1,
-                avoid_table_split=avoid_table_split,
+                opts=opts,
             )
 
     for section_index, section in enumerate(sections, start=1):
@@ -240,7 +286,7 @@ def _chunk_fine(
             section_heading=section.get_heading_text() or None,
             section_level=section.level,
             section_index=section_index,
-            avoid_table_split=avoid_table_split,
+            opts=opts,
         )
 
     return chunks
@@ -260,6 +306,7 @@ def _chunk_coarse(
     document_id: str,
     document_path: Optional[str],
     counter: TokenCounter,
+    opts: _UnitOpts,
 ) -> list[ProvenanceChunk]:
     if strategy == "section":
         splits = DocumentSplitter.split_by_sections(doc, include_preamble=True)
@@ -291,7 +338,7 @@ def _chunk_coarse(
             section_heading=split.title,
             section_level=_first_heading_level(provenance_nodes),
             section_index=split.index,
-            avoid_table_split=False,
+            opts=opts,
         )
     return chunks
 
@@ -315,16 +362,17 @@ def _emit_unit(
     section_heading: Optional[str],
     section_level: Optional[int],
     section_index: int,
-    avoid_table_split: bool,
+    opts: _UnitOpts,
 ) -> int:
     """Render ``unit_nodes`` to Markdown, chunk it, and append provenance chunks.
 
-    With ``avoid_table_split``, the unit is segmented at :class:`Table` boundaries:
-    each table becomes one atomic chunk (never split mid-row, may exceed the token
-    budget) and prose segments are windowed normally. Chunk numbering stays
-    continuous across segments. Returns the new running index.
+    When ``opts.atomic_types`` is non-empty, the unit is segmented at those node
+    boundaries: each atomic node (e.g. a table or code block) becomes one chunk
+    (never split, may exceed the token budget) and prose segments are windowed
+    normally. Chunk numbering stays continuous across segments. Returns the new
+    running index.
     """
-    pieces = _build_pieces(chunker, unit_nodes, provenance_nodes, avoid_table_split)
+    pieces = _build_pieces(chunker, unit_nodes, provenance_nodes, opts)
     for chunk_in_unit, (text, tokens, char_start, char_end, prov_nodes) in enumerate(pieces, start=1):
         page, page_end, line_start, line_end = _node_provenance(prov_nodes)
         chunks.append(
@@ -362,18 +410,18 @@ def _build_pieces(
     chunker: PositionTrackingChunker,
     unit_nodes: list[Node],
     provenance_nodes: list[Node],
-    avoid_table_split: bool,
+    opts: _UnitOpts,
 ) -> list[_Piece]:
-    """Render and chunk a unit into pieces, keeping tables atomic when asked."""
+    """Render and chunk a unit into pieces, keeping atomic nodes whole when asked."""
     pieces: list[_Piece] = []
 
-    if avoid_table_split and any(isinstance(n, Table) for n in unit_nodes):
-        for seg_nodes, is_atomic in _segment_at_tables(unit_nodes):
-            text = _render_markdown(seg_nodes)
+    if opts.atomic_types and any(isinstance(n, opts.atomic_types) for n in unit_nodes):
+        for seg_nodes, is_atomic in _segment_atomic(unit_nodes, opts.atomic_types):
+            text = _render_markdown(seg_nodes, opts.elide_data_uris)
             if not text.strip():
                 continue
             if is_atomic:
-                # Whole table is one chunk; allowed to exceed max_tokens.
+                # Whole atomic node is one chunk; allowed to exceed max_tokens.
                 pieces.append((text, chunker.counter.count(text), 0, len(text), seg_nodes))
             else:
                 for window in chunker.chunk(text):
@@ -382,19 +430,19 @@ def _build_pieces(
                     )
         return pieces
 
-    text = _render_markdown(unit_nodes)
+    text = _render_markdown(unit_nodes, opts.elide_data_uris)
     if text.strip():
         for window in chunker.chunk(text):
             pieces.append((window.content, window.tokens, window.position.start, window.position.end, provenance_nodes))
     return pieces
 
 
-def _segment_at_tables(nodes: list[Node]) -> list[tuple[list[Node], bool]]:
-    """Split ``nodes`` into ``(segment, is_atomic)`` runs, each Table its own atomic run."""
+def _segment_atomic(nodes: list[Node], atomic_types: tuple[type, ...]) -> list[tuple[list[Node], bool]]:
+    """Split ``nodes`` into ``(segment, is_atomic)`` runs; each atomic node is its own run."""
     segments: list[tuple[list[Node], bool]] = []
     buffer: list[Node] = []
     for node in nodes:
-        if isinstance(node, Table):
+        if isinstance(node, atomic_types):
             if buffer:
                 segments.append((buffer, False))
                 buffer = []
@@ -406,14 +454,34 @@ def _segment_at_tables(nodes: list[Node]) -> list[tuple[list[Node], bool]]:
     return segments
 
 
-def _render_markdown(nodes: list[Node]) -> str:
+def _render_markdown(nodes: list[Node], elide_data_uris: bool = True) -> str:
     """Render a list of AST nodes to Markdown (the chunk source text)."""
     if not nodes:
         return ""
     from all2md.api import from_ast
 
     rendered = from_ast(Document(children=list(nodes)), cast(DocumentFormat, "markdown"))
-    return rendered if isinstance(rendered, str) else ""
+    if not isinstance(rendered, str):
+        return ""
+    return _elide_data_uris(rendered) if elide_data_uris else rendered
+
+
+def _elide_data_uris(text: str) -> str:
+    """Replace long ``data:…;base64,…`` payloads with a short placeholder.
+
+    Keeps the surrounding Markdown (e.g. ``![alt](…)``) intact so a chunk records
+    that an embedded asset was present without carrying the base64 blob — which
+    would otherwise inflate token counts and shred into noise chunks.
+    """
+
+    def _repl(match: re.Match[str]) -> str:
+        data = match.group("data")
+        if len(data) <= _DATA_URI_ELIDE_THRESHOLD:
+            return match.group(0)
+        mime = match.group("mime") or "application/octet-stream"
+        return f"data:{mime};base64,<elided:{len(data)}B>"
+
+    return _DATA_URI_RE.sub(_repl, text)
 
 
 def _iter_nodes(nodes: Iterable[Node]) -> Iterable[Node]:

--- a/src/all2md/chunking/provenance.py
+++ b/src/all2md/chunking/provenance.py
@@ -1,0 +1,478 @@
+#  Copyright (c) 2025 Tom Villani, Ph.D.
+#
+# src/all2md/chunking/provenance.py
+"""The AST -> chunk bridge.
+
+:func:`chunk_ast` is the heart of ``all2md chunk``. It turns a parsed
+:class:`~all2md.ast.nodes.Document` into a list of
+:class:`~all2md.chunking.records.ProvenanceChunk` records, each carrying the
+section context and source page/line span that distinguish all2md's chunking
+from flat-text chunkers.
+
+Two strategy families:
+
+- **Coarse** (``heading``/``section``/``auto``) reuse
+  :class:`~all2md.ast.splitting.DocumentSplitter` to cut at semantic boundaries;
+  each split becomes one chunk, sub-split only when it exceeds the token budget.
+- **Fine** (``semantic``/``token``/``sentence``/``paragraph``/``word``/``line``/
+  ``char``/``code``) iterate sections (plus the preamble) and run a
+  position-tracking chunker over each section's *rendered Markdown*.
+
+Rendering each unit to Markdown (rather than flattening with ``extract_text``)
+preserves the blank-line/structure boundaries the paragraph/line/section
+chunkers depend on, and yields clean, RAG-friendly chunk text. Character spans
+are therefore into that rendered section text (``char_basis="section_text"``),
+not the original binary.
+"""
+
+from __future__ import annotations
+
+from typing import Iterable, Optional, cast
+
+from all2md.ast.nodes import Document, Node, Table, get_node_children
+from all2md.ast.sections import get_all_sections, get_preamble
+from all2md.ast.splitting import DocumentSplitter
+from all2md.chunking.primitives import ChunkerFactory, PositionTrackingChunker
+from all2md.chunking.records import ProvenanceChunk
+from all2md.chunking.tokenization import TokenCounter, get_counter
+from all2md.constants import DocumentFormat
+
+#: Coarse strategies cut at semantic boundaries (one chunk per unit).
+_COARSE_STRATEGIES = frozenset({"heading", "section", "auto"})
+
+#: Fine strategy -> ChunkerFactory method name.
+_FINE_METHOD = {
+    "semantic": "tokens",
+    "token": "tokens",
+    "sentence": "sentences",
+    "paragraph": "paragraphs",
+    "word": "words",
+    "line": "lines",
+    "char": "characters",
+    "code": "code-blocks",
+}
+
+STRATEGIES = (
+    "semantic",
+    "heading",
+    "section",
+    "token",
+    "sentence",
+    "paragraph",
+    "word",
+    "line",
+    "char",
+    "code",
+    "auto",
+)
+
+
+def chunk_ast(
+    doc: Document,
+    *,
+    strategy: str = "semantic",
+    max_tokens: int = 512,
+    overlap: int = 0,
+    document_id: str = "document",
+    document_path: Optional[str] = None,
+    include_preamble: bool = True,
+    heading_merge: bool = True,
+    max_heading_level: Optional[int] = None,
+    avoid_table_split: bool = False,
+    token_counter: str = "auto",
+    counter: Optional[TokenCounter] = None,
+) -> list[ProvenanceChunk]:
+    """Chunk a document AST into provenance-carrying records.
+
+    Parameters
+    ----------
+    doc : Document
+        Parsed document AST.
+    strategy : str
+        One of :data:`STRATEGIES`. ``semantic`` (default) windows each section by
+        real tokens.
+    max_tokens : int
+        Maximum tokens per chunk.
+    overlap : int
+        Overlap between consecutive windows (units depend on the strategy; coerced
+        to 0 for coarse strategies).
+    document_id : str
+        Identifier woven into chunk ids and metadata (typically the file stem).
+    document_path : str, optional
+        POSIX path recorded on each chunk.
+    include_preamble : bool
+        Whether content before the first heading becomes its own chunk(s).
+    heading_merge : bool
+        Whether each section's heading line is prepended to its chunk text.
+    max_heading_level : int, optional
+        For fine strategies, only descend into sections at or above this level.
+    avoid_table_split : bool
+        For fine strategies, emit each table as its own atomic chunk so a table is
+        never split mid-row (it may exceed ``max_tokens``). Coarse strategies never
+        split tables regardless.
+    token_counter : {"auto", "tiktoken", "whitespace"}
+        Token-counting backend (ignored when ``counter`` is provided).
+    counter : TokenCounter, optional
+        Pre-resolved counter; if omitted one is resolved from ``token_counter``.
+
+    Returns
+    -------
+    list of ProvenanceChunk
+        Chunks in document reading order, with ``prev``/``next`` ids linked.
+
+    """
+    if strategy not in STRATEGIES:
+        raise ValueError(f"Unknown strategy {strategy!r}. Choose from: {', '.join(STRATEGIES)}")
+    if max_tokens < 1:
+        raise ValueError(f"max_tokens must be >= 1, got {max_tokens}")
+
+    if counter is None:
+        counter = get_counter(token_counter, strategy=strategy)
+
+    if strategy in _COARSE_STRATEGIES:
+        chunks = _chunk_coarse(
+            doc,
+            strategy=strategy,
+            max_tokens=max_tokens,
+            heading_merge=heading_merge,
+            document_id=document_id,
+            document_path=document_path,
+            counter=counter,
+        )
+    else:
+        chunks = _chunk_fine(
+            doc,
+            strategy=strategy,
+            max_tokens=max_tokens,
+            overlap=overlap,
+            include_preamble=include_preamble,
+            heading_merge=heading_merge,
+            max_heading_level=max_heading_level,
+            avoid_table_split=avoid_table_split,
+            document_id=document_id,
+            document_path=document_path,
+            counter=counter,
+        )
+
+    _link_neighbors(chunks)
+    return chunks
+
+
+# --------------------------------------------------------------------------- #
+# Fine strategies: per-section windowing                                       #
+# --------------------------------------------------------------------------- #
+
+
+def _chunk_fine(
+    doc: Document,
+    *,
+    strategy: str,
+    max_tokens: int,
+    overlap: int,
+    include_preamble: bool,
+    heading_merge: bool,
+    max_heading_level: Optional[int],
+    avoid_table_split: bool,
+    document_id: str,
+    document_path: Optional[str],
+    counter: TokenCounter,
+) -> list[ProvenanceChunk]:
+    method = _FINE_METHOD[strategy]
+    chunker = ChunkerFactory.create_chunker(method, max_tokens, overlap, counter=counter)
+
+    sections = get_all_sections(doc, max_level=max_heading_level) if max_heading_level else get_all_sections(doc)
+
+    chunks: list[ProvenanceChunk] = []
+    running_index = 0
+
+    # No headings at all: chunk the whole document as a single unnumbered unit
+    # (otherwise nothing would be emitted for heading-light documents).
+    if not sections:
+        running_index = _emit_unit(
+            chunks,
+            chunker=chunker,
+            unit_nodes=list(doc.children),
+            provenance_nodes=list(doc.children),
+            id_base=f"{document_id}::preamble",
+            strategy=strategy,
+            running_index=running_index,
+            document_id=document_id,
+            document_path=document_path,
+            section_heading=None,
+            section_level=None,
+            section_index=-1,
+            avoid_table_split=avoid_table_split,
+        )
+        return chunks
+
+    if include_preamble:
+        preamble_nodes = get_preamble(doc)
+        if preamble_nodes:
+            running_index = _emit_unit(
+                chunks,
+                chunker=chunker,
+                unit_nodes=preamble_nodes,
+                provenance_nodes=preamble_nodes,
+                id_base=f"{document_id}::preamble",
+                strategy=strategy,
+                running_index=running_index,
+                document_id=document_id,
+                document_path=document_path,
+                section_heading=None,
+                section_level=None,
+                section_index=-1,
+                avoid_table_split=avoid_table_split,
+            )
+
+    for section_index, section in enumerate(sections, start=1):
+        provenance_nodes = [section.heading] + list(section.content)
+        unit_nodes: list[Node] = provenance_nodes if heading_merge else list(section.content)
+        running_index = _emit_unit(
+            chunks,
+            chunker=chunker,
+            unit_nodes=unit_nodes,
+            provenance_nodes=provenance_nodes,
+            id_base=f"{document_id}::s{section_index}",
+            strategy=strategy,
+            running_index=running_index,
+            document_id=document_id,
+            document_path=document_path,
+            section_heading=section.get_heading_text() or None,
+            section_level=section.level,
+            section_index=section_index,
+            avoid_table_split=avoid_table_split,
+        )
+
+    return chunks
+
+
+# --------------------------------------------------------------------------- #
+# Coarse strategies: one chunk per semantic split                              #
+# --------------------------------------------------------------------------- #
+
+
+def _chunk_coarse(
+    doc: Document,
+    *,
+    strategy: str,
+    max_tokens: int,
+    heading_merge: bool,
+    document_id: str,
+    document_path: Optional[str],
+    counter: TokenCounter,
+) -> list[ProvenanceChunk]:
+    if strategy == "section":
+        splits = DocumentSplitter.split_by_sections(doc, include_preamble=True)
+    elif strategy == "heading":
+        splits = DocumentSplitter.split_by_heading_level(doc, level=1, include_preamble=True)
+    else:  # auto
+        splits = DocumentSplitter.split_auto(doc)
+
+    # Oversized splits are sub-split: real token windows when available, else
+    # paragraph windows (count-only) so the whitespace fallback still works.
+    sub_method = "tokens" if getattr(counter, "encoding", None) is not None else "paragraphs"
+    chunker = ChunkerFactory.create_chunker(sub_method, max_tokens, 0, counter=counter)
+
+    chunks: list[ProvenanceChunk] = []
+    running_index = 0
+    for split in splits:
+        provenance_nodes = list(split.document.children)
+        unit_nodes = provenance_nodes if heading_merge else _drop_leading_heading(provenance_nodes)
+        running_index = _emit_unit(
+            chunks,
+            chunker=chunker,
+            unit_nodes=unit_nodes,
+            provenance_nodes=provenance_nodes,
+            id_base=f"{document_id}::p{split.index}",
+            strategy=strategy,
+            running_index=running_index,
+            document_id=document_id,
+            document_path=document_path,
+            section_heading=split.title,
+            section_level=_first_heading_level(provenance_nodes),
+            section_index=split.index,
+            avoid_table_split=False,
+        )
+    return chunks
+
+
+# --------------------------------------------------------------------------- #
+# Shared helpers                                                               #
+# --------------------------------------------------------------------------- #
+
+
+def _emit_unit(
+    chunks: list[ProvenanceChunk],
+    *,
+    chunker: PositionTrackingChunker,
+    unit_nodes: list[Node],
+    provenance_nodes: list[Node],
+    id_base: str,
+    strategy: str,
+    running_index: int,
+    document_id: str,
+    document_path: Optional[str],
+    section_heading: Optional[str],
+    section_level: Optional[int],
+    section_index: int,
+    avoid_table_split: bool,
+) -> int:
+    """Render ``unit_nodes`` to Markdown, chunk it, and append provenance chunks.
+
+    With ``avoid_table_split``, the unit is segmented at :class:`Table` boundaries:
+    each table becomes one atomic chunk (never split mid-row, may exceed the token
+    budget) and prose segments are windowed normally. Chunk numbering stays
+    continuous across segments. Returns the new running index.
+    """
+    pieces = _build_pieces(chunker, unit_nodes, provenance_nodes, avoid_table_split)
+    for chunk_in_unit, (text, tokens, char_start, char_end, prov_nodes) in enumerate(pieces, start=1):
+        page, page_end, line_start, line_end = _node_provenance(prov_nodes)
+        chunks.append(
+            ProvenanceChunk(
+                chunk_id=f"{id_base}-c{chunk_in_unit}",
+                index=running_index,
+                text=text,
+                token_count=tokens,
+                token_counter=chunker.counter.name,
+                strategy=strategy,
+                document_id=document_id,
+                document_path=document_path,
+                section_heading=section_heading,
+                section_level=section_level,
+                section_index=section_index,
+                page=page,
+                page_end=page_end,
+                source_line_start=line_start,
+                source_line_end=line_end,
+                char_start=char_start,
+                char_end=char_end,
+                char_basis="section_text",
+            )
+        )
+        running_index += 1
+    return running_index
+
+
+# A renderable chunk before id/provenance assignment:
+# (text, token_count, char_start, char_end, provenance_nodes).
+_Piece = tuple[str, int, int, int, list[Node]]
+
+
+def _build_pieces(
+    chunker: PositionTrackingChunker,
+    unit_nodes: list[Node],
+    provenance_nodes: list[Node],
+    avoid_table_split: bool,
+) -> list[_Piece]:
+    """Render and chunk a unit into pieces, keeping tables atomic when asked."""
+    pieces: list[_Piece] = []
+
+    if avoid_table_split and any(isinstance(n, Table) for n in unit_nodes):
+        for seg_nodes, is_atomic in _segment_at_tables(unit_nodes):
+            text = _render_markdown(seg_nodes)
+            if not text.strip():
+                continue
+            if is_atomic:
+                # Whole table is one chunk; allowed to exceed max_tokens.
+                pieces.append((text, chunker.counter.count(text), 0, len(text), seg_nodes))
+            else:
+                for window in chunker.chunk(text):
+                    pieces.append(
+                        (window.content, window.tokens, window.position.start, window.position.end, seg_nodes)
+                    )
+        return pieces
+
+    text = _render_markdown(unit_nodes)
+    if text.strip():
+        for window in chunker.chunk(text):
+            pieces.append((window.content, window.tokens, window.position.start, window.position.end, provenance_nodes))
+    return pieces
+
+
+def _segment_at_tables(nodes: list[Node]) -> list[tuple[list[Node], bool]]:
+    """Split ``nodes`` into ``(segment, is_atomic)`` runs, each Table its own atomic run."""
+    segments: list[tuple[list[Node], bool]] = []
+    buffer: list[Node] = []
+    for node in nodes:
+        if isinstance(node, Table):
+            if buffer:
+                segments.append((buffer, False))
+                buffer = []
+            segments.append(([node], True))
+        else:
+            buffer.append(node)
+    if buffer:
+        segments.append((buffer, False))
+    return segments
+
+
+def _render_markdown(nodes: list[Node]) -> str:
+    """Render a list of AST nodes to Markdown (the chunk source text)."""
+    if not nodes:
+        return ""
+    from all2md.api import from_ast
+
+    rendered = from_ast(Document(children=list(nodes)), cast(DocumentFormat, "markdown"))
+    return rendered if isinstance(rendered, str) else ""
+
+
+def _iter_nodes(nodes: Iterable[Node]) -> Iterable[Node]:
+    """Yield ``nodes`` and all their descendants (depth-first)."""
+    for node in nodes:
+        yield node
+        yield from _iter_nodes(get_node_children(node))
+
+
+def _node_provenance(
+    nodes: list[Node],
+) -> tuple[Optional[int], Optional[int], Optional[int], Optional[int]]:
+    """Derive ``(page, page_end, line_start, line_end)`` from nodes' source locations.
+
+    Spans are the min/max of the populated ``SourceLocation.page`` / ``.line`` over
+    the contributing nodes (recursively). Returns ``None`` for an axis no node
+    populated — common for formats that don't track pages or lines.
+    """
+    pages: list[int] = []
+    lines: list[int] = []
+    for node in _iter_nodes(nodes):
+        loc = node.source_location
+        if loc is None:
+            continue
+        if loc.page is not None:
+            pages.append(loc.page)
+        if loc.line is not None:
+            lines.append(loc.line)
+    page = min(pages) if pages else None
+    page_end = max(pages) if pages else None
+    line_start = min(lines) if lines else None
+    line_end = max(lines) if lines else None
+    return page, page_end, line_start, line_end
+
+
+def _drop_leading_heading(nodes: list[Node]) -> list[Node]:
+    """Return ``nodes`` without a leading Heading (for ``--no-heading-merge``)."""
+    from all2md.ast.nodes import Heading
+
+    if nodes and isinstance(nodes[0], Heading):
+        return list(nodes[1:])
+    return list(nodes)
+
+
+def _first_heading_level(nodes: list[Node]) -> Optional[int]:
+    """Return the level of the first Heading among ``nodes``, if any."""
+    from all2md.ast.nodes import Heading
+
+    for node in nodes:
+        if isinstance(node, Heading):
+            return node.level
+    return None
+
+
+def _link_neighbors(chunks: list[ProvenanceChunk]) -> None:
+    """Populate ``prev_chunk_id``/``next_chunk_id`` across the sequence."""
+    for i, chunk in enumerate(chunks):
+        chunk.prev_chunk_id = chunks[i - 1].chunk_id if i > 0 else None
+        chunk.next_chunk_id = chunks[i + 1].chunk_id if i + 1 < len(chunks) else None
+
+
+__all__ = ["chunk_ast", "STRATEGIES"]

--- a/src/all2md/chunking/provenance.py
+++ b/src/all2md/chunking/provenance.py
@@ -240,7 +240,7 @@ def _chunk_fine(
     # No headings at all: chunk the whole document as a single unnumbered unit
     # (otherwise nothing would be emitted for heading-light documents).
     if not sections:
-        running_index = _emit_unit(
+        _emit_unit(
             chunks,
             chunker=chunker,
             unit_nodes=list(doc.children),

--- a/src/all2md/chunking/records.py
+++ b/src/all2md/chunking/records.py
@@ -1,0 +1,89 @@
+#  Copyright (c) 2025 Tom Villani, Ph.D.
+#
+# src/all2md/chunking/records.py
+"""The public chunk output record.
+
+:class:`ProvenanceChunk` is the single record type emitted by
+:func:`all2md.chunking.chunk_ast`. It carries the chunk text plus the
+AST-derived provenance that distinguishes all2md's chunking from flat-text
+chunkers: which section a chunk came from, and (where the parser populated it)
+the source page and line span.
+"""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass
+from typing import Any, Optional
+
+
+@dataclass
+class ProvenanceChunk:
+    """A text chunk with AST-derived provenance.
+
+    Attributes
+    ----------
+    chunk_id : str
+        Stable id, ``{document_id}::s{section}-c{chunk_in_section}`` (or
+        ``::preamble-N`` / ``::p{part}`` for preamble / coarse parts).
+    index : int
+        0-based position of this chunk in the document-wide sequence.
+    text : str
+        The chunk text.
+    token_count : int
+        Token count under ``token_counter``.
+    token_counter : str
+        Name of the counter used (``tiktoken`` or ``whitespace``).
+    strategy : str
+        The chunking strategy that produced this chunk.
+    document_id : str
+        Identifier for the source document (defaults to the file stem).
+    document_path : str or None
+        POSIX path to the source document when known.
+    section_heading : str or None
+        Heading text of the section this chunk belongs to (None for preamble).
+    section_level : int or None
+        Heading level (1-6) of that section.
+    section_index : int
+        1-based section ordinal; ``-1`` marks preamble / non-section content.
+    page, page_end : int or None
+        Source page span, when the parser populated ``SourceLocation.page``
+        (PDF and a few others). None otherwise.
+    source_line_start, source_line_end : int or None
+        Source line span, when the parser populated ``SourceLocation.line``.
+        Rarely available; None otherwise.
+    char_start, char_end : int
+        Character span of this chunk. By default these index into the
+        section's extracted text (see ``char_basis``), not the original binary.
+    char_basis : str
+        What ``char_start``/``char_end`` index into. ``"section_text"`` for
+        fine-grained strategies; ``"document"`` is reserved for future
+        binary-accurate spans.
+    prev_chunk_id, next_chunk_id : str or None
+        Neighbor ids, for reconstructing reading order downstream.
+
+    """
+
+    chunk_id: str
+    index: int
+    text: str
+    token_count: int
+    token_counter: str
+    strategy: str
+    document_id: str
+    document_path: Optional[str] = None
+    section_heading: Optional[str] = None
+    section_level: Optional[int] = None
+    section_index: int = -1
+    page: Optional[int] = None
+    page_end: Optional[int] = None
+    source_line_start: Optional[int] = None
+    source_line_end: Optional[int] = None
+    char_start: int = 0
+    char_end: int = 0
+    char_basis: str = "section_text"
+    prev_chunk_id: Optional[str] = None
+    next_chunk_id: Optional[str] = None
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return a flat JSON-serializable dict (one object per JSONL line)."""
+        return asdict(self)

--- a/src/all2md/chunking/tokenization.py
+++ b/src/all2md/chunking/tokenization.py
@@ -1,0 +1,150 @@
+#  Copyright (c) 2025 Tom Villani, Ph.D.
+#
+# src/all2md/chunking/tokenization.py
+"""Token counting backends for chunking.
+
+Chunking needs a notion of "token" to bound chunk sizes. Two backends are
+provided:
+
+- :class:`TiktokenCounter` — real BPE token counts via ``tiktoken`` (the same
+  ``cl100k_base`` encoding used by recent OpenAI models). Required for any
+  strategy that must split *on* token boundaries (``token``/``char`` and the
+  default ``semantic`` strategy), because those need the encoder's
+  ``encode``/``decode`` round-trip, not just a count.
+- :class:`WhitespaceCounter` — a dependency-free approximation that counts
+  whitespace-delimited runs. This mirrors the approximation used by the search
+  subsystem (``all2md.search.chunking``) so count-only strategies behave
+  consistently whether or not ``tiktoken`` is installed.
+
+Use :func:`get_counter` to resolve a counter by name with graceful fallback.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Optional, Protocol, runtime_checkable
+
+from all2md.constants import DEPS_CHUNK
+from all2md.exceptions import DependencyError
+
+_WHITESPACE_RE = re.compile(r"\s+")
+
+#: Strategies that need the encoder's ``encode``/``decode`` round-trip (split on
+#: real token boundaries), so the whitespace fallback cannot serve them.
+_TIKTOKEN_REQUIRED_STRATEGIES = frozenset({"semantic", "token", "char"})
+
+
+@runtime_checkable
+class TokenCounter(Protocol):
+    """Counts tokens in text. Optionally exposes a tiktoken ``encoding``."""
+
+    name: str
+
+    def count(self, text: str) -> int:
+        """Return the number of tokens in ``text``."""
+        ...
+
+
+class WhitespaceCounter:
+    """Approximate token count by whitespace-delimited runs (no dependency)."""
+
+    name = "whitespace"
+    #: No real encoder; strategies needing encode/decode must reject this.
+    encoding = None
+
+    def count(self, text: str) -> int:
+        """Count whitespace-delimited tokens in ``text``."""
+        return len([tok for tok in _WHITESPACE_RE.split(text) if tok])
+
+
+class TiktokenCounter:
+    """Real BPE token counts via ``tiktoken``.
+
+    Exposes the underlying ``encoding`` so token-boundary chunkers can
+    ``encode``/``decode``. Counting uses ``encode_ordinary`` to skip the
+    special-token scan (pure overhead here, and it would raise on text that
+    merely contains a special-token literal).
+    """
+
+    name = "tiktoken"
+
+    def __init__(self, encoding_name: str = "cl100k_base") -> None:
+        """Load the named ``tiktoken`` encoding (raising DependencyError if absent)."""
+        try:
+            import tiktoken
+        except ImportError as exc:  # pragma: no cover - exercised via get_counter
+            raise DependencyError(
+                converter_name="chunk",
+                missing_packages=[(name, spec) for name, _import, spec in DEPS_CHUNK],
+                install_command="pip install all2md[chunk]",
+                original_import_error=exc,
+            ) from exc
+        self.encoding = tiktoken.get_encoding(encoding_name)
+
+    def count(self, text: str) -> int:
+        """Count BPE tokens in ``text`` using ``encode_ordinary``."""
+        return len(self.encoding.encode_ordinary(text))
+
+
+def tiktoken_available() -> bool:
+    """Return True when ``tiktoken`` can be imported."""
+    try:
+        import tiktoken  # noqa: F401
+    except ImportError:
+        return False
+    return True
+
+
+def get_counter(name: str = "auto", *, strategy: Optional[str] = None) -> TokenCounter:
+    """Resolve a token counter by name.
+
+    Parameters
+    ----------
+    name : {"auto", "tiktoken", "whitespace"}
+        ``auto`` prefers ``tiktoken`` and falls back to whitespace counting when
+        it is not installed (unless ``strategy`` requires real tokens, in which
+        case a :class:`DependencyError` is raised). ``tiktoken`` forces the BPE
+        backend (raising if unavailable). ``whitespace`` forces the
+        approximation.
+    strategy : str, optional
+        The chunking strategy the counter is for. Used to decide whether the
+        whitespace fallback is acceptable under ``auto``: strategies that split
+        on token boundaries (``semantic``/``token``/``char``) cannot use it.
+
+    Returns
+    -------
+    TokenCounter
+        A ready-to-use counter.
+
+    Raises
+    ------
+    DependencyError
+        If ``tiktoken`` is required (explicitly, or implied by ``strategy``) but
+        not installed.
+    ValueError
+        If ``name`` is not a recognized backend.
+
+    """
+    needs_real_tokens = strategy in _TIKTOKEN_REQUIRED_STRATEGIES
+
+    if name == "whitespace":
+        if needs_real_tokens:
+            raise ValueError(
+                f"Strategy '{strategy}' splits on real token boundaries and cannot use the "
+                "whitespace token counter; use --token-counter tiktoken (pip install all2md[chunk])."
+            )
+        return WhitespaceCounter()
+
+    if name == "tiktoken":
+        return TiktokenCounter()
+
+    if name == "auto":
+        if tiktoken_available():
+            return TiktokenCounter()
+        if needs_real_tokens:
+            # Surface a clean dependency error instead of silently degrading a
+            # strategy that cannot work without real token boundaries.
+            return TiktokenCounter()  # raises DependencyError
+        return WhitespaceCounter()
+
+    raise ValueError(f"Unknown token counter: {name!r}. Choose from auto, tiktoken, whitespace.")

--- a/src/all2md/chunking/tokenization.py
+++ b/src/all2md/chunking/tokenization.py
@@ -42,7 +42,6 @@ class TokenCounter(Protocol):
 
     def count(self, text: str) -> int:
         """Return the number of tokens in ``text``."""
-        ...
 
 
 class WhitespaceCounter:

--- a/src/all2md/cli/commands/__init__.py
+++ b/src/all2md/cli/commands/__init__.py
@@ -108,6 +108,12 @@ def dispatch_command(args: list[str] | None = None) -> int | None:  # noqa: C901
 
         return handle_diff_command(args[1:])
 
+    # Check for chunk command
+    if args[0] == "chunk":
+        from all2md.cli.commands.chunk import handle_chunk_command
+
+        return handle_chunk_command(args[1:])
+
     # Check for lint command
     if args[0] == "lint":
         from all2md.cli.commands.lint import handle_lint_command

--- a/src/all2md/cli/commands/chunk.py
+++ b/src/all2md/cli/commands/chunk.py
@@ -143,6 +143,19 @@ def _create_chunk_parser() -> argparse.ArgumentParser:
         "(the table chunk may exceed --max-tokens). Applies to fine strategies.",
     )
     parser.add_argument(
+        "--avoid-code-split",
+        action="store_true",
+        help="Keep each fenced code block whole: emit it as its own chunk rather than splitting it "
+        "(the code chunk may exceed --max-tokens). Applies to fine strategies.",
+    )
+    parser.add_argument(
+        "--elide-data-uris",
+        action=argparse.BooleanOptionalAction,
+        default=True,
+        help="Replace long base64 'data:' URIs (e.g. embedded images) with a short placeholder so "
+        "they don't inflate token counts or shred into noise (default: enabled).",
+    )
+    parser.add_argument(
         "--drop-elements",
         metavar="TYPES",
         help="Comma-separated AST node types to strip before chunking, e.g. 'image,table,code_block'. "
@@ -336,6 +349,8 @@ def handle_chunk_command(args: list[str] | None = None) -> int:
                 heading_merge=parsed.heading_merge,
                 max_heading_level=parsed.max_heading_level,
                 avoid_table_split=parsed.avoid_table_split,
+                avoid_code_split=parsed.avoid_code_split,
+                elide_data_uris=parsed.elide_data_uris,
                 token_counter=parsed.token_counter,
             )
             all_chunks.extend(_apply_min_tokens(chunks, parsed.min_tokens))

--- a/src/all2md/cli/commands/chunk.py
+++ b/src/all2md/cli/commands/chunk.py
@@ -245,18 +245,6 @@ def _load_ast(source: str, converter_options: dict) -> tuple[Document, str, str 
     return cast(Document, to_ast(source, **kwargs)), path.stem, path.as_posix()
 
 
-def _apply_min_tokens(chunks: list[ProvenanceChunk], min_tokens: int) -> list[ProvenanceChunk]:
-    """Drop chunks below ``min_tokens`` and relink neighbors / reindex."""
-    if min_tokens <= 0:
-        return chunks
-    kept = [c for c in chunks if c.token_count >= min_tokens]
-    for i, chunk in enumerate(kept):
-        chunk.index = i
-        chunk.prev_chunk_id = kept[i - 1].chunk_id if i > 0 else None
-        chunk.next_chunk_id = kept[i + 1].chunk_id if i + 1 < len(kept) else None
-    return kept
-
-
 def _render_pretty(chunks: list[ProvenanceChunk]) -> str:
     """Render chunks as a compact human-readable listing."""
     lines: list[str] = []
@@ -351,9 +339,10 @@ def handle_chunk_command(args: list[str] | None = None) -> int:
                 avoid_table_split=parsed.avoid_table_split,
                 avoid_code_split=parsed.avoid_code_split,
                 elide_data_uris=parsed.elide_data_uris,
+                min_tokens=parsed.min_tokens,
                 token_counter=parsed.token_counter,
             )
-            all_chunks.extend(_apply_min_tokens(chunks, parsed.min_tokens))
+            all_chunks.extend(chunks)
     except DependencyError as e:
         print(f"Error: {e}", file=sys.stderr)
         return EXIT_DEPENDENCY_ERROR

--- a/src/all2md/cli/commands/chunk.py
+++ b/src/all2md/cli/commands/chunk.py
@@ -1,0 +1,365 @@
+#  Copyright (c) 2025 Tom Villani, Ph.D.
+#
+# src/all2md/cli/commands/chunk.py
+"""Document chunking command.
+
+``all2md chunk`` splits one or more documents into provenance-carrying chunks
+suitable for RAG / LLM pipelines, emitting JSONL by default (one chunk per
+line). Each chunk records its section context and, where the source format
+tracks it, the originating page / line span — provenance most chunkers drop.
+
+Examples
+--------
+    all2md chunk report.pdf --strategy semantic --max-tokens 512 --overlap 64
+    all2md chunk notes.md --strategy paragraph --token-counter whitespace
+    all2md chunk *.docx --format json --out chunks.json
+    cat doc.html | all2md chunk - --strategy section
+
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import cast
+
+from all2md.ast.nodes import Document
+from all2md.chunking import STRATEGIES, ProvenanceChunk, chunk_ast
+from all2md.cli.builder import (
+    EXIT_DEPENDENCY_ERROR,
+    EXIT_ERROR,
+    EXIT_FILE_ERROR,
+    EXIT_SUCCESS,
+    EXIT_VALIDATION_ERROR,
+)
+from all2md.cli.config import apply_config_to_parser
+from all2md.exceptions import All2MdError, DependencyError
+
+
+def _positive_int(value: str) -> int:
+    """Validate a strictly positive integer argument."""
+    try:
+        ivalue = int(value)
+    except ValueError as e:
+        raise argparse.ArgumentTypeError(f"expected an integer, got '{value}'") from e
+    if ivalue < 1:
+        raise argparse.ArgumentTypeError(f"must be >= 1, got {ivalue}")
+    return ivalue
+
+
+def _non_negative_int(value: str) -> int:
+    """Validate a non-negative integer argument."""
+    try:
+        ivalue = int(value)
+    except ValueError as e:
+        raise argparse.ArgumentTypeError(f"expected an integer, got '{value}'") from e
+    if ivalue < 0:
+        raise argparse.ArgumentTypeError(f"must be >= 0, got {ivalue}")
+    return ivalue
+
+
+def _heading_level(value: str) -> int:
+    """Validate a heading level (1-6)."""
+    try:
+        ivalue = int(value)
+    except ValueError as e:
+        raise argparse.ArgumentTypeError(f"expected an integer 1-6, got '{value}'") from e
+    if not 1 <= ivalue <= 6:
+        raise argparse.ArgumentTypeError(f"heading level must be between 1 and 6, got {ivalue}")
+    return ivalue
+
+
+def _create_chunk_parser() -> argparse.ArgumentParser:
+    """Build the argparse parser for ``all2md chunk``."""
+    parser = argparse.ArgumentParser(
+        prog="all2md chunk",
+        description="Split documents into provenance-carrying chunks (JSONL) for RAG/LLM pipelines.",
+        add_help=True,
+    )
+    parser.add_argument(
+        "inputs",
+        nargs="+",
+        help="One or more documents to chunk (any supported format; use '-' for stdin).",
+    )
+
+    parser.add_argument(
+        "--strategy",
+        choices=list(STRATEGIES),
+        default="semantic",
+        help="Chunking strategy. 'semantic' (default) windows each section by real tokens; "
+        "'heading'/'section'/'auto' cut at semantic boundaries; "
+        "'token'/'sentence'/'paragraph'/'word'/'line'/'char'/'code' are fine-grained.",
+    )
+    parser.add_argument(
+        "--max-tokens",
+        type=_positive_int,
+        default=512,
+        help="Maximum tokens per chunk (default: 512).",
+    )
+    parser.add_argument(
+        "--overlap",
+        type=_non_negative_int,
+        default=0,
+        help="Overlap between consecutive windows (coerced to 0 for coarse strategies; default: 0).",
+    )
+    parser.add_argument(
+        "--min-tokens",
+        type=_non_negative_int,
+        default=0,
+        help="Drop trailing chunks smaller than this many tokens (default: 0, keep all).",
+    )
+    parser.add_argument(
+        "--max-heading-level",
+        type=_heading_level,
+        default=None,
+        help="For fine strategies, only descend into sections at or above this heading level (1-6).",
+    )
+    parser.add_argument(
+        "--include-preamble",
+        action=argparse.BooleanOptionalAction,
+        default=True,
+        help="Emit content before the first heading as its own chunk(s) (default: enabled).",
+    )
+    parser.add_argument(
+        "--heading-merge",
+        action=argparse.BooleanOptionalAction,
+        default=True,
+        help="Prepend each section's heading line to its chunk text (default: enabled).",
+    )
+    parser.add_argument(
+        "--token-counter",
+        choices=["auto", "tiktoken", "whitespace"],
+        default="auto",
+        help="Token-counting backend. 'auto' prefers tiktoken, falling back to a whitespace "
+        "approximation for count-only strategies (default: auto).",
+    )
+
+    parser.add_argument(
+        "--avoid-table-split",
+        action="store_true",
+        help="Keep each table whole: emit it as its own chunk rather than splitting it mid-row "
+        "(the table chunk may exceed --max-tokens). Applies to fine strategies.",
+    )
+    parser.add_argument(
+        "--drop-elements",
+        metavar="TYPES",
+        help="Comma-separated AST node types to strip before chunking, e.g. 'image,table,code_block'. "
+        "Aliases like 'images'/'tables'/'code' are accepted. Useful for removing noise (e.g. base64 images).",
+    )
+
+    parser.add_argument(
+        "--attachment-mode",
+        choices=["skip", "alt_text", "save", "base64"],
+        default=None,
+        help="How the converter handles images/attachments before chunking (overrides config; "
+        "default: the converter default, 'alt_text'). Use 'skip'/'alt_text' to avoid huge base64 blobs.",
+    )
+
+    parser.add_argument(
+        "--format",
+        "-f",
+        dest="output_format",
+        choices=["jsonl", "json", "pretty"],
+        default="jsonl",
+        help="Output format: jsonl (default, one object per line), json (array), pretty (human-readable).",
+    )
+    parser.add_argument("--out", "-o", help="Write output to a file (default: stdout).")
+
+    parser.add_argument(
+        "--config",
+        help="Path to a configuration file. Values in its [chunk] section provide defaults "
+        "(CLI flags still override). If omitted, ALL2MD_CONFIG and auto-discovered configs apply.",
+    )
+    parser.add_argument(
+        "--no-config",
+        action="store_true",
+        help="Disable configuration file loading for this command.",
+    )
+
+    return parser
+
+
+# Friendly aliases for --drop-elements onto canonical AST node-type names.
+_DROP_ALIASES = {
+    "images": "image",
+    "tables": "table",
+    "code": "code_block",
+    "code-block": "code_block",
+    "code-blocks": "code_block",
+    "codeblocks": "code_block",
+    "figures": "image",
+    "lists": "list",
+    "links": "link",
+    "headings": "heading",
+}
+
+
+def _parse_drop_elements(spec: str | None) -> list[str]:
+    """Parse a ``--drop-elements`` spec into canonical node-type names."""
+    if not spec:
+        return []
+    types: list[str] = []
+    for raw in spec.split(","):
+        name = raw.strip().lower()
+        if not name:
+            continue
+        types.append(_DROP_ALIASES.get(name, name))
+    return types
+
+
+def _load_ast(source: str, converter_options: dict) -> tuple[Document, str, str | None]:
+    """Load an input to an AST, returning ``(doc, document_id, document_path)``.
+
+    ``converter_options`` is a dot-notation options dict (from config + CLI
+    overrides); it is projected onto the detected format before conversion.
+    """
+    from all2md import to_ast
+    from all2md.cli.processors import prepare_options_for_execution
+
+    if source == "-":
+        data = sys.stdin.buffer.read()
+        if not data:
+            raise All2MdError("No data received from stdin")
+        kwargs = prepare_options_for_execution(converter_options, None, "auto")
+        return cast(Document, to_ast(data, **kwargs)), "stdin", None
+
+    path = Path(source)
+    if not path.exists():
+        raise FileNotFoundError(f"Input file not found: {source}")
+    kwargs = prepare_options_for_execution(converter_options, path, "auto")
+    return cast(Document, to_ast(source, **kwargs)), path.stem, path.as_posix()
+
+
+def _apply_min_tokens(chunks: list[ProvenanceChunk], min_tokens: int) -> list[ProvenanceChunk]:
+    """Drop chunks below ``min_tokens`` and relink neighbors / reindex."""
+    if min_tokens <= 0:
+        return chunks
+    kept = [c for c in chunks if c.token_count >= min_tokens]
+    for i, chunk in enumerate(kept):
+        chunk.index = i
+        chunk.prev_chunk_id = kept[i - 1].chunk_id if i > 0 else None
+        chunk.next_chunk_id = kept[i + 1].chunk_id if i + 1 < len(kept) else None
+    return kept
+
+
+def _render_pretty(chunks: list[ProvenanceChunk]) -> str:
+    """Render chunks as a compact human-readable listing."""
+    lines: list[str] = []
+    for chunk in chunks:
+        loc = []
+        if chunk.section_heading:
+            loc.append(f"§ {chunk.section_heading}")
+        if chunk.page is not None:
+            loc.append(f"p.{chunk.page}" + (f"-{chunk.page_end}" if chunk.page_end != chunk.page else ""))
+        location = "  ".join(loc) if loc else "(preamble)"
+        preview = chunk.text.strip().replace("\n", " ")
+        if len(preview) > 100:
+            preview = preview[:97] + "..."
+        lines.append(f"[{chunk.index}] {chunk.chunk_id}  ({chunk.token_count} tok)  {location}")
+        lines.append(f"    {preview}")
+    return "\n".join(lines)
+
+
+def _format_output(chunks: list[ProvenanceChunk], output_format: str) -> str:
+    """Serialize chunks to the requested output format."""
+    if output_format == "jsonl":
+        return "\n".join(json.dumps(c.to_dict(), ensure_ascii=False) for c in chunks)
+    if output_format == "json":
+        return json.dumps([c.to_dict() for c in chunks], ensure_ascii=False, indent=2)
+    return _render_pretty(chunks)
+
+
+def handle_chunk_command(args: list[str] | None = None) -> int:
+    """Handle the ``chunk`` command.
+
+    Parameters
+    ----------
+    args : list[str], optional
+        Command line arguments (beyond 'chunk').
+
+    Returns
+    -------
+    int
+        Exit code (0 for success).
+
+    """
+    parser = _create_chunk_parser()
+    try:
+        pre_args, _ = parser.parse_known_args(args or [])
+        apply_config_to_parser(parser, "chunk", explicit_path=pre_args.config, no_config=pre_args.no_config)
+        parsed = parser.parse_args(args or [])
+    except SystemExit as e:
+        return e.code if isinstance(e.code, int) else 0
+
+    stdin_count = sum(1 for src in parsed.inputs if src == "-")
+    if stdin_count > 1:
+        print("Error: stdin ('-') may only be used once.", file=sys.stderr)
+        return EXIT_FILE_ERROR
+
+    # Converter options from the config file (e.g. [pdf], [html], top-level keys),
+    # mirroring `view`/`serve`, with an explicit --attachment-mode override.
+    from all2md.cli.processors import load_converter_config_options
+
+    converter_options = load_converter_config_options(explicit_path=parsed.config, no_config=parsed.no_config)
+    if parsed.attachment_mode:
+        converter_options["attachment_mode"] = parsed.attachment_mode
+
+    drop_types = _parse_drop_elements(parsed.drop_elements)
+    drop_transform = None
+    if drop_types:
+        from all2md.transforms.builtin import RemoveNodesTransform
+
+        try:
+            drop_transform = RemoveNodesTransform(node_types=drop_types)
+        except ValueError as e:
+            print(f"Error: invalid --drop-elements: {e}", file=sys.stderr)
+            return EXIT_VALIDATION_ERROR
+
+    all_chunks: list[ProvenanceChunk] = []
+    try:
+        for source in parsed.inputs:
+            doc, document_id, document_path = _load_ast(source, converter_options)
+            if drop_transform is not None:
+                doc = cast(Document, drop_transform.transform(doc))
+            label = document_path or document_id
+            print(f"Chunking {label} (strategy={parsed.strategy}, max_tokens={parsed.max_tokens})...", file=sys.stderr)
+            chunks = chunk_ast(
+                doc,
+                strategy=parsed.strategy,
+                max_tokens=parsed.max_tokens,
+                overlap=parsed.overlap,
+                document_id=document_id,
+                document_path=document_path,
+                include_preamble=parsed.include_preamble,
+                heading_merge=parsed.heading_merge,
+                max_heading_level=parsed.max_heading_level,
+                avoid_table_split=parsed.avoid_table_split,
+                token_counter=parsed.token_counter,
+            )
+            all_chunks.extend(_apply_min_tokens(chunks, parsed.min_tokens))
+    except DependencyError as e:
+        print(f"Error: {e}", file=sys.stderr)
+        return EXIT_DEPENDENCY_ERROR
+    except FileNotFoundError as e:
+        print(f"Error: {e}", file=sys.stderr)
+        return EXIT_FILE_ERROR
+    except ValueError as e:
+        print(f"Error: {e}", file=sys.stderr)
+        return EXIT_VALIDATION_ERROR
+    except All2MdError as e:
+        print(f"Error chunking document: {e}", file=sys.stderr)
+        return EXIT_ERROR
+
+    output = _format_output(all_chunks, parsed.output_format)
+
+    if parsed.out:
+        out_path = Path(parsed.out)
+        out_path.write_text(output + ("\n" if output and not output.endswith("\n") else ""), encoding="utf-8")
+        print(f"Wrote {len(all_chunks)} chunk(s) to {out_path}", file=sys.stderr)
+    else:
+        if output:
+            print(output)
+    print(f"Done: {len(all_chunks)} chunk(s) from {len(parsed.inputs)} input(s).", file=sys.stderr)
+    return EXIT_SUCCESS

--- a/src/all2md/cli/commands/config.py
+++ b/src/all2md/cli/commands/config.py
@@ -132,6 +132,7 @@ def _subcommand_parser_factories() -> Dict[str, Any]:
     dependencies) into the CLI startup path.
     """
     from all2md.cli.commands.arxiv import _create_arxiv_parser
+    from all2md.cli.commands.chunk import _create_chunk_parser
     from all2md.cli.commands.diff import _create_diff_parser
     from all2md.cli.commands.edit import _create_edit_parser
     from all2md.cli.commands.generate_site import _create_generate_site_parser
@@ -145,6 +146,7 @@ def _subcommand_parser_factories() -> Dict[str, Any]:
         "diff": _create_diff_parser,
         "arxiv": _create_arxiv_parser,
         "generate-site": _create_generate_site_parser,
+        "chunk": _create_chunk_parser,
     }
 
 

--- a/src/all2md/cli/config.py
+++ b/src/all2md/cli/config.py
@@ -37,6 +37,7 @@ SUBCOMMAND_CONFIG_SECTIONS: tuple[str, ...] = (
     "diff",
     "arxiv",
     "generate-site",
+    "chunk",
 )
 
 

--- a/src/all2md/cli/help_formatter.py
+++ b/src/all2md/cli/help_formatter.py
@@ -165,6 +165,7 @@ _SUBCOMMAND_SUMMARIES: Sequence[tuple[str, str]] = (
     ("context-menu", 'Manage the Windows right-click "View with all2md" entry (install/uninstall/status)'),
     ("search", "Search documents using keyword, vector, or hybrid retrieval"),
     ("grep", "Search for text patterns in documents (like grep for any format)"),
+    ("chunk", "Split documents into provenance-carrying chunks (JSONL) for RAG/LLM pipelines"),
     ("lint", "Lint converted documents for structural, heading, link, list, table, and typography issues"),
     ("generate-site", "Generate Hugo, Jekyll, MkDocs, Zola, or Eleventy static site from documents"),
     ("arxiv", "Generate an ArXiv-ready LaTeX submission package from a document"),

--- a/src/all2md/constants.py
+++ b/src/all2md/constants.py
@@ -253,6 +253,9 @@ DEPS_RTF_RENDER = [("pyth3", "pyth", ">=0.7"), ("six", "six", ">=1.16.0")]
 DEPS_JINJA = [("jinja2", "jinja2", ">=3.1.0")]
 DEPS_NETWORK = [("httpx", "httpx", ">=0.28.1")]
 
+# Chunking (token-boundary strategies need a real BPE tokenizer)
+DEPS_CHUNK = [("tiktoken", "tiktoken", ">=0.7.0")]
+
 # Search backends
 DEPS_SEARCH_BM25 = [("rank-bm25", "rank_bm25", ">=0.2.2")]
 

--- a/src/all2md/skills/all2md/SKILL.md
+++ b/src/all2md/skills/all2md/SKILL.md
@@ -22,6 +22,7 @@ This file is the overview and index. Pick the task below and read the matching r
 | Find a pattern inside documents (like grep) | [references/grep.md](references/grep.md) | `all2md grep` |
 | Ranked keyword/semantic search across a collection | [references/search.md](references/search.md) | `all2md search` |
 | Compare two documents / see what changed | [references/diff.md](references/diff.md) | `all2md diff` |
+| Chunk a document for RAG/LLM pipelines (JSONL + provenance) | [references/chunk.md](references/chunk.md) | `all2md chunk` |
 
 ## Core model
 
@@ -67,5 +68,5 @@ from_ast(doc, "html", output="report.html")   # render
 - `all2md check-deps` verifies optional dependencies (PyMuPDF for PDF, etc.).
 - Beyond the task families above, the CLI also has: `all2md view <file>` (preview in a browser), `all2md serve` (local HTTP API), `all2md edit <file>` (web editor), `all2md lint <file>` (Markdown linter with `--fix`), and `all2md config generate|show` (configuration files). Run `all2md <command> --help` for flags.
 - `all2md --help full` prints the complete flag reference, including all format-specific options.
-- `all2md llm-help [topic]` prints these references to stdout (topics: read, convert, generate, grep, search, diff) — handy when driving the CLI without installing the skill.
+- `all2md llm-help [topic]` prints these references to stdout (topics: read, convert, generate, grep, search, diff, chunk) — handy when driving the CLI without installing the skill.
 - Every CLI option also reads an environment variable: `ALL2MD_<OPTION>` (e.g. `ALL2MD_PDF_OCR_ENABLED=true`).

--- a/src/all2md/skills/all2md/references/chunk.md
+++ b/src/all2md/skills/all2md/references/chunk.md
@@ -117,22 +117,40 @@ Notes:
 
 ## Python API
 
+The one-call convenience — converts and chunks in a single step (mirrors `to_markdown`):
+
+```python
+import all2md
+
+chunks = all2md.chunk("report.pdf", strategy="semantic", max_tokens=512, overlap=64)
+for c in chunks:
+    print(c.chunk_id, c.section_heading, c.page, c.token_count)
+    # c.to_dict() gives the same flat object emitted as JSONL
+
+# Extra kwargs flow to the converter; chunk-shaping flags are first-class:
+chunks = all2md.chunk(
+    "report.pdf",
+    strategy="paragraph",
+    max_tokens=256,
+    min_tokens=20,
+    avoid_table_split=True,
+    drop_elements=["image"],
+    attachment_mode="skip",   # forwarded to the converter
+)
+```
+
+`document_id`/`document_path` are derived from the source automatically (the file stem;
+`"document"` for bytes/streams) — override with `document_id=...`.
+
+For lower-level control over an AST you already have, use `chunk_ast`:
+
 ```python
 from all2md import to_ast
 from all2md.chunking import chunk_ast
 
 doc = to_ast("report.pdf")
-chunks = chunk_ast(
-    doc,
-    strategy="semantic",
-    max_tokens=512,
-    overlap=64,
-    document_id="report",
-    document_path="report.pdf",
-)
-for c in chunks:
-    print(c.chunk_id, c.section_heading, c.page, c.token_count)
-    # c.to_dict() gives the same flat object emitted as JSONL
+# ... manipulate the AST ...
+chunks = chunk_ast(doc, strategy="semantic", max_tokens=512, document_id="report")
 ```
 
 ## Tips

--- a/src/all2md/skills/all2md/references/chunk.md
+++ b/src/all2md/skills/all2md/references/chunk.md
@@ -71,11 +71,14 @@ show up as their Markdown form. Fine strategies split by token budget and can cu
 table mid-row — these flags control that:
 
 ```bash
-# Keep each table whole (its own chunk; may exceed --max-tokens)
-all2md chunk report.pdf --avoid-table-split
+# Keep each table or fenced code block whole (its own chunk; may exceed --max-tokens)
+all2md chunk report.pdf --avoid-table-split --avoid-code-split
 
 # Strip noisy node types before chunking (aliases images/tables/code accepted)
 all2md chunk report.pdf --drop-elements image,table
+
+# Long base64 data: URIs are elided to a placeholder by default; keep them raw with:
+all2md chunk report.pdf --no-elide-data-uris
 
 # Control how the converter handles images, e.g. avoid huge base64 blobs
 all2md chunk report.pdf --attachment-mode skip   # skip | alt_text | save | base64

--- a/src/all2md/skills/all2md/references/chunk.md
+++ b/src/all2md/skills/all2md/references/chunk.md
@@ -1,0 +1,140 @@
+# Chunk Documents with all2md
+
+## Overview
+
+`all2md chunk` splits any supported document into chunks for RAG / LLM pipelines and emits them as **JSONL** (one chunk per line) by default. Unlike flat-text chunkers, each chunk carries AST-derived **provenance** — its section heading/level and, where the format records it, the source page span — so downstream answers can cite where a passage came from.
+
+## CLI Quick Reference
+
+### Basic Usage
+
+```bash
+# Semantic chunks (section-bounded real-token windows) as JSONL
+all2md chunk report.pdf --strategy semantic --max-tokens 512 --overlap 64
+
+# One chunk per section, written to a file
+all2md chunk handbook.docx --strategy section --out chunks.jsonl
+
+# Read from stdin
+cat page.html | all2md chunk - --strategy paragraph
+```
+
+### Strategies
+
+Coarse — one chunk per semantic boundary:
+
+```bash
+all2md chunk doc.md --strategy heading   # split at H1
+all2md chunk doc.md --strategy section   # one chunk per heading/section
+all2md chunk doc.md --strategy auto      # pick a sensible boundary automatically
+```
+
+Fine — windowed within each section, up to `--max-tokens`:
+
+```bash
+all2md chunk doc.md --strategy semantic    # default: real-token windows
+all2md chunk doc.md --strategy token       # split on token boundaries
+all2md chunk doc.md --strategy sentence
+all2md chunk doc.md --strategy paragraph
+all2md chunk doc.md --strategy word
+all2md chunk doc.md --strategy line
+all2md chunk doc.md --strategy char
+all2md chunk doc.md --strategy code        # respect function/class blocks
+```
+
+### Size & Structure Flags
+
+```bash
+# Bound chunk size and overlap (overlap is coerced to 0 for coarse strategies)
+all2md chunk doc.md --max-tokens 256 --overlap 32 --min-tokens 20
+
+# Limit how deep section detection descends
+all2md chunk doc.md --max-heading-level 2
+
+# Drop the pre-heading preamble; don't prepend the heading line to each chunk
+all2md chunk doc.md --no-include-preamble --no-heading-merge
+```
+
+### Output Formats
+
+```bash
+all2md chunk doc.md                    # jsonl (default), one object per line
+all2md chunk doc.md --format json      # a single JSON array
+all2md chunk doc.md --format pretty     # human-readable listing
+all2md chunk doc.md --out chunks.jsonl  # write to a file instead of stdout
+```
+
+### Tables, Images & Attachments
+
+Chunks are built from each section's rendered Markdown, so tables/images/code blocks
+show up as their Markdown form. Fine strategies split by token budget and can cut a
+table mid-row — these flags control that:
+
+```bash
+# Keep each table whole (its own chunk; may exceed --max-tokens)
+all2md chunk report.pdf --avoid-table-split
+
+# Strip noisy node types before chunking (aliases images/tables/code accepted)
+all2md chunk report.pdf --drop-elements image,table
+
+# Control how the converter handles images, e.g. avoid huge base64 blobs
+all2md chunk report.pdf --attachment-mode skip   # skip | alt_text | save | base64
+```
+
+`all2md chunk` also reads converter settings from a config file (the same `[pdf]`,
+`[html]`, and top-level keys as `all2md`/`view`/`serve`), with `--config`/`--no-config`.
+`--attachment-mode` overrides the config value.
+
+### Tokenizer
+
+Real BPE token counting — and the `semantic`/`token`/`char` strategies that split *on* token boundaries — need `tiktoken`:
+
+```bash
+pip install all2md[chunk]
+```
+
+Count-only strategies (`sentence`/`word`/`line`/`paragraph`/`section`/`heading`/`auto`) fall back to a whitespace approximation when `tiktoken` is absent. Force a backend:
+
+```bash
+all2md chunk doc.md --strategy paragraph --token-counter whitespace
+all2md chunk doc.md --strategy semantic  --token-counter tiktoken
+```
+
+## JSONL Schema
+
+Each line is a flat object with these keys:
+
+`chunk_id`, `index`, `text`, `token_count`, `token_counter`, `strategy`, `document_id`, `document_path`, `section_heading`, `section_level`, `section_index`, `page`, `page_end`, `source_line_start`, `source_line_end`, `char_start`, `char_end`, `char_basis`, `prev_chunk_id`, `next_chunk_id`.
+
+Notes:
+- `char_start`/`char_end` index into the chunk's rendered **section text** (`char_basis="section_text"`), not the original binary.
+- `page`/`page_end` are populated only for formats that track pages (PDF and similar); otherwise `null`.
+- `section_index` is `-1` for preamble / pre-heading content.
+- `prev_chunk_id`/`next_chunk_id` chain chunks in reading order within a document.
+
+## Python API
+
+```python
+from all2md import to_ast
+from all2md.chunking import chunk_ast
+
+doc = to_ast("report.pdf")
+chunks = chunk_ast(
+    doc,
+    strategy="semantic",
+    max_tokens=512,
+    overlap=64,
+    document_id="report",
+    document_path="report.pdf",
+)
+for c in chunks:
+    print(c.chunk_id, c.section_heading, c.page, c.token_count)
+    # c.to_dict() gives the same flat object emitted as JSONL
+```
+
+## Tips
+
+- `semantic` (the default) is the best general-purpose RAG strategy: it keeps chunks inside section boundaries and windows them by real tokens.
+- Use `section`/`heading` when you want exactly one chunk per logical unit and don't need a hard token cap.
+- Pass several inputs at once (`all2md chunk *.md`); `document_id` and `chunk_id` keep chunks from different files distinct.
+- For building and querying a persistent index instead of raw chunks, see the `all2md-search` skill (`all2md search`).

--- a/tests/integration/test_cli_chunk.py
+++ b/tests/integration/test_cli_chunk.py
@@ -1,0 +1,271 @@
+#  Copyright (c) 2025 Tom Villani, Ph.D.
+"""Integration tests for the ``all2md chunk`` CLI command."""
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+pytestmark = [pytest.mark.integration, pytest.mark.cli]
+
+SAMPLE_MD = """# Introduction
+
+The introduction explains the motivation and the goals of the work in a
+few sentences so there is enough text to chunk.
+
+# Methods
+
+The methods section describes how the study was conducted, step by step,
+with enough detail to produce multiple chunks under a small token budget.
+
+# Results
+
+The results section reports what was found.
+"""
+
+TABLE_MD = """# Data
+
+Intro paragraph with several words to chunk here first.
+
+| Name | Role | Notes |
+|------|------|-------|
+| Alice | Engineer | builds things |
+| Bob | Designer | draws things |
+| Carol | PM | plans things |
+
+An image: ![pic](https://example.com/logo.png)
+
+Trailing paragraph after the table content.
+"""
+
+
+@pytest.fixture
+def sample_file(tmp_path) -> Path:
+    """Write a multi-section markdown file to a temp dir."""
+    path = tmp_path / "doc.md"
+    path.write_text(SAMPLE_MD, encoding="utf-8")
+    return path
+
+
+@pytest.fixture
+def table_file(tmp_path) -> Path:
+    """Write a markdown file containing a table and an image."""
+    path = tmp_path / "table.md"
+    path.write_text(TABLE_MD, encoding="utf-8")
+    return path
+
+
+def _run(args: list[str], cwd: Path) -> subprocess.CompletedProcess:
+    """Invoke the all2md CLI as a subprocess."""
+    return subprocess.run(
+        [sys.executable, "-m", "all2md", "chunk", *args],
+        cwd=cwd,
+        capture_output=True,
+        text=True,
+    )
+
+
+class TestChunkCLI:
+    """End-to-end behavior of the chunk subcommand."""
+
+    def test_jsonl_default(self, sample_file):
+        """Default JSONL output: every line parses and respects the token budget."""
+        result = _run(
+            [str(sample_file), "--strategy", "paragraph", "--max-tokens", "40", "--token-counter", "whitespace"],
+            cwd=sample_file.parent,
+        )
+        assert result.returncode == 0, result.stderr
+        lines = [ln for ln in result.stdout.splitlines() if ln.strip()]
+        assert lines
+        objs = [json.loads(ln) for ln in lines]
+        assert all(o["token_count"] <= 40 for o in objs)
+        # Provenance fields present and sections captured.
+        assert {"chunk_id", "section_heading", "page", "char_basis"} <= set(objs[0])
+        assert "Introduction" in {o["section_heading"] for o in objs}
+
+    def test_json_array(self, sample_file):
+        """JSON format emits a single parseable array."""
+        result = _run(
+            [
+                str(sample_file),
+                "--strategy",
+                "section",
+                "--max-tokens",
+                "200",
+                "--format",
+                "json",
+                "--token-counter",
+                "whitespace",
+            ],
+            cwd=sample_file.parent,
+        )
+        assert result.returncode == 0, result.stderr
+        data = json.loads(result.stdout)
+        assert isinstance(data, list) and data
+
+    def test_pretty_output(self, sample_file):
+        """Pretty format is human-readable and mentions a section."""
+        result = _run(
+            [
+                str(sample_file),
+                "--strategy",
+                "section",
+                "--max-tokens",
+                "200",
+                "--format",
+                "pretty",
+                "--token-counter",
+                "whitespace",
+            ],
+            cwd=sample_file.parent,
+        )
+        assert result.returncode == 0, result.stderr
+        assert "Introduction" in result.stdout
+
+    def test_out_file(self, sample_file, tmp_path):
+        """--out writes JSONL to a file and reports the count on stderr."""
+        out = tmp_path / "chunks.jsonl"
+        result = _run(
+            [
+                str(sample_file),
+                "--strategy",
+                "paragraph",
+                "--max-tokens",
+                "40",
+                "--out",
+                str(out),
+                "--token-counter",
+                "whitespace",
+            ],
+            cwd=sample_file.parent,
+        )
+        assert result.returncode == 0, result.stderr
+        assert out.exists()
+        for ln in out.read_text(encoding="utf-8").splitlines():
+            if ln.strip():
+                json.loads(ln)
+
+    def test_stdin(self, sample_file):
+        """Reading from stdin labels the document 'stdin'."""
+        proc = subprocess.run(
+            [
+                sys.executable,
+                "-m",
+                "all2md",
+                "chunk",
+                "-",
+                "--strategy",
+                "paragraph",
+                "--max-tokens",
+                "60",
+                "--token-counter",
+                "whitespace",
+            ],
+            cwd=sample_file.parent,
+            input=SAMPLE_MD,
+            capture_output=True,
+            text=True,
+        )
+        assert proc.returncode == 0, proc.stderr
+        first = json.loads(next(ln for ln in proc.stdout.splitlines() if ln.strip()))
+        assert first["document_id"] == "stdin"
+
+    def test_whitespace_token_strategy_rejected(self, sample_file):
+        """A token-boundary strategy with --token-counter whitespace fails cleanly."""
+        result = _run(
+            [str(sample_file), "--strategy", "token", "--token-counter", "whitespace"],
+            cwd=sample_file.parent,
+        )
+        assert result.returncode != 0
+        assert "token" in result.stderr.lower()
+
+    def test_help(self, sample_file):
+        """--help renders and lists the strategy flag."""
+        result = _run(["--help"], cwd=sample_file.parent)
+        assert result.returncode == 0
+        assert "--strategy" in result.stdout
+        assert "--avoid-table-split" in result.stdout
+        assert "--drop-elements" in result.stdout
+
+
+class TestChunkElementHandling:
+    """Flags governing tables, dropped elements, and attachments."""
+
+    def test_avoid_table_split(self, table_file):
+        """--avoid-table-split keeps the table in a single chunk."""
+        result = _run(
+            [
+                str(table_file),
+                "--strategy",
+                "paragraph",
+                "--max-tokens",
+                "8",
+                "--avoid-table-split",
+                "--token-counter",
+                "whitespace",
+            ],
+            cwd=table_file.parent,
+        )
+        assert result.returncode == 0, result.stderr
+        objs = [json.loads(ln) for ln in result.stdout.splitlines() if ln.strip()]
+        table_chunks = [o for o in objs if "|" in o["text"]]
+        assert len(table_chunks) == 1
+
+    def test_drop_elements_removes_table_and_image(self, table_file):
+        """--drop-elements strips tables and images from the output entirely."""
+        result = _run(
+            [
+                str(table_file),
+                "--strategy",
+                "paragraph",
+                "--max-tokens",
+                "200",
+                "--drop-elements",
+                "images,tables",
+                "--token-counter",
+                "whitespace",
+            ],
+            cwd=table_file.parent,
+        )
+        assert result.returncode == 0, result.stderr
+        text = result.stdout
+        assert "| Name |" not in text
+        assert "example.com/logo.png" not in text
+        # Prose survives.
+        assert "Intro paragraph" in text
+
+    def test_drop_elements_typo_is_rejected(self, table_file):
+        """A misspelled node type fails cleanly with a suggestion."""
+        result = _run(
+            [str(table_file), "--drop-elements", "tabel", "--token-counter", "whitespace"],
+            cwd=table_file.parent,
+        )
+        assert result.returncode != 0
+        assert "table" in result.stderr.lower()
+
+    def test_attachment_mode_accepted(self, table_file):
+        """--attachment-mode is accepted and threads to the converter cleanly.
+
+        It is a parse-time lever (controls whether a binary format embeds images
+        as base64 / alt-text / skips them); a plain Markdown image link is not a
+        binary attachment, so this only asserts the flag runs and yields chunks.
+        Binary-attachment handling is covered by the parser option tests.
+        """
+        result = _run(
+            [
+                str(table_file),
+                "--strategy",
+                "section",
+                "--max-tokens",
+                "300",
+                "--attachment-mode",
+                "skip",
+                "--token-counter",
+                "whitespace",
+            ],
+            cwd=table_file.parent,
+        )
+        assert result.returncode == 0, result.stderr
+        assert [ln for ln in result.stdout.splitlines() if ln.strip()]

--- a/tests/integration/test_cli_chunk.py
+++ b/tests/integration/test_cli_chunk.py
@@ -187,7 +187,9 @@ class TestChunkCLI:
         assert result.returncode == 0
         assert "--strategy" in result.stdout
         assert "--avoid-table-split" in result.stdout
+        assert "--avoid-code-split" in result.stdout
         assert "--drop-elements" in result.stdout
+        assert "--elide-data-uris" in result.stdout
 
 
 class TestChunkElementHandling:
@@ -244,6 +246,61 @@ class TestChunkElementHandling:
         )
         assert result.returncode != 0
         assert "table" in result.stderr.lower()
+
+    def test_avoid_code_split(self, tmp_path):
+        """--avoid-code-split keeps a fenced code block in a single chunk."""
+        code = "\n".join(f"line_{i} = compute(value_{i})" for i in range(12))
+        path = tmp_path / "code.md"
+        path.write_text(f"# Code\n\nIntro words here now.\n\n```python\n{code}\n```\n", encoding="utf-8")
+        result = _run(
+            [
+                str(path),
+                "--strategy",
+                "paragraph",
+                "--max-tokens",
+                "8",
+                "--avoid-code-split",
+                "--token-counter",
+                "whitespace",
+            ],
+            cwd=path.parent,
+        )
+        assert result.returncode == 0, result.stderr
+        objs = [json.loads(ln) for ln in result.stdout.splitlines() if ln.strip()]
+        code_chunks = [o for o in objs if "compute(" in o["text"]]
+        assert len(code_chunks) == 1
+
+    def test_data_uri_elided_by_default(self, tmp_path):
+        """A long base64 data URI is elided from chunk text by default."""
+        path = tmp_path / "img.md"
+        path.write_text(f"# Pic\n\nBefore.\n\n![x](data:image/png;base64,{'A' * 200})\n", encoding="utf-8")
+        result = _run(
+            [str(path), "--strategy", "section", "--max-tokens", "400", "--token-counter", "whitespace"],
+            cwd=path.parent,
+        )
+        assert result.returncode == 0, result.stderr
+        assert "AAAA" not in result.stdout
+        assert "elided" in result.stdout
+
+    def test_data_uri_kept_with_no_elide(self, tmp_path):
+        """--no-elide-data-uris keeps the raw base64 payload."""
+        path = tmp_path / "img.md"
+        path.write_text(f"# Pic\n\nBefore.\n\n![x](data:image/png;base64,{'A' * 200})\n", encoding="utf-8")
+        result = _run(
+            [
+                str(path),
+                "--strategy",
+                "section",
+                "--max-tokens",
+                "400",
+                "--no-elide-data-uris",
+                "--token-counter",
+                "whitespace",
+            ],
+            cwd=path.parent,
+        )
+        assert result.returncode == 0, result.stderr
+        assert "AAAA" in result.stdout
 
     def test_attachment_mode_accepted(self, table_file):
         """--attachment-mode is accepted and threads to the converter cleanly.

--- a/tests/unit/chunking/test_chunk_api.py
+++ b/tests/unit/chunking/test_chunk_api.py
@@ -1,0 +1,87 @@
+#  Copyright (c) 2025 Tom Villani, Ph.D.
+"""Tests for the top-level ``all2md.chunk`` one-call convenience API."""
+
+import pytest
+
+import all2md
+from all2md.chunking import ProvenanceChunk
+
+pytestmark = pytest.mark.unit
+
+SAMPLE = b"""# Intro
+
+Some introductory prose with enough words to chunk a few times over here.
+
+# Body
+
+More body text in a second section, also with a fair number of words to split.
+"""
+
+
+def test_chunk_is_exported():
+    """`all2md.chunk` is part of the public API."""
+    assert hasattr(all2md, "chunk")
+    assert "chunk" in all2md.__all__
+
+
+def test_one_call_returns_provenance_chunks():
+    """chunk(bytes) converts and chunks in a single call."""
+    chunks = all2md.chunk(SAMPLE, source_format="markdown", strategy="paragraph", token_counter="whitespace")
+    assert chunks
+    assert all(isinstance(c, ProvenanceChunk) for c in chunks)
+    headings = {c.section_heading for c in chunks}
+    assert "Intro" in headings and "Body" in headings
+
+
+def test_bytes_source_gets_generic_id():
+    """A non-file source defaults document_id to 'document' with no path."""
+    chunks = all2md.chunk(SAMPLE, source_format="markdown", strategy="section", token_counter="whitespace")
+    assert chunks[0].document_id == "document"
+    assert chunks[0].document_path is None
+
+
+def test_document_id_override():
+    """An explicit document_id is woven into chunk ids."""
+    chunks = all2md.chunk(
+        SAMPLE, source_format="markdown", strategy="section", document_id="mydoc", token_counter="whitespace"
+    )
+    assert all(c.document_id == "mydoc" for c in chunks)
+    assert all(c.chunk_id.startswith("mydoc::") for c in chunks)
+
+
+def test_file_source_derives_id_from_stem(tmp_path):
+    """A file path yields document_id=<stem> and a recorded document_path."""
+    path = tmp_path / "report.md"
+    path.write_bytes(SAMPLE)
+    chunks = all2md.chunk(str(path), strategy="section", token_counter="whitespace")
+    assert chunks[0].document_id == "report"
+    assert chunks[0].document_path is not None and chunks[0].document_path.endswith("report.md")
+
+
+def test_drop_elements_through_api():
+    """drop_elements strips node types before chunking."""
+    md = b"# H\n\nText.\n\n| A | B |\n|---|---|\n| 1 | 2 |\n"
+    kept = all2md.chunk(md, source_format="markdown", strategy="section", token_counter="whitespace")
+    dropped = all2md.chunk(
+        md, source_format="markdown", strategy="section", drop_elements=["table"], token_counter="whitespace"
+    )
+    assert any("|" in c.text for c in kept)
+    assert all("|" not in c.text for c in dropped)
+
+
+def test_min_tokens_through_api():
+    """min_tokens filters small chunks via the convenience API."""
+    chunks = all2md.chunk(
+        SAMPLE, source_format="markdown", strategy="word", max_tokens=4, min_tokens=4, token_counter="whitespace"
+    )
+    assert chunks
+    assert all(c.token_count >= 4 for c in chunks)
+
+
+def test_converter_options_forwarded():
+    """Extra kwargs (e.g. attachment_mode) are forwarded to to_ast without error."""
+    md = b"# H\n\n![x](data:image/png;base64,%s)\n" % (b"A" * 80)
+    chunks = all2md.chunk(
+        md, source_format="markdown", strategy="section", attachment_mode="skip", token_counter="whitespace"
+    )
+    assert chunks

--- a/tests/unit/chunking/test_primitives.py
+++ b/tests/unit/chunking/test_primitives.py
@@ -1,0 +1,127 @@
+#  Copyright (c) 2025 Tom Villani, Ph.D.
+"""Tests for the vendored position-tracking chunkers."""
+
+import pytest
+
+from all2md.chunking.primitives import (
+    ChunkerFactory,
+    ParagraphChunker,
+    SectionChunker,
+    SentenceChunker,
+    WordChunker,
+    reconstruct_document,
+)
+from all2md.chunking.tokenization import WhitespaceCounter, get_counter, tiktoken_available
+
+pytestmark = pytest.mark.unit
+
+WS = WhitespaceCounter()
+
+LONG_PARAGRAPHS = "\n\n".join(f"Paragraph {i} has several words in it here." for i in range(20))
+
+
+class TestCountOnlyChunkers:
+    """Chunkers that only need token counting work under the whitespace backend."""
+
+    @pytest.mark.parametrize("cls", [WordChunker, SentenceChunker, ParagraphChunker])
+    def test_respects_token_budget(self, cls):
+        """No emitted chunk exceeds max_tokens (whitespace tokens)."""
+        chunker = cls(max_tokens=10, overlap=0, counter=WS)
+        chunks = chunker.chunk(LONG_PARAGRAPHS)
+        assert chunks
+        assert all(c.tokens <= 10 for c in chunks)
+
+    def test_empty_text_yields_no_chunks(self):
+        """Whitespace-only input produces no chunks."""
+        assert WordChunker(max_tokens=10, counter=WS).chunk("   \n  ") == []
+
+    def test_short_text_single_chunk(self):
+        """Text under the budget returns exactly one chunk spanning it."""
+        chunks = ParagraphChunker(max_tokens=100, counter=WS).chunk("Just a few words.")
+        assert len(chunks) == 1
+        assert chunks[0].position.start == 0
+
+    def test_positions_are_consistent(self):
+        """Each chunk's content matches the span it reports into the source text."""
+        chunker = WordChunker(max_tokens=8, counter=WS)
+        chunks = chunker.chunk(LONG_PARAGRAPHS)
+        for c in chunks:
+            assert LONG_PARAGRAPHS[c.position.start : c.position.end] == c.content
+
+
+class TestSectionChunker:
+    """Section chunker forbids overlap and keeps small sections whole."""
+
+    def test_overlap_must_be_zero(self):
+        """Constructing with non-zero overlap raises."""
+        with pytest.raises(ValueError, match="overlap"):
+            SectionChunker(max_tokens=50, overlap=2, counter=WS)
+
+    def test_splits_on_headers(self):
+        """A multi-section markdown body yields multiple chunks."""
+        text = "# A\n\nalpha beta gamma\n\n# B\n\ndelta epsilon zeta\n\n# C\n\neta theta iota"
+        chunks = SectionChunker(max_tokens=4, counter=WS).chunk(text)
+        assert len(chunks) >= 2
+
+
+class TestWordOverlap:
+    """Word-level overlap repeats trailing context and still makes progress."""
+
+    def test_overlap_repeats_context(self):
+        """With overlap, total emitted words exceed the unique word count."""
+        text = " ".join(f"w{i}" for i in range(40))
+        no_overlap = WordChunker(max_tokens=5, overlap=0, counter=WS).chunk(text)
+        with_overlap = WordChunker(max_tokens=5, overlap=2, counter=WS).chunk(text)
+        assert len(with_overlap) >= len(no_overlap)
+        # Progress guarantee: never an infinite number of chunks.
+        assert len(with_overlap) < 100
+
+
+class TestReconstruction:
+    """Non-overlapping chunks reconstruct the source exactly."""
+
+    def test_word_chunker_roundtrip(self):
+        """WordChunker output reassembles to the original text."""
+        chunks = WordChunker(max_tokens=6, overlap=0, counter=WS).chunk(LONG_PARAGRAPHS)
+        assert reconstruct_document(chunks, len(LONG_PARAGRAPHS)) == LONG_PARAGRAPHS
+
+
+class TestFactory:
+    """ChunkerFactory construction."""
+
+    def test_lists_methods(self):
+        """The factory advertises the expected method names."""
+        methods = ChunkerFactory.list_methods()
+        assert {"sentences", "tokens", "words", "lines", "paragraphs", "sections", "characters"} <= set(methods)
+
+    def test_unknown_method(self):
+        """An unknown method name raises ValueError."""
+        with pytest.raises(ValueError, match="Unknown chunking method"):
+            ChunkerFactory.create_chunker("bogus", 100, counter=WS)
+
+    def test_sections_overlap_coerced(self):
+        """Sections strategy is constructed with overlap 0 even if asked otherwise."""
+        chunker = ChunkerFactory.create_chunker("sections", 100, overlap=5, counter=WS)
+        assert chunker.overlap == 0
+
+
+@pytest.mark.skipif(not tiktoken_available(), reason="tiktoken not installed")
+class TestTokenChunker:
+    """Token-boundary chunking requires a real encoder."""
+
+    def test_requires_encoding(self):
+        """TokenChunker rejects the whitespace counter (no encoding)."""
+        from all2md.chunking.primitives import TokenChunker
+
+        with pytest.raises(ValueError, match="tiktoken-backed"):
+            TokenChunker(max_tokens=10, counter=WS)
+
+    def test_token_budget_respected(self):
+        """Real token windows never exceed max_tokens."""
+        from all2md.chunking.primitives import TokenChunker
+
+        counter = get_counter("tiktoken")
+        text = " ".join(f"word{i}" for i in range(500))
+        chunks = TokenChunker(max_tokens=32, overlap=4, counter=counter).chunk(text)
+        assert chunks
+        assert all(c.tokens <= 32 for c in chunks)

--- a/tests/unit/chunking/test_provenance.py
+++ b/tests/unit/chunking/test_provenance.py
@@ -1,0 +1,224 @@
+#  Copyright (c) 2025 Tom Villani, Ph.D.
+"""Tests for the AST -> chunk provenance bridge (``chunk_ast``)."""
+
+import pytest
+
+from all2md.ast.nodes import (
+    Document,
+    Heading,
+    Paragraph,
+    SourceLocation,
+    Table,
+    TableCell,
+    TableRow,
+    Text,
+)
+from all2md.chunking import chunk_ast
+from all2md.chunking.tokenization import tiktoken_available
+
+pytestmark = pytest.mark.unit
+
+
+def _cell(text):
+    """Build a single table cell."""
+    return TableCell(content=[Text(content=text)])
+
+
+def _table(n_rows):
+    """Build a small 2-column GFM table with ``n_rows`` body rows."""
+    header = TableRow(cells=[_cell("Name"), _cell("Role")])
+    rows = [TableRow(cells=[_cell(f"person{i}"), _cell(f"role{i}")]) for i in range(n_rows)]
+    return Table(rows=rows, header=header)
+
+
+@pytest.fixture
+def doc():
+    """A small document: preamble + two H1 sections."""
+    return Document(
+        children=[
+            Paragraph(content=[Text(content="Preamble text before any heading.")]),
+            Heading(level=1, content=[Text(content="Introduction")]),
+            Paragraph(content=[Text(content="The introduction explains the motivation and goals.")]),
+            Heading(level=1, content=[Text(content="Methods")]),
+            Paragraph(content=[Text(content="The methods describe how the study was conducted.")]),
+        ]
+    )
+
+
+@pytest.fixture
+def paged_doc():
+    """A document whose nodes carry PDF-style page provenance."""
+    return Document(
+        children=[
+            Heading(
+                level=1,
+                content=[Text(content="Chapter")],
+                source_location=SourceLocation(format="pdf", page=3),
+            ),
+            Paragraph(
+                content=[Text(content="Body text on a later page of the same section.")],
+                source_location=SourceLocation(format="pdf", page=5),
+            ),
+        ]
+    )
+
+
+class TestFineStrategies:
+    """Per-section windowing strategies (count-only here, via whitespace)."""
+
+    @pytest.mark.parametrize("strategy", ["paragraph", "sentence", "word", "line"])
+    def test_emits_chunks_with_section_context(self, doc, strategy):
+        """Each strategy emits chunks; section chunks carry their heading."""
+        chunks = chunk_ast(doc, strategy=strategy, max_tokens=50, token_counter="whitespace", document_id="d")
+        assert chunks
+        headings = {c.section_heading for c in chunks}
+        assert "Introduction" in headings
+        assert "Methods" in headings
+
+    def test_preamble_chunk_has_no_section(self, doc):
+        """The preamble becomes an unnumbered chunk (section_index -1, no heading)."""
+        chunks = chunk_ast(doc, strategy="paragraph", max_tokens=50, token_counter="whitespace", document_id="d")
+        preamble = chunks[0]
+        assert preamble.section_index == -1
+        assert preamble.section_heading is None
+        assert preamble.chunk_id == "d::preamble-c1"
+
+    def test_include_preamble_false_drops_preamble(self, doc):
+        """Disabling preamble omits the pre-heading content."""
+        chunks = chunk_ast(
+            doc,
+            strategy="paragraph",
+            max_tokens=50,
+            include_preamble=False,
+            token_counter="whitespace",
+            document_id="d",
+        )
+        assert all(c.section_index != -1 for c in chunks)
+
+    def test_neighbor_links_and_index(self, doc):
+        """Chunks are linked head-to-tail and indexed 0..n-1."""
+        chunks = chunk_ast(doc, strategy="word", max_tokens=8, token_counter="whitespace", document_id="d")
+        assert chunks[0].prev_chunk_id is None
+        assert chunks[-1].next_chunk_id is None
+        assert [c.index for c in chunks] == list(range(len(chunks)))
+        for i in range(len(chunks) - 1):
+            assert chunks[i].next_chunk_id == chunks[i + 1].chunk_id
+            assert chunks[i + 1].prev_chunk_id == chunks[i].chunk_id
+
+    def test_heading_merge_toggle(self, doc):
+        """With heading-merge off, section text omits the heading line."""
+        merged = chunk_ast(doc, strategy="paragraph", max_tokens=200, heading_merge=True, token_counter="whitespace")
+        unmerged = chunk_ast(doc, strategy="paragraph", max_tokens=200, heading_merge=False, token_counter="whitespace")
+        intro_merged = next(c for c in merged if c.section_heading == "Introduction")
+        intro_unmerged = next(c for c in unmerged if c.section_heading == "Introduction")
+        assert "Introduction" in intro_merged.text
+        assert "Introduction" not in intro_unmerged.text
+
+
+class TestCoarseStrategies:
+    """One-chunk-per-boundary strategies."""
+
+    def test_section_strategy_one_chunk_per_section(self, doc):
+        """Section strategy yields a preamble part plus one chunk per heading."""
+        chunks = chunk_ast(doc, strategy="section", max_tokens=500, token_counter="whitespace", document_id="d")
+        headings = [c.section_heading for c in chunks]
+        assert "Introduction" in headings
+        assert "Methods" in headings
+        assert all(c.chunk_id.startswith("d::p") for c in chunks)
+
+    def test_auto_strategy_runs(self, doc):
+        """Auto strategy produces chunks without error."""
+        chunks = chunk_ast(doc, strategy="auto", max_tokens=500, token_counter="whitespace", document_id="d")
+        assert chunks
+
+
+class TestProvenanceDerivation:
+    """Page/line spans are derived from contributing nodes' source locations."""
+
+    def test_page_span_from_nodes(self, paged_doc):
+        """A section spanning pages 3-5 reports page=3, page_end=5."""
+        chunks = chunk_ast(paged_doc, strategy="paragraph", max_tokens=500, token_counter="whitespace")
+        assert chunks
+        assert chunks[0].page == 3
+        assert chunks[0].page_end == 5
+
+    def test_no_provenance_when_absent(self, doc):
+        """Formats without page info leave page fields None."""
+        chunks = chunk_ast(doc, strategy="paragraph", max_tokens=50, token_counter="whitespace")
+        assert all(c.page is None and c.source_line_start is None for c in chunks)
+
+
+class TestAvoidTableSplit:
+    """Atomic-table handling in the fine path."""
+
+    def _doc_with_table(self):
+        """A section containing prose, a big table, then more prose."""
+        return Document(
+            children=[
+                Heading(level=1, content=[Text(content="Data")]),
+                Paragraph(content=[Text(content="Intro paragraph with several words to chunk.")]),
+                _table(8),
+                Paragraph(content=[Text(content="Trailing paragraph after the table here.")]),
+            ]
+        )
+
+    def test_table_split_without_flag(self):
+        """A small token budget shreds the table across multiple chunks by default."""
+        doc = self._doc_with_table()
+        chunks = chunk_ast(doc, strategy="paragraph", max_tokens=8, token_counter="whitespace")
+        table_chunks = [c for c in chunks if "|" in c.text]
+        assert len(table_chunks) >= 2  # table was fragmented
+
+    def test_table_atomic_with_flag(self):
+        """With --avoid-table-split, the whole table is exactly one chunk."""
+        doc = self._doc_with_table()
+        chunks = chunk_ast(doc, strategy="paragraph", max_tokens=8, avoid_table_split=True, token_counter="whitespace")
+        table_chunks = [c for c in chunks if "|" in c.text]
+        assert len(table_chunks) == 1
+        # The atomic table chunk legitimately exceeds the token budget.
+        assert table_chunks[0].token_count > 8
+        # Surrounding prose is still present and chunked.
+        assert any("Intro" in c.text for c in chunks)
+        assert any("Trailing" in c.text for c in chunks)
+
+    def test_ids_stay_unique_across_segments(self):
+        """Segmenting a unit around a table must not produce duplicate chunk ids."""
+        doc = self._doc_with_table()
+        chunks = chunk_ast(
+            doc, strategy="word", max_tokens=6, avoid_table_split=True, token_counter="whitespace", document_id="d"
+        )
+        ids = [c.chunk_id for c in chunks]
+        assert len(ids) == len(set(ids))
+
+
+class TestEdgeCases:
+    """Degenerate documents."""
+
+    def test_headingless_document(self):
+        """A document with no headings still chunks (whole-doc unit)."""
+        doc = Document(children=[Paragraph(content=[Text(content="lonely paragraph with words")])])
+        chunks = chunk_ast(doc, strategy="paragraph", max_tokens=50, token_counter="whitespace", document_id="d")
+        assert len(chunks) == 1
+        assert chunks[0].section_index == -1
+
+    def test_invalid_strategy(self, doc):
+        """An unknown strategy raises ValueError."""
+        with pytest.raises(ValueError, match="Unknown strategy"):
+            chunk_ast(doc, strategy="nope")
+
+    def test_invalid_max_tokens(self, doc):
+        """max_tokens < 1 raises ValueError."""
+        with pytest.raises(ValueError, match="max_tokens"):
+            chunk_ast(doc, strategy="paragraph", max_tokens=0, token_counter="whitespace")
+
+
+@pytest.mark.skipif(not tiktoken_available(), reason="tiktoken not installed")
+class TestSemanticStrategy:
+    """The default tiktoken-backed strategy."""
+
+    def test_semantic_respects_token_budget(self, doc):
+        """Semantic windows never exceed max_tokens under real tokenization."""
+        chunks = chunk_ast(doc, strategy="semantic", max_tokens=16, overlap=2, document_id="d")
+        assert chunks
+        assert all(c.token_count <= 16 for c in chunks)
+        assert all(c.token_counter == "tiktoken" for c in chunks)

--- a/tests/unit/chunking/test_provenance.py
+++ b/tests/unit/chunking/test_provenance.py
@@ -4,8 +4,10 @@
 import pytest
 
 from all2md.ast.nodes import (
+    CodeBlock,
     Document,
     Heading,
+    Image,
     Paragraph,
     SourceLocation,
     Table,
@@ -189,6 +191,71 @@ class TestAvoidTableSplit:
         )
         ids = [c.chunk_id for c in chunks]
         assert len(ids) == len(set(ids))
+
+
+class TestAvoidCodeSplit:
+    """Atomic code-block handling in the fine path."""
+
+    def _doc_with_code(self):
+        """A section containing prose then a multi-line code block."""
+        code = "\n".join(f"line_{i} = compute(value_{i}, other_{i})" for i in range(12))
+        return Document(
+            children=[
+                Heading(level=1, content=[Text(content="Code")]),
+                Paragraph(content=[Text(content="Intro paragraph before the code block here.")]),
+                CodeBlock(content=code, language="python"),
+            ]
+        )
+
+    def test_code_atomic_with_flag(self):
+        """--avoid-code-split keeps the whole code block in one chunk."""
+        doc = self._doc_with_code()
+        chunks = chunk_ast(doc, strategy="paragraph", max_tokens=8, avoid_code_split=True, token_counter="whitespace")
+        code_chunks = [c for c in chunks if "compute(" in c.text]
+        assert len(code_chunks) == 1
+        assert code_chunks[0].token_count > 8  # atomic block exceeds the budget
+
+    def test_code_split_without_flag(self):
+        """Without the flag, a small budget fragments the code block."""
+        doc = self._doc_with_code()
+        chunks = chunk_ast(doc, strategy="paragraph", max_tokens=8, token_counter="whitespace")
+        code_chunks = [c for c in chunks if "compute(" in c.text]
+        assert len(code_chunks) >= 2
+
+
+class TestDataUriElision:
+    """Long base64 data URIs are elided from chunk text by default."""
+
+    def _doc_with_data_uri(self):
+        """A section whose image is a long base64 data URI."""
+        payload = "A" * 200
+        return Document(
+            children=[
+                Heading(level=1, content=[Text(content="Pic")]),
+                Paragraph(content=[Text(content="Before image.")]),
+                Image(url=f"data:image/png;base64,{payload}", alt_text="x"),
+            ]
+        )
+
+    def test_elided_by_default(self):
+        """The base64 payload is replaced with a short placeholder."""
+        doc = self._doc_with_data_uri()
+        joined = " ".join(
+            c.text for c in chunk_ast(doc, strategy="section", max_tokens=400, token_counter="whitespace")
+        )
+        assert "AAAA" not in joined
+        assert "elided" in joined
+
+    def test_kept_when_disabled(self):
+        """elide_data_uris=False leaves the raw base64 in place."""
+        doc = self._doc_with_data_uri()
+        joined = " ".join(
+            c.text
+            for c in chunk_ast(
+                doc, strategy="section", max_tokens=400, elide_data_uris=False, token_counter="whitespace"
+            )
+        )
+        assert "AAAA" in joined
 
 
 class TestEdgeCases:

--- a/tests/unit/chunking/test_provenance.py
+++ b/tests/unit/chunking/test_provenance.py
@@ -279,6 +279,24 @@ class TestEdgeCases:
             chunk_ast(doc, strategy="paragraph", max_tokens=0, token_counter="whitespace")
 
 
+class TestMinTokens:
+    """min_tokens drops small chunks and renumbers the survivors."""
+
+    def test_drops_small_chunks_and_reindexes(self, doc):
+        """Chunks below the floor are removed; indices/links stay contiguous."""
+        unfiltered = chunk_ast(doc, strategy="word", max_tokens=4, token_counter="whitespace")
+        assert any(c.token_count < 4 for c in unfiltered)  # there are small chunks to drop
+
+        filtered = chunk_ast(doc, strategy="word", max_tokens=4, min_tokens=4, token_counter="whitespace")
+        assert filtered
+        assert all(c.token_count >= 4 for c in filtered)
+        assert [c.index for c in filtered] == list(range(len(filtered)))
+        assert filtered[0].prev_chunk_id is None
+        assert filtered[-1].next_chunk_id is None
+        for i in range(len(filtered) - 1):
+            assert filtered[i].next_chunk_id == filtered[i + 1].chunk_id
+
+
 @pytest.mark.skipif(not tiktoken_available(), reason="tiktoken not installed")
 class TestSemanticStrategy:
     """The default tiktoken-backed strategy."""

--- a/tests/unit/chunking/test_tokenization.py
+++ b/tests/unit/chunking/test_tokenization.py
@@ -1,0 +1,76 @@
+#  Copyright (c) 2025 Tom Villani, Ph.D.
+"""Tests for chunking token-counter resolution and backends."""
+
+import pytest
+
+from all2md.chunking.tokenization import (
+    WhitespaceCounter,
+    get_counter,
+    tiktoken_available,
+)
+from all2md.exceptions import DependencyError
+
+pytestmark = pytest.mark.unit
+
+
+class TestWhitespaceCounter:
+    """The dependency-free approximate counter."""
+
+    def test_counts_whitespace_runs(self):
+        """Tokens are whitespace-delimited runs; collapsed whitespace ignored."""
+        counter = WhitespaceCounter()
+        assert counter.count("one two three") == 3
+        assert counter.count("  leading   and   trailing  ") == 3
+        assert counter.count("") == 0
+        assert counter.name == "whitespace"
+
+    def test_has_no_encoding(self):
+        """Whitespace counter exposes no tiktoken encoding."""
+        assert WhitespaceCounter().encoding is None
+
+
+class TestGetCounter:
+    """Backend resolution and fallback rules."""
+
+    def test_whitespace_explicit(self):
+        """Explicit whitespace request returns the approximation."""
+        assert isinstance(get_counter("whitespace", strategy="paragraph"), WhitespaceCounter)
+
+    def test_whitespace_rejected_for_token_strategies(self):
+        """Whitespace cannot serve strategies that split on real token boundaries."""
+        for strategy in ("semantic", "token", "char"):
+            with pytest.raises(ValueError, match="real token boundaries"):
+                get_counter("whitespace", strategy=strategy)
+
+    def test_auto_falls_back_for_count_only(self, monkeypatch):
+        """When tiktoken is unavailable, auto degrades to whitespace for count-only strategies."""
+        monkeypatch.setattr("all2md.chunking.tokenization.tiktoken_available", lambda: False)
+        assert isinstance(get_counter("auto", strategy="paragraph"), WhitespaceCounter)
+
+    def test_auto_raises_for_token_strategy_without_tiktoken(self, monkeypatch):
+        """Auto surfaces a DependencyError (not silent degradation) for token strategies."""
+        monkeypatch.setattr("all2md.chunking.tokenization.tiktoken_available", lambda: False)
+
+        def _boom(*_a, **_k):
+            raise DependencyError(converter_name="chunk", missing_packages=[("tiktoken", ">=0.7.0")])
+
+        monkeypatch.setattr("all2md.chunking.tokenization.TiktokenCounter", _boom)
+        with pytest.raises(DependencyError):
+            get_counter("auto", strategy="semantic")
+
+    def test_unknown_backend(self):
+        """An unrecognized backend name raises ValueError."""
+        with pytest.raises(ValueError, match="Unknown token counter"):
+            get_counter("bogus")
+
+
+@pytest.mark.skipif(not tiktoken_available(), reason="tiktoken not installed")
+class TestTiktokenCounter:
+    """Real BPE counting (only when tiktoken is installed)."""
+
+    def test_counts_and_exposes_encoding(self):
+        """Tiktoken counter returns positive counts and exposes its encoding."""
+        counter = get_counter("tiktoken")
+        assert counter.name == "tiktoken"
+        assert counter.encoding is not None
+        assert counter.count("hello world") >= 2

--- a/tests/unit/cli/commands/test_skills.py
+++ b/tests/unit/cli/commands/test_skills.py
@@ -27,7 +27,7 @@ from all2md.cli.commands.skills import (
 
 # The single bundled skill and its reference topics.
 PRIMARY_SKILL = "all2md"
-EXPECTED_TOPICS = ["convert", "diff", "generate", "grep", "read", "search"]
+EXPECTED_TOPICS = ["chunk", "convert", "diff", "generate", "grep", "read", "search"]
 
 
 @pytest.mark.unit

--- a/uv.lock
+++ b/uv.lock
@@ -60,6 +60,7 @@ all = [
     { name = "reportlab" },
     { name = "rich" },
     { name = "textile" },
+    { name = "tiktoken" },
     { name = "tqdm" },
     { name = "watchdog" },
 ]
@@ -69,6 +70,9 @@ archive = [
 ]
 chm = [
     { name = "pychm" },
+]
+chunk = [
+    { name = "tiktoken" },
 ]
 cli-extras = [
     { name = "rich" },
@@ -122,6 +126,7 @@ dev = [
     { name = "sphinx-rtd-theme", marker = "python_full_version >= '3.11'" },
     { name = "syrupy" },
     { name = "textile" },
+    { name = "tiktoken" },
     { name = "tqdm" },
     { name = "types-beautifulsoup4" },
     { name = "types-docutils" },
@@ -341,6 +346,8 @@ requires-dist = [
     { name = "syrupy", marker = "extra == 'dev'", specifier = ">=4.6.0" },
     { name = "textile", marker = "extra == 'all'", specifier = ">=4.0.1" },
     { name = "textile", marker = "extra == 'textile'", specifier = ">=4.0.1" },
+    { name = "tiktoken", marker = "extra == 'all'", specifier = ">=0.7.0" },
+    { name = "tiktoken", marker = "extra == 'chunk'", specifier = ">=0.7.0" },
     { name = "tomli", marker = "python_full_version < '3.11'", specifier = ">=2.0.0" },
     { name = "tomli-w", specifier = ">=1.0.0" },
     { name = "tqdm", marker = "extra == 'all'", specifier = ">=4.66.0" },
@@ -356,7 +363,7 @@ requires-dist = [
     { name = "watchdog", marker = "extra == 'all'", specifier = ">=4.0.0" },
     { name = "watchdog", marker = "extra == 'cli-extras'", specifier = ">=4.0.0" },
 ]
-provides-extras = ["odf", "pdf", "pdf-layout", "docx", "fb2", "enex", "pptx", "rtf", "html", "http", "html-readability", "sanitizer", "latex", "search", "chm", "dev", "epub", "cli-extras", "xlsx", "markdown", "pdf-render", "docx-render", "mcp", "templates", "rst", "org", "archive", "ocr", "ocr-easyocr", "outlook", "textile", "openapi", "all", "wiki", "langdetect", "window"]
+provides-extras = ["odf", "pdf", "pdf-layout", "docx", "fb2", "enex", "pptx", "rtf", "html", "http", "html-readability", "sanitizer", "latex", "search", "chunk", "chm", "dev", "epub", "cli-extras", "xlsx", "markdown", "pdf-render", "docx-render", "mcp", "templates", "rst", "org", "archive", "ocr", "ocr-easyocr", "outlook", "textile", "openapi", "all", "wiki", "langdetect", "window"]
 
 [[package]]
 name = "annotated-types"
@@ -4620,6 +4627,67 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/b7/38/5e2ecef5af2f4fd4a89bb8d6240de9458bab4d51a4cbd97aeb3a0cd618e2/tifffile-2026.6.1.tar.gz", hash = "sha256:626c892c0e899d959b9438e7c0e1491dc154a7fead1f1f37a991724a50eceba9", size = 429694, upload-time = "2026-05-31T23:57:12.165Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/81/59/208f71d70ddc6184f79b8c6d87d46eb7d7b12c19186a817dec9c9c3f3693/tifffile-2026.6.1-py3-none-any.whl", hash = "sha256:0d7382d2769b855b81ce358528e2b40c16d48aa39031746efa81215205332a8d", size = 267108, upload-time = "2026-05-31T23:57:10.597Z" },
+]
+
+[[package]]
+name = "tiktoken"
+version = "0.13.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "regex" },
+    { name = "requests" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e4/e5/5f3cb2159769d0f4324c0e9e87f9de3c4b1cd45848a96b2eb3566ad5ca77/tiktoken-0.13.0.tar.gz", hash = "sha256:c9435714c3a84c2319499de9a300c0e604449dd0799ff246458b3bb6a7f433c1", size = 38986, upload-time = "2026-05-15T04:51:27.153Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/38/e3/03c90dadcf5b3f82b83cee9adee60ef666b329c654f58c066af44eae0287/tiktoken-0.13.0-cp310-cp310-macosx_10_12_x86_64.whl", hash = "sha256:47b1df8d73390a24f94980c75158cdd5c56d256f16d55f30cb49c230caba9ba4", size = 1036627, upload-time = "2026-05-15T04:50:11.229Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/30/760463e5b2e8ad2bc229ae0a17ecb06727b6cbc094f08d8f65844315632e/tiktoken-0.13.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:7d40c6c5aab171dcd6eb8455bc567bde404bb9def60cdb8c1299cc782b242bb9", size = 984699, upload-time = "2026-05-15T04:50:12.874Z" },
+    { url = "https://files.pythonhosted.org/packages/de/8a/8895f342a6b6aabd1a358e672f6f077b3ae51d0c63ca605d142db3bcd8ab/tiktoken-0.13.0-cp310-cp310-manylinux_2_28_aarch64.whl", hash = "sha256:9b842981fa91accdffd48ff6408a977b7a91c3fbda55d353c3c68114d5c9d69e", size = 1118690, upload-time = "2026-05-15T04:50:14.234Z" },
+    { url = "https://files.pythonhosted.org/packages/51/e0/92557768fb0801f0d9dd9243cb9b6d342900b05e4b1006d4771f49ce233e/tiktoken-0.13.0-cp310-cp310-manylinux_2_28_x86_64.whl", hash = "sha256:ed5a30027cb4d8c7ca8b273d4766f3db3cf58fad9e9f3b1a68a351ffb54873d5", size = 1138423, upload-time = "2026-05-15T04:50:15.668Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/b9/a3d99feeedb032ffd09cd6652077f86bdee9a70dd0b990b2b272b445d4c3/tiktoken-0.13.0-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:7ab10f4a21c2999846940113f6dbd72e0fa06a24119feddd74cc47e85818e06d", size = 1185077, upload-time = "2026-05-15T04:50:17.19Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/93/bab868277d475dc6d2aaacd34cdd239c282f4908dcc8702e0a3311a8e032/tiktoken-0.13.0-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:a2937ad042d49d50eac6e1ba07c5661d4bd3942a5b1e0c0d08475c4df83676e1", size = 1241702, upload-time = "2026-05-15T04:50:18.772Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/16/27e9f7e0ed76e501cfefc9fb2112df4c7bf70ca96945b15ecb7615aac860/tiktoken-0.13.0-cp310-cp310-win_amd64.whl", hash = "sha256:44733b99bfd72b590cd0936b1c01b3b4dd73122db2d544bc1ceeb18a7678c910", size = 876565, upload-time = "2026-05-15T04:50:20.268Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/4c/1bc81f4cd53e827c4ee67ca951b5935724716049452d8dfa09b8b82372bb/tiktoken-0.13.0-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:7bfe1849caa65d1e1d9871817170ec497bbb7984e182012e1bdce72f66608cdb", size = 1036353, upload-time = "2026-05-15T04:50:21.757Z" },
+    { url = "https://files.pythonhosted.org/packages/75/91/10b9c7076bc02c246c853201fdbbe300a4b8c5ed7b84c25f7403f4e32655/tiktoken-0.13.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:91c180fe255bd5a86d8316210d2833a1d4d33d026cd86a67812f4773743c8d26", size = 984644, upload-time = "2026-05-15T04:50:23.256Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/e4/fceae98015fab47fcd49b8bd7f46145bcd187a47e0add1e5378ed67ef980/tiktoken-0.13.0-cp311-cp311-manylinux_2_28_aarch64.whl", hash = "sha256:059c8ecf554eb5b41e6e054ba467b871b03277d267dee7244380aca4359747d4", size = 1119261, upload-time = "2026-05-15T04:50:24.348Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/39/fe42ad00de01a8c4a49ad8649a2c8a316835a9cad5961b11d21eac0020a5/tiktoken-0.13.0-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:36217497eaffc158607a3b26f065300db2aefd43b115263f3b9688ce38146173", size = 1138253, upload-time = "2026-05-15T04:50:25.505Z" },
+    { url = "https://files.pythonhosted.org/packages/03/c4/ccee1ecccca107e9a16efcecdeeb964c325305038554d466ece65b42338f/tiktoken-0.13.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:303f7d91b4fce3baddbcde05c139091d4caa5026ac7214c1dc7ff7a71ee429ff", size = 1185747, upload-time = "2026-05-15T04:50:27.02Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/03/cd0cba295522b91eb55c6b2704f1df895f8226cfe60ab10d4d51d0cc9e69/tiktoken-0.13.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:5d48843bee149630eb735a99e1f4a85b47308d21868ea63163f6e87768d3cfed", size = 1241265, upload-time = "2026-05-15T04:50:28.815Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/25/a10efd564402d82c2ff50d12057353ace447aa8007deceaa48641f63d35c/tiktoken-0.13.0-cp311-cp311-win_amd64.whl", hash = "sha256:fc1c44cd37b43fc46bae593129164f4f281e82ea116b57a85aa81bda57eafc94", size = 876509, upload-time = "2026-05-15T04:50:30.026Z" },
+    { url = "https://files.pythonhosted.org/packages/85/8e/144bde4e01df66b34bb865557c7cd754ed08b036217ebd79c9db5e9048a9/tiktoken-0.13.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:32ac870a806cfb260a02d0cb70426aef02e038297f8ad50df5040bb5af360791", size = 1034888, upload-time = "2026-05-15T04:50:31.579Z" },
+    { url = "https://files.pythonhosted.org/packages/36/18/d4ac9d20956cdebca04841316660ed584c2fecdc2b81722a28bc7ad3b1e4/tiktoken-0.13.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:4d9980f11429ed2d737c463bb1fb78cf330caa026adf002f714aced7849a687b", size = 982970, upload-time = "2026-05-15T04:50:32.961Z" },
+    { url = "https://files.pythonhosted.org/packages/74/ed/6bb8d05b9f731f749fee5c6f5ca63e981143c826a5985877330507bd13b7/tiktoken-0.13.0-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:3f277ebea5edd7b8bf03c6f9431e1d67d517530115572b2dc1d465326e8f88c7", size = 1115741, upload-time = "2026-05-15T04:50:34.475Z" },
+    { url = "https://files.pythonhosted.org/packages/34/de/2ca96b07a82d972b74fe4b46de055b79c904e45c7eab699354a0bfa697dc/tiktoken-0.13.0-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:a116178fa7e1b4065bff05214360373a65cac22f965be7b3f73d00a0dbfe7649", size = 1136523, upload-time = "2026-05-15T04:50:35.782Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/dc/9dafec002c2d4424378563cf4cf5c7fb93631d2a55013c8b87554ee4012c/tiktoken-0.13.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:2c397ddda233208345b01bd30f2fca79ff730e55731d0108a603f9bc57f6af3b", size = 1181954, upload-time = "2026-05-15T04:50:36.99Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/d0/1f8578c45b2f24759b46f0b50d31878c63c73e6bf0f2227e10ec5c5408dc/tiktoken-0.13.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:95097e4f89b06403976e498abf61a0ee73a7497e73fb599cb211d8197a054d91", size = 1240069, upload-time = "2026-05-15T04:50:38.221Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/90/28d7f154888610aa9237e541986beb62b479df29d193a5a0617dbb1514d0/tiktoken-0.13.0-cp312-cp312-win_amd64.whl", hash = "sha256:8f2d16e7a7c783ad81f36e457d046d1f1c8af70b22aec8a13238efe531977c41", size = 874748, upload-time = "2026-05-15T04:50:39.587Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/83/b096c859c2a47c11731bf2f5885f4028b809dfe2396582883eed9cae372f/tiktoken-0.13.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:5df5d1507bd245f1ccad4a074698240021239e455eb0bb4ced4e3d7181872154", size = 1034228, upload-time = "2026-05-15T04:50:40.988Z" },
+    { url = "https://files.pythonhosted.org/packages/53/61/c68e123b6d753e3fc2751e9b18e732c9d8bf1e1926762e736eee935d931c/tiktoken-0.13.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:8fe806a50664e83a6ffd56cbd1e4f5dcc6cd32a3e7538f70dc38b1a271384545", size = 982978, upload-time = "2026-05-15T04:50:42.195Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/8b/96cc178cc584e65d363134500f297790b06cd48cdeb1e8fcf7bbe60f4715/tiktoken-0.13.0-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:125bc05005e747f993a83dc67934249932d6e4209854452cd4c0b1d53fba3ba2", size = 1116355, upload-time = "2026-05-15T04:50:43.564Z" },
+    { url = "https://files.pythonhosted.org/packages/86/f5/bab735d2c72ea55404b295d02d092644eb5f7cc6205e34d35eb9abfb9ab2/tiktoken-0.13.0-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:5e6358911cab4adee6712da27d65573496a4f68cf8a2b5fca6a4ad10fc5748cf", size = 1135772, upload-time = "2026-05-15T04:50:44.782Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/b9/6de04ebdf904edfaad87788011b3735087a0c9ea671b9027e1e4e965e8c8/tiktoken-0.13.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:975cbd78d085d75d26b59660e262736dcaed1e35f8f142cd6291025c01d25486", size = 1182415, upload-time = "2026-05-15T04:50:46.422Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/9c/470a05f3b1caf038f44880e334d47ab674e0c80d514c66b375d14d5afa10/tiktoken-0.13.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:75ab9bc99fa020a4c283424590ecd7f3afd70c1c281cb3fa3192a6c3af9f9615", size = 1239879, upload-time = "2026-05-15T04:50:48.052Z" },
+    { url = "https://files.pythonhosted.org/packages/42/a6/c1936d16055436cb32e6c6128d68629622e00f4768562f55653752d34768/tiktoken-0.13.0-cp313-cp313-win_amd64.whl", hash = "sha256:6b1615f0ff71953d19729ceb18865429c185b0a23c5353f1bbca34a394bf60f7", size = 874829, upload-time = "2026-05-15T04:50:49.202Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/07/acb5992c3772b5a36284f742cfb7a5895aa4471d1848ac31464ad50d7fdf/tiktoken-0.13.0-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:6eb4a5bfbc6426938026b1a334e898ac53541360d62d8c689870160cc80abd67", size = 1033600, upload-time = "2026-05-15T04:50:50.4Z" },
+    { url = "https://files.pythonhosted.org/packages/14/e9/742e9aec30f59b9f161f7ff7cd072e02ea836c9e1c0854a8076dfcd40d5c/tiktoken-0.13.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:43cee3e5400573b2046fbf092cc7a5bc30164f9e4c95ce20714da929df48737a", size = 982516, upload-time = "2026-05-15T04:50:52.03Z" },
+    { url = "https://files.pythonhosted.org/packages/72/74/ca1541b053e7648254d2e4b42a253e1bb4359f2c91a0a8d49228c794e1a0/tiktoken-0.13.0-cp313-cp313t-manylinux_2_28_aarch64.whl", hash = "sha256:7de52e3f566d19b3b11bd37eea552c6c305ad74081f736882bd44d148ed4c48d", size = 1115518, upload-time = "2026-05-15T04:50:53.543Z" },
+    { url = "https://files.pythonhosted.org/packages/46/e3/93825eaf5a4a504795b787e5d5dea07fbeb3dabf97aa7b450be8bde59c89/tiktoken-0.13.0-cp313-cp313t-manylinux_2_28_x86_64.whl", hash = "sha256:51384448aa508e4df84c0f7c1dc3211c7f7b8096325660ee5fc82f3e11b381ce", size = 1136867, upload-time = "2026-05-15T04:50:55.191Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/46/002b68de6827091d5ae90b048f326e8aad8d953520950e5ce1508879414f/tiktoken-0.13.0-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:e28157350f7ebf35008dd8e9e0fdb621f976e4230c881099c85e8cf07eaa50e2", size = 1181826, upload-time = "2026-05-15T04:50:56.296Z" },
+    { url = "https://files.pythonhosted.org/packages/db/c6/d393e3185a276505182f7abd93fe714f3c444a2be9180798fa052347504e/tiktoken-0.13.0-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:165cf1820ea4a354985c2490a5205d4cc74661c934aca79dd0368232fff94e0f", size = 1239489, upload-time = "2026-05-15T04:50:57.918Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/4d/bc07d1f1635d4897a202acc0ae11c2886eaa7325c359ba4741b47bf8e225/tiktoken-0.13.0-cp313-cp313t-win_amd64.whl", hash = "sha256:6c43a675ca14f6f2749ba7f12075d37456015a24b859f2517b9beb4ef30807ec", size = 873820, upload-time = "2026-05-15T04:50:59.528Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/93/0dd6adca026a616c3a92974566b43381eea4b475ce1f36c062b8271a9ac5/tiktoken-0.13.0-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:eaaaef47c2406277181d2086484c317bf7fc433e2d5d03ff94f56b0dcec87471", size = 1034977, upload-time = "2026-05-15T04:51:00.957Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/77/5ec6e6bc5b30bed6d93f7f2162d8f6b32437b3ba27cb527cfe004f6109c9/tiktoken-0.13.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:ca8b310bd93b3772cb1b7922d915446864860f562bdfe4825c63a0aed3fb28cd", size = 983635, upload-time = "2026-05-15T04:51:02.629Z" },
+    { url = "https://files.pythonhosted.org/packages/94/b0/c8ae9aff00d625c50659b4513e707a0462c4bf5d4d6cc1b802103225c02e/tiktoken-0.13.0-cp314-cp314-manylinux_2_28_aarch64.whl", hash = "sha256:32e0c12305105002c047b3bb1070b0dd9a73b0cb3b2856a8972b810e7a4f5881", size = 1116036, upload-time = "2026-05-15T04:51:04.082Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/ac/6a5dddd1d0a6018ecb389bd0353e6b4a515eb4d2286611bd0ace1937b9e1/tiktoken-0.13.0-cp314-cp314-manylinux_2_28_x86_64.whl", hash = "sha256:5ba5fd62507a932d1241346179e3b39bc7bf7408f03c272652d93b3bedf5db24", size = 1135544, upload-time = "2026-05-15T04:51:05.229Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/b8/585032b4384b2f7dcdaddcb52865c83a701a420d09e3c2b4a2be1c450c57/tiktoken-0.13.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:d108bc2d470fc53c8ecd24f2c0fd2b5f98c33e87cdb6aa2e9b8c5dced703d273", size = 1182217, upload-time = "2026-05-15T04:51:06.517Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/b6/993ff1ded3958215fd341a847b8e5ffeb5de473f435296870d314fc91ac4/tiktoken-0.13.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:cb99cb5127449f58d0a2d5f5ccfb390d8dbdfd919c221246caaee29d8725ed51", size = 1239404, upload-time = "2026-05-15T04:51:07.843Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/3d/fef7e06e3b33e7538db0ced734cf9fe23b6832d2ac4990c119c377aec55e/tiktoken-0.13.0-cp314-cp314-win_amd64.whl", hash = "sha256:115c4f26ffa11caac8b54eea35c2ad38c612c20a48d35dd15d70a02ac6f51f58", size = 918686, upload-time = "2026-05-15T04:51:08.925Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/82/a7fc44582bc32ab00de988a2299bf77c077f59068b233109e34b7d6ca7e6/tiktoken-0.13.0-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:472527e9132952f2fbf77cd290658bacf003d4d5a3fabc18e5fbd407cbae4d9b", size = 1034454, upload-time = "2026-05-15T04:51:10.035Z" },
+    { url = "https://files.pythonhosted.org/packages/37/d0/24d8a890c14f432a05cea669c17bebeaa99f96a7c79523b590f564246411/tiktoken-0.13.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:4e2f67d27c9626cdd25fe33d9313c5cdb3d8d82da646b68d6eb8e7e9c20e6448", size = 982976, upload-time = "2026-05-15T04:51:11.23Z" },
+    { url = "https://files.pythonhosted.org/packages/49/b7/2ab43f62788a9266187a9bfc1d3af99ad83e5eaa25fbef168a69cd5ad14f/tiktoken-0.13.0-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:2b920b35805cd64585a37c3dc7ce65fba4d2d36016be01e1d7942482ca29093a", size = 1115526, upload-time = "2026-05-15T04:51:12.608Z" },
+    { url = "https://files.pythonhosted.org/packages/64/39/1494321ed323ce7a14d88e3cd6cb9058625977df1c6961ddc492bd10a9f3/tiktoken-0.13.0-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:493af3aa28a4aaf2e3d2600a2ee717252c9bf5ab38fff94eb5a02db5ab77e5ad", size = 1136466, upload-time = "2026-05-15T04:51:13.926Z" },
+    { url = "https://files.pythonhosted.org/packages/96/d9/dfd086aa2d918c563a140720e0ce296cada1634efd2783d5cf51e05f984e/tiktoken-0.13.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:6644c9c2b5cf3916f5a3641d7d12fdb3f006a7b3d9ff6acdaec44e29ab1ff91e", size = 1181863, upload-time = "2026-05-15T04:51:15.025Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/68/a18b4f307086954fdae32714cb4f85562e34f9d34ab206e61f1816aa6018/tiktoken-0.13.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:5cb65b60b9408563676d874a3a4ee573370066f0dc4e29d84e82e989c6517424", size = 1239218, upload-time = "2026-05-15T04:51:16.103Z" },
+    { url = "https://files.pythonhosted.org/packages/16/5b/f2aa703a4fc5d2dff73460a7d46cc2f3f44aa0f3dd8eeb20d2a0ecf68862/tiktoken-0.13.0-cp314-cp314t-win_amd64.whl", hash = "sha256:85b78cc3a2c3d48723ca751fa981f1fedccd54194ca0471b957364353a898b07", size = 918110, upload-time = "2026-05-15T04:51:17.237Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Adds a first-class `all2md chunk` command that splits any supported document into chunks for RAG/LLM pipelines, emitting **JSONL** (or `json`/`pretty`). Unlike flat-text chunkers, every chunk carries **AST-derived provenance** — its section heading/level and, where the format records it, the source page span — so a downstream answer can cite where a passage came from. This is the roadmap's "first-class chunking" item (Theme 1, RAG-native output).

## What's included

**Core (`src/all2md/chunking/`)**
- `primitives.py` — 8 position-tracking chunkers vendored from the `localvectordb` sister project, adapted to inject a `TokenCounter` rather than constructing a tiktoken encoder directly.
- `tokenization.py` — `TiktokenCounter` / `WhitespaceCounter` + `get_counter()` with graceful fallback (count-only strategies work without tiktoken).
- `provenance.py` — `chunk_ast()` bridges AST → chunks. Coarse strategies (`heading`/`section`/`auto`) reuse `DocumentSplitter`; fine strategies window each section's rendered Markdown. Page/line spans derive from contributing nodes.
- `records.py` — `ProvenanceChunk`, the flat JSONL output record.

**Python API — one-call, mirrors `to_markdown`**
```python
import all2md
chunks = all2md.chunk("report.pdf", strategy="semantic", max_tokens=512, overlap=64)
# converts + chunks in one step; derives document_id/path from the source;
# forwards converter kwargs (e.g. attachment_mode="skip"); returns ProvenanceChunk records
```
`all2md.chunking.chunk_ast(doc, ...)` remains available for an AST you already hold.

**CLI**
- 11 strategies (`semantic` default, `heading`/`section`/`auto`, `token`/`sentence`/`paragraph`/`word`/`line`/`char`/`code`).
- `--max-tokens` / `--overlap` / `--min-tokens` / `--max-heading-level`, `--include-preamble` / `--heading-merge`, `--token-counter`, `jsonl`/`json`/`pretty` output, `--out`.

**Element & attachment handling**
- `--avoid-table-split` / `--avoid-code-split` — keep each table or fenced code block whole (one atomic chunk rather than fragmenting it).
- `--drop-elements image,table,…` — strip noisy node types before chunking (via the existing `RemoveNodesTransform`).
- `--elide-data-uris` (on by default) — replace long base64 `data:` URIs with a short placeholder so embedded images never inflate token counts or shred into noise.
- `--attachment-mode {skip,alt_text,save,base64}` + config-file converter options (`[pdf]`, `[html]`, top-level keys, honoring `--config`/`--no-config`).

**Packaging & docs**
- `tiktoken` added as the optional `chunk` extra (and to `all`).
- `docs/source/cli.rst` Chunk Command section (incl. Python API), CHANGELOG entry, and a `chunk.md` skill reference surfaced by `all2md llm-help chunk`.

## Testing

- 69 tests (`tests/unit/chunking/`, `tests/integration/test_cli_chunk.py`): chunker invariants/parity, tokenizer fallback + dependency gating, provenance derivation, JSONL schema, atomic table/code handling, data-URI elision, `min_tokens` filtering, the one-call `all2md.chunk()` API, and CLI end-to-end.
- `ruff`, `ruff format`, and `mypy` clean; all pre-commit hooks pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)