### PR TITLE
feat(view,serve): mermaid diagrams, syntax highlighting, richer index, custom themes

### DIFF
--- a/docs/source/cli.rst
+++ b/docs/source/cli.rst
@@ -1647,7 +1647,10 @@ Arguments
       all2md view document.pdf --window
 
 ``--theme THEME``
-   Specify a theme for the HTML output. Can be either a built-in theme name or a path to a custom HTML template file.
+   Specify a theme for the HTML output. ``THEME`` may be a built-in theme name, a path
+   to a custom ``.html`` template, a path to a plain ``.css`` file (wrapped automatically
+   in a minimal HTML shell), or a name registered in the ``[themes]`` table of a
+   configuration file (see :ref:`custom-themes`).
 
    **Built-in themes:**
 
@@ -1670,6 +1673,24 @@ Arguments
 
       # Use custom theme template
       all2md view document.pdf --theme /path/to/custom-theme.html
+
+``--no-mermaid``
+   Disable client-side rendering of ``mermaid`` code blocks as diagrams. By
+   default, fenced blocks tagged ``mermaid`` are drawn with `mermaid.js
+   <https://mermaid.js.org/>`_ loaded from a CDN; with this flag they render as ordinary
+   code blocks instead.
+
+``--no-syntax-highlight``
+   Disable client-side syntax highlighting of code blocks. By default, code blocks are
+   highlighted with `highlight.js <https://highlightjs.org/>`_ loaded from a CDN, matching
+   the language tag on each fence (and the detected language of raw source files).
+
+.. note::
+
+   Mermaid and highlight.js are loaded from ``cdn.jsdelivr.net``. When offline the page
+   still renders: diagrams appear as their source text and code blocks are shown without
+   highlighting. The dark variants are used automatically with ``--dark`` or the ``dark``
+   theme.
 
 Built-in Themes
 ~~~~~~~~~~~~~~~
@@ -1723,6 +1744,8 @@ Built-in Themes
    * **Colors:** White background with light gray sidebar
    * **Special:** Sticky TOC navigation, smooth scrolling, mobile-responsive
    * **Requires:** Must be used with ``--toc`` flag for meaningful layout
+
+.. _custom-themes:
 
 Custom Themes
 ~~~~~~~~~~~~~
@@ -1796,6 +1819,38 @@ You can create custom HTML themes using placeholder replacement. Themes are stan
    all2md view document.pdf --theme ./my-theme.html --toc
 
 The HTML renderer will replace all placeholders with the appropriate content while preserving all your custom styling and structure.
+
+**CSS-only themes:**
+
+If you only want to change styling, you can point ``--theme`` at a plain ``.css`` file
+instead of authoring a full HTML template. The stylesheet is wrapped automatically in a
+minimal HTML shell that provides the ``{TITLE}``/``{CONTENT}`` placeholders:
+
+.. code-block:: bash
+
+   all2md view document.pdf --theme ./my-styles.css
+   all2md serve ./docs --theme ./my-styles.css
+
+**Named themes via configuration:**
+
+Register reusable theme names in a ``[themes]`` table in any all2md configuration file
+(``.all2md.toml``, ``pyproject.toml`` under ``[tool.all2md.themes]``, etc.). Values may
+point at ``.html`` templates or ``.css`` files:
+
+.. code-block:: toml
+
+   [themes]
+   corporate = "~/themes/corporate.html"
+   brand = "~/themes/brand.css"
+
+.. code-block:: bash
+
+   # Resolve the registered name
+   all2md view report.pdf --theme corporate
+   all2md serve ./docs --theme brand
+
+You can also set a default theme per command via the ``[view]``/``[serve]`` sections
+(``theme = "corporate"``).
 
 Examples
 ~~~~~~~~
@@ -2383,7 +2438,9 @@ Arguments
       all2md serve ./docs --dark
 
 ``--theme THEME``
-   Specify a theme for HTML output. Can be a built-in theme name or path to custom template.
+   Specify a theme for HTML output. ``THEME`` may be a built-in theme name, a custom
+   ``.html`` template, a plain ``.css`` file, or a name registered in a ``[themes]``
+   configuration table (see :ref:`custom-themes`).
 
    **Built-in themes:**
 
@@ -2400,6 +2457,19 @@ Arguments
 
       # Use custom theme
       all2md serve ./docs --theme /path/to/theme.html
+
+``--no-mermaid``
+   Disable client-side rendering of ``mermaid`` code blocks as diagrams (loaded
+   from a CDN, on by default). See the note under the ``view`` command's options.
+
+``--no-syntax-highlight``
+   Disable client-side syntax highlighting of code blocks and source files (highlight.js
+   loaded from a CDN, on by default).
+
+.. note::
+
+   The directory index lists only files all2md can convert. It offers an aligned
+   **table** view (default) and a **card** view; the toggle is remembered per browser.
 
 ``--enable-upload``
    Enable file upload form at ``/upload`` route. This provides a web interface for uploading and converting documents. **For development use only - do not expose to untrusted networks.**

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -123,6 +123,7 @@ Guides & References
 
    python_api
    cli
+   viewer
    cheatsheet
    lint_guide
    options

--- a/docs/source/options.rst
+++ b/docs/source/options.rst
@@ -2081,6 +2081,15 @@ Inherits attachment handling from AttachmentOptionsMixin for email attachments.
    :Default: ``True``
    :Importance: advanced
 
+**include_rtf_parts**
+
+   Include RTF body parts from emails (converted to Markdown; used when no plain-text or HTML body is present)
+
+   :Type: ``bool``
+   :CLI flag: ``--eml-no-include-rtf-parts``
+   :Default: ``True``
+   :Importance: advanced
+
 ENEX Options
 ~~~~~~~~~~~~
 
@@ -3045,6 +3054,15 @@ including document structure, styling, templating, and feature toggles.
    :CLI flag: ``--html-renderer-no-syntax-highlighting``
    :Default: ``True``
    :Importance: core
+
+**render_mermaid**
+
+   Render fenced code blocks tagged 'mermaid' as <pre class="mermaid"> (so a client-side mermaid.js can draw them) instead of a plain code block
+
+   :Type: ``bool``
+   :CLI flag: ``--html-renderer-render-mermaid``
+   :Default: ``False``
+   :Importance: advanced
 
 **escape_html**
 
@@ -4490,7 +4508,7 @@ modules to ensure consistent Markdown generation.
 
    :Type: ``UnsupportedTableMode | object``
    :CLI flag: ``--markdown-renderer-unsupported-table-mode``
-   :Default: ``<object object at 0x000001B32AD24BC0>``
+   :Default: ``<object object at 0x000001C52C6B4BD0>``
    :Choices: ``drop``, ``ascii``, ``force``, ``html``
    :Importance: advanced
 
@@ -4500,7 +4518,7 @@ modules to ensure consistent Markdown generation.
 
    :Type: ``UnsupportedInlineMode | object``
    :CLI flag: ``--markdown-renderer-unsupported-inline-mode``
-   :Default: ``<object object at 0x000001B32AD24BC0>``
+   :Default: ``<object object at 0x000001C52C6B4BD0>``
    :Choices: ``plain``, ``force``, ``html``
    :Importance: advanced
 
@@ -4936,6 +4954,15 @@ message filtering, and folder handling.
 
    :Type: ``bool``
    :CLI flag: ``--mbox-no-include-plain-parts``
+   :Default: ``True``
+   :Importance: advanced
+
+**include_rtf_parts**
+
+   Include RTF body parts from emails (converted to Markdown; used when no plain-text or HTML body is present)
+
+   :Type: ``bool``
+   :CLI flag: ``--mbox-no-include-rtf-parts``
    :Default: ``True``
    :Importance: advanced
 
@@ -6771,6 +6798,15 @@ PST/OST archive handling, and advanced message selection.
 
    :Type: ``bool``
    :CLI flag: ``--outlook-no-include-plain-parts``
