### PR TITLE
fix: conversion-fidelity quick wins (dehyphenation, DOCX blank line, .md detection)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **DOCX no longer opens with a stray blank line.** A Word document whose first
+  paragraph is empty (a common template artifact) produced a leading blank line
+  in the Markdown output — including when that empty paragraph carried a list
+  style, which slipped past the empty-paragraph filter as a blank bullet. Empty
+  paragraphs are now dropped uniformly across regular, list-item, and post-list
+  paths, and the Markdown renderer strips any leading blank line as a final
+  safeguard (so no converter can emit one).
+- **Capitalization-aware dehyphenation.** When merging words split across a line
+  break by a hyphen (OCR text, `merge_hyphenated_words`), an uppercase
+  continuation letter now keeps the hyphen — "Anglo-\nSaxon" becomes
+  "Anglo-Saxon" rather than "AngloSaxon" — so legitimately hyphenated compounds
+  and names survive instead of being fused.
 - **Persistent search index no longer serves stale results.** A keyword index
   saved with `--search-index-dir` (MCP `search_documents`) was reused whenever the
   directory existed, with no record of the corpus it was built from — so pointing

--- a/src/all2md/parsers/_pdf_ocr.py
+++ b/src/all2md/parsers/_pdf_ocr.py
@@ -41,6 +41,24 @@ logger = logging.getLogger(__name__)
 _HYPHEN_LINEBREAK_RE = re.compile(r"([^\W\d_])[-­‐][ \t]*\r?\n[ \t]*([^\W\d_])", re.UNICODE)
 
 
+def _merge_hyphenation(match: "re.Match[str]") -> str:
+    r"""Join the two halves of a line-break-hyphenated word.
+
+    When the continuation letter is uppercase the hyphen is *kept* (only the line
+    break is removed), because an uppercase second half signals a genuine
+    hyphenated compound — "Anglo-\\nSaxon" → "Anglo-Saxon", "Marie-\\nClaire" →
+    "Marie-Claire" — rather than a word soft-wrapped mid-token. A lowercase
+    continuation is treated as ordinary hyphenation and the hyphen is dropped:
+    "be-\\nwusst" → "bewusst". The kept hyphen is normalized to a plain
+    hyphen-minus so an invisible soft hyphen at the break still renders as a
+    visible "-" in the compound.
+    """
+    lead, cont = match.group(1), match.group(2)
+    if cont.isupper():
+        return f"{lead}-{cont}"
+    return f"{lead}{cont}"
+
+
 def dehyphenate_text(text: str) -> str:
     r"""Merge words split across line breaks by hyphenation.
 
@@ -54,7 +72,12 @@ def dehyphenate_text(text: str) -> str:
 
     Only hyphens that sit at a line break between two letters are merged;
     hyphens followed by digits, punctuation, or whitespace (e.g. em-dash usage
-    or a trailing "- " list marker) are left untouched.
+    or a trailing "- " list marker) are left untouched. The merge is
+    capitalization-aware: an uppercase continuation letter keeps the hyphen
+    (dropping only the line break) so legitimately hyphenated compounds such as
+    "Anglo-\\nSaxon" survive as "Anglo-Saxon" instead of collapsing to
+    "AngloSaxon". Numeric continuations ("COVID-\\n19") are already excluded by
+    the letter-only pattern.
 
     Parameters
     ----------
@@ -69,7 +92,7 @@ def dehyphenate_text(text: str) -> str:
     """
     if not text:
         return text
-    return _HYPHEN_LINEBREAK_RE.sub(r"\1\2", text)
+    return _HYPHEN_LINEBREAK_RE.sub(_merge_hyphenation, text)
 
 
 def calculate_image_coverage(page: "fitz.Page") -> float:

--- a/src/all2md/parsers/docx.py
+++ b/src/all2md/parsers/docx.py
@@ -505,18 +505,29 @@ class DocxToAstConverter(BaseParser):
             para.metadata["source_style"] = style_name
         return para
 
