### PR TITLE
docs(install): add one-click uv-based install scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -104,3 +104,4 @@ benchmarks/corpus/.test/
 
 .claude/
 broken/
+design/

--- a/README.md
+++ b/README.md
@@ -381,9 +381,32 @@ The core library has no dependencies. You can install it and add support for for
 pip install all2md
 ```
 
-**2. System-Wide CLI Installation (Recommended for CLI users)**
+**2. One-Click Install (easiest — no Python setup required)**
 
-Install the CLI globally using [uv](https://docs.astral.sh/uv/) for instant access from anywhere:
+The install scripts set up [uv](https://docs.astral.sh/uv/) (installing it first if
+needed) and then install the `all2md` CLI globally, so it's available from any terminal.
+
+macOS / Linux (bash or zsh):
+
+```bash
+curl -LsSf https://raw.githubusercontent.com/thomas-villani/all2md/main/scripts/install.sh | sh
+```
+
+Windows (PowerShell):
+
+```powershell
+powershell -ExecutionPolicy Bypass -c "irm https://raw.githubusercontent.com/thomas-villani/all2md/main/scripts/install.ps1 | iex"
+```
+
+Both scripts install the `all` extra by default. To slim it down, download the script
+and pass a comma-separated extras list — `sh install.sh pdf,docx,html` or
+`.\install.ps1 -Extras pdf,docx,html` (use `none` for a base-only install). The scripts
+are also attached to each [GitHub release](https://github.com/thomas-villani/all2md/releases).
+
+**3. System-Wide CLI Installation (manual)**
+
+Prefer to drive [uv](https://docs.astral.sh/uv/) yourself? Install the CLI globally for
+instant access from anywhere:
 
 ```bash
 # Install uv if you don't have it
@@ -401,7 +424,7 @@ all2md document.pdf
 
 This gives you the `all2md` command globally without activating virtual environments.
 
-**3. Installation with Extras**
+**4. Installation with Extras**
 
 Install support for only the formats you need. You can combine multiple extras.
 
@@ -428,7 +451,7 @@ pip install "all2md[outlook]"
 # pip install libpff-python  # For PST/OST files (platform-specific)
 ```
 
-**4. Full Installation**
+**5. Full Installation**
 
 To install all optional dependencies for all supported formats:
 
@@ -436,7 +459,7 @@ To install all optional dependencies for all supported formats:
 pip install "all2md[all]"
 ```
 
-**5. Check Dependencies**
+**6. Check Dependencies**
 
 You can check the status of optional dependencies at any time using the built-in CLI command:
 

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -28,6 +28,48 @@ This includes support for:
 HTML parsing requires the ``html`` extra (see below). Images are handled as embedded
 attachments inside other documents rather than as a standalone input format.
 
