### PR TITLE
fix(search): invalidate persisted index when corpus or options change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Persistent search index no longer serves stale results.** A keyword index
+  saved with `--search-index-dir` (MCP `search_documents`) was reused whenever the
+  directory existed, with no record of the corpus it was built from — so pointing
+  it at a changed corpus, or a different `paths` set, could silently return stale
+  hits. The index now records a fingerprint of the documents and index-relevant
+  options at save time and is rebuilt when they no longer match.
+
 ## [1.8.1] - 2026-07-06
 
 ### Added

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -2,9 +2,17 @@
 
 > A living, intentionally-wide brainstorm of where `all2md` could go. Nothing here is
 > committed — it's a menu of directions, sequenced roughly by leverage and effort.
-> Tactical, near-term items live in [`todo.md`](todo.md); this doc is the big picture.
 
 Legend: 🌱 natural next step · 🚀 ambitious · 🌙 moonshot · ✅ foundation already exists
+· 🚢 **shipped**
+
+> **Status note (updated 2026-07-08).** Since this roadmap was first written we've
+> shipped the headline Theme 1 item — `all2md chunk` (provenance-aware chunking, 11
+> strategies, `all2md.chunk()` Python API, `[chunk]` extra) — plus mermaid/syntax-
+> highlighting in `view`/`serve` and one-click `uv` install scripts. Shipped items are
+> marked 🚢 inline below; the license question that gated chunking is resolved (chunkers
+> vendored, optional extra). Tactical near-term work still lives in [`todo.md`](todo.md);
+> the highest-signal outstanding todo items are cross-referenced into the themes below.
 
 ---
 
@@ -32,18 +40,24 @@ We have an AST with line mapping and source spans; `localvectordb` (sister lib) 
 composable, position-tracking chunkers and a clean `ChunkerFactory` API. The synergy is
 obvious.
 
-- 🌱 **First-class `all2md chunk`** — `all2md chunk doc.pdf --strategy semantic|heading|token
-  --max-tokens 512 --overlap 64` emitting chunks + metadata + source spans as JSONL.
-  Draw chunking strategies from `localvectordb.ChunkerFactory` (sentence, token, word,
-  line, char, paragraph, section/heading, code-block) rather than reinventing them.
-- 🚀 **Provenance-preserving conversion** — every output node retains a pointer back to
-  source (page, bbox, char offset). We already track line mapping in the AST; extend it
-  end-to-end so an LLM answer can cite *exactly* where it came from. This is a genuine
-  RAG-trust differentiator.
-- 🌱 **Token-budget conversion** — grow `llm-minify` into "fit this 400-page PDF into
-  100k tokens" with section-aware elision/summarization.
-- 🚀 **Structured extraction** — `all2md extract doc.pdf --schema invoice.json` → typed,
-  schema-validated JSON (tables → records, key/value fields). Document → data, not prose.
+- 🚢 **First-class `all2md chunk`** — *shipped (v1.8.0).* Eleven strategies (`semantic`
+  default, `heading`, `section`, `auto`, `token`, `sentence`, `paragraph`, `word`, `line`,
+  `char`, `code`), JSONL/JSON/pretty output, `--max-tokens`/`--overlap`/`--min-tokens`,
+  tiktoken-backed real BPE counting via the `[chunk]` extra, atomic table/code chunks,
+  data-URI elision, and a one-call `all2md.chunk()` Python API. Fine-grained chunkers are
+  vendored from `localvectordb`.
+- 🚀 **Provenance-preserving conversion** — *partially shipped.* `all2md chunk` records
+  provenance now include section heading/level and (where the parser tracks it, e.g. PDF)
+  the source page span. The remaining ambition is end-to-end node-level provenance
+  (page, bbox, char offset) on *every* output node so an LLM answer can cite exactly where
+  it came from — the RAG-trust differentiator. Bbox/char-offset spans are the gap.
+- 🌱 **Token-budget conversion** — `llm-minify` (🚢 v1.3.0) and `--slice X/Y` paging
+  (🚢 v1.7.1) exist; the open piece is "fit this 400-page PDF into 100k tokens" with
+  section-aware elision/summarization rather than uniform minification.
+- 🚀 **Structured extraction** — *not started* (distinct from the shipped `--extract`
+  selector, which pulls sections/tables/figures as Markdown). The ambition here is
+  `all2md extract doc.pdf --schema invoice.json` → typed, schema-validated JSON
+  (tables → records, key/value fields). Document → data, not prose.
 - 🚀 **Loader adapters (two tiers).** Every framework wants the same payload —
   *text + metadata records* — which our AST + chunker already produces. Split the work:
   - **RAG-framework adapters** (🌱, easy, high-visibility) — one thin module each:
