### PR TITLE
feat(cli): add `all2md help cheatsheet`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **`all2md help cheatsheet`.** A bundled, grouped quick reference of the most common
+  commands (convert, view/serve/edit, extract/navigate, grep/search, chunk, diff/lint,
+  generate, transforms, stdin pipes, utilities), printable offline from the terminal
+  (`--rich` renders it as Markdown). The cheatsheet ships in the wheel as a single
+  source of truth and is mirrored into the docs (:doc:`cheatsheet`); the quick-help
+  footer now points at it.
+
 - **`all2md chunk`: provenance-aware document chunking for RAG/LLM pipelines.**
   Splits any supported document into chunks and emits them as JSONL (one object
   per line) — or ``--format json``/``pretty``. Unlike flat-text chunkers, every

--- a/docs/source/cheatsheet.rst
+++ b/docs/source/cheatsheet.rst
@@ -1,0 +1,17 @@
+CLI Cheatsheet
+==============
+
+A quick reference for the most common ``all2md`` commands, grouped by task.
+
+The same cheatsheet is available offline from the terminal:
+
+.. code-block:: bash
+
+   all2md help cheatsheet           # print it
+   all2md help cheatsheet --rich    # rendered Markdown (needs the rich extra)
+
+For the full, auto-generated option reference, run ``all2md help full`` or
+``all2md <command> --help``; see :doc:`cli` for the narrative guide.
+
+.. literalinclude:: ../../src/all2md/cli/cheatsheet.md
+   :language: text

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -123,6 +123,7 @@ Guides & References
 
    python_api
    cli
+   cheatsheet
    lint_guide
    options
    batch

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -81,6 +81,7 @@ include = ["src/**", "pyproject.toml", "README.md", "LICENSE"]
 [tool.hatch.metadata]
 include = [
     "src/all2md/_plaintext-exts.json",
+    "src/all2md/cli/cheatsheet.md",
     "src/all2md/cli/templates/*.html",
     "src/all2md/skills/**/*.md"
 ]

--- a/src/all2md/cli/cheatsheet.md
+++ b/src/all2md/cli/cheatsheet.md
@@ -1,0 +1,125 @@
+# all2md CLI Cheatsheet
+
+Quick reference for the most common `all2md` commands. Run `all2md help` for the
+tiered help, `all2md help full` for every option, or `all2md <command> --help` for a
+specific subcommand.
+
+## Convert
+
+```bash
+all2md document.pdf                      # convert to Markdown on stdout
+all2md report.docx --out report.md       # write to a file
+all2md page.html --output-format rst     # choose the output format
+all2md slides.pptx | wc -w               # pipe Markdown into other tools
+
+# Many files / directories
+all2md ./docs -o ./out                   # convert a directory into ./out
+all2md ./docs -o ./out --recursive       # recurse into subdirectories
+all2md ./docs -o ./out -p 8              # parallel, 8 workers
+all2md ./docs -o ./out --preserve-structure   # mirror the input tree
+
+# Attachments / images
+all2md report.pdf --attachment-mode save --attachment-output-dir ./images
+all2md report.pdf --attachment-mode skip      # drop images entirely
+```
+
+## Read in the terminal
+
+```bash
+all2md document.pdf --rich               # render Markdown with colors (fancy cat)
+rcat document.pdf                        # alias for `all2md ... --rich`
+all2md document.pdf --pager              # page long output
+```
+
+## Preview, serve & edit
+
+```bash
+all2md view report.pdf                   # open an HTML preview in the browser
+all2md view report.pdf --dark            # dark theme
+all2md serve ./docs                      # serve a directory over HTTP with live preview
+all2md serve ./docs --port 8080 --browse
+all2md edit notes.md                     # browser-based Markdown/WYSIWYG editor, saves back
+```
+
+## Extract & navigate
+
+```bash
+all2md book.pdf --outline                # print the heading outline
+all2md book.pdf --extract "Introduction" # extract a section by heading
+all2md book.pdf --extract "#:1-3"        # extract sections 1-3 (1-based)
+all2md book.pdf --extract table:2        # extract the 2nd table
+all2md book.pdf --head 20                # first 20 rendered lines
+all2md book.pdf --lines 40:80            # a line range
+all2md book.pdf --slice 2/5              # the 2nd of 5 balanced slices
+all2md book.pdf --split-by h1 -o parts/  # split into files at H1 boundaries
+```
+
+## Search
+
+```bash
+all2md grep "revenue" report.pdf         # grep through any document format
+all2md grep -i "todo" ./specs/*.docx     # case-insensitive across many files
+all2md search "machine learning" ./papers/        # ranked keyword search
+all2md search "project timeline" --semantic ./docs/   # vector / semantic search
+```
+
+## Chunk for RAG / LLMs
+
+```bash
+all2md chunk report.pdf --strategy semantic --max-tokens 512 --overlap 64   # JSONL
+all2md chunk report.pdf --strategy section --out chunks.jsonl
+all2md chunk report.pdf --avoid-table-split --avoid-code-split   # keep tables/code whole
+all2md chunk report.pdf --drop-elements image,table              # strip noise
+all2md chunk report.pdf --format pretty                          # human-readable
+```
+
+Each chunk is JSONL with section + page provenance. `pip install all2md[chunk]` enables
+real token counting (`--strategy semantic/token/char`).
+
+## Compare, lint & minify
+
+```bash
+all2md diff old.pdf new.pdf              # unified diff of two documents (any format)
+all2md diff old.docx new.docx --format html --output diff.html
+all2md lint report.docx                  # lint structure/headings/links/tables/typography
+all2md lint report.docx --profile prose  # a curated rule bundle
+all2md llm-minify report.pdf             # strip tokens for cheaper LLM input
+```
+
+## Generate
+
+```bash
+all2md notes.md --output-format docx --out notes.docx   # Markdown -> DOCX/PDF/...
+all2md generate-site ./docs --generator mkdocs          # build a static site
+all2md arxiv paper.md                                   # ArXiv-ready LaTeX package
+```
+
+## Transform during conversion
+
+```bash
+all2md report.docx --transform remove-images
+all2md report.docx --transform heading-offset --heading-offset 1
+all2md list-transforms                   # list available transforms
+```
+
+## Stdin / pipes (use '-' for stdin)
+
+```bash
+cat report.html | all2md - --format html --rich
+curl https://example.com/doc.pdf | all2md - | grep "important"
+echo "<h1>Note</h1>" | all2md view -
+cat doc.pdf | all2md grep "term" -
+echo "<p>v1</p>" | all2md diff - v2.html
+```
+
+## Utilities
+
+```bash
+all2md list-formats                      # list supported input/output formats
+all2md check-deps                        # check optional dependencies
+all2md config generate --out .all2md.toml   # scaffold a config file
+all2md completion bash                   # shell completion script (bash/zsh/powershell)
+all2md install-skills                    # install bundled agent skills
+all2md llm-help [topic]                  # print the CLI guide for LLMs/agents
+all2md help cheatsheet                   # print this cheatsheet
+```