+One-Click Install
+-----------------
+
+If you don't already manage Python environments, the one-click scripts are the
+simplest path. Each script installs `uv <https://docs.astral.sh/uv/>`_ (if it
+isn't already present) and then installs the ``all2md`` CLI as a uv-managed tool,
+so the ``all2md`` command works from any terminal. Re-running a script upgrades an
+existing install in place.
+
+**macOS / Linux (bash or zsh):**
+
+.. code-block:: bash
+
+   curl -LsSf https://raw.githubusercontent.com/thomas-villani/all2md/main/scripts/install.sh | sh
+
+**Windows (PowerShell):**
+
+.. code-block:: powershell
+
+   powershell -ExecutionPolicy Bypass -c "irm https://raw.githubusercontent.com/thomas-villani/all2md/main/scripts/install.ps1 | iex"
+
+Both scripts install the ``all`` extra by default. To install a slimmer set,
+download the script and pass a comma-separated extras list (use ``none`` for a
+base-only install):
+
+.. code-block:: bash
+
+   # macOS / Linux
+   sh install.sh pdf,docx,html
+   sh install.sh none
+
+.. code-block:: powershell
+
+   # Windows
+   .\install.ps1 -Extras "pdf,docx,html"
+   .\install.ps1 -Extras none
+
+The scripts are also attached to each
+`GitHub release <https://github.com/thomas-villani/all2md/releases>`_, so they can
+be downloaded and inspected before running. After installation, open a new terminal
+(so the updated ``PATH`` takes effect) and run ``all2md --help``.
+
 Installing with uv
 ------------------
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -2,6 +2,33 @@
 
 This directory contains utility scripts for maintaining the all2md codebase.
 
+## install.sh / install.ps1
+
+One-click end-user installers. Each script installs [uv](https://docs.astral.sh/uv/)
+if it isn't already present, then installs the `all2md` CLI as a uv-managed tool so
+the `all2md` command is available from any terminal. Safe to re-run (upgrades in place).
+
+These are meant to be run by end users, either straight from GitHub or from the copies
+attached to each release:
+
+```bash
+# macOS / Linux (bash or zsh)
+curl -LsSf https://raw.githubusercontent.com/thomas-villani/all2md/main/scripts/install.sh | sh
+
+# Slim it down (default installs the "all" extra); "none" for base-only:
+sh install.sh pdf,docx,html
+```
+
+```powershell
+# Windows (PowerShell)
+powershell -ExecutionPolicy Bypass -c "irm https://raw.githubusercontent.com/thomas-villani/all2md/main/scripts/install.ps1 | iex"
+.\install.ps1 -Extras "pdf,docx,html"
+```
+
+`install.sh` is POSIX `sh` and covers both bash and zsh (no separate zsh script is
+needed). Both are documented for users in `docs/source/installation.rst` and the
+project README.
+
 ## update_document_formats.py
 
 Manages the synchronization between the `DocumentFormat` Literal type hint in `constants.py` and the dynamically discovered formats in the converter registry.

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -1,0 +1,83 @@
+<#
+.SYNOPSIS
+    One-click installer for all2md on Windows.
+
+.DESCRIPTION
+    Installs uv (https://docs.astral.sh/uv/) if it isn't already present, then
+    installs all2md as a uv-managed tool so the `all2md` command is available
+    from any terminal without activating a virtual environment.
+
+    Safe to re-run: `uv tool install --upgrade` updates an existing install in place.
+
+.PARAMETER Extras
+    Comma-separated optional format extras to include (default: "all").
+    Use "none" for a minimal base install with no optional formats.
+
+.EXAMPLE
+    # Run straight from GitHub (recommended for new users):
+    powershell -ExecutionPolicy Bypass -c "irm https://raw.githubusercontent.com/thomas-villani/all2md/main/scripts/install.ps1 | iex"
+
+.EXAMPLE
+    # Download and run with a slimmer extras set:
+    .\install.ps1 -Extras "pdf,docx,html"
+
+.EXAMPLE
+    .\install.ps1 -Extras none
+#>
+param(
+    [string]$Extras = "all"
+)
+
+$ErrorActionPreference = "Stop"
+
+function Write-Step($message) { Write-Host "==> $message" -ForegroundColor Cyan }
+
+# Build the package spec, e.g. "all2md[all]". "none"/blank => bare "all2md".
+$spec = if ([string]::IsNullOrWhiteSpace($Extras) -or $Extras -ieq "none") {
+    "all2md"
+} else {
+    "all2md[$Extras]"
+}
+
+function Test-Uv { [bool](Get-Command uv -ErrorAction SilentlyContinue) }
+
+# The standalone uv installer drops the binary in %USERPROFILE%\.local\bin and
+# updates the *persisted* user PATH, but not the current session. Add the
+# well-known locations so we (and `uv tool`'s shims) are reachable right away.
+function Add-LocalBinToPath {
+    $dirs = @(
+        (Join-Path $env:USERPROFILE ".local\bin"),
+        (Join-Path $env:USERPROFILE ".cargo\bin")
+    )
+    foreach ($d in $dirs) {
+        if ((Test-Path $d) -and ($env:PATH -notlike "*$d*")) {
+            $env:PATH = "$d;$env:PATH"
+        }
+    }
+}
+
+if (-not (Test-Uv)) { Add-LocalBinToPath }
+
+if (-not (Test-Uv)) {
+    Write-Step "Installing uv (fast Python package manager)..."
+    Invoke-RestMethod https://astral.sh/uv/install.ps1 | Invoke-Expression
+    Add-LocalBinToPath
+}
+
+if (-not (Test-Uv)) {
+    throw "uv was installed but isn't on PATH yet. Open a NEW terminal and re-run this script."
+}
+
+Write-Step "Installing all2md ($spec) as a uv tool..."
+uv tool install --upgrade $spec
+
+# Ensure the uv tools bin directory is on PATH for future shells.
+try { uv tool update-shell | Out-Null } catch { }
+
+Write-Step "Done."
+if (Get-Command all2md -ErrorAction SilentlyContinue) {
+    try { all2md --version } catch { }
+    Write-Host "`nTry it:  all2md --help"
+} else {
+    Write-Host "`nInstalled. Open a NEW terminal, then run:  all2md --help"
+}

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,0 +1,87 @@
+#!/bin/sh
+# shellcheck shell=sh
+# all2md one-click installer for macOS / Linux (works in bash and zsh).
+#
+# What it does:
+#   1. Installs uv (https://docs.astral.sh/uv/) if it isn't already present.
+#   2. Installs all2md as a uv-managed tool, so the `all2md` command is available
+#      from any terminal without activating a virtual environment.
+#
+# Safe to re-run: `uv tool install --upgrade` updates an existing install in place.
+#
+# Usage:
+#   # Run straight from GitHub (recommended for new users):
+#   curl -LsSf https://raw.githubusercontent.com/thomas-villani/all2md/main/scripts/install.sh | sh
+#
+#   # Or download and run, choosing which optional formats to include:
+#   sh install.sh pdf,docx,html          # only these extras
+#   sh install.sh none                   # base install, no optional formats
+#   ALL2MD_EXTRAS="all" sh install.sh    # same as the default
+#
+# The default installs the "all" extra (every optional format that ships in the
+# aggregate). Pass a comma-separated extras list to slim it down.
+set -eu
+
+EXTRAS="${1:-${ALL2MD_EXTRAS:-all}}"
+
+info() { printf '\033[1;36m==>\033[0m %s\n' "$1"; }
+err() { printf '\033[1;31merror:\033[0m %s\n' "$1" >&2; }
+
+# Build the package spec, e.g. "all2md[all]". "none"/empty => bare "all2md".
+case "$EXTRAS" in
+    "" | none | None | NONE) SPEC="all2md" ;;
+    *) SPEC="all2md[$EXTRAS]" ;;
+esac
+
+# The standalone uv installer drops the binary in ~/.local/bin (or a couple of
+# other well-known spots) and updates future shells' PATH -- but not the shell
+# we're running in right now. Prepend those dirs so we can call uv immediately.
+ensure_uv_on_path() {
+    for d in "$HOME/.local/bin" "$HOME/.cargo/bin" "${XDG_BIN_HOME:-}"; do
+        [ -n "$d" ] && [ -d "$d" ] || continue
+        case ":$PATH:" in
+            *":$d:"*) ;;
+            *) PATH="$d:$PATH" ;;
+        esac
+    done
+    export PATH
+}
+
+has_uv() { command -v uv >/dev/null 2>&1; }
+
+if ! has_uv; then
+    ensure_uv_on_path
+fi
+
+if ! has_uv; then
+    info "Installing uv (fast Python package manager)..."
+    if command -v curl >/dev/null 2>&1; then
+        curl -LsSf https://astral.sh/uv/install.sh | sh
+    elif command -v wget >/dev/null 2>&1; then
+        wget -qO- https://astral.sh/uv/install.sh | sh
+    else
+        err "Need either curl or wget to download uv. Install one and re-run."
+        exit 1
+    fi
+    ensure_uv_on_path
+fi
+
+if ! has_uv; then
+    err "uv was installed but isn't on PATH yet. Open a NEW terminal and re-run this script,"
+    err "or add \$HOME/.local/bin to your PATH."
+    exit 1
+fi
+
+info "Installing all2md ($SPEC) as a uv tool..."
+uv tool install --upgrade "$SPEC"
+
+# Make sure the uv tools bin directory is on PATH in future shells.
+uv tool update-shell >/dev/null 2>&1 || true
+
+info "Done."
+if command -v all2md >/dev/null 2>&1; then
+    all2md --version || true
+    printf '\nTry it:  all2md --help\n'
+else
+    printf '\nInstalled. Open a NEW terminal, then run:  all2md --help\n'
+fi