@@ -62,10 +76,11 @@ obvious.
     - *TensorFlow* — `tf.data.from_generator` for live use, but the real story is
       pre-sharded TFRecords from the batch engine.
 
-**Reuse note:** `localvectordb` is PolyForm Noncommercial-licensed. For an MIT/permissive
-`all2md`, prefer extracting/porting the chunking *primitives* (they're self-contained and
-depend mostly on `tiktoken`) rather than taking a hard dependency — or expose chunking
-behind an optional extra. Decide license posture before wiring it in.
+**Reuse note (resolved):** `localvectordb` is PolyForm Noncommercial-licensed. We took the
+recommended path — the fine-grained chunking primitives were **vendored** into `all2md`
+(self-contained, `tiktoken`-based) rather than added as a hard dependency, and BPE counting
+lives behind the optional `[chunk]` extra. License posture settled; no runtime dependency
+on the noncommercial package.
 
 ---
 
@@ -75,7 +90,14 @@ People star us because "it just converted my gnarly PDF perfectly." Protect and 
 
 - 🌱 **Round-trip fidelity scoring** — `all2md roundtrip doc.docx` converts → md → back and
   reports a structural diff score (built on the existing diff engine). Turns fidelity into
-  a measurable, regression-testable, marketable metric.
+  a measurable, regression-testable, marketable metric. *Groundwork exists:* the corpus
+  benchmark harness under `benchmarks/corpus/` (🚢 v1.1.1) already times conversion across a
+  stratified real-world corpus and has an `inspect` mode; a `roundtrip` score sits naturally
+  on top of it plus the diff engine. **Still the single best leverage-per-effort item.**
+- 🌱 **DOCX round-trip: character styles** — *outstanding (see `todo.md`).* Paragraph-level
+  `source_style` already round-trips (🚢 v1.1.1); extend the same approach to run-level named
+  character styles ("Quote Char", "Intense Reference") by folding the style name into the
+  run-grouping key in `_process_paragraph_runs_to_inline`. Concrete, scoped fidelity win.
 - 🚀 **Layout-aware PDF reconstruction** — correct reading order across columns,
   footnote/endnote linking, running header/footer stripping, caption↔figure association.
   The eternal PDF pain points; we already have `_pdf_layout.py` to build on.
@@ -83,8 +105,11 @@ People star us because "it just converted my gnarly PDF perfectly." Protect and 
   HTML MathML, and (optionally) images of equations via OCR. Huge for academic/technical
   users and a natural pairing with the existing arxiv packager.
 - 🚀 **Public fidelity benchmark** — a golden corpus + scores vs markitdown / pandoc /
-  docling. Marketing + regression guard in one. Cheap given the diff engine. Corpora,
-  split by job:
+  docling. Marketing + regression guard in one. Cheap given the diff engine. *Groundwork
+  exists:* `benchmarks/corpus/` already pulls deterministic samples from arxiv, PubMed
+  Central, govdocs1, Apache POI, and Enron and emits a stratified report (🚢 v1.1.1); a
+  manual-dispatch CI workflow runs it on a clean VM. What's missing is the *quality* score
+  (vs. ground truth) and the head-to-head against other tools. Corpora, split by job:
   - **Structure ground-truth (headline metric):** [**OmniDocBench**](https://github.com/opendatalab/OmniDocBench)
     (CVPR 2025) — 981 pages, 9 doc types, with table (Markdown/HTML/LaTeX), formula, and
     reading-order metrics that map directly onto our output. Anchor the public score here.
@@ -101,7 +126,30 @@ People star us because "it just converted my gnarly PDF perfectly." Protect and 
     Wikipedia HTML dumps, and **arXiv source↔PDF pairs** (free round-trip *math* ground
     truth — pairs with the math-support work).
 - 🌱 **Conversion confidence report** — surface per-document warnings (dropped elements,
-  OCR confidence, ambiguous tables) as a structured "quality card."
+  OCR confidence, ambiguous tables) as a structured "quality card." *Note:* many of these
+  signals are already computed as **guards** inside the PDF parser (table cell-fill density,
+  uniformity, dot-leader ratio; ghost/tiny-image counts; near-empty-page ratio). This item
+  is largely about *surfacing* them as structured output instead of log noise — and doing so
+  is the enabling substrate for the **conversion optimizer** below.
+- 🚀 **Conversion optimizer (`all2md optimize`)** — auto-tune converter settings for a
+  difficult document (headline case: gnarly PDFs). Searches the parameter space
+  (`table_detection_mode`, `detect_columns`, OCR mode/engine, `min_image_dimension`,
+  header/footer filtering, dehyphenation, layout model, heading size-ratio, …) and returns
+  the settings that maximize a quality score — emitted as a reusable preset / `.all2md.toml`
+  snippet.
+  - **Objective (the crux):** difficult PDFs rarely have a reference to diff against, so the
+    optimizer needs a **reference-free** quality score — exactly the vector the *confidence
+    report* produces (real-word ratio, table sanity, ghost-image count, reading-order
+    coherence, near-empty-page ratio, hyphenation-merge success). **This item is therefore
+    gated on the confidence report + round-trip scoring; it's the capstone of the fidelity
+    batch, not a standalone.**
+  - **Search shape (keep it cheap):** score a handful of named presets first (interpretable,
+    fast), then a 1-D refine on the highest-impact continuous knob — not a full grid. Sample
+    a page subset (first N + random) rather than reconverting a 400-page doc, and **cache per
+    (param-set × content-hash)**, reusing the Theme 3 conversion-cache fingerprint.
+  - **Two levels:** per-document autotune, *and* a corpus-level mode that tunes over
+    `benchmarks/corpus/` to improve **shipped defaults** — a concrete step toward the
+    self-improving converters in Theme 7.
 - 🌙 **Vision-model fallback** — when structural parsing fails (scanned tables, complex
   figures, handwriting), optionally hand the page to a vision LLM and merge its structured
   output back into the AST.