+   :Default: ``True``
+   :Importance: advanced
+
+**include_rtf_parts**
+
+   Include RTF body parts from emails (converted to Markdown; used when no plain-text or HTML body is present)
+
+   :Type: ``bool``
+   :CLI flag: ``--outlook-no-include-rtf-parts``
    :Default: ``True``
    :Importance: advanced
 
@@ -10186,7 +10222,7 @@ modules to ensure consistent Markdown generation.
 
    :Type: ``UnsupportedTableMode | object``
    :CLI flag: ``--markdown-unsupported-table-mode``
-   :Default: ``<object object at 0x000001B32AD24BC0>``
+   :Default: ``<object object at 0x000001C52C6B4BD0>``
    :Choices: ``drop``, ``ascii``, ``force``, ``html``
    :Importance: advanced
 
@@ -10196,7 +10232,7 @@ modules to ensure consistent Markdown generation.
 
    :Type: ``UnsupportedInlineMode | object``
    :CLI flag: ``--markdown-unsupported-inline-mode``
-   :Default: ``<object object at 0x000001B32AD24BC0>``
+   :Default: ``<object object at 0x000001C52C6B4BD0>``
    :Choices: ``plain``, ``force``, ``html``
    :Importance: advanced
 

--- a/docs/source/viewer.rst
+++ b/docs/source/viewer.rst
@@ -1,0 +1,224 @@
+Document Viewer & Server
+========================
+
+all2md ships two commands for looking at converted documents in a browser instead of
+piping Markdown to a file:
+
+* ``all2md view`` converts a single document to a self-contained HTML page and opens it in
+  your browser (or a standalone window with ``-w``).
+* ``all2md serve`` starts a small local HTTP server that converts documents on demand,
+  including a live directory index when you point it at a folder.
+
+Both share the same theming, diagram rendering, and syntax-highlighting features described
+below. For the exhaustive list of flags, see the ``view`` and ``serve`` sections of the
+:doc:`cli` reference.
+
+Quick start
+-----------
+
+.. code-block:: bash
+
+   # View a single file
+   all2md view report.pdf
+   all2md view notes.md --dark
+
+   # Serve a whole directory (browse the index, click any file)
+   all2md serve ./docs
+   all2md serve ./docs --recursive --browse
+
+   # Serve a filtered set
+   all2md serve "reports/*.pdf"
+
+Both commands accept ``-`` for stdin, so you can preview piped content:
+
+.. code-block:: bash
+
+   echo "# Hello" | all2md view -
+
+Diagrams and syntax highlighting
+--------------------------------
+
+When viewing or serving, all2md automatically enriches the page:
+
+* **Mermaid diagrams** – fenced code blocks tagged ``mermaid`` are rendered as diagrams
+  using `mermaid.js <https://mermaid.js.org/>`_.
+* **Syntax highlighting** – code blocks (and raw source files such as ``.py`` or ``.js``)
+  are highlighted with `highlight.js <https://highlightjs.org/>`_, matching each block's
+  language.
+
+Both libraries are loaded from ``cdn.jsdelivr.net``. This is on by default; disable either
+with ``--no-mermaid`` / ``--no-syntax-highlight``. Offline, the page still renders --
+diagrams appear as their source text and code is shown without highlighting. The dark
+variants are selected automatically with ``--dark`` or the ``dark`` theme.
+
+For example, a Markdown file containing:
+
+.. code-block:: text
+
+   ```mermaid
+   graph TD
+       A[Start] --> B{Ready?}
+       B -- Yes --> C[View it]
+       B -- No --> A
+   ```
+
+renders as a flowchart in ``all2md view`` / ``all2md serve``.
+
+Themes
+------
+
+Every page is built from a **theme**: a small HTML template with ``{TITLE}`` and
+``{CONTENT}`` placeholders (plus optional ``{TOC}``, ``{AUTHOR}``, ``{DATE}``,
+``{DESCRIPTION}``). Select one with ``--theme`` on either command.
+
+Built-in themes
+~~~~~~~~~~~~~~~
+
+* ``minimal`` (default) – clean, centered layout
+* ``dark`` – dark mode (also reachable via ``--dark``)
+* ``newspaper`` – serif, justified, drop-cap first paragraph
+* ``docs`` – GitHub-style technical documentation
+* ``sidebar`` – two-column layout with a sticky TOC (use with ``--toc``)
+
+.. code-block:: bash
+
+   all2md view article.md --theme newspaper
+   all2md serve ./docs --theme docs
+
+.. _viewer-custom-theme:
+
+Writing a custom theme
+~~~~~~~~~~~~~~~~~~~~~~~
+
+A theme is just an HTML file. Save the following as ``my-theme.html`` -- the only
+requirement is a ``{CONTENT}`` placeholder where the converted document is injected:
+
+.. code-block:: html
+
+   <!DOCTYPE html>
+   <html lang="en">
+   <head>
+       <meta charset="UTF-8">
+       <meta name="viewport" content="width=device-width, initial-scale=1.0">
+       <title>{TITLE}</title>
+       <style>
+           body {
+               font-family: "Iowan Old Style", Georgia, serif;
+               max-width: 46rem;
+               margin: 3rem auto;
+               padding: 0 1.25rem;
+               color: #2b2b2b;
+               line-height: 1.7;
+           }
+           h1, h2, h3 { font-family: "Helvetica Neue", Arial, sans-serif; }
+           h1 { border-bottom: 3px double #ccc; padding-bottom: .3rem; }
+           a { color: #8a1f11; }
+           pre {
+               background: #faf7f0;
+               border: 1px solid #e7e0d0;
+               border-radius: 6px;
+               padding: 1rem;
+               overflow-x: auto;
+           }
+           blockquote {
+               border-left: 4px solid #d9c9a3;
+               margin: 1.5rem 0;
+               padding-left: 1rem;
+               color: #555;
+           }
+       </style>
+   </head>
+   <body>
+       {CONTENT}
+   </body>
+   </html>
+
+Then point ``--theme`` at the file:
+
+.. code-block:: bash
+
+   all2md view document.pdf --theme ./my-theme.html
+   all2md serve ./docs --theme ./my-theme.html
+
+Because mermaid.js and highlight.js are injected automatically, your theme does **not**
+need to include any diagram or highlighting scripts -- just style ``pre``/``code`` to taste.
+
+CSS-only themes
+~~~~~~~~~~~~~~~
+
+If you only want to change styling, skip the HTML boilerplate and point ``--theme`` at a
+plain ``.css`` file. all2md wraps it in a minimal HTML shell automatically:
+
+.. code-block:: css
+
+   /* brand.css */
+   body { font-family: system-ui, sans-serif; max-width: 50rem; margin: 2rem auto; }
+   h1, h2, h3 { color: #0b5; }
+   a { color: #0b5; }
+
+.. code-block:: bash
+
+   all2md view report.pdf --theme ./brand.css
+   all2md serve ./docs --theme ./brand.css
+
+Named themes in configuration
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Register reusable theme names in a ``[themes]`` table in any all2md configuration file
+(``.all2md.toml``, ``pyproject.toml`` under ``[tool.all2md.themes]``, ...). Values can be
+``.html`` templates or ``.css`` files, and paths may use ``~``:
+
+.. code-block:: toml
+
+   [themes]
+   corporate = "~/themes/corporate.html"
+   brand = "~/themes/brand.css"
+
+   # Optionally set a default theme per command
+   [view]
+   theme = "corporate"
+
+   [serve]
+   theme = "brand"
+
+Now the registered name resolves on either command:
+
+.. code-block:: bash
+
+   all2md view report.pdf --theme corporate
+   all2md serve ./docs --theme brand
+
+See :doc:`configuration` for how configuration files are discovered and merged.
+
+Serving directories
+--------------------
+
+Point ``all2md serve`` at a folder to get a browsable index. The index:
+
+* lists only files all2md can convert (unsupported files are hidden);
+* offers an aligned **table** view (Name / Size / Modified / Created) and a **card** view,
+  with a toggle that is remembered per browser (table is the default);
+* updates live as files are added or removed (see ``--poll-interval``);
+* honors a hand-authored ``index.html`` / ``index.md`` / ``README.md`` unless you pass
+  ``--force-auto-index``.
+
+.. code-block:: bash
+
+   # Recursively serve a docs tree and open it
+   all2md serve ./docs --recursive --browse
+
+   # Always show the generated listing, ignoring a repo README
+   all2md serve . --recursive --force-auto-index
+
+.. note::
+
+   ``--enable-upload`` and ``--enable-api`` expose write/convert endpoints intended for
+   local development only. Do not expose a server started with those flags to untrusted
+   networks. See the :doc:`cli` reference and :doc:`security` for details.
+
+See also
+--------
+
+* :doc:`cli` -- complete flag reference for ``view`` and ``serve``
+* :doc:`configuration` -- configuration files, ``[themes]``, and per-command defaults
+* :doc:`static_sites` -- generating a static HTML site instead of serving live

--- a/src/all2md/cli/commands/server.py
+++ b/src/all2md/cli/commands/server.py
@@ -28,9 +28,11 @@ from urllib.parse import quote, unquote
 from all2md.api import from_ast, to_ast
 from all2md.cli.builder import EXIT_ERROR, EXIT_FILE_ERROR, EXIT_SUCCESS
 from all2md.cli.commands.shared import has_hidden_component, split_glob_pattern
-from all2md.cli.config import apply_config_to_parser
+from all2md.cli.commands.web_assets import ThemeError, inject_web_assets, resolve_theme
+from all2md.cli.config import apply_config_to_parser, load_config_with_priority
 from all2md.converter_registry import registry
 from all2md.options.html import HtmlRendererOptions
+from all2md.utils.html_utils import escape_html
 
 # Filenames that can stand in for an auto-generated directory listing,
 # in descending priority order.
@@ -266,6 +268,52 @@ def _compute_directory_state(
     return files, subdirs, mapping, signature
 
 
+# Scoped styling + behaviour for the auto-generated directory index. Class-prefixed so
+# it overrides a theme's generic table/list rules without leaking into document pages.
+_INDEX_STYLE = """<style>
+.a2m-toolbar { display: flex; gap: .5rem; margin: 1rem 0; }
+.a2m-view-btn { cursor: pointer; padding: .35rem .8rem; border: 1px solid currentColor;
+    border-radius: 6px; background: transparent; color: inherit; font: inherit; opacity: .55; }
+.a2m-view-btn.active { opacity: 1; font-weight: 600; }
+.file-table { width: 100%; border-collapse: collapse; margin: 0; }
+.file-table th, .file-table td { text-align: left; padding: .4rem .75rem;
+    border-bottom: 1px solid rgba(128,128,128,.25); white-space: nowrap; }
+.file-table th { font-weight: 600; }
+.file-table td:first-child, .file-table th:first-child { white-space: normal; width: 100%; }
+.file-table .num { font-variant-numeric: tabular-nums; }
+.file-cards { display: grid; grid-template-columns: repeat(auto-fill, minmax(220px, 1fr)); gap: .75rem; }
+.file-card { display: block; padding: .75rem 1rem; border: 1px solid rgba(128,128,128,.3);
+    border-radius: 8px; text-decoration: none; color: inherit; }
+.file-card:hover { border-color: currentColor; }
+.file-card-name { font-weight: 600; word-break: break-word; }
+.file-card-meta { opacity: .7; font-size: .85em; margin-top: .3rem; }
+.a2m-subdirs { list-style: none; padding-left: 0; margin: 1rem 0; }
+.a2m-subdirs li { margin: .3rem 0; }
+.a2m-listing[data-view="table"] .file-cards { display: none; }
+.a2m-listing[data-view="cards"] .file-table { display: none; }
+</style>"""
+
+# Toggles the listing between table and card view, remembering the choice per browser.
+_INDEX_SCRIPT = """<script>
+(function () {
+    var root = document.currentScript.parentNode;
+    var listing = root.querySelector('.a2m-listing');
+    var btns = root.querySelectorAll('.a2m-view-btn');
+    var KEY = 'all2md-index-view';
+    function apply(v) {
+        if (v !== 'cards') { v = 'table'; }
+        listing.setAttribute('data-view', v);
+        btns.forEach(function (b) { b.classList.toggle('active', b.dataset.view === v); });
+        try { localStorage.setItem(KEY, v); } catch (e) {}
+    }
+    btns.forEach(function (b) { b.addEventListener('click', function () { apply(b.dataset.view); }); });
+    var saved = 'table';
+    try { saved = localStorage.getItem(KEY) || 'table'; } catch (e) {}
+    apply(saved);
+})();
+</script>"""
+
+
 def _generate_directory_index(
     all_files: List[Path],
     theme_path: Path,
@@ -332,7 +380,8 @@ def _generate_directory_index(
 
     # Build content
     content = breadcrumbs
-    content += f"<h1>Directory: {dir_display}</h1>"
+    content += _INDEX_STYLE
+    content += f"<h1>Directory: {escape_html(dir_display)}</h1>"
 
     # Add upload link if enabled (root only)
     if enable_upload and not current_subdir:
@@ -348,48 +397,70 @@ def _generate_directory_index(
 
     # Show subdirectories
     if child_dir_names:
-        content += "<div style='font-family: monospace;'>"
-        content += "<ul style='list-style: none; padding-left: 20px;'>"
+        content += "<ul class='a2m-subdirs'>"
         for dir_name in sorted(child_dir_names):
             if current_subdir:
                 dir_url = "/" + "/".join(quote(p) for p in current_subdir.split("/")) + "/" + quote(dir_name) + "/"
             else:
                 dir_url = "/" + quote(dir_name) + "/"
-            content += "<li style='margin: 5px 0;'>"
-            content += f"<a href='{dir_url}' style='text-decoration: none; font-size: 1.0em;'>{dir_name}/</a>"
-            content += "</li>"
-        content += "</ul></div>"
+            content += f"<li><a href='{dir_url}'>&#128193; {escape_html(dir_name)}/</a></li>"
+        content += "</ul>"
 
-    # Show file count
+    # Show file count. The listing only ever contains files the registry can convert
+    # (see _scan_directory_for_documents), so every row here is viewable.
     content += f"<p>Found {len(current_files)} document(s)"
     if child_dir_names:
         content += f" and {len(child_dir_names)} subdirectory(ies)"
-    content += " - click to view:</p>"
+    content += ":</p>"
 
-    # List files at this level
+    # List files at this level as an aligned table plus a card grid; a toggle picks
+    # which is shown (default table, remembered in localStorage).
     if current_files:
-        content += "<div style='font-family: monospace;'>"
-        content += "<ul style='list-style: none; padding-left: 20px;'>"
+        rows = ""
+        cards = ""
         for file in sorted(current_files, key=lambda f: f.name.lower()):
             rel_path = file.relative_to(base_dir)
             url = "/" + quote(str(rel_path).replace("\\", "/"))
-            modified_str: Optional[str] = None
-            created_str: Optional[str] = None
+            name = escape_html(file.name)
+            size_str = "?"
+            modified_str = "—"
+            created_str = "—"
             try:
                 stat_result = file.stat()
                 size_str = _format_file_size(stat_result.st_size)
-                modified_str = f"modified {_format_timestamp(stat_result.st_mtime)}"
+                modified_str = _format_timestamp(stat_result.st_mtime)
                 created_ts = _file_created_timestamp(stat_result)
                 if created_ts is not None:
-                    created_str = f"created {_format_timestamp(created_ts)}"
+                    created_str = _format_timestamp(created_ts)
             except OSError:
-                size_str = "?"
-            details = " · ".join(part for part in (size_str, modified_str, created_str) if part)
-            content += "<li style='margin: 5px 0;'>"
-            content += f"<a href='{url}' style='text-decoration: none; font-size: 1.0em;'>{file.name}</a>"
-            content += f" <span style='color: #888; font-size: 0.9em;'>({details})</span>"
-            content += "</li>"
-        content += "</ul></div>"
+                pass
+            rows += (
+                f"<tr><td><a href='{url}'>{name}</a></td>"
+                f"<td class='num'>{size_str}</td>"
+                f"<td class='num'>{modified_str}</td>"
+                f"<td class='num'>{created_str}</td></tr>"
+            )
+            meta = " · ".join(
+                part for part in (size_str, f"modified {modified_str}", f"created {created_str}") if "—" not in part
+            )
+            cards += (
+                f"<a class='file-card' href='{url}'>"
+                f"<div class='file-card-name'>{name}</div>"
+                f"<div class='file-card-meta'>{meta}</div></a>"
+            )
+        content += "<div class='a2m-toolbar'>"
+        content += "<button type='button' class='a2m-view-btn' data-view='table'>Table</button>"
+        content += "<button type='button' class='a2m-view-btn' data-view='cards'>Cards</button>"
+        content += "</div>"
+        content += "<div class='a2m-listing' data-view='table'>"
+        content += (
+            "<table class='file-table'><thead><tr>"
+            "<th>Name</th><th>Size</th><th>Modified</th><th>Created</th>"
+            f"</tr></thead><tbody>{rows}</tbody></table>"
+        )
+        content += f"<div class='file-cards'>{cards}</div>"
+        content += "</div>"
+        content += _INDEX_SCRIPT
 
     # Apply theme template
     title = f"Directory: {dir_display}"
@@ -640,7 +711,7 @@ def _create_serve_parser() -> argparse.ArgumentParser:
         "-a",
         "--address",
         metavar="HOST:PORT",
-        help="Bind address as 'host:port', 'host:', or ':port' (overrides --host/--port). " "Example: -a 0.0.0.0:9000",
+        help="Bind address as 'host:port', 'host:', or ':port' (overrides --host/--port). Example: -a 0.0.0.0:9000",
     )
     parser.add_argument(
         "-r", "--recursive", action="store_true", help="Recursively serve subdirectories (for directory input)"
@@ -654,7 +725,19 @@ def _create_serve_parser() -> argparse.ArgumentParser:
     parser.add_argument("--dark", action="store_true", help="Use dark mode theme")
     parser.add_argument(
         "--theme",
-        help="Custom theme template path or built-in theme name (minimal, dark, newspaper, docs, sidebar)",
+        help="Theme to use: a built-in name (minimal, dark, newspaper, docs, sidebar), "
+        "a custom .html template or plain .css file path, or a name registered in the "
+        "config [themes] table",
+    )
+    parser.add_argument(
+        "--no-mermaid",
+        action="store_true",
+        help="Disable client-side rendering of ```mermaid code blocks as diagrams",
+    )
+    parser.add_argument(
+        "--no-syntax-highlight",
+        action="store_true",
+        help="Disable client-side syntax highlighting of code blocks (highlight.js)",
     )
     parser.add_argument(
         "-B",
@@ -777,32 +860,19 @@ def handle_serve_command(args: list[str] | None = None) -> int:  # noqa: C901
             print(f"Error: Input path not found: {parsed.input}", file=sys.stderr)
             return EXIT_FILE_ERROR
 
-    # Select theme template
-    if parsed.theme:
-        # Check if it's a built-in theme name or a custom path
-        theme_path = Path(parsed.theme)
-        # First check if it's a valid HTML file path
-        if theme_path.exists() and theme_path.is_file() and theme_path.suffix == ".html":
-            # Use the provided file path
-            pass
-        else:
-            # Try as built-in theme name
-            builtin_theme = Path(__file__).parent / "themes" / f"{parsed.theme}.html"
-            if builtin_theme.exists():
-                theme_path = builtin_theme
-            else:
-                print(f"Error: Theme not found: {parsed.theme}", file=sys.stderr)
-                print("Available built-in themes: minimal, dark, newspaper, docs, sidebar", file=sys.stderr)
-                return EXIT_FILE_ERROR
-    elif parsed.dark:
-        theme_path = Path(__file__).parent / "themes" / "dark.html"
-    else:
-        theme_path = Path(__file__).parent / "themes" / "minimal.html"
-
-    # Verify theme template exists
+    # Select theme template (built-in name, .html/.css path, or [themes] config name).
+    theme_config = {} if parsed.no_config else load_config_with_priority(explicit_path=parsed.config)
+    try:
+        theme_path = resolve_theme(parsed.theme, dark=parsed.dark, config=theme_config)
+    except ThemeError as e:
+        print(f"Error: {e}", file=sys.stderr)
+        return EXIT_FILE_ERROR
     if not theme_path.exists():
         print(f"Error: Theme template not found: {theme_path}", file=sys.stderr)
         return EXIT_FILE_ERROR
+
+    # Whether to serve the dark variant of the highlight.js / mermaid themes.
+    is_dark = parsed.dark or parsed.theme == "dark"
 
     # Determine if input is file or directory (a glob always serves a listing).
     is_directory = serve_pattern is not None or input_path.is_dir()
@@ -830,10 +900,19 @@ def handle_serve_command(args: list[str] | None = None) -> int:  # noqa: C901
             template_file=str(theme_path),
             include_toc=parsed.toc,
             external_links_new_tab=True,
+            render_mermaid=not parsed.no_mermaid,
         )
         html_content = from_ast(doc, "html", renderer_options=html_opts)
         if not isinstance(html_content, str):
             raise RuntimeError("Expected string result from HTML rendering")
+        # Splice in the mermaid / highlight.js CDN includes (graceful offline degrade)
+        # before breadcrumbs so the injection targets the original <head>.
+        html_content = inject_web_assets(
+            html_content,
+            mermaid=not parsed.no_mermaid,
+            highlight=not parsed.no_syntax_highlight,
+            dark=is_dark,
+        )
         if breadcrumb_path:
             breadcrumbs = _generate_breadcrumbs(breadcrumb_path)
             html_content = html_content.replace("<body>", "<body>\n" + breadcrumbs, 1)

--- a/src/all2md/cli/commands/view.py
+++ b/src/all2md/cli/commands/view.py
@@ -19,7 +19,8 @@ from pathlib import Path
 from all2md import HtmlRendererOptions, from_ast, to_ast
 from all2md.cli import EXIT_FILE_ERROR, window
 from all2md.cli.builder import EXIT_ERROR, EXIT_SUCCESS
-from all2md.cli.config import apply_config_to_parser
+from all2md.cli.commands.web_assets import ThemeError, inject_web_assets, resolve_theme
+from all2md.cli.config import apply_config_to_parser, load_config_with_priority
 
 
 def _create_view_parser() -> argparse.ArgumentParser:
@@ -53,7 +54,19 @@ def _create_view_parser() -> argparse.ArgumentParser:
     parser.add_argument(
         "-t",
         "--theme",
-        help="Custom theme template path or built-in theme name (minimal, dark, newspaper, docs, sidebar)",
+        help="Theme to use: a built-in name (minimal, dark, newspaper, docs, sidebar), "
+        "a custom .html template or plain .css file path, or a name registered in the "
+        "config [themes] table",
+    )
+    parser.add_argument(
+        "--no-mermaid",
+        action="store_true",
+        help="Disable client-side rendering of ```mermaid code blocks as diagrams",
+    )
+    parser.add_argument(
+        "--no-syntax-highlight",
+        action="store_true",
+        help="Disable client-side syntax highlighting of code blocks (highlight.js)",
     )
     parser.add_argument(
         "-x",
@@ -129,29 +142,13 @@ def handle_view_command(args: list[str] | None = None) -> int:
         input_source = parsed.input
         input_display_name = input_path.name
 
-    # Select theme template
-    if parsed.theme:
-        # Check if it's a built-in theme name or a custom path
-        theme_path = Path(parsed.theme)
-        # First check if it's a valid HTML file path
-        if theme_path.exists() and theme_path.is_file() and theme_path.suffix == ".html":
-            # Use the provided file path
-            pass
-        else:
-            # Try as built-in theme name
-            builtin_theme = Path(__file__).parent / "themes" / f"{parsed.theme}.html"
-            if builtin_theme.exists():
-                theme_path = builtin_theme
-            else:
-                print(f"Error: Theme not found: {parsed.theme}", file=sys.stderr)
-                print("Available built-in themes: minimal, dark, newspaper, docs, sidebar", file=sys.stderr)
-                return EXIT_FILE_ERROR
-    elif parsed.dark:
-        theme_path = Path(__file__).parent / "themes" / "dark.html"
-    else:
-        theme_path = Path(__file__).parent / "themes" / "minimal.html"
-
-    # Verify theme template exists
+    # Select theme template (built-in name, .html/.css path, or [themes] config name).
+    theme_config = {} if parsed.no_config else load_config_with_priority(explicit_path=parsed.config)
+    try:
+        theme_path = resolve_theme(parsed.theme, dark=parsed.dark, config=theme_config)
+    except ThemeError as e:
+        print(f"Error: {e}", file=sys.stderr)
+        return EXIT_FILE_ERROR
     if not theme_path.exists():
         print(f"Error: Theme template not found: {theme_path}", file=sys.stderr)
         return EXIT_FILE_ERROR
@@ -191,13 +188,22 @@ def handle_view_command(args: list[str] | None = None) -> int:
             template_file=str(theme_path),
             include_toc=parsed.toc,
             external_links_new_tab=True,
+            render_mermaid=not parsed.no_mermaid,
         )
         html_result = from_ast(doc, "html", renderer_options=html_opts)
 
         # from_ast with string format returns str, not bytes or None
         if not isinstance(html_result, str):
             raise RuntimeError("Expected string result from HTML rendering")
-        html_content = html_result
+
+        # Splice in the mermaid / highlight.js CDN includes (graceful offline degrade).
+        is_dark = parsed.dark or parsed.theme == "dark"
+        html_content = inject_web_assets(
+            html_result,
+            mermaid=not parsed.no_mermaid,
+            highlight=not parsed.no_syntax_highlight,
+            dark=is_dark,
+        )
 
         # Determine output path
         if isinstance(parsed.keep, str):

--- a/src/all2md/cli/commands/web_assets.py
+++ b/src/all2md/cli/commands/web_assets.py
@@ -1,0 +1,196 @@
+#  Copyright (c) 2025 Tom Villani, Ph.D.
+
+"""Shared browser-viewing helpers for the ``view`` and ``serve`` commands.
+
+Both commands render documents with ``HtmlRendererOptions(template_mode="replace")``,
+so the page ``<head>`` comes entirely from a theme file and the renderer never injects
+scripts. This module centralises two concerns that both commands need:
+
+* :func:`resolve_theme` -- turn a ``--theme`` argument (built-in name, custom ``.html``
+  template, plain ``.css`` file, or a name registered in the config ``[themes]`` table)
+  into a concrete template file path.
+* :func:`inject_web_assets` -- splice the client-side mermaid.js and highlight.js CDN
+  includes into a rendered HTML page so diagrams draw and code blocks are highlighted.
+"""
+
+from __future__ import annotations
+
+import atexit
+import os
+import tempfile
+from pathlib import Path
+from typing import Any, Mapping
+
+# Directory holding the packaged built-in theme templates.
+_THEMES_DIR = Path(__file__).parent / "themes"
+
+# ``editor.html`` backs the ``edit`` command, not a ``--theme`` choice, so it is not a
+# user-selectable theme name.
+_NON_THEME_STEMS = frozenset({"editor"})
+
+# CDN endpoints (pinned to major versions). mermaid was requested explicitly; highlight.js
+# uses the official browser build published via jsDelivr's GitHub mirror.
+_MERMAID_ESM = "https://cdn.jsdelivr.net/npm/mermaid@11/dist/mermaid.esm.min.mjs"
+_HLJS_BASE = "https://cdn.jsdelivr.net/gh/highlightjs/cdn-release@11/build"
+
+# Minimal HTML shell used to wrap a plain ``.css`` theme into a valid replace-mode
+# template. ``{TITLE}``/``{CONTENT}`` mirror the placeholders the built-in themes expose.
+_CSS_SHELL = """<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta content="width=device-width, initial-scale=1.0" name="viewport">
+    <title>{{TITLE}}</title>
+    <style>
+{css}
+    </style>
+</head>
+<body>
+{{CONTENT}}
+</body>
+</html>
+"""
+
+
+class ThemeError(Exception):
+    """Raised when a ``--theme`` argument cannot be resolved to a template."""
+
+
+def builtin_theme_names() -> list[str]:
+    """Return the sorted names of the packaged built-in themes."""
+    return sorted(p.stem for p in _THEMES_DIR.glob("*.html") if p.stem not in _NON_THEME_STEMS)
+
+
+def _write_temp_template(text: str) -> Path:
+    """Write ``text`` to a temp ``.html`` file, scheduling it for cleanup at exit."""
+    fd, name = tempfile.mkstemp(suffix=".html", prefix="all2md-theme-")
+    try:
+        os.write(fd, text.encode("utf-8"))
+    finally:
+        os.close(fd)
+    path = Path(name)
+    atexit.register(lambda: path.unlink(missing_ok=True))
+    return path
+
+
+def _template_from_file(path: Path) -> Path:
+    """Turn a concrete theme file into a replace-mode template path.
+
+    ``.html`` files are used as-is; ``.css`` files are wrapped in :data:`_CSS_SHELL`.
+    """
+    suffix = path.suffix.lower()
+    if suffix == ".html":
+        return path
+    if suffix == ".css":
+        css = path.read_text(encoding="utf-8")
+        return _write_temp_template(_CSS_SHELL.format(css=css))
+    raise ThemeError(f"Unsupported theme file type: {path} (expected .html or .css)")
+
+
+def resolve_theme(
+    theme_arg: str | None,
+    *,
+    dark: bool,
+    config: Mapping[str, Any] | None = None,
+) -> Path:
+    """Resolve a ``--theme`` argument to a replace-mode template file path.
+
+    Resolution order for a given ``theme_arg``:
+
+    1. an existing ``.html`` file path -> used directly;
+    2. an existing ``.css`` file path -> wrapped in a minimal HTML shell;
+    3. a name registered in the config ``[themes]`` table -> its ``.html``/``.css`` file;
+    4. a built-in theme name -> ``themes/{name}.html``.
+
+    When ``theme_arg`` is ``None`` the ``dark`` built-in is used if ``dark`` is set,
+    otherwise ``minimal``.
+
+    Raises
+    ------
+    ThemeError
+        If the theme cannot be resolved (message lists the available names).
+
+    """
+    registered: Mapping[str, Any] = {}
+    if config:
+        maybe = config.get("themes")
+        if isinstance(maybe, Mapping):
+            registered = maybe
+
+    if not theme_arg:
+        name = "dark" if dark else "minimal"
+        return _THEMES_DIR / f"{name}.html"
+
+    # 1 & 2: a direct path to an existing theme file.
+    candidate = Path(theme_arg)
+    if candidate.is_file() and candidate.suffix.lower() in (".html", ".css"):
+        return _template_from_file(candidate)
+
+    # 3: a name registered in the config [themes] table.
+    if theme_arg in registered:
+        mapped = Path(str(registered[theme_arg])).expanduser()
+        if not mapped.is_file():
+            raise ThemeError(f"Configured theme {theme_arg!r} points to a missing file: {mapped}")
+        return _template_from_file(mapped)
+
+    # 4: a packaged built-in theme name.
+    builtin = _THEMES_DIR / f"{theme_arg}.html"
+    if builtin.is_file():
+        return builtin
+
+    available = builtin_theme_names()
+    msg = f"Theme not found: {theme_arg}\nAvailable built-in themes: {', '.join(available)}"
+    if registered:
+        msg += f"\nConfigured themes: {', '.join(sorted(registered))}"
+    raise ThemeError(msg)
+
+
+def _highlight_block(dark: bool) -> str:
+    """Return the highlight.js ``<link>``/``<script>`` include block."""
+    style = "github-dark" if dark else "github"
+    return (
+        f'<link rel="stylesheet" href="{_HLJS_BASE}/styles/{style}.min.css">\n'
+        f'<script src="{_HLJS_BASE}/highlight.min.js"></script>\n'
+        "<script>window.addEventListener('DOMContentLoaded',function(){"
+        "if(window.hljs){window.hljs.highlightAll();}});</script>\n"
+    )
+
+
+def _mermaid_block(dark: bool) -> str:
+    """Return the mermaid.js ESM ``<script>`` include block."""
+    theme = "dark" if dark else "default"
+    return (
+        '<script type="module">'
+        f"import mermaid from '{_MERMAID_ESM}';"
+        f"mermaid.initialize({{startOnLoad:true,theme:'{theme}'}});"
+        "</script>\n"
+    )
+
+
+def inject_web_assets(
+    html: str,
+    *,
+    mermaid: bool = True,
+    highlight: bool = True,
+    dark: bool = False,
+) -> str:
+    """Splice mermaid.js / highlight.js CDN includes into a rendered HTML page.
+
+    The assets are inserted immediately before ``</head>`` (appended if there is no
+    ``</head>``). highlight.js only targets ``<pre><code>`` elements, so it leaves the
+    ``<pre class="mermaid">`` diagram blocks untouched. If the CDN is unreachable the
+    page degrades gracefully: diagrams stay as readable text and code stays unhighlighted.
+    """
+    block = ""
+    if highlight:
+        block += _highlight_block(dark)
+    if mermaid:
+        block += _mermaid_block(dark)
+    if not block:
+        return html
+
+    marker = "</head>"
+    idx = html.lower().find(marker)
+    if idx == -1:
+        return html + "\n" + block
+    return html[:idx] + block + html[idx:]

--- a/src/all2md/cli/config.py
+++ b/src/all2md/cli/config.py
@@ -82,21 +82,26 @@ def _load_pyproject_all2md_section(pyproject_path: Path) -> Dict[str, Any]:
         raise argparse.ArgumentTypeError(f"Error reading pyproject.toml {pyproject_path}: {e}") from e
 
 
-def find_config_in_parents(start_dir: Optional[Path] = None) -> Optional[Path]:
+def find_config_in_parents(start_dir: Optional[Path] = None, stop_dir: Optional[Path] = None) -> Optional[Path]:
     """Find configuration file by searching parent directories.
 
-    Walks up the directory tree from start_dir to the filesystem root,
-    checking each directory for configuration files in priority order:
+    Walks up the directory tree from start_dir, checking each directory for
+    configuration files in priority order:
     1. .all2md.toml
     2. .all2md.json
     3. pyproject.toml (with [tool.all2md] section)
 
-    Returns the first configuration file found.
+    The walk stops after checking ``stop_dir`` (inclusive) when given, otherwise it
+    continues to the filesystem root. Returns the first configuration file found.
 
     Parameters
     ----------
     start_dir : Path, optional
         Starting directory for search, defaults to current working directory
+    stop_dir : Path, optional
+        Highest directory to search (inclusive). When provided, the walk does not
+        ascend past it. Used to keep project discovery from escaping above the user's
+        home directory into shared parents such as the drive root.
 
     Returns
     -------
@@ -114,8 +119,9 @@ def find_config_in_parents(start_dir: Optional[Path] = None) -> Optional[Path]:
         start_dir = Path.cwd()
 
     current = start_dir.resolve()
+    boundary = stop_dir.resolve() if stop_dir is not None else None
 
-    # Walk up directory tree to root
+    # Walk up directory tree to root (or to the boundary, inclusive)
     while True:
         # Check for dedicated config files first (.all2md.toml, .all2md.yaml, .all2md.yml, .all2md.json)
         for filename in [".all2md.toml", ".all2md.yaml", ".all2md.yml", ".all2md.json"]:
@@ -134,6 +140,10 @@ def find_config_in_parents(start_dir: Optional[Path] = None) -> Optional[Path]:
             except argparse.ArgumentTypeError:
                 # Invalid pyproject.toml, skip it and continue searching
                 pass
+
+        # Stop once the boundary directory has been checked (inclusive).
+        if boundary is not None and current == boundary:
+            break
 
         # Check if we've reached the filesystem root
         parent = current.parent
@@ -180,13 +190,15 @@ def discover_config_file() -> Optional[Path]:
     ...     print(f"Found config at: {config_path}")
 
     """
-    # First, search parent directories from cwd to root
-    config_in_parents = find_config_in_parents()
+    # First, search parent directories from cwd up to (and including) the home
+    # directory. Bounding at home keeps a stray config in a shared parent such as
+    # C:\Users or / from silently applying to every project.
+    home = Path.home()
+    config_in_parents = find_config_in_parents(stop_dir=home)
     if config_in_parents:
         return config_in_parents
 
-    # Fall back to user home directory
-    home = Path.home()
+    # Fall back to user home directory (covers cwd outside the home subtree)
     for filename in [".all2md.toml", ".all2md.yaml", ".all2md.yml", ".all2md.json"]:
         config_path = home / filename
         if config_path.exists() and config_path.is_file():

--- a/src/all2md/options/html.py
+++ b/src/all2md/options/html.py
@@ -80,6 +80,10 @@ class HtmlRendererOptions(BaseRendererOptions):
         Generate table of contents from headings.
     syntax_highlighting : bool, default True
         Add language classes to code blocks for syntax highlighting.
+    render_mermaid : bool, default False
+        Render fenced code blocks whose language is ``mermaid`` as
+        ``<pre class="mermaid">`` (a hook for a client-side mermaid.js) instead of the
+        usual ``<pre><code>``. Used by the view/serve commands.
     escape_html : bool, default True
         Escape HTML special characters in text content.
     math_renderer : {"mathjax", "katex", "none"}, default "mathjax"
@@ -204,6 +208,14 @@ class HtmlRendererOptions(BaseRendererOptions):
             "importance": "core",
         },
     )
+    render_mermaid: bool = field(
+        default=False,
+        metadata={
+            "help": "Render fenced code blocks tagged 'mermaid' as <pre class=\"mermaid\"> "
+            "(so a client-side mermaid.js can draw them) instead of a plain code block",
+            "importance": "advanced",
+        },
+    )
     escape_html: bool = field(
         default=DEFAULT_HTML_ESCAPE_HTML,
         metadata={
@@ -301,7 +313,7 @@ class HtmlRendererOptions(BaseRendererOptions):
     csp_policy: str | None = field(
         default=DEFAULT_CSP_POLICY,
         metadata={
-            "help": "Custom Content-Security-Policy header value. " "If None, uses default secure policy.",
+            "help": "Custom Content-Security-Policy header value. If None, uses default secure policy.",
             "importance": "security",
         },
     )
@@ -509,7 +521,7 @@ class HtmlOptions(BaseParserOptions, AttachmentOptionsMixin):
         default=DEFAULT_HTML_FIGURES_PARSING,
         metadata={
             "help": (
-                "How to parse <figure> elements: blockquote, paragraph, image_with_caption, " "caption_only, html, skip"
+                "How to parse <figure> elements: blockquote, paragraph, image_with_caption, caption_only, html, skip"
             ),
             "choices": ["blockquote", "paragraph", "image_with_caption", "caption_only", "html", "skip"],
             "importance": "advanced",

--- a/src/all2md/renderers/html.py
+++ b/src/all2md/renderers/html.py
@@ -813,6 +813,14 @@ hr {
             Code block to render
 
         """
+        # Mermaid diagrams: emit a bare <pre class="mermaid"> holding the raw source
+        # so a client-side mermaid.js can render it. The text is still escaped -- the
+        # browser decodes entities when reading textContent, so `-->` etc. survive.
+        if self.options.render_mermaid and node.language == "mermaid":
+            escaped = escape_html(node.content, enabled=self.options.escape_html)
+            self._output.append(f'<pre class="mermaid">{escaped}</pre>\n')
+            return
+
         # Build class attribute
         classes = []
         if self.options.syntax_highlighting and node.language:

--- a/tests/e2e/test_config_cli.py
+++ b/tests/e2e/test_config_cli.py
@@ -42,7 +42,9 @@ class TestConfigCLIEndToEnd:
 
         cleanup_test_dir(self.temp_dir)
 
-    def _run_cli(self, args: list[str], env: dict[str, str] | None = None) -> subprocess.CompletedProcess:
+    def _run_cli(
+        self, args: list[str], env: dict[str, str] | None = None, cwd: Path | str | None = None
+    ) -> subprocess.CompletedProcess:
         """Run the CLI as a subprocess.
 
         Parameters
@@ -51,6 +53,8 @@ class TestConfigCLIEndToEnd:
             Command line arguments to pass to the CLI
         env : dict[str, str], optional
             Environment variables to set for the subprocess
+        cwd : Path or str, optional
+            Working directory for the subprocess. Defaults to the repository root.
 
         Returns
         -------
@@ -65,7 +69,7 @@ class TestConfigCLIEndToEnd:
 
         return subprocess.run(
             cmd,
-            cwd=self.cli_path.parent.parent.parent,
+            cwd=str(cwd) if cwd is not None else self.cli_path.parent.parent.parent,
             capture_output=True,
             text=True,
             env=subprocess_env,
@@ -175,8 +179,13 @@ class TestConfigCLIEndToEnd:
 
     def test_config_show_no_config_found(self):
         """Test config show when no configuration file exists."""
-        # Use an empty directory with no config files
-        result = self._run_cli(["config", "show"])
+        # Run from an empty directory that also serves as HOME, so the (home-bounded)
+        # config discovery has nothing to find -- and cannot pick up the developer's
+        # real ~/.all2md config. self.temp_dir is empty at this point.
+        env = {"USERPROFILE": str(self.temp_dir), "HOME": str(self.temp_dir)}
+        if "ALL2MD_CONFIG" in os.environ:
+            env["ALL2MD_CONFIG"] = ""
+        result = self._run_cli(["config", "show"], env=env, cwd=self.temp_dir)
 
         assert result.returncode == 0
         assert "No configuration found" in result.stdout

--- a/tests/e2e/test_serve_cli.py
+++ b/tests/e2e/test_serve_cli.py
@@ -205,6 +205,40 @@ def hello():
         assert "Test File" in html
         assert "Content here" in html
 
+    def test_serve_injects_web_assets(self):
+        """Served documents include the mermaid + highlight.js CDN includes."""
+        md_file = self._create_test_markdown()
+
+        self._start_server(["serve", str(md_file), "--port", "8031"])
+
+        html = self._fetch_url("http://127.0.0.1:8031/").decode("utf-8")
+        assert "mermaid@11" in html
+        assert "highlight.min.js" in html
+        # highlight.js hooks the language class the renderer already emits.
+        assert "language-python" in html
+
+    def test_serve_no_mermaid_no_highlight_flags(self):
+        """The --no-* flags suppress the injected assets."""
+        md_file = self._create_test_markdown()
+
+        self._start_server(["serve", str(md_file), "--no-mermaid", "--no-syntax-highlight", "--port", "8032"])
+
+        html = self._fetch_url("http://127.0.0.1:8032/").decode("utf-8")
+        assert "mermaid@11" not in html
+        assert "highlight.min.js" not in html
+
+    def test_serve_directory_uses_table_and_cards(self):
+        """The auto-generated directory index is a toggleable table/card listing."""
+        self._create_test_markdown("file1.md", "# File 1")
+        self._create_test_markdown("file2.md", "# File 2")
+
+        self._start_server(["serve", str(self.temp_dir), "--port", "8033"])
+
+        html = self._fetch_url("http://127.0.0.1:8033/").decode("utf-8")
+        assert "file-table" in html
+        assert "file-cards" in html
+        assert "a2m-view-btn" in html
+
     def test_serve_with_custom_port(self):
         """Test serving on a custom port."""
         md_file = self._create_test_markdown()

--- a/tests/unit/cli/commands/test_web_assets.py
+++ b/tests/unit/cli/commands/test_web_assets.py
@@ -1,0 +1,89 @@
+"""Unit tests for the shared view/serve web-asset helpers."""
+
+from pathlib import Path
+
+import pytest
+
+from all2md.cli.commands.web_assets import (
+    ThemeError,
+    builtin_theme_names,
+    inject_web_assets,
+    resolve_theme,
+)
+
+
+@pytest.mark.unit
+class TestResolveTheme:
+    def test_default_theme_is_minimal(self):
+        assert resolve_theme(None, dark=False, config={}).name == "minimal.html"
+
+    def test_dark_default_theme(self):
+        assert resolve_theme(None, dark=True, config={}).name == "dark.html"
+
+    def test_builtin_name(self):
+        path = resolve_theme("newspaper", dark=False, config={})
+        assert path.name == "newspaper.html"
+        assert path.is_file()
+
+    def test_builtin_names_exclude_editor(self):
+        names = builtin_theme_names()
+        assert "minimal" in names
+        assert "editor" not in names
+
+    def test_explicit_html_path(self, tmp_path: Path):
+        theme = tmp_path / "custom.html"
+        theme.write_text("<html><head></head><body>{CONTENT}</body></html>")
+        assert resolve_theme(str(theme), dark=False, config={}) == theme
+
+    def test_css_path_is_wrapped_in_shell(self, tmp_path: Path):
+        css = tmp_path / "look.css"
+        css.write_text("body { background: #abcdef; }")
+        result = resolve_theme(str(css), dark=False, config={})
+        text = result.read_text(encoding="utf-8")
+        assert result.suffix == ".html"
+        assert "#abcdef" in text
+        assert "{CONTENT}" in text
+        assert "{TITLE}" in text
+
+    def test_named_registry_from_config(self, tmp_path: Path):
+        theme = tmp_path / "corp.html"
+        theme.write_text("<html><head></head><body>{CONTENT}</body></html>")
+        path = resolve_theme("corp", dark=False, config={"themes": {"corp": str(theme)}})
+        assert path == theme
+
+    def test_registry_missing_file_errors(self, tmp_path: Path):
+        with pytest.raises(ThemeError, match="missing file"):
+            resolve_theme("corp", dark=False, config={"themes": {"corp": str(tmp_path / "gone.html")}})
+
+    def test_unknown_theme_lists_available(self):
+        with pytest.raises(ThemeError) as exc:
+            resolve_theme("does-not-exist", dark=False, config={})
+        assert "Available built-in themes" in str(exc.value)
+
+
+@pytest.mark.unit
+class TestInjectWebAssets:
+    HTML = "<html><head><title>t</title></head><body>x</body></html>"
+
+    def test_injects_both_before_head_close(self):
+        out = inject_web_assets(self.HTML)
+        assert "mermaid@11" in out
+        assert "highlight.min.js" in out
+        assert out.index("mermaid@11") < out.index("</head>")
+        assert out.index("highlight.min.js") < out.index("</head>")
+
+    def test_dark_switches_highlight_stylesheet(self):
+        assert "github-dark.min.css" in inject_web_assets(self.HTML, dark=True)
+        assert "github.min.css" in inject_web_assets(self.HTML, dark=False)
+
+    def test_disabling_both_is_a_noop(self):
+        assert inject_web_assets(self.HTML, mermaid=False, highlight=False) == self.HTML
+
+    def test_only_mermaid(self):
+        out = inject_web_assets(self.HTML, mermaid=True, highlight=False)
+        assert "mermaid@11" in out
+        assert "highlight.min.js" not in out
+
+    def test_appends_when_no_head_close(self):
+        out = inject_web_assets("<body>x</body>", highlight=False)
+        assert "mermaid@11" in out

--- a/tests/unit/cli/test_cli_config.py
+++ b/tests/unit/cli/test_cli_config.py
@@ -78,13 +78,16 @@ class TestConfigDiscovery:
             config_file = temp_path / ".all2md.json"
             config_file.write_text('{"pdf": {"detect_columns": true}}')
 
-            # Mock both cwd (empty) and home (has config)
-            with patch("pathlib.Path.cwd", return_value=Path(tempfile.mkdtemp())):
+            # cwd is an empty subdirectory of the mocked home. The parent walk is
+            # bounded at home, so it cannot escape into the real home directory.
+            cwd = temp_path / "work"
+            cwd.mkdir()
+            with patch("pathlib.Path.cwd", return_value=cwd):
                 with patch("pathlib.Path.home", return_value=temp_path):
                     discovered = discover_config_file()
 
                     assert discovered is not None
-                    assert discovered == config_file
+                    assert discovered.resolve() == config_file.resolve()
 
     def test_discover_config_prefers_toml_over_json(self):
         """Test that TOML files are preferred over JSON when both exist."""
@@ -125,16 +128,18 @@ class TestConfigDiscovery:
 
     def test_discover_config_returns_none_when_not_found(self):
         """Test that None is returned when no config file exists."""
-        with tempfile.TemporaryDirectory() as cwd_dir:
-            with tempfile.TemporaryDirectory() as home_dir:
-                cwd_path = Path(cwd_dir)
-                home_path = Path(home_dir)
+        with tempfile.TemporaryDirectory() as home_dir:
+            home_path = Path(home_dir)
+            # cwd is an empty subdirectory of the (empty) mocked home. The bounded
+            # parent walk stops at home, so no real ancestor config is discovered.
+            cwd_path = home_path / "work"
+            cwd_path.mkdir()
 
-                with patch("pathlib.Path.cwd", return_value=cwd_path):
-                    with patch("pathlib.Path.home", return_value=home_path):
-                        discovered = discover_config_file()
+            with patch("pathlib.Path.cwd", return_value=cwd_path):
+                with patch("pathlib.Path.home", return_value=home_path):
+                    discovered = discover_config_file()
 
-                        assert discovered is None
+                    assert discovered is None
 
     def test_get_config_search_paths(self):
         """Test getting list of config search paths."""
@@ -328,7 +333,9 @@ class TestPyprojectTomlSupport:
             with open(pyproject_file, "wb") as f:
                 tomli_w.dump(config_data, f)
 
-            found = find_config_in_parents(start_dir=temp_path)
+            # Bound the search to temp_path so the walk cannot escape into real
+            # ancestor directories that may hold an .all2md config.
+            found = find_config_in_parents(start_dir=temp_path, stop_dir=temp_path)
 
             # Should not find config (no [tool.all2md] section)
             assert found is None
@@ -342,8 +349,9 @@ class TestPyprojectTomlSupport:
             pyproject_file = temp_path / "pyproject.toml"
             pyproject_file.write_text("invalid toml [[[")
 
-            # Should not crash, just return None
-            found = find_config_in_parents(start_dir=temp_path)
+            # Should not crash, just return None. Bound the search to temp_path so
+            # the walk cannot escape into real ancestor .all2md configs.
+            found = find_config_in_parents(start_dir=temp_path, stop_dir=temp_path)
             assert found is None
 
 

--- a/tests/unit/renderers/test_html_renderer.py
+++ b/tests/unit/renderers/test_html_renderer.py
@@ -435,6 +435,31 @@ class TestBlockElements:
         result = renderer.render_to_string(doc)
         assert "<pre><code>" in result
 
+    def test_mermaid_code_block_rendered_as_diagram(self):
+        """With render_mermaid, a mermaid fence becomes <pre class="mermaid">."""
+        doc = Document(children=[CodeBlock(content="graph TD; A-->B;", language="mermaid")])
+        renderer = HtmlRenderer(HtmlRendererOptions(standalone=False, render_mermaid=True))
+        result = renderer.render_to_string(doc)
+        assert '<pre class="mermaid">' in result
+        assert "<code" not in result
+        # Escaped source is preserved (the browser decodes it back when reading textContent).
+        assert "A--&gt;B" in result
+
+    def test_mermaid_default_is_a_plain_code_block(self):
+        """Without render_mermaid, a mermaid fence renders like any other code block."""
+        doc = Document(children=[CodeBlock(content="graph TD; A-->B;", language="mermaid")])
+        renderer = HtmlRenderer(HtmlRendererOptions(standalone=False))
+        result = renderer.render_to_string(doc)
+        assert '<pre class="mermaid">' not in result
+        assert 'class="language-mermaid"' in result
+
+    def test_render_mermaid_leaves_other_languages_untouched(self):
+        """render_mermaid only special-cases mermaid, not other languages."""
+        doc = Document(children=[CodeBlock(content="print('x')", language="python")])
+        renderer = HtmlRenderer(HtmlRendererOptions(standalone=False, render_mermaid=True))
+        result = renderer.render_to_string(doc)
+        assert '<pre><code class="language-python">' in result
+
     def test_blockquote(self):
         """Test blockquote rendering."""
         doc = Document(children=[BlockQuote(children=[Paragraph(content=[Text(content="Quoted text")])])])


### PR DESCRIPTION
## Summary

Enhances the browser-viewing experience for `all2md view` and `all2md serve`, plus an independent config-discovery fix (see the second commit).

### Viewer/server enhancements
- **Mermaid diagrams** — ` ```mermaid ` fences render as diagrams via mermaid.js (jsDelivr CDN). Gated by a new `HtmlRendererOptions.render_mermaid` (default `off`, so no change to any other output); `view`/`serve` turn it on. `visit_code_block` emits `<pre class="mermaid">` for mermaid blocks.
- **Syntax highlighting** — highlight.js (CDN) is injected and hooks the `language-*` classes the renderer already emitted, so both fenced code blocks and raw source files (`.py`, `.js`, …) get highlighted with no renderer change. It only targets `<pre><code>`, so it ignores diagrams.
- On by default with **graceful offline degradation** (diagrams show as text, code unhighlighted); toggle with `--no-mermaid` / `--no-syntax-highlight`; dark variants auto-selected with `--dark`/dark theme.
- **Richer `serve` index** — the directory listing is now an aligned **table** (Name / Size / Modified / Created) plus a **card** view, with a `localStorage`-remembered toggle (table default) and HTML-escaped names. Only convertible files are listed (already the case; documented).
- **Customizable themes** — new shared `cli/commands/web_assets.py` centralizes theme resolution (dedups logic previously copied across both commands) and asset injection. `--theme` now also accepts a **plain `.css` file** (wrapped in a minimal HTML shell) and a name registered in a **`[themes]` config table**; the not-found error lists available names dynamically.

### Config-discovery fix (2nd commit)
`find_config_in_parents()` walked from cwd all the way to the filesystem root, so a config in a shared parent (a drive root, `/`) would silently apply to every project — and on machines where temp dirs live under the user's home, it made several discovery tests non-hermetic by finding the developer's real `~/.all2md` config. The walk is now bounded at `Path.home()` (inclusive) via a new optional `stop_dir`. Real behavior is unchanged (`~/.all2md.*` still found; home fallback still covers a cwd outside the home subtree). The affected unit + e2e tests are made hermetic.

## Docs
- New **"Document Viewer & Server"** guide (`docs/source/viewer.rst`) with a complete custom-theme walkthrough (full HTML template, CSS-only, and `[themes]` config), added to the toctree.
- Expanded `view`/`serve` theme docs in `cli.rst`; regenerated `options.rst`.

## Testing
- New unit tests: `test_web_assets.py` (theme resolution incl. CSS + registry; asset injection) and mermaid cases in `test_html_renderer.py`.
- New e2e assertions in `test_serve_cli.py` (injected assets, `--no-*` flags, table/card index).
- Config discovery unit + e2e tests made hermetic and passing.
- `ruff`, `black`, `mypy` clean; full unit suite green; docs build with no warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)