### PR DESCRIPTION
## Summary

Lowers the barrier to CLI adoption with **one-click install scripts** that set up `uv` (installing it first if needed) and then install the `all2md` CLI as a uv-managed tool — so `all2md` works from any terminal without manual Python/venv setup.

This is the outcome of a discussion on how to reach non-Python users. We deliberately chose uv-based scripts over a PyInstaller/frozen binary: the dependency spread (torch via `ocr-easyocr`, the C-extension `chm`) plus signing/AV friction make a frozen binary high-cost, while `uv tool install` is near-zero maintenance.

## Changes

- **`scripts/install.sh`** — POSIX `sh`, covers both bash and zsh. Installs uv if missing, then `uv tool install --upgrade all2md[<extras>]`.
- **`scripts/install.ps1`** — Windows/PowerShell equivalent.
- Both: safe to re-run (upgrade in place), handle "uv installed but not yet on PATH in this shell", and accept a comma-separated extras list (default `all`; `none` for base-only).
- Docs wired up: README (new one-click section; the manual `uv tool install` instructions are **kept**), `docs/source/installation.rst`, and `scripts/README.md`.
- `.gitignore`: ignore the local-only `design/` notes folder.

## Notes

- Default extra is `all` (friendly for newcomers; excludes the problem extras `chm`/`ocr-easyocr`/`pdf_layout`).
- Raw one-liner URLs track `main`; the scripts are also intended as GitHub release assets for a pinned/inspectable copy.
- Syntax/parse-checked (`sh -n`, PowerShell parser); not executed end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)