@@ -118,8 +166,16 @@ See the **Async Architecture Decision** below for the strategy. The shape:
 - 🚀 **Deferred asset resolution** — parse to AST with asset placeholders, then resolve all
   remote assets concurrently (`asyncio.gather`), then finalize. Turns N serial fetches into
   one concurrent batch — the real user-visible speedup for asset-heavy HTML.
-- 🌱 **Persistent / incremental search index** — the existing TODO; key conversion + BM25
-  index off a content-hash + mtime fingerprint (ties into `todo.md` cache item).
+- 🌱 **Persistent / incremental search index + shared conversion cache** — *outstanding
+  (`todo.md`).* Today `--search-index-dir` (`mcp/query_tools.py`) is keyed only by directory,
+  so reusing an index across a changed corpus or a different `paths` set can return **stale
+  results**. Roll the MCP search index together with a general conversion cache: stash
+  converted documents/ASTs keyed by content-hash + mtime, and key/invalidate the BM25 index
+  off the same fingerprint. Fixes correctness *and* avoids redundant re-conversions across
+  tools — a rare "fixes a bug and adds a feature" item. The same cache is reusable well
+  beyond MCP: `view` and `serve` re-convert a file on every scan/request today and would
+  skip unchanged files, and the **conversion optimizer** (Theme 2) reuses the fingerprint to
+  avoid reconverting identical param-sets.
 - 🚀 **Parallel batch engine v2** — the `ProcessPoolExecutor` path with resume, a failure
   manifest, and as-completed streaming progress.
 - 🌙 **WASM build** — `all2md` in-browser (Pyodide, or a Rust core for hot paths) for
@@ -136,11 +192,18 @@ See the **Async Architecture Decision** below for the strategy. The shape:
 - 🚀 **Spreadsheet semantics** — preserve formulas, named ranges, and cross-sheet refs,
   not just rendered values.
 - 🌙 **Diagram intelligence** — Mermaid / Graphviz / draw.io / PlantUML round-tripping, and
-  reverse-engineering diagrams from images.
+  reverse-engineering diagrams from images. *Down-payment:* `view`/`serve` now **render**
+  ```mermaid``` fences via mermaid.js and the HTML renderer has `render_mermaid`
+  (🚢 v1.8.0) — rendering exists; parsing/round-tripping other diagram formats is the gap.
 
 ---
 
 ## Theme 5 — Ecosystem & distribution
+
+> **Install experience — decided.** We shipped one-click **`uv`-based install scripts**
+> (🚢 v1.8.0) rather than a frozen PyInstaller binary; that resolves the "build a binary so
+> people can install directly?" question in `todo.md`. A browser/web-UI is still planned
+> (local-only design spec). The channels below (Docker, Action, hosted API) are unstarted.
 
 - 🌱 **Docker image** — `docker run all2md` as a one-line microservice / CI step. Also the
   building block for the GitHub Action and hosted API below — bake PyMuPDF/tesseract in once.
@@ -171,8 +234,17 @@ See the **Async Architecture Decision** below for the strategy. The shape:
 
 ## Theme 6 — Editing, collaboration & live workflows
 