+    @staticmethod
+    def _is_effectively_empty(content: list[Node]) -> bool:
+        """Return True if inline content is empty or only whitespace ``Text`` nodes.
+
+        Empty paragraphs carry no meaning in this AST — inter-block spacing is
+        synthesized by the renderer — so they are dropped everywhere they can
+        appear (regular, list-item, and post-list paragraphs) to avoid emitting
+        stray blank lines such as a DOCX template's empty first paragraph.
+        """
+        if not content:
+            return True
+        return not any(not isinstance(node, Text) or node.content.strip() for node in content)
+
     def _process_regular_paragraph(
         self, paragraph: "Paragraph", math_blocks: list[MathBlock], style_name: str = ""
     ) -> Node | list[Node] | None:
         """Process a regular (non-list) paragraph with optional math blocks."""
         content = self._process_paragraph_runs_to_inline(paragraph)
-        if content:
-            has_non_whitespace = any(not isinstance(node, Text) or node.content.strip() for node in content)
-            if has_non_whitespace:
-                para_node = self._build_paragraph_node(content, style_name)
-                if math_blocks:
-                    return [para_node, *math_blocks]
-                return para_node
+        if not self._is_effectively_empty(content):
+            para_node = self._build_paragraph_node(content, style_name)
+            if math_blocks:
+                return [para_node, *math_blocks]
+            return para_node
 
         if math_blocks:
             return math_blocks[0] if len(math_blocks) == 1 else cast(list[Node], math_blocks)
@@ -566,7 +577,7 @@ class DocxToAstConverter(BaseParser):
             nodes: list[Node] = []
             if accumulated_list:
                 nodes.append(accumulated_list)
-            if content:
+            if not self._is_effectively_empty(content):
                 nodes.append(self._build_paragraph_node(content, style_name))
             if math_blocks:
                 nodes.extend(math_blocks)