--- a/src/all2md/cli/commands/help.py
+++ b/src/all2md/cli/commands/help.py
@@ -15,6 +15,29 @@ from typing import Optional
 from all2md.cli.help_formatter import display_help
 
 
+def _read_cheatsheet() -> str:
+    """Read the bundled CLI cheatsheet Markdown shipped in the wheel."""
+    import importlib.resources  # nosemgrep: python.lang.compatibility.python37.python37-compatibility-importlib2
+
+    ref = importlib.resources.files("all2md.cli") / "cheatsheet.md"
+    return ref.read_text(encoding="utf-8")
+
+
+def _print_cheatsheet(use_rich: bool) -> None:
+    """Print the CLI cheatsheet, optionally rendered with rich Markdown."""
+    text = _read_cheatsheet()
+    if use_rich:
+        try:
+            from rich.console import Console
+            from rich.markdown import Markdown
+
+            Console().print(Markdown(text))
+            return
+        except ImportError:
+            print("Warning: rich not installed; printing plain text.", file=sys.stderr)
+    print(text)
+
+
 def handle_help_command(args: list[str] | None = None) -> int | None:
     """Handle the ``help`` subcommand for tiered CLI documentation."""
     if not args:
@@ -27,13 +50,13 @@ def handle_help_command(args: list[str] | None = None) -> int | None:
 
     parser = argparse.ArgumentParser(
         prog="all2md help",
-        description="Show all2md CLI help sections (quick, full, or format-specific).",
+        description="Show all2md CLI help sections (quick, full, cheatsheet, or format-specific).",
     )
     parser.add_argument(
         "section",
         nargs="?",
         default="quick",
-        help="Help selector (quick, full, pdf, docx, html, etc.). Default: quick.",
+        help="Help selector: quick (default), full, cheatsheet, or a format (pdf, docx, html, ...).",
     )
     parser.add_argument(
         "--rich",
@@ -42,6 +65,10 @@ def handle_help_command(args: list[str] | None = None) -> int | None:
     )
 
     parsed = parser.parse_args(help_args)