-- 🌱 **Expand the edit API** — beyond section ops: table-cell edits, find-and-restructure,
+- 🌱 **Expand the edit API** — *groundwork shipped:* the MCP `edit_document` tool does
+  atomic, in-place batch edits with format-preserving write-back (🚢 v1.6.0) and the
+  `all2md edit` web editor exists (🚢 v1.1.0). Outstanding: **CLI** insert/replace/delete
+  commands (`todo.md`), and beyond section ops — table-cell edits, find-and-restructure,
   programmatic AST patches with undo.
+- 🌱 **Element re-routing on conversion** — *outstanding (`todo.md`).* One pass that can
+  drop images/tables entirely, extract tables to separate file(s) (combined or per-table),
+  or collate all images/tables to the end of the document. Overlaps the chunker's
+  `--drop-elements` (🚢) but as a conversion-output restructuring, not just chunking; useful
+  for both human reading and RAG prep. Also: **extract text around a table/anchor** and
+  **extend `--extract` to all AST element types**.
 - 🚀 **Watch-and-sync daemon** — keep a markdown mirror of a source doc continuously
   updated; optionally bidirectional.
 - 🌙 **Bidirectional live editing** — edit the markdown, regenerate the DOCX *preserving the
@@ -230,14 +302,26 @@ CPU core.
 
 ## Suggested sequencing
 