@@ -595,8 +606,13 @@ class DocxToAstConverter(BaseParser):
             Completed list node if transitioning out, None if still accumulating
 
         """
-        # Process paragraph content
+        # Process paragraph content. An effectively-empty list paragraph (e.g. a
+        # blank paragraph that merely carries list styling) is dropped rather than
+        # emitted as an empty bullet; accumulation of the surrounding list is
+        # otherwise unaffected.
         content = self._process_paragraph_runs_to_inline(paragraph)
+        if self._is_effectively_empty(content):
+            return None
         item_node = ListItem(children=[AstParagraph(content=content)])
 
         # Handle level changes

--- a/src/all2md/renderers/markdown.py
+++ b/src/all2md/renderers/markdown.py
@@ -250,6 +250,10 @@ class MarkdownRenderer(NodeVisitor, InlineContentMixin, BaseRenderer):
         text = text.replace("\r\n", "\n").replace("\r", "\n")
         if self.options.collapse_blank_lines:
             text = re.sub(r"\n{3,}", "\n\n", text)
+        # Drop leading blank/whitespace-only lines so a document never opens with
+        # a stray blank line (e.g. a DOCX template's empty first paragraph). The
+        # first real line's own indentation is preserved.
+        text = re.sub(r"\A(?:[ \t]*\n)+", "", text)
         text = text.rstrip()
         return text
 

--- a/tests/golden/__snapshots__/test_generated_fixtures_golden.ambr
+++ b/tests/golden/__snapshots__/test_generated_fixtures_golden.ambr
@@ -264,7 +264,6 @@
 # ---
 # name: test_generated_fixture[latex-math.tex]
   '''
-  
   Inline math such as 
   
   $E = mc^2$

--- a/tests/golden/__snapshots__/test_textual_formats_golden.ambr
+++ b/tests/golden/__snapshots__/test_textual_formats_golden.ambr
@@ -117,7 +117,6 @@
 # ---
 # name: TestLatexGolden.test_latex_with_math
   '''
-  
   Inline math such as 
   
   $E = mc^2$

--- a/tests/unit/core/test_converter_registry_new_api.py
+++ b/tests/unit/core/test_converter_registry_new_api.py
@@ -161,6 +161,41 @@ class TestRegistryNewAPI:
         detected = registry.detect_format(html_stream)
         assert detected == "html"
 
+    @pytest.mark.parametrize("ext", [".md", ".markdown", ".mdown", ".mkd", ".mkdn"])
+    def test_markdown_extension_detected_from_filename(self, ext):
+        """A markdown file extension routes to the markdown parser (filename hint)."""
+        assert registry.detect_format(f"notes{ext}") == "markdown"
+
+    @pytest.mark.parametrize(
+        "content",
+        [
+            b"<html><body><h1>hi</h1></body></html>",
+            b"<?xml version='1.0'?><root/>",
+            b'{"a": 1}',
+            b"import os\nprint(os.getcwd())\n",
+        ],
+    )
+    def test_markdown_extension_wins_over_content(self, tmp_path, content):
+        """A .md extension takes precedence over content that resembles another format.
+
+        Filename detection runs before content sniffing, so a markdown file whose
+        body happens to look like HTML/XML/JSON/source code is still parsed as
+        markdown rather than misclassified from its content.
+        """
+        f = tmp_path / "readme.md"
+        f.write_bytes(content)
+        assert registry.detect_format(str(f)) == "markdown"
+
+    def test_markdown_beats_sourcecode_for_md_extension(self):
+        """Guard the latent markdown/sourcecode extension overlap.
+
+        Both the ``markdown`` and ``sourcecode`` converters claim ``.md`` in their
+        extension lists; markdown only wins because it has the higher detection
+        priority. This locks that ordering in so a future priority change or
+        manifest regeneration can't silently reroute ``.md`` to sourcecode.
+        """
+        assert registry.detect_format("example.md") == "markdown"
+
     def test_options_class_can_be_instantiated(self):
         """Test that options classes returned by get_parser_options_class are usable."""
         options_class = registry.get_parser_options_class("pdf")

--- a/tests/unit/parsers/test_docx_parser.py
+++ b/tests/unit/parsers/test_docx_parser.py
@@ -43,6 +43,7 @@ from all2md.ast import (
 from all2md.ast.transforms import extract_nodes
 from all2md.options import DocxOptions
 from all2md.parsers.docx import DocxToAstConverter
+from all2md.renderers.markdown import MarkdownRenderer
 
 FIXTURE_FOOTNOTES_DOC = FIXTURES_PATH / "documents" / "footnotes-endnotes-comments.docx"
 FIXTURE_MATH_DOC = FIXTURES_PATH / "documents" / "math-basic.docx"
@@ -155,6 +156,37 @@ class TestBasicElements:
         assert len(ast_doc.children) == 2
         assert ast_doc.children[0].content[0].content == "First"
         assert ast_doc.children[1].content[0].content == "Second"
+
+    def test_empty_list_styled_paragraph_skipped(self) -> None:
+        """An empty paragraph carrying a list style must not emit a blank bullet.
+
+        Regression: a stray empty leading paragraph styled ``List Bullet`` (a
+        common DOCX template artifact) previously slipped past the empty-paragraph
+        filter and produced a leading blank list item / blank line.
+        """
+        doc = docx.Document()
+        empty = doc.add_paragraph("")
+        try:
+            empty.style = doc.styles["List Bullet"]
+        except KeyError:  # pragma: no cover - style always present in default template
+            pytest.skip("List Bullet style unavailable")
+        doc.add_paragraph("Hello world")
+
+        converter = DocxToAstConverter()
+        ast_doc = converter.convert_to_ast(doc)
+
+        assert len(ast_doc.children) == 1
+        assert isinstance(ast_doc.children[0], Paragraph)
+        assert ast_doc.children[0].content[0].content == "Hello world"
+
+    def test_leading_empty_paragraph_no_blank_line(self) -> None:
+        """The rendered markdown must not open with a blank line."""
+        doc = docx.Document()
+        doc.add_paragraph("")  # stray leading empty paragraph (template artifact)
+        doc.add_paragraph("Title text")
+
+        md = MarkdownRenderer().render_to_string(DocxToAstConverter().convert_to_ast(doc))
+        assert md.startswith("Title text")
 
     def test_inline_math_extraction(self) -> None:
         """Inline OMML equations should become MathInline nodes."""

--- a/tests/unit/parsers/test_pdf_ocr.py
+++ b/tests/unit/parsers/test_pdf_ocr.py
@@ -405,6 +405,26 @@ class TestDehyphenateText:
     def test_leaves_non_hyphenation_untouched(self, text: str) -> None:
         assert dehyphenate_text(text) == text
 
+    @pytest.mark.parametrize(
+        ("text", "expected"),
+        [
+            # An uppercase continuation signals a genuine hyphenated compound:
+            # keep the hyphen, drop only the line break.
+            ("Anglo-\nSaxon heritage", "Anglo-Saxon heritage"),
+            ("Marie-\nClaire arrived", "Marie-Claire arrived"),
+            ("Sino-\nAmerican relations", "Sino-American relations"),
+            # Preserves the whichever hyphen character was used at the break.
+            ("Nord­\nSüd", "Nord-Süd"),
+            ("Judeo‐\nChristian", "Judeo-Christian"),
+            # Windows line endings and surrounding whitespace still collapse to
+            # a bare hyphen join.
+            ("Anglo-\r\nSaxon", "Anglo-Saxon"),
+            ("Anglo- \n  Saxon", "Anglo-Saxon"),
+        ],
+    )
+    def test_uppercase_continuation_keeps_hyphen(self, text: str, expected: str) -> None:
+        assert dehyphenate_text(text) == expected
+
     def test_empty_string(self) -> None:
         assert dehyphenate_text("") == ""
 


### PR DESCRIPTION
Three small, independent conversion-fidelity fixes, batched into one branch per the "quick wins" plan (Track B of the Fidelity & Trust batch).

## B3 — Capitalization-aware dehyphenation
When merging words split across a line break by a hyphen (OCR text, `merge_hyphenated_words`), an **uppercase continuation letter now keeps the hyphen**: `Anglo-\nSaxon` → `Anglo-Saxon` instead of `AngloSaxon`. Legitimately hyphenated compounds and names survive instead of being fused. The kept hyphen is normalized to a visible hyphen-minus so an invisible soft hyphen at the break still renders.

_Scope note:_ this covers the OCR path (`dehyphenate_text`). The native PyMuPDF extraction path uses the non-configurable `TEXT_DEHYPHENATE` C flag and stays capitalization-unaware — a follow-up if we want parity there.

## B2 — DOCX no longer opens with a stray blank line
A Word doc whose first paragraph is empty (a common template artifact) produced a leading blank line — including when that empty paragraph carried a **list style**, which slipped past the empty-paragraph filter as a blank bullet. Empty paragraphs are now dropped uniformly across the regular, list-item, and post-list paths (via a shared `_is_effectively_empty` helper), and the Markdown renderer strips any leading blank line as a **format-agnostic safeguard**. Two LaTeX golden snapshots were updated — they likewise shed a spurious leading blank line.

## B1 — Filename-hint detection (`.md` → markdown)
Investigated and **verified already correct** for every named input: on-disk files, named streams, and even `.md` files whose content resembles HTML/XML/JSON/source (the extension wins over content sniffing). The only unhandled case is truly nameless raw bytes, which is genuinely undetectable. This PR adds the **missing regression coverage** and a guard on the latent markdown-vs-`sourcecode` extension-priority overlap (both claim `.md`; markdown wins only by priority).

## Tests
- New: capitalization-aware dehyphenation cases; DOCX empty list-styled paragraph + leading-blank-line cases; `.md` extension-detection + content-precedence + sourcecode-priority guards.
- Full suite green (2550 passed, 9 skipped); ruff/black/mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)