+
+    if parsed.section == "cheatsheet":
+        _print_cheatsheet(use_rich=parsed.rich)
+        return 0
 
     requested_rich: Optional[bool]
     if parsed.rich:

--- a/src/all2md/cli/help_formatter.py
+++ b/src/all2md/cli/help_formatter.py
@@ -150,7 +150,7 @@ class HelpCatalog:
 LLM_HELP_CALLOUT = "For LLMs & agents: run `all2md llm-help` for a CLI usage guide written for you."
 
 _SUBCOMMAND_SUMMARIES: Sequence[tuple[str, str]] = (
-    ("help", "Show tiered CLI help (all2md help [section])"),
+    ("help", "Show tiered CLI help — quick, full, cheatsheet, or a format (all2md help [section])"),
     ("llm-help", "Print the all2md CLI guide for LLMs/agents (full guide or a single topic)"),
     ("list-formats", "List available input formats"),
     ("list-transforms", "List registered AST transforms"),
@@ -578,6 +578,7 @@ class HelpRenderer:
 
         lines.append(
             "\nNote: showing only global options."
+            "\nRun: `all2md help cheatsheet` for a quick reference of common commands."
             "\nRun: `all2md help full` for all options including format-specific parser/renderer options."
             "\nRun: `all2md help <format>` to see options for a specific format (e.g., `all2md help pdf`)."
         )

--- a/tests/unit/cli/test_cli_help.py
+++ b/tests/unit/cli/test_cli_help.py
@@ -127,3 +127,42 @@ def test_help_batch_topic_lists_batch_flags(capsys):
     assert "--preserve-structure" in out
     assert "--output-dir" in out
     assert "--parallel" in out
+
+
+@pytest.mark.unit
+def test_help_cheatsheet_prints(capsys):
+    """`all2md help cheatsheet` prints the bundled quick reference."""
+    rc = handle_help_command(["help", "cheatsheet"])
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "all2md CLI Cheatsheet" in out
+    assert "## Chunk for RAG" in out
+    assert "all2md chunk" in out
+    assert "all2md grep" in out
+
+
+@pytest.mark.unit
+def test_cheatsheet_bundled_resource_loads():
+    """The cheatsheet ships as a package resource and has the expected sections."""
+    from all2md.cli.commands.help import _read_cheatsheet
+
+    text = _read_cheatsheet()
+    assert text.strip()
+    for section in ("## Convert", "## Search", "## Chunk for RAG", "## Utilities"):
+        assert section in text
+
+
+@pytest.mark.unit
+def test_quick_help_points_at_cheatsheet(capsys):
+    """The quick-help footer advertises `all2md help cheatsheet`."""
+    handle_help_command(["help"])
+    out = capsys.readouterr().out
+    assert "all2md help cheatsheet" in out
+
+
+@pytest.mark.unit
+def test_help_cheatsheet_rich_does_not_crash(capsys):
+    """The --rich path renders without error (falls back to plain if rich is absent)."""
+    rc = handle_help_command(["help", "cheatsheet", "--rich"])
+    assert rc == 0
+    assert capsys.readouterr().out.strip()


### PR DESCRIPTION
## Summary

Adds `all2md help cheatsheet` — a bundled, grouped quick reference of the most common commands, printable offline from the terminal. Closes the discoverability loop on the recent `chunk` work (the cheatsheet documents it alongside everything else).

```bash
all2md help cheatsheet          # plain text
all2md help cheatsheet --rich   # rendered Markdown (needs the rich extra)
```

## Design

- **Single source of truth.** The cheatsheet lives at `src/all2md/cli/cheatsheet.md`. It ships in the wheel (added to `[tool.hatch.metadata] include`) and is read at runtime via `importlib.resources` — the same mechanism the bundled agent skills already use.
- **Wiring.** `cheatsheet` is a new selector in the existing tiered-help command (`all2md help <section>`), honoring `--rich`. The quick-help footer and the `help` subcommand summary now advertise it.
- **Docs.** Mirrored into Sphinx at `docs/source/cheatsheet.rst` via `literalinclude`, so the rendered docs are sourced from the same file and can't drift. The README's existing "Essential CLI Commands" stays as the shorter marketing subset (different audience).

## Testing

- New tests in `tests/unit/cli/test_cli_help.py`: the command prints the cheatsheet, the bundled resource loads with the expected sections, the quick-help footer points at it, and the `--rich` path renders without error.
- Verified the built wheel actually contains `all2md/cli/cheatsheet.md`.
- `ruff`, `ruff format`, `mypy` clean; help + completion test suites pass; pre-commit hooks green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)