-A rough first arc, ordered by leverage-per-effort:
+**Done since first draft:** ~~`all2md chunk`~~ 🚢 (was #2) — the biggest single item is
+shipped, along with mermaid rendering and `uv` install scripts.
 
-1. **Round-trip fidelity scoring** + **conversion confidence report** — small, build on the
-   diff engine, immediately useful and marketable.
-2. **`all2md chunk`** (porting `localvectordb` chunkers) — high demand, foundation exists.
-3. **Async facade + async I/O edge** — unblocks the server/MCP story.
-4. **GitHub Action + Docker image** — adoption channels for a project gaining stars.
-5. **Math support** + **layout-aware PDF** — deepen the fidelity moat.
-6. **Public fidelity benchmark** — once round-trip scoring exists, productize it.
+Revised arc for the **next batch**, ordered by leverage-per-effort:
 
-Everything below 🚀/🌙 is opportunistic — pull forward whatever a real user asks for.
+1. **Round-trip fidelity scoring** + **conversion confidence report** — still the top pick:
+   small, builds on the diff engine *and* the existing corpus harness, immediately useful and
+   marketable. Pairs naturally with the **DOCX character-style** round-trip fix. Together
+   these two produce the quality score that unlocks the **conversion optimizer**
+   (`all2md optimize`) as the batch capstone — build them first, in that order.
+2. **Search-index / conversion-cache correctness** — fixes a real staleness *bug* in
+   `--search-index-dir` while adding a broadly useful cache layer. Small, high-certainty.
+3. **Async facade + async I/O edge** — unblocks the server/MCP story (see the Async
+   Architecture Decision); the deferred-asset-resolution phase is the user-visible win.
+4. **GitHub Action + Docker image** — adoption channels for a project gaining stars; Docker
+   is the shared building block for the Action and a future hosted API.
+5. **Math support** + **layout-aware PDF** — deepen the fidelity moat (larger efforts).
+6. **Public fidelity benchmark** — once round-trip scoring exists, productize it into a
+   head-to-head vs. markitdown / pandoc / docling.
+
+Everything below 🚀/🌙 is opportunistic — pull forward whatever a real user asks for. The
+small `todo.md` bug-fixes (filename-hint detection, leading blank line in DOCX, smarter
+capitalization-aware dehyphenation, rich `--help` by default) are independent quick wins.

--- a/src/all2md/mcp/query_tools.py
+++ b/src/all2md/mcp/query_tools.py
@@ -173,10 +173,18 @@ def search_documents_impl(input_data: SearchDocumentsInput, config: MCPConfig) -
         persist_dir = _validate_index_dir(config.search_index_dir, config.write_allowlist)
 
     try:
-        if persist_dir is not None and (persist_dir / "keyword").exists():
+        index_is_current = (
+            persist_dir is not None
+            and (persist_dir / "keyword").exists()
+            and SearchService.persisted_index_matches(persist_dir, documents, options)
+        )
+        if index_is_current:
+            assert persist_dir is not None  # narrowed by index_is_current
             logger.info(f"Loading persisted keyword index from: {persist_dir}")
             service = SearchService.load(persist_dir, options=options)
         else:
+            if persist_dir is not None and (persist_dir / "keyword").exists():
+                logger.info(f"Persisted index at {persist_dir} is stale (corpus/options changed); rebuilding")
             service = SearchService(options=options)
             service.build_indexes(documents, modes={service_mode})
             if persist_dir is not None:

--- a/src/all2md/parsers/mbox.py
+++ b/src/all2md/parsers/mbox.py
@@ -298,10 +298,7 @@ class MboxToAstConverter(BaseParser):
             for folder_name in self.options.folder_filter:
                 try:
                     folder = mbox.get_folder(folder_name)
-                    # Type ignore: Maildir.get_folder returns Maildir but we accept it as Mailbox
-                    messages.extend(
-                        self._process_folder_messages(folder, folder_name, processed_count)  # type: ignore[arg-type]
-                    )
+                    messages.extend(self._process_folder_messages(folder, folder_name, processed_count))
                     processed_count = len(messages)
                 except (KeyError, mailbox.NoSuchMailboxError):
                     # Folder doesn't exist, skip
@@ -359,7 +356,7 @@ class MboxToAstConverter(BaseParser):
         return messages
 
     def _process_folder_messages(
-        self, folder: mailbox.Mailbox[Message[str, str]], folder_name: str, start_count: int = 0
+        self, folder: mailbox.Maildir, folder_name: str, start_count: int = 0
     ) -> list[dict[str, Any]]:
         """Process messages from a specific folder.
 

--- a/src/all2md/search/service.py
+++ b/src/all2md/search/service.py
@@ -20,6 +20,40 @@ from all2md.search.chunking import ChunkingContext, chunk_document
 from all2md.search.hybrid import blend_results
 from all2md.search.types import Chunk, SearchMode, SearchQuery, SearchResult
 from all2md.search.vector import VectorIndex, VectorIndexConfig
+from all2md.utils.fingerprint import corpus_fingerprint
+
+# Name of the sidecar manifest recording the corpus fingerprint a persisted
+# index was built from, so a stale index can be detected and rebuilt.
+_CORPUS_MANIFEST_NAME = "corpus.json"
+
+# Option fields that change the *content* of the index (chunk boundaries or
+# scoring), and so must invalidate a persisted index when altered. Grep/display
+# options are deliberately excluded — changing them should not force a rebuild.
+_INDEX_RELEVANT_OPTION_KEYS: tuple[str, ...] = (
+    "chunk_size_tokens",
+    "chunk_overlap_tokens",
+    "min_chunk_tokens",
+    "include_preamble",
+    "heading_merge",
+    "max_heading_level",
+    "bm25_k1",
+    "bm25_b",
+    "vector_model_name",
+    "vector_normalize_embeddings",
+)
+
+
+def _index_relevant_options(options: SearchOptions) -> dict[str, object]:
+    """Extract the option subset that affects a persisted index's contents."""
+    return {key: getattr(options, key) for key in _INDEX_RELEVANT_OPTION_KEYS}
+
+
+def compute_corpus_fingerprint(documents: Sequence[SearchDocumentInput], options: SearchOptions) -> str:
+    """Fingerprint a document set + index-relevant options for cache validation."""
+    return corpus_fingerprint(
+        [doc.source for doc in documents],
+        extra=_index_relevant_options(options),
+    )
 
 
 @dataclass(frozen=True)
@@ -192,6 +226,41 @@ class SearchService:
             self._state.keyword_index.save(directory / "keyword")
         if self._state.vector_index:
             self._state.vector_index.save(directory / "vector")
+
+        # Record the corpus fingerprint so a later load can tell whether the
+        # persisted index still matches the documents/options it was built from.
+        if self._state.documents is not None:
+            fingerprint = corpus_fingerprint(
+                [doc_input.source for _doc, doc_input in self._state.documents],
+                extra=_index_relevant_options(self.options),
+            )
+            manifest = {"fingerprint": fingerprint}
+            (directory / _CORPUS_MANIFEST_NAME).write_text(json.dumps(manifest, indent=2), encoding="utf-8")
+
+    @staticmethod
+    def persisted_index_matches(
+        directory: Path,
+        documents: Sequence[SearchDocumentInput],
+        options: SearchOptions,
+    ) -> bool:
+        """Return True if a persisted index in ``directory`` is still current.
+
+        Compares the fingerprint recorded at save time (corpus files +
+        index-relevant options) against the fingerprint of the documents/options
+        supplied now. A missing or unreadable manifest, or any mismatch, returns
+        False — the caller should rebuild rather than serve a stale index.
+        """
+        manifest_path = directory / _CORPUS_MANIFEST_NAME
+        if not manifest_path.exists():
+            return False
+        try:
+            stored = json.loads(manifest_path.read_text(encoding="utf-8")).get("fingerprint")
+        except (OSError, ValueError):
+            return False
+        if not stored:
+            return False
+        current = compute_corpus_fingerprint(documents, options)
+        return bool(stored == current)
 
     @classmethod
     def load(cls, directory: Path, options: SearchOptions | None = None) -> "SearchService":

--- a/src/all2md/utils/fingerprint.py
+++ b/src/all2md/utils/fingerprint.py
@@ -1,0 +1,139 @@
+"""Content/identity fingerprinting for cache invalidation.
+
+A small, dependency-free primitive shared by any subsystem that persists an
+artifact derived from a set of input files and wants to reuse it *only* while
+those inputs are unchanged. Today it guards the persistent search index
+(:mod:`all2md.search.service`); the same digest is intended to key the broader
+conversion cache (converted ASTs/output reused by ``view``/``serve`` and the
+conversion optimizer).
+
+The default signature is ``(size, mtime_ns)`` — an ``os.stat`` with no read —
+because the decision "may I reuse this artifact?" must be cheap on the hot path
+(the whole point is to avoid re-reading/re-parsing the corpus). ``content_hash``
+is available for callers that need robustness against mtime-preserving copies
+and can afford to read the bytes.
+"""
+
+#  Copyright (c) 2025 Tom Villani, Ph.D.
+
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+from typing import Iterable, Mapping
+
+__all__ = ["file_signature", "bytes_signature", "corpus_fingerprint"]
+
+_HASH_READ_CHUNK = 1 << 20  # 1 MiB
+
+
+def _hash_file(path: Path, *, chunk_size: int = _HASH_READ_CHUNK) -> str:
+    """Return the hex SHA-256 of a file's bytes, read in bounded chunks."""
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for block in iter(lambda: handle.read(chunk_size), b""):
+            digest.update(block)
+    return digest.hexdigest()
+
+
+def file_signature(path: str | Path, *, content_hash: bool = False) -> dict[str, object]:
+    """Return a change-signature for a single file.
+
+    Parameters
+    ----------
+    path : str | Path
+        File to signature. Resolved to an absolute path so the identity is
+        stable regardless of the working directory.
+    content_hash : bool, default False
+        When True, also hash the file bytes (SHA-256). Robust against
+        mtime-preserving copies at the cost of a full read. When False, only
+        ``(size, mtime_ns)`` is captured — an O(1) stat that still changes
+        whenever the file is rewritten.
+
+    Returns
+    -------
+    dict[str, object]
+        JSON-serializable signature (``path``, ``size``, ``mtime_ns`` and,
+        optionally, ``sha256``).
+
+    Raises
+    ------
+    OSError
+        If the file cannot be stat-ed (missing, permission denied, ...).
+
+    """
+    resolved = Path(path).resolve()
+    stat = resolved.stat()
+    signature: dict[str, object] = {
+        "path": str(resolved),
+        "size": stat.st_size,
+        "mtime_ns": stat.st_mtime_ns,
+    }
+    if content_hash:
+        signature["sha256"] = _hash_file(resolved)
+    return signature
+
+
+def bytes_signature(data: bytes) -> dict[str, object]:
+    """Return a content signature for an in-memory bytes source (e.g. stdin)."""
+    return {"size": len(data), "sha256": hashlib.sha256(data).hexdigest()}
+
+
+def _normalize_extra(mapping: Mapping[str, object]) -> dict[str, object]:
+    """Coerce a parameter mapping into a deterministic, JSON-safe dict."""
+    normalized: dict[str, object] = {}
+    for key, value in mapping.items():
+        if isinstance(value, (str, int, float, bool)) or value is None:
+            normalized[str(key)] = value
+        else:
+            normalized[str(key)] = str(value)
+    return normalized
+
+
+def corpus_fingerprint(
+    sources: Iterable[str | Path | bytes],
+    *,
+    extra: Mapping[str, object] | None = None,
+    content_hash: bool = False,
+) -> str:
+    """Return a stable hex digest over a set of sources plus parameters.
+
+    The digest is **order-independent** (entries are sorted before hashing), so
+    the same set of documents supplied in a different order reuses a cached
+    artifact. Missing / unstat-able files contribute a sentinel entry so their
+    disappearance still changes the digest (a removed file must invalidate).
+
+    Parameters
+    ----------
+    sources : Iterable[str | Path | bytes]
+        The input documents the artifact was built from. ``bytes`` sources are
+        always content-hashed; path sources use :func:`file_signature`.
+    extra : Mapping[str, object] | None
+        Parameters that affect the derived artifact (e.g. chunking / scoring
+        options). Included in the digest so a settings change invalidates too.
+    content_hash : bool, default False
+        Forwarded to :func:`file_signature` for path sources.
+
+    Returns
+    -------
+    str
+        Hex SHA-256 digest of the normalized ``(entries, extra)`` payload.
+
+    """
+    entries: list[dict[str, object]] = []
+    for source in sources:
+        if isinstance(source, (bytes, bytearray)):
+            entries.append(bytes_signature(bytes(source)))
+            continue
+        try:
+            entries.append(file_signature(source, content_hash=content_hash))
+        except OSError:
+            entries.append({"path": str(source), "missing": True})
+
+    # Sort by a canonical rendering so ordering of ``sources`` is irrelevant.
+    entries.sort(key=lambda entry: json.dumps(entry, sort_keys=True))
+
+    payload = {"entries": entries, "extra": _normalize_extra(extra or {})}
+    blob = json.dumps(payload, sort_keys=True, ensure_ascii=False).encode("utf-8")
+    return hashlib.sha256(blob).hexdigest()

--- a/tests/unit/test_mcp/test_mcp_query_tools.py
+++ b/tests/unit/test_mcp/test_mcp_query_tools.py
@@ -223,11 +223,40 @@ class TestSearch:
         assert (index_dir / "keyword").exists()
         assert (index_dir / "chunks.jsonl").exists()
 
+        # A fingerprint manifest is written so staleness can be detected later.
+        assert (index_dir / "corpus.json").exists()
+
         # Second call reuses the persisted index and still returns results
         second = search_documents_impl(
             SearchDocumentsInput(query="alpha protocol", mode="keyword", paths=[str(corpus)]), config
         )
         assert second.total >= 1
+
+    @pytest.mark.skipif(not HAS_BM25, reason="rank-bm25 not installed")
+    def test_keyword_persistence_rebuilds_when_corpus_changes(self, tmp_path):
+        """A persisted index must not serve stale results after the corpus changes."""
+        corpus = tmp_path / "corpus"
+        corpus.mkdir()
+        (corpus / "doc.md").write_text("# Doc\n\nThe alpha protocol is described here.\n", encoding="utf-8")
+        index_dir = tmp_path / "idx"
+        config = _make_config(tmp_path, search_index_dir=str(index_dir))
+
+        # Build + persist against the original content.
+        first = search_documents_impl(SearchDocumentsInput(query="alpha", mode="keyword", paths=[str(corpus)]), config)
+        assert first.total >= 1
+        assert any("alpha" in item.snippet.lower() for item in first.results)
+
+        # Replace the document's content entirely: "alpha" is gone, "zeta" is new.
+        (corpus / "doc.md").write_text("# Doc\n\nThe zeta procedure supersedes everything.\n", encoding="utf-8")
+
+        # The stale term must no longer match (the index was rebuilt, not reused)...
+        stale = search_documents_impl(SearchDocumentsInput(query="alpha", mode="keyword", paths=[str(corpus)]), config)
+        assert all("alpha" not in item.snippet.lower() for item in stale.results)
+
+        # ...and the new term must be found.
+        fresh = search_documents_impl(SearchDocumentsInput(query="zeta", mode="keyword", paths=[str(corpus)]), config)
+        assert fresh.total >= 1
+        assert any("zeta" in item.snippet.lower() for item in fresh.results)
 
     @pytest.mark.skipif(not HAS_BM25, reason="rank-bm25 not installed")
     def test_index_dir_outside_write_allowlist_denied(self, tmp_path):

--- a/tests/unit/utils/test_fingerprint.py
+++ b/tests/unit/utils/test_fingerprint.py
@@ -1,0 +1,71 @@
+"""Unit tests for the corpus-fingerprint cache-invalidation primitive."""
+
+import pytest
+
+from all2md.utils.fingerprint import bytes_signature, corpus_fingerprint, file_signature
+
+pytestmark = pytest.mark.unit
+
+
+def _write(path, text):
+    path.write_text(text, encoding="utf-8")
+    return path
+
+
+class TestFileSignature:
+    def test_signature_has_stable_absolute_path(self, tmp_path):
+        f = _write(tmp_path / "a.txt", "hello")
+        sig = file_signature(f)
+        assert sig["path"].endswith("a.txt")
+        assert sig["size"] == 5
+        assert "mtime_ns" in sig
+        assert "sha256" not in sig  # stat-only by default
+
+    def test_content_hash_opt_in(self, tmp_path):
+        f = _write(tmp_path / "a.txt", "hello")
+        sig = file_signature(f, content_hash=True)
+        assert sig["sha256"] == bytes_signature(b"hello")["sha256"]
+
+    def test_missing_file_raises(self, tmp_path):
+        with pytest.raises(OSError):
+            file_signature(tmp_path / "nope.txt")
+
+
+class TestCorpusFingerprint:
+    def test_identical_inputs_match(self, tmp_path):
+        a = _write(tmp_path / "a.txt", "alpha")
+        b = _write(tmp_path / "b.txt", "beta")
+        assert corpus_fingerprint([a, b]) == corpus_fingerprint([a, b])
+
+    def test_order_independent(self, tmp_path):
+        a = _write(tmp_path / "a.txt", "alpha")
+        b = _write(tmp_path / "b.txt", "beta")
+        assert corpus_fingerprint([a, b]) == corpus_fingerprint([b, a])
+
+    def test_changed_content_changes_digest(self, tmp_path):
+        a = _write(tmp_path / "a.txt", "alpha")
+        before = corpus_fingerprint([a])
+        _write(a, "alpha and more")  # size changes regardless of mtime granularity
+        assert corpus_fingerprint([a]) != before
+
+    def test_added_and_removed_file_changes_digest(self, tmp_path):
+        a = _write(tmp_path / "a.txt", "alpha")
+        b = _write(tmp_path / "b.txt", "beta")
+        assert corpus_fingerprint([a]) != corpus_fingerprint([a, b])
+
+    def test_missing_file_contributes_sentinel(self, tmp_path):
+        a = _write(tmp_path / "a.txt", "alpha")
+        present = corpus_fingerprint([a])
+        a.unlink()
+        # A vanished file must still change the digest rather than raising.
+        assert corpus_fingerprint([tmp_path / "a.txt"]) != present
+
+    def test_extra_params_affect_digest(self, tmp_path):
+        a = _write(tmp_path / "a.txt", "alpha")
+        assert corpus_fingerprint([a], extra={"k": 1}) != corpus_fingerprint([a], extra={"k": 2})
+        assert corpus_fingerprint([a], extra={"k": 1}) == corpus_fingerprint([a], extra={"k": 1})
+
+    def test_bytes_source_is_content_hashed(self):
+        # Same bytes → same digest; different bytes → different digest.
+        assert corpus_fingerprint([b"payload"]) == corpus_fingerprint([b"payload"])
+        assert corpus_fingerprint([b"payload"]) != corpus_fingerprint([b"other"])

--- a/uv.lock
+++ b/uv.lock
@@ -61,7 +61,7 @@ wheels = [
 
 [[package]]
 name = "all2md"
-version = "1.8.0"
+version = "1.8.1"
 source = { editable = "." }
 dependencies = [
     { name = "pyyaml" },


### PR DESCRIPTION
## Summary

First item of the **Fidelity & Trust** batch (Track A1): a shared cache-fingerprint primitive, used to fix a real staleness bug in the persistent search index.

**The bug.** The MCP `search_documents` tool reused a persisted keyword index whenever `<index_dir>/keyword` merely existed — with no record of *what* it was built from. Pointing the same `--search-index-dir` at a changed corpus (edited/added/removed files) or a different `paths` set silently returned **stale results**.

**The fix.**
- New `all2md/utils/fingerprint.py` — `corpus_fingerprint()` hashes an order-independent set of file signatures (`size + mtime_ns` by default; opt-in content hash) plus an `extra` params mapping. Missing files contribute a sentinel so deletions invalidate. This is the reusable substrate the broader conversion cache (view/serve, the conversion optimizer) will key off in later batch items.
- `SearchService.save()` writes a `corpus.json` manifest recording the fingerprint of the indexed documents + index-relevant options (chunking + BM25/vector scoring; display/grep options excluded so they don't force needless rebuilds).
- New `SearchService.persisted_index_matches()` compares stored vs. current fingerprint; `query_tools` reuses the persisted index only on a match, rebuilding (with a log line) otherwise.

**Scope.** The CLI `search` command shares the same save path and now writes the manifest too, but its UX already guards against silent staleness (rejects inputs when reusing an index; offers `--rebuild`), so its behavior is unchanged. The bug was MCP-specific and that's where the reuse gate went.

## Testing
- Regression test: build index → rewrite the corpus so `alpha`→`zeta` → old term no longer matches, new term does (fails without the fix — stale index still contains `alpha`).
- 8 fingerprint unit tests: order-independence, add/remove/change detection, missing-file sentinel, params sensitivity.
- `ruff`, `mypy`, `black` all clean; affected search/MCP/CLI suites green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
