### PR TITLE
fix(pdf): dehyphenate OCR text when merge_hyphenated_words is set (#51)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,6 +72,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   existing ``--extract line:`` range. ``--head``/``--tail`` default to 10 lines and
   honor ``--line-numbers``.
 
+### Fixed
+
+- **`merge_hyphenated_words` now applies to OCR text.** PyMuPDF's
+  ``TEXT_DEHYPHENATE`` flag only affects native text extraction, so words
+  hyphenated across a line break (``be-\nwusst``) survived unmerged whenever a
+  PDF page went through OCR (``--pdf-ocr-enabled``), even with
+  ``merge_hyphenated_words = true``. OCR output is now dehyphenated the same way,
+  joining the split halves (``bewusst``). Numeric ranges (``10-\n20``) and
+  hyphens not sitting between two letters are left untouched. (#51)
+
 ## [1.7.0] - 2026-06-24
 
 ### Changed

--- a/src/all2md/parsers/_pdf_ocr.py
+++ b/src/all2md/parsers/_pdf_ocr.py
@@ -11,6 +11,7 @@ applied to PDF pages and language detection for OCR optimization.
 from __future__ import annotations
 
 import logging
+import re
 from typing import TYPE_CHECKING
 
 from all2md.constants import DEPS_PDF_LANGDETECT
@@ -21,9 +22,54 @@ from all2md.utils.decorators import requires_dependencies
 if TYPE_CHECKING:
     import fitz
 
-__all__ = ["should_use_ocr", "get_tesseract_lang", "detect_page_language", "calculate_image_coverage"]
+__all__ = [
+    "should_use_ocr",
+    "get_tesseract_lang",
+    "detect_page_language",
+    "calculate_image_coverage",
+    "dehyphenate_text",
+]
 
 logger = logging.getLogger(__name__)
+
+# A word broken across a line by hyphenation: a letter, a hyphen character,
+# optional trailing spaces/tabs, a newline, optional leading whitespace, then the
+# continuation letter. Matches the hyphen-minus (U+002D), soft hyphen (U+00AD),
+# and Unicode hyphen (U+2010) that OCR engines emit at a line break. ``[^\W\d_]``
+# matches any letter, including accented and non-Latin ones (ü, ß, …), while
+# excluding digits and underscore so numeric ranges ("10-\n20") are left alone.
+_HYPHEN_LINEBREAK_RE = re.compile(r"([^\W\d_])[-­‐][ \t]*\r?\n[ \t]*([^\W\d_])", re.UNICODE)
+
+
+def dehyphenate_text(text: str) -> str:
+    r"""Merge words split across line breaks by hyphenation.
+
+    OCR engines preserve the source layout, so a word hyphenated at the end of a
+    line ("be-\\nwusst") comes back with the hyphen and newline intact. PyMuPDF's
+    native extraction can strip these via ``TEXT_DEHYPHENATE``, but that flag does
+    not touch OCR output, so this reproduces the same behaviour for OCR text: the
+    trailing hyphen and the line break are removed and the two halves are joined
+    ("bewusst"). The line break itself is consumed so downstream paragraph
+    reconstruction does not re-insert a space between the halves.
+
+    Only hyphens that sit at a line break between two letters are merged;
+    hyphens followed by digits, punctuation, or whitespace (e.g. em-dash usage
+    or a trailing "- " list marker) are left untouched.
+
+    Parameters
+    ----------
+    text : str
+        Text that may contain line-break hyphenation.
+
+    Returns
+    -------
+    str
+        Text with line-break hyphenation merged.
+
+    """
+    if not text:
+        return text
+    return _HYPHEN_LINEBREAK_RE.sub(r"\1\2", text)
 
 
 def calculate_image_coverage(page: "fitz.Page") -> float:
@@ -123,8 +169,7 @@ def should_use_ocr(page: "fitz.Page", extracted_text: str, options: PdfOptions) 
         meaningful_chars = sum(1 for char in extracted_text if char.isalnum())
         if meaningful_chars < ocr_opts.text_threshold:
             logger.debug(
-                f"Page has {meaningful_chars} meaningful chars "
-                f"(threshold: {ocr_opts.text_threshold}), triggering OCR"
+                f"Page has {meaningful_chars} meaningful chars (threshold: {ocr_opts.text_threshold}), triggering OCR"
             )
             return True
 

--- a/src/all2md/parsers/pdf.py
+++ b/src/all2md/parsers/pdf.py
@@ -76,6 +76,9 @@ from all2md.parsers._pdf_layout import (
 )
 from all2md.parsers._pdf_numbering import parse_numbering_prefix
 from all2md.parsers._pdf_ocr import (
+    dehyphenate_text,
+)
+from all2md.parsers._pdf_ocr import (
     should_use_ocr as _should_use_ocr,
 )
 from all2md.parsers._pdf_tables import (
@@ -1140,6 +1143,13 @@ class PdfToAstConverter(BaseParser):
             if not ocr_text.strip():
                 logger.warning("OCR returned empty text, keeping original extraction")
                 return all_blocks, False
+
+            # PyMuPDF's TEXT_DEHYPHENATE flag only affects its native extraction,
+            # not OCR output, so line-break hyphenation ("be-\nwusst") survives in
+            # OCR text. Merge it here so merge_hyphenated_words behaves the same
+            # regardless of whether a page went through OCR.
+            if self.options.merge_hyphenated_words:
+                ocr_text = dehyphenate_text(ocr_text)
 
             # Handle preserve_existing_text option
             if self.options.ocr.preserve_existing_text and extracted_text.strip():

--- a/tests/unit/parsers/test_pdf_ocr.py
+++ b/tests/unit/parsers/test_pdf_ocr.py
@@ -12,6 +12,7 @@ from all2md.options.common import OCROptions
 from all2md.options.pdf import PdfOptions
 from all2md.parsers._pdf_ocr import (
     calculate_image_coverage,
+    dehyphenate_text,
 )
 from all2md.parsers._pdf_ocr import (
     detect_page_language as _detect_page_language,
@@ -352,6 +353,87 @@ class TestOCRPageToText:
         # Verify custom config was passed
         call_args = mock_pytesseract.call_args
         assert call_args[1]["config"] == "--psm 6"
+
+
+class TestDehyphenateText:
+    """Test line-break dehyphenation of OCR text (issue #51)."""
+
+    @pytest.mark.parametrize(
+        ("text", "expected"),
+        [
+            # The exact cases reported in issue #51 (German prose from test.pdf).
+            ("wieder einmal be-\nwusst, wie", "wieder einmal bewusst, wie"),
+            ("Stadtar-\nchiv von", "Stadtarchiv von"),
+            ("Krieg ver-\nloren gegangen", "Krieg verloren gegangen"),
+            ("heute erhal-\nten, wie", "heute erhalten, wie"),
+            ("in Mag-\ndeburg befindliche", "in Magdeburg befindliche"),
+            ("des Politi-\nkers, Naturwissenschaftlers", "des Politikers, Naturwissenschaftlers"),
+            # ß and other letters are covered by the letter class.
+            ("nur erschlie-\nßen lassen", "nur erschließen lassen"),
+            # Single-letter fragments still merge.
+            ("x-\ny axis", "xy axis"),
+            # Windows line endings.
+            ("be-\r\nwusst", "bewusst"),
+            # Soft hyphen (U+00AD) and Unicode hyphen (U+2010) at the break.
+            ("be­\nwusst", "bewusst"),
+            ("be‐\nwusst", "bewusst"),
+            # Trailing/leading whitespace around the break is tolerated.
+            ("be- \n  wusst", "bewusst"),
+        ],
+    )
+    def test_merges_line_break_hyphenation(self, text: str, expected: str) -> None:
+        assert dehyphenate_text(text) == expected
+
+    @pytest.mark.parametrize(
+        "text",
+        [
+            # Numeric ranges must not be joined into a single number.
+            "10-\n20",
+            "end-\n42 next",
+            "Kapitel-\n3",
+            # A hyphen not attached to a letter (list marker, dangling dash).
+            "a list-\n- item",
+            "trailing hyphen -\nword",
+            # A spaced hyphen (en/em-dash usage) on one line is left alone.
+            "range 10 - 20",
+            # Hyphen followed by punctuation, not a letter.
+            "foo-\n.bar",
+            # No hyphen at all.
+            "just\nregular text",
+        ],
+    )
+    def test_leaves_non_hyphenation_untouched(self, text: str) -> None:
+        assert dehyphenate_text(text) == text
+
+    def test_empty_string(self) -> None:
+        assert dehyphenate_text("") == ""
+
+
+class TestApplyOCRDehyphenation:
+    """OCR text is dehyphenated only when merge_hyphenated_words is enabled."""
+
+    def _run(self, *, merge: bool) -> str:
+        """Run _apply_ocr_if_needed with a forced, hyphenated OCR result."""
+        options = PdfOptions(
+            ocr=OCROptions(enabled=True, mode="force"),
+            merge_hyphenated_words=merge,
+        )
+        converter = PdfToAstConverter(options=options)
+
+        mock_page = Mock()
+        mock_page.rect = "PAGE_RECT"
+
+        with patch.object(PdfToAstConverter, "_ocr_page_to_text", return_value="be-\nwusst sein"):
+            blocks, applied = converter._apply_ocr_if_needed(mock_page, [], extracted_text="")
+
+        assert applied is True
+        return blocks[0]["lines"][0]["spans"][0]["text"]
+
+    def test_dehyphenates_when_merge_enabled(self) -> None:
+        assert self._run(merge=True) == "bewusst sein"
+
+    def test_preserves_hyphenation_when_merge_disabled(self) -> None:
+        assert self._run(merge=False) == "be-\nwusst sein"
 
 
 class TestPdfOptionsWithOCR:


### PR DESCRIPTION
## Summary

Fixes #51 — `merge_hyphenated_words = true` had no effect on OCR'd pages, so words hyphenated across a line break came out unmerged (e.g. `be-\nwusst` → `be- wusst` instead of `bewusst`).

## Root cause

The merge is implemented via PyMuPDF's `TEXT_DEHYPHENATE` flag, which only affects PyMuPDF's *native* text extraction. When a page goes through OCR (`--pdf-ocr-enabled`), the OCR string is inserted into the block stream verbatim in `_apply_ocr_if_needed`, bypassing the flag entirely. The reporter's repro forces OCR, so every hyphenated line-break survived.

## Fix

- New `dehyphenate_text()` helper in `_pdf_ocr.py` that joins `letter + hyphen + linebreak + letter` sequences. Handles hyphen-minus (U+002D), soft hyphen (U+00AD), Unicode hyphen (U+2010), CRLF, and surrounding whitespace. Uses `[^\W\d_]` so accented/non-Latin letters (ü, ß, …) merge while **numeric ranges (`10-\n20`) and non-letter hyphens are left untouched**.
- Applied to OCR output in `_apply_ocr_if_needed` only when `merge_hyphenated_words` is enabled — covers both the replace and `preserve_existing_text` paths.

Verified against the exact German prose from the attached `test.pdf` (`Stadtar-\nchiv`, `ver-\nloren`, `Mag-\ndeburg`, `erschlie-\nßen`, …).

## Tests

- `TestDehyphenateText` — parametrized positive/negative cases including the issue examples and edge cases (numeric ranges, list markers, spaced dashes).
- `TestApplyOCRDehyphenation` — verifies OCR blocks are dehyphenated when the flag is on and preserved when off.

All 1234 parser unit tests pass; ruff + mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)