### PR TITLE
feat(confidence): conversion confidence report ("quality card")

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Conversion confidence report ("quality card").** Every conversion now
+  attaches a reference-free `ConfidenceReport` to `Document.metadata['confidence']`
+  — a `0-100` `score`, a `high`/`medium`/`low` `band`, the signals behind it, and
+  the discrete degraded-content incidents the converter recorded — surfacing
+  sanity signals converters previously computed and threw away. PDF reports
+  meaningful-text density (`chars_per_page`), OCR reliance (`ocr_page_fraction`),
+  detected/rejected table counts (each rejected non-tabular region is recorded
+  with its reason), and running-heading demotions; DOCX reports table/image
+  counts and flags silently-dropped embedded objects, charts, and SmartArt. The
+  single `score` doubles as an optimizer fitness function (no ground-truth needed).
+  Read it programmatically with `all2md.confidence_report(source)` or from the
+  command line with the new `all2md report <file>` verb (aligned pretty card by
+  default, `--json` for machine use, `--fail-under SCORE` as a CI gate). Any
+  parser can contribute incidents via `BaseParser._record_degraded`; container
+  formats (`zip`, archives) already flag members that could not be parsed.
 - **Opt-in conversion cache (`--cache`).** `grep`, `search`, `chunk`, and `view`
   gain a `--cache` flag (and `--cache-dir DIR`) that stashes parsed documents on
   disk so repeated runs over unchanged files skip the expensive parse step. The

--- a/src/all2md/__init__.py
+++ b/src/all2md/__init__.py
@@ -123,12 +123,14 @@ if TYPE_CHECKING:
 
 from all2md.api import (
     chunk,
+    confidence_report,
     convert,
     from_ast,
     from_markdown,
     to_ast,
     to_markdown,
 )
+from all2md.confidence import ConfidenceReport, DegradedEvent
 from all2md.constants import DocumentFormat
 
 # Extensions lists moved to constants.py - keep references for backward compatibility
@@ -201,6 +203,10 @@ __all__ = [
     "from_markdown",
     "convert",
     "chunk",
+    # Conversion confidence ("quality card")
+    "confidence_report",
+    "ConfidenceReport",
+    "DegradedEvent",
     # Registry system
     "registry",
     # Type definitions

--- a/src/all2md/api.py
+++ b/src/all2md/api.py
@@ -27,6 +27,7 @@ from all2md.utils.io_utils import write_content
 
 if TYPE_CHECKING:
     from all2md.chunking import ProvenanceChunk
+    from all2md.confidence import ConfidenceReport
 
 logger = logging.getLogger(__name__)
 
@@ -755,6 +756,11 @@ def to_ast(
         parser_class = registry.get_parser(actual_format)
         parser = parser_class(options=final_parser_options, progress_callback=progress_callback)
         ast_doc = parser.parse(resolved_payload)
+        # Attach the conversion confidence report ("quality card") assembled from
+        # the sanity signals and degraded-content incidents the parser collected
+        # during parse(). Stashed here (rather than inside each parser's parse())
+        # so every format gets it uniformly and it lands before the cache put.
+        _attach_confidence_report(ast_doc, parser)
         # Auto-stash the originating file path on the document so callers
         # (including LLM-driven edit workflows) can round-trip back to the
         # same format using preserve_formatting=True without manually
@@ -880,6 +886,90 @@ def chunk(
         document_id=doc_id,
         document_path=doc_path,
     )
+
+
+def _attach_confidence_report(ast_doc: "Document", parser: Any) -> None:
+    """Stash the parser's conversion confidence report on the AST.
+
+    Populates ``ast_doc.metadata['confidence']`` with the JSON-safe quality card
+    (score, band, signals, degraded events) assembled from what the parser
+    observed during ``parse``. Best-effort: a failure here must never break an
+    otherwise-successful conversion, so any error is swallowed with a debug log.
+    """
+    builder = getattr(parser, "build_confidence_report", None)
+    if builder is None:
+        return
+    try:
+        ast_doc.metadata["confidence"] = builder(ast_doc)
+    except Exception as exc:  # noqa: BLE001 - reporting is auxiliary; never fail the parse
+        logger.debug("Confidence report assembly failed: %r", exc)
+
+
+def confidence_report(
+    source: Union[str, Path, IO[bytes], bytes, Document],
+    *,
+    parser_options: Optional[BaseParserOptions] = None,
+    source_format: DocumentFormat = "auto",
+    progress_callback: Optional[ProgressCallback] = None,
+    remote_input_options: Optional[RemoteInputOptions] = None,
+    **kwargs: Any,
+) -> "ConfidenceReport":
+    """Convert a document and return its conversion confidence report ("quality card").
+
+    A reference-free read on how much to trust a conversion, built from the
+    sanity signals converters already compute (meaningful-text density, OCR
+    reliance, rejected tables, dropped images) plus discrete degraded-content
+    incidents. The single ``0-100`` ``score`` doubles as an optimizer fitness
+    function.
+
+    Parameters
+    ----------
+    source : str, Path, IO[bytes], bytes, or Document
+        Document to inspect. A pre-parsed ``Document`` is read directly (its
+        report was attached when it was first parsed via :func:`to_ast`).
+    parser_options : BaseParserOptions, optional
+        Pre-configured parser options.
+    source_format : DocumentFormat, default "auto"
+        Explicit source format, or auto-detect.
+    progress_callback : ProgressCallback, optional
+        Optional progress callback forwarded to parsing.
+    remote_input_options : RemoteInputOptions, optional
+        Controls remote retrieval behaviour. Defaults to None (disabled).
+    kwargs : Any
+        Individual parser options forwarded to :func:`to_ast`.
+
+    Returns
+    -------
+    ConfidenceReport
+        The scored quality card. Formats that produce no signals and record no
+        degraded events yield a perfect ``score`` of 100 (band ``"high"``).
+
+    Examples
+    --------
+        >>> from all2md import confidence_report
+        >>> report = confidence_report("scan.pdf")
+        >>> report.score, report.band  # doctest: +SKIP
+        (72, 'medium')
+
+    """
+    from all2md.confidence import ConfidenceReport
+
+    if isinstance(source, Document):
+        ast_doc = source
+    else:
+        ast_doc = to_ast(
+            source,
+            parser_options=parser_options,
+            source_format=source_format,
+            progress_callback=progress_callback,
+            remote_input_options=remote_input_options,
+            **kwargs,
+        )
+    raw = ast_doc.metadata.get("confidence") if ast_doc.metadata else None
+    if isinstance(raw, dict):
+        return ConfidenceReport.from_dict(raw)
+    # No report attached (e.g. a hand-built Document): report a clean card.
+    return ConfidenceReport(score=100, band="high", producer="", signals={}, degraded_events=[])
 
 
 def _record_source_path(ast_doc: "Document", source: Any) -> None:

--- a/src/all2md/cli/commands/__init__.py
+++ b/src/all2md/cli/commands/__init__.py
@@ -114,6 +114,12 @@ def dispatch_command(args: list[str] | None = None) -> int | None:  # noqa: C901
 
         return handle_chunk_command(args[1:])
 
+    # Check for report command (conversion confidence "quality card")
+    if args[0] == "report":
+        from all2md.cli.commands.report import handle_report_command
+
+        return handle_report_command(args[1:])
+
     # Check for lint command
     if args[0] == "lint":
         from all2md.cli.commands.lint import handle_lint_command

--- a/src/all2md/cli/commands/config.py
+++ b/src/all2md/cli/commands/config.py
@@ -136,6 +136,7 @@ def _subcommand_parser_factories() -> Dict[str, Any]:
     from all2md.cli.commands.diff import _create_diff_parser
     from all2md.cli.commands.edit import _create_edit_parser
     from all2md.cli.commands.generate_site import _create_generate_site_parser
+    from all2md.cli.commands.report import _create_report_parser
     from all2md.cli.commands.server import _create_serve_parser
     from all2md.cli.commands.view import _create_view_parser
 
@@ -147,6 +148,7 @@ def _subcommand_parser_factories() -> Dict[str, Any]:
         "arxiv": _create_arxiv_parser,
         "generate-site": _create_generate_site_parser,
         "chunk": _create_chunk_parser,
+        "report": _create_report_parser,
     }
 
 

--- a/src/all2md/cli/commands/report.py
+++ b/src/all2md/cli/commands/report.py
@@ -22,10 +22,12 @@ Examples
 from __future__ import annotations
 
 import argparse
+import contextlib
 import json
+import os
 import sys
 from pathlib import Path
-from typing import Any, cast
+from typing import Any, Iterator, cast
 
 from all2md.ast.nodes import Document
 from all2md.cli.builder import (
@@ -50,6 +52,33 @@ _INFO_SIGNALS = {
     "image_count",
     "running_headings_demoted",
 }
+
+
+@contextlib.contextmanager
+def _protect_stdout() -> Iterator[None]:
+    """Redirect OS-level stdout (fd 1) to stderr for the duration.
+
+    Some libraries in the conversion pipeline (notably PyMuPDF) print advisories
+    straight to stdout, which would corrupt the ``--json`` output stream. We
+    point fd 1 at stderr while parsing, then restore it before emitting the
+    report. This catches both Python-level ``print`` and C-level writes. Falls
+    back to a no-op if fd duplication is unavailable (e.g. a captured stdout with
+    no real file descriptor).
+    """
+    try:
+        saved_fd = os.dup(1)
+    except (OSError, ValueError):
+        yield
+        return
+    sys.stdout.flush()
+    sys.stderr.flush()
+    try:
+        os.dup2(2, 1)
+        yield
+    finally:
+        sys.stdout.flush()
+        os.dup2(saved_fd, 1)
+        os.close(saved_fd)
 
 
 def _create_report_parser() -> argparse.ArgumentParser:
@@ -233,7 +262,9 @@ def handle_report_command(args: list[str] | None = None) -> int:
 
     results: list[tuple[str, ConfidenceReport]] = []
     try:
-        with conversion_cache_from_args(parsed):
+        # Guard fd 1 so PyMuPDF (and friends) advisory prints during parsing
+        # cannot corrupt the report — especially the machine-readable --json stream.
+        with _protect_stdout(), conversion_cache_from_args(parsed):
             for source in parsed.inputs:
                 doc, label = _load_ast(source, converter_options)
                 results.append((label, confidence_report(doc)))

--- a/src/all2md/cli/commands/report.py
+++ b/src/all2md/cli/commands/report.py
@@ -1,0 +1,272 @@
+#  Copyright (c) 2025 Tom Villani, Ph.D.
+#
+# src/all2md/cli/commands/report.py
+"""Conversion confidence report command.
+
+``all2md report`` converts one or more documents and prints a "quality card"
+for each: a reference-free ``0-100`` confidence score, the signals behind it
+(text density, OCR reliance, rejected tables, dropped embedded objects), and
+the discrete degraded-content incidents the converter recorded. It answers
+"how much should I trust this conversion?" without needing the original to
+compare against.
+
+Examples
+--------
+    all2md report scan.pdf
+    all2md report report.pdf --json
+    all2md report *.docx --fail-under 60
+    cat doc.pdf | all2md report -
+
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any, cast
+
+from all2md.ast.nodes import Document
+from all2md.cli.builder import (
+    EXIT_DEPENDENCY_ERROR,
+    EXIT_ERROR,
+    EXIT_FILE_ERROR,
+    EXIT_SUCCESS,
+    EXIT_VALIDATION_ERROR,
+)
+from all2md.cli.commands.shared import add_cache_arguments, conversion_cache_from_args
+from all2md.confidence import ConfidenceReport
+from all2md.exceptions import All2MdError, DependencyError
+
+# Signal keys that are purely informative context, not evidence of a problem —
+# rendered without a warning marker regardless of value.
+_INFO_SIGNALS = {
+    "page_count",
+    "meaningful_chars",
+    "tables_detected",
+    "tables_emitted",
+    "table_count",
+    "image_count",
+    "running_headings_demoted",
+}
+
+
+def _create_report_parser() -> argparse.ArgumentParser:
+    """Build the argparse parser for ``all2md report``."""
+    parser = argparse.ArgumentParser(
+        prog="all2md report",
+        description="Print a conversion confidence report ('quality card') for each document.",
+        add_help=True,
+    )
+    parser.add_argument(
+        "inputs",
+        nargs="+",
+        help="One or more documents to inspect (any supported format; use '-' for stdin).",
+    )
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Emit the report(s) as JSON (an array when multiple inputs are given).",
+    )
+    parser.add_argument(
+        "--fail-under",
+        type=int,
+        default=None,
+        metavar="SCORE",
+        help="Exit non-zero if any document scores below SCORE (0-100). Useful as a CI gate.",
+    )
+    parser.add_argument("--out", "-o", help="Write output to a file (default: stdout).")
+    parser.add_argument(
+        "--attachment-mode",
+        choices=["skip", "alt_text", "save", "base64"],
+        default=None,
+        help="How the converter handles images/attachments (overrides config). Report is unaffected "
+        "by the choice; use 'skip'/'alt_text' to avoid decoding large embedded images.",
+    )
+    parser.add_argument(
+        "--config",
+        help="Path to a configuration file whose converter sections provide parsing defaults.",
+    )
+    parser.add_argument(
+        "--no-config",
+        action="store_true",
+        help="Disable configuration file loading for this command.",
+    )
+    add_cache_arguments(parser)
+    return parser
+
+
+def _load_ast(source: str, converter_options: dict) -> tuple[Document, str]:
+    """Load an input to an AST, returning ``(doc, label)``.
+
+    ``converter_options`` is a dot-notation options dict (config + CLI overrides)
+    projected onto the detected format before conversion.
+    """
+    from all2md import to_ast
+    from all2md.cli.processors import prepare_options_for_execution
+
+    if source == "-":
+        data = sys.stdin.buffer.read()
+        if not data:
+            raise All2MdError("No data received from stdin")
+        kwargs = prepare_options_for_execution(converter_options, None, "auto")
+        return cast(Document, to_ast(data, **kwargs)), "stdin"
+
+    path = Path(source)
+    if not path.exists():
+        raise FileNotFoundError(f"Input file not found: {source}")
+    kwargs = prepare_options_for_execution(converter_options, path, "auto")
+    return cast(Document, to_ast(source, **kwargs)), path.as_posix()
+
+
+def _band_upper(band: str) -> str:
+    return band.upper()
+
+
+def _format_signal_value(value: Any) -> str:
+    """Render a signal value compactly (thousands-separated ints, trimmed floats)."""
+    if isinstance(value, bool):
+        return str(value)
+    if isinstance(value, int):
+        return f"{value:,}"
+    if isinstance(value, float):
+        return f"{value:g}"
+    return str(value)
+
+
+def _render_pretty(label: str, report: ConfidenceReport) -> str:
+    """Render a single report as a compact, human-readable quality card."""
+    lines: list[str] = [label]
+    lines.append(f"  confidence: {report.score}/100  ({_band_upper(report.band)})")
+    if report.producer:
+        lines.append(f"  producer:   {report.producer}")
+
+    if report.signals:
+        lines.append("")
+        lines.append("  signals")
+        width = max(len(key.replace("_", " ")) for key in report.signals)
+        for key, value in report.signals.items():
+            friendly = key.replace("_", " ")
+            marker = "" if key in _INFO_SIGNALS else _signal_marker(key, value)
+            suffix = f"   {marker}" if marker else ""
+            lines.append(f"    {friendly.ljust(width)}  {_format_signal_value(value)}{suffix}")
+
+    if report.degraded_events:
+        lines.append("")
+        lines.append("  degraded events")
+        for event in report.degraded_events:
+            detail = f"  ({event.detail})" if event.detail else ""
+            times = f" x{event.count}" if event.count > 1 else ""
+            lines.append(f"    {event.severity:<5} {event.kind}{times}{detail}")
+
+    return "\n".join(lines)
+
+
+def _signal_marker(key: str, value: Any) -> str:
+    """Return a short 'warn'/'info' marker for a signal worth flagging.
+
+    Healthy signals return an empty marker so the card stays calm and problems
+    stand out.
+    """
+    if key == "chars_per_page":
+        try:
+            return "warn" if float(value) < 200 else ""
+        except (TypeError, ValueError):
+            return ""
+    if key == "ocr_page_fraction":
+        try:
+            fraction = float(value)
+        except (TypeError, ValueError):
+            return ""
+        if fraction > 0.5:
+            return "warn"
+        return "info" if fraction > 0 else ""
+    # Any other non-info signal that surfaced (tables_rejected, *_dropped) is a
+    # count of lost/rejected content; flag it when non-zero.
+    try:
+        return "warn" if float(value) > 0 else ""
+    except (TypeError, ValueError):
+        return ""
+
+
+def handle_report_command(args: list[str] | None = None) -> int:
+    """Handle the ``report`` command.
+
+    Parameters
+    ----------
+    args : list[str], optional
+        Command line arguments (beyond 'report').
+
+    Returns
+    -------
+    int
+        Exit code. ``0`` on success; non-zero on load errors or when
+        ``--fail-under`` is tripped.
+
+    """
+    from all2md.cli.config import apply_config_to_parser
+
+    parser = _create_report_parser()
+    try:
+        pre_args, _ = parser.parse_known_args(args or [])
+        apply_config_to_parser(parser, "report", explicit_path=pre_args.config, no_config=pre_args.no_config)
+        parsed = parser.parse_args(args or [])
+    except SystemExit as e:
+        return e.code if isinstance(e.code, int) else 0
+
+    if parsed.fail_under is not None and not 0 <= parsed.fail_under <= 100:
+        print("Error: --fail-under must be between 0 and 100.", file=sys.stderr)
+        return EXIT_VALIDATION_ERROR
+
+    stdin_count = sum(1 for src in parsed.inputs if src == "-")
+    if stdin_count > 1:
+        print("Error: stdin ('-') may only be used once.", file=sys.stderr)
+        return EXIT_FILE_ERROR
+
+    from all2md import confidence_report
+    from all2md.cli.processors import load_converter_config_options
+
+    converter_options = load_converter_config_options(explicit_path=parsed.config, no_config=parsed.no_config)
+    if parsed.attachment_mode:
+        converter_options["attachment_mode"] = parsed.attachment_mode
+
+    results: list[tuple[str, ConfidenceReport]] = []
+    try:
+        with conversion_cache_from_args(parsed):
+            for source in parsed.inputs:
+                doc, label = _load_ast(source, converter_options)
+                results.append((label, confidence_report(doc)))
+    except DependencyError as e:
+        print(f"Error: {e}", file=sys.stderr)
+        return EXIT_DEPENDENCY_ERROR
+    except FileNotFoundError as e:
+        print(f"Error: {e}", file=sys.stderr)
+        return EXIT_FILE_ERROR
+    except All2MdError as e:
+        print(f"Error building report: {e}", file=sys.stderr)
+        return EXIT_ERROR
+
+    if parsed.json:
+        payload = [{"input": label, **report.to_dict()} for label, report in results]
+        output = json.dumps(payload if len(payload) != 1 else payload[0], ensure_ascii=False, indent=2)
+    else:
+        output = "\n\n".join(_render_pretty(label, report) for label, report in results)
+
+    if parsed.out:
+        out_path = Path(parsed.out)
+        out_path.write_text(output + "\n", encoding="utf-8")
+        print(f"Wrote {len(results)} report(s) to {out_path}", file=sys.stderr)
+    elif output:
+        print(output)
+
+    if parsed.fail_under is not None:
+        worst = min((report.score for _, report in results), default=100)
+        if worst < parsed.fail_under:
+            print(
+                f"Confidence {worst} is below --fail-under {parsed.fail_under}.",
+                file=sys.stderr,
+            )
+            return EXIT_ERROR
+
+    return EXIT_SUCCESS

--- a/src/all2md/cli/config.py
+++ b/src/all2md/cli/config.py
@@ -38,6 +38,7 @@ SUBCOMMAND_CONFIG_SECTIONS: tuple[str, ...] = (
     "arxiv",
     "generate-site",
     "chunk",
+    "report",
 )
 
 

--- a/src/all2md/cli/help_formatter.py
+++ b/src/all2md/cli/help_formatter.py
@@ -166,6 +166,7 @@ _SUBCOMMAND_SUMMARIES: Sequence[tuple[str, str]] = (
     ("search", "Search documents using keyword, vector, or hybrid retrieval"),
     ("grep", "Search for text patterns in documents (like grep for any format)"),
     ("chunk", "Split documents into provenance-carrying chunks (JSONL) for RAG/LLM pipelines"),
+    ("report", "Print a conversion confidence report ('quality card') scoring how much to trust a conversion"),
     ("lint", "Lint converted documents for structural, heading, link, list, table, and typography issues"),
     ("generate-site", "Generate Hugo, Jekyll, MkDocs, Zola, or Eleventy static site from documents"),
     ("arxiv", "Generate an ArXiv-ready LaTeX submission package from a document"),

--- a/src/all2md/confidence.py
+++ b/src/all2md/confidence.py
@@ -1,0 +1,282 @@
+#  Copyright (c) 2025 Tom Villani, Ph.D.
+# src/all2md/confidence.py
+"""Conversion confidence reporting — a structured "quality card".
+
+Converters already compute a raft of sanity signals while parsing: how much
+meaningful text a PDF page yielded, whether a detected "table" was really a
+decorative frame (empty-cell ratio) or a table-of-contents (dot-leader ratio),
+how many pages had to fall back to OCR, whether an archive entry could not be
+parsed, and so on. Historically these were consumed for a single accept/reject
+decision and then discarded (surviving only as a ``logger.debug`` line).
+
+This module captures those signals as a structured :class:`ConfidenceReport`
+that rides on ``Document.metadata["confidence"]``. It gives callers a
+reference-free read on how much to trust a conversion, and — because it emits a
+single ``0-100`` scalar ``score`` — doubles as the fitness function the
+``optimize`` capstone hill-climbs on (no ground-truth reference needed).
+
+Two kinds of evidence feed a report:
+
+* **signals** — continuous per-document metrics (``meaningful_chars``,
+  ``chars_per_page``, ``ocr_page_fraction``, table/image counts). The PDF parser
+  is by far the richest producer; most other formats leave these empty.
+* **degraded_events** — discrete incidents where the converter knowingly lost or
+  approximated content (a table rejected as non-tabular, an archive member that
+  would not parse, a readability/alt-text fallback taken, an OCR failure). Every
+  parser can record these through ``BaseParser._record_degraded``.
+
+The report is intentionally a plain, JSON-safe structure so it serializes with
+the rest of the AST metadata and round-trips through ``ast_to_json``.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Literal
+
+Severity = Literal["info", "warn", "error"]
+Band = Literal["high", "medium", "low"]
+
+# --- Scoring model -----------------------------------------------------------
+#
+# A conversion starts from a perfect 100 and loses points for evidence of lost
+# or low-fidelity content. The weights are deliberately modest and exposed as
+# module constants so the ``optimize`` capstone (and tests) can reason about —
+# and tune — them. The score is reference-free: it only inspects what the
+# converter itself observed, never a ground-truth original.
+
+#: Points a fully text-empty page-image document can lose to the text-density
+#: penalty. Recovering that text (e.g. by enabling OCR) claws these points back,
+#: which is what makes the score usable as an optimizer fitness function.
+TEXT_DENSITY_MAX_PENALTY = 45.0
+
+#: Meaningful characters per page at or above which the text-density penalty is
+#: fully waived. Below it the penalty ramps linearly to ``TEXT_DENSITY_MAX_PENALTY``.
+TEXT_DENSITY_FLOOR_CPP = 200.0
+
+#: Points lost when the entire document had to be recovered via OCR. OCR text is
+#: serviceable but lower-fidelity than a native text layer, so reliance on it is
+#: a mild — not catastrophic — confidence hit, scaled by the OCR page fraction.
+OCR_RELIANCE_MAX_PENALTY = 12.0
+
+#: Per-event penalty by severity. ``info`` events are surfaced but never scored
+#: (e.g. dropping a decorative sub-20px image is usually correct).
+SEVERITY_PENALTY: dict[str, float] = {"info": 0.0, "warn": 4.0, "error": 10.0}
+
+#: Ceiling on the total penalty from ``degraded_events`` so a single pathological
+#: document (hundreds of unparsed archive members) cannot swamp every other
+#: signal. The score is clamped to ``[0, 100]`` regardless.
+DEGRADED_EVENT_PENALTY_CAP = 45.0
+
+#: Score at or above which confidence is reported as ``"high"``.
+BAND_HIGH_THRESHOLD = 80
+#: Score at or above which confidence is reported as ``"medium"`` (below is ``"low"``).
+BAND_MEDIUM_THRESHOLD = 50
+
+
+@dataclass
+class DegradedEvent:
+    """A single incident where a converter knowingly lost or approximated content.
+
+    Parameters
+    ----------
+    parser : str
+        Short label of the producing parser (e.g. ``"pdf"``, ``"archive"``).
+    kind : str
+        Machine-readable event category (e.g. ``"table_rejected"``,
+        ``"unparsed_member"``, ``"readability_fallback"``, ``"ocr_failed"``).
+    count : int, default = 1
+        How many times this event occurred. Repeated events of the same
+        ``(parser, kind, detail, severity)`` are coalesced with their counts summed.
+    detail : str or None, default = None
+        Optional human-readable qualifier (e.g. the rejection reason).
+    severity : {"info", "warn", "error"}, default = "warn"
+        How much the event should weigh on the score.
+
+    """
+
+    parser: str
+    kind: str
+    count: int = 1
+    detail: str | None = None
+    severity: Severity = "warn"
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return a JSON-safe dict, omitting ``detail`` when unset."""
+        data: dict[str, Any] = {
+            "parser": self.parser,
+            "kind": self.kind,
+            "count": self.count,
+            "severity": self.severity,
+        }
+        if self.detail is not None:
+            data["detail"] = self.detail
+        return data
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> "DegradedEvent":
+        """Reconstruct a :class:`DegradedEvent` from its :meth:`to_dict` form."""
+        return cls(
+            parser=str(data.get("parser", "")),
+            kind=str(data.get("kind", "")),
+            count=int(data.get("count", 1)),
+            detail=data.get("detail"),
+            severity=data.get("severity", "warn"),
+        )
+
+
+@dataclass
+class ConfidenceReport:
+    """Structured "quality card" summarizing how much to trust a conversion.
+
+    Parameters
+    ----------
+    score : int
+        Overall confidence, ``0`` (untrustworthy) to ``100`` (no problems observed).
+    band : {"high", "medium", "low"}
+        Coarse bucket derived from ``score`` for quick human/CLI display.
+    producer : str
+        Label of the primary producing parser (e.g. ``"pdf"``).
+    signals : dict
+        Continuous per-document metrics. Keys are producer-specific; common PDF
+        keys include ``meaningful_chars``, ``chars_per_page``, ``page_count``,
+        ``ocr_page_fraction``, ``tables_detected``, ``tables_rejected``,
+        ``images_dropped`` and ``running_headings_demoted``.
+    degraded_events : list of DegradedEvent
+        Discrete lost/approximated-content incidents recorded during parsing.
+
+    """
+
+    score: int
+    band: Band
+    producer: str
+    signals: dict[str, Any] = field(default_factory=dict)
+    degraded_events: list[DegradedEvent] = field(default_factory=list)
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return a JSON-safe dict suitable for ``Document.metadata['confidence']``."""
+        return {
+            "score": self.score,
+            "band": self.band,
+            "producer": self.producer,
+            "signals": dict(self.signals),
+            "degraded_events": [event.to_dict() for event in self.degraded_events],
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> "ConfidenceReport":
+        """Reconstruct a :class:`ConfidenceReport` from its :meth:`to_dict` form."""
+        return cls(
+            score=int(data.get("score", 0)),
+            band=data.get("band", "low"),
+            producer=str(data.get("producer", "")),
+            signals=dict(data.get("signals", {}) or {}),
+            degraded_events=[DegradedEvent.from_dict(event) for event in data.get("degraded_events", []) or []],
+        )
+
+
+def coalesce_events(events: list[DegradedEvent]) -> list[DegradedEvent]:
+    """Merge events sharing ``(parser, kind, detail, severity)``, summing counts.
+
+    Keeps first-seen order so the most significant early events lead the list.
+    """
+    merged: dict[tuple[str, str, str | None, str], DegradedEvent] = {}
+    for event in events:
+        key = (event.parser, event.kind, event.detail, event.severity)
+        existing = merged.get(key)
+        if existing is None:
+            merged[key] = DegradedEvent(
+                parser=event.parser,
+                kind=event.kind,
+                count=event.count,
+                detail=event.detail,
+                severity=event.severity,
+            )
+        else:
+            existing.count += event.count
+    return list(merged.values())
+
+
+def _text_density_penalty(signals: dict[str, Any]) -> float:
+    """Penalty for a document that yielded little meaningful text per page.
+
+    Ramps linearly from ``0`` at ``TEXT_DENSITY_FLOOR_CPP`` chars/page up to
+    ``TEXT_DENSITY_MAX_PENALTY`` at zero. No-ops when the producer did not report
+    ``chars_per_page`` (most non-PDF formats), so those keep a clean score.
+    """
+    cpp = signals.get("chars_per_page")
+    if cpp is None:
+        return 0.0
+    try:
+        cpp_val = float(cpp)
+    except (TypeError, ValueError):
+        return 0.0
+    if cpp_val >= TEXT_DENSITY_FLOOR_CPP:
+        return 0.0
+    shortfall = (TEXT_DENSITY_FLOOR_CPP - cpp_val) / TEXT_DENSITY_FLOOR_CPP
+    return max(0.0, min(1.0, shortfall)) * TEXT_DENSITY_MAX_PENALTY
+
+
+def _ocr_reliance_penalty(signals: dict[str, Any]) -> float:
+    """Penalty scaled by the fraction of pages recovered via OCR."""
+    fraction = signals.get("ocr_page_fraction")
+    if fraction is None:
+        return 0.0
+    try:
+        fraction_val = float(fraction)
+    except (TypeError, ValueError):
+        return 0.0
+    return max(0.0, min(1.0, fraction_val)) * OCR_RELIANCE_MAX_PENALTY
+
+
+def _degraded_event_penalty(events: list[DegradedEvent]) -> float:
+    """Total penalty from degraded events, capped at ``DEGRADED_EVENT_PENALTY_CAP``."""
+    total = 0.0
+    for event in events:
+        total += SEVERITY_PENALTY.get(event.severity, SEVERITY_PENALTY["warn"]) * max(0, event.count)
+    return min(total, DEGRADED_EVENT_PENALTY_CAP)
+
+
+def band_for_score(score: int) -> Band:
+    """Bucket a ``0-100`` score into ``"high"`` / ``"medium"`` / ``"low"``."""
+    if score >= BAND_HIGH_THRESHOLD:
+        return "high"
+    if score >= BAND_MEDIUM_THRESHOLD:
+        return "medium"
+    return "low"
+
+
+def score_conversion(signals: dict[str, Any], events: list[DegradedEvent]) -> tuple[int, Band]:
+    """Compute the ``(score, band)`` for a conversion from its signals and events.
+
+    Reference-free: the score starts at ``100`` and subtracts a text-density
+    penalty, an OCR-reliance penalty, and a (capped) degraded-event penalty. The
+    result is clamped to ``[0, 100]``.
+
+    Parameters
+    ----------
+    signals : dict
+        Continuous per-document metrics (see :class:`ConfidenceReport`).
+    events : list of DegradedEvent
+        Discrete degraded-content incidents.
+
+    Returns
+    -------
+    tuple of (int, str)
+        The integer score and its confidence band.
+
+    """
+    penalty = _text_density_penalty(signals) + _ocr_reliance_penalty(signals) + _degraded_event_penalty(events)
+    score = int(round(max(0.0, min(100.0, 100.0 - penalty))))
+    return score, band_for_score(score)
+
+
+def build_report(producer: str, signals: dict[str, Any], events: list[DegradedEvent]) -> ConfidenceReport:
+    """Assemble a scored :class:`ConfidenceReport` from raw signals and events.
+
+    Events are coalesced (see :func:`coalesce_events`) before scoring so repeated
+    incidents count once with an aggregate ``count``.
+    """
+    coalesced = coalesce_events(events)
+    score, band = score_conversion(signals, coalesced)
+    return ConfidenceReport(score=score, band=band, producer=producer, signals=dict(signals), degraded_events=coalesced)

--- a/src/all2md/parsers/archive.py
+++ b/src/all2md/parsers/archive.py
@@ -707,6 +707,7 @@ class ArchiveToAstConverter(BaseParser):
                     if self.options.create_section_headings:
                         children.append(Heading(level=2, content=[Text(content=display_path)]))
                     children.append(Paragraph(content=[Text(content="(Could not parse this file)")]))
+                    self._record_degraded("unparsed_member", detail=display_path, severity="warn")
 
                 processed_count += 1
 
@@ -951,6 +952,7 @@ class ArchiveToAstConverter(BaseParser):
                 if self.options.create_section_headings:
                     children.append(Heading(level=2, content=[Text(content=display_path)]))
                 children.append(Paragraph(content=[Text(content="(Could not parse this file)")]))
+                self._record_degraded("unparsed_member", detail=display_path, severity="warn")
 
         return children
 

--- a/src/all2md/parsers/base.py
+++ b/src/all2md/parsers/base.py
@@ -236,6 +236,103 @@ class BaseParser(ABC):
             # Log but don't interrupt conversion if callback fails
             logger.warning(f"Progress callback raised exception: {e}", exc_info=True)
 
+    # --- Conversion-confidence collection ------------------------------------
+    #
+    # Parsers accumulate two kinds of evidence while converting: discrete
+    # "degraded content" incidents (a rejected table, an unparsed archive member,
+    # a fallback path taken) and continuous quality signals (chars/page, OCR
+    # fraction, ...). ``to_ast`` calls :meth:`build_confidence_report` after
+    # ``parse`` returns and stashes the result on ``Document.metadata["confidence"]``.
+    #
+    # The backing stores are created lazily via ``setdefault`` rather than in
+    # ``__init__`` so a parser subclass that forgets to call ``super().__init__``
+    # (or records before doing so) still works.
+
+    def _producer_label(self) -> str:
+        """Return a short, stable label for this parser (e.g. ``"pdf"``, ``"docx"``).
+
+        Derived from the class name by stripping the conventional
+        ``ToAstConverter`` / ``Converter`` / ``Parser`` suffixes and lowercasing.
+        Used as the ``parser`` / ``producer`` field on confidence records.
+        """
+        name = type(self).__name__
+        for suffix in ("ToAstConverter", "Converter", "Parser"):
+            if name.endswith(suffix):
+                name = name[: -len(suffix)]
+                break
+        return name.lower() or "unknown"
+
+    def _record_degraded(
+        self,
+        kind: str,
+        *,
+        count: int = 1,
+        detail: str | None = None,
+        severity: str = "warn",
+    ) -> None:
+        """Record a discrete degraded/approximated-content incident.
+
+        Call this wherever the converter knowingly drops, skips, or approximates
+        content (rejecting a non-tabular "table", inserting an "(unparsed)"
+        placeholder, taking an alt-text/readability fallback, an OCR failure).
+        The incidents feed the conversion :class:`~all2md.confidence.ConfidenceReport`.
+
+        Parameters
+        ----------
+        kind : str
+            Machine-readable event category (e.g. ``"table_rejected"``).
+        count : int, default = 1
+            Number of occurrences represented by this call.
+        detail : str or None, default = None
+            Optional human-readable qualifier (e.g. the rejection reason).
+        severity : {"info", "warn", "error"}, default = "warn"
+            How much the incident weighs on the confidence score.
+
+        """
+        from all2md.confidence import DegradedEvent
+
+        events: list[Any] = self.__dict__.setdefault("_degraded_events", [])
+        events.append(
+            DegradedEvent(
+                parser=self._producer_label(),
+                kind=kind,
+                count=count,
+                detail=detail,
+                severity=severity,  # type: ignore[arg-type]
+            )
+        )
+
+    def _set_quality_signal(self, key: str, value: Any) -> None:
+        """Record a continuous per-document quality signal for the confidence report."""
+        signals: dict[str, Any] = self.__dict__.setdefault("_quality_signals", {})
+        signals[key] = value
+
+    def build_confidence_report(self, document: Document) -> dict[str, Any]:
+        """Assemble the conversion :class:`~all2md.confidence.ConfidenceReport` as a dict.
+
+        Combines the quality signals and degraded events collected during
+        :meth:`parse` into a scored report. Returns the JSON-safe ``to_dict``
+        form ready to stash on ``Document.metadata["confidence"]``.
+
+        Parameters
+        ----------
+        document : Document
+            The freshly parsed document (available for subclasses that want to
+            derive additional signals from the finished AST).
+
+        Returns
+        -------
+        dict
+            The report's ``to_dict()`` representation.
+
+        """
+        from all2md.confidence import build_report
+
+        signals: dict[str, Any] = dict(self.__dict__.get("_quality_signals", {}))
+        events: list[Any] = list(self.__dict__.get("_degraded_events", []))
+        report = build_report(producer=self._producer_label(), signals=signals, events=events)
+        return report.to_dict()
+
     @staticmethod
     def _validate_zip_security(input_data: Union[str, Path, IO[bytes], bytes], suffix: str = ".zip") -> None:
         """Validate security of a zip archive across different input types.

--- a/src/all2md/parsers/docx.py
+++ b/src/all2md/parsers/docx.py
@@ -64,6 +64,7 @@ from all2md.ast import (
 from all2md.ast import (
     Table as AstTable,
 )
+from all2md.ast.transforms import extract_nodes
 from all2md.converter_metadata import ConverterMetadata
 from all2md.options.docx import DocxOptions
 from all2md.parsers.base import BaseParser
@@ -457,9 +458,62 @@ class DocxToAstConverter(BaseParser):
             metadata_dict = metadata.to_dict()
 
         document = Document(children=children, metadata=metadata_dict)
+        self._record_docx_quality_signals(doc, document)
         self._footnote_collector = None
         self._comments_map = {}
         return document
+
+    # DrawingML ``graphicData/@uri`` values for content types all2md does not
+    # render (and therefore drops): embedded charts and SmartArt diagrams.
+    _DOCX_CHART_URI = "http://schemas.openxmlformats.org/drawingml/2006/chart"
+    _DOCX_DIAGRAM_URI = "http://schemas.openxmlformats.org/drawingml/2006/diagram"
+
+    def _record_docx_quality_signals(self, source_doc: Any, document: Document) -> None:
+        """Populate the confidence-report signals from the finished DOCX conversion.
+
+        DOCX is a high-fidelity structured format, so — unlike PDF — there is no
+        text-density risk. The meaningful confidence signal is *silently dropped
+        content*: embedded OLE objects, charts, and SmartArt diagrams that the
+        DrawingML/VML XML carries but all2md has no Markdown representation for.
+        Each is surfaced as a signal count and a degraded-content event. Table
+        and image counts are recorded as informative (non-scoring) signals.
+        """
+        self._set_quality_signal("table_count", sum(1 for _ in extract_nodes(document, AstTable)))
+        self._set_quality_signal("image_count", sum(1 for _ in extract_nodes(document, Image)))
+
+        dropped = self._count_dropped_docx_objects(source_doc)
+        for kind, count in dropped.items():
+            if count:
+                self._set_quality_signal(kind, count)
+                self._record_degraded(kind, count=count, severity="warn")
+
+    def _count_dropped_docx_objects(self, source_doc: Any) -> dict[str, int]:
+        """Count embedded objects/charts/SmartArt in the source that all2md drops.
+
+        Walks the document body XML once, matching classic embedded OLE objects
+        (``w:object``) and DrawingML graphic frames whose ``graphicData/@uri``
+        marks a chart or SmartArt diagram. Best-effort: returns zero counts if
+        the underlying XML is not reachable.
+        """
+        counts = {"embedded_object_dropped": 0, "chart_dropped": 0, "smartart_dropped": 0}
+        try:
+            body = source_doc.element.body
+        except AttributeError:
+            return counts
+        for element in body.iter():
+            tag = element.tag
+            if not isinstance(tag, str):
+                continue
+            local = tag.rsplit("}", 1)[-1]
+            if local == "object":
+                counts["embedded_object_dropped"] += 1
+            elif local == "graphicData":
+                uri = element.get("uri") or ""
+                if uri == self._DOCX_CHART_URI:
+                    counts["chart_dropped"] += 1
+                elif uri == self._DOCX_DIAGRAM_URI:
+                    counts["smartart_dropped"] += 1
+        return counts
 
     def _try_process_heading(self, paragraph: "Paragraph", style_name: str) -> Heading | None:
         """Try to process paragraph as a heading. Returns Heading or None."""

--- a/src/all2md/parsers/pdf.py
+++ b/src/all2md/parsers/pdf.py
@@ -52,7 +52,7 @@ from all2md.ast import (
 from all2md.ast import (
     extract_text as extract_node_text,
 )
-from all2md.ast.transforms import InlineFormattingConsolidator
+from all2md.ast.transforms import InlineFormattingConsolidator, extract_nodes
 from all2md.constants import (
     DEFAULT_OVERLAP_THRESHOLD_PX,
     DEPS_PDF,
@@ -165,7 +165,7 @@ def _normalize_heading_for_dedup(text: str) -> str:
     return " ".join(text.lower().split())
 
 
-def _demote_running_headings(doc: "Document", total_pages: int) -> None:
+def _demote_running_headings(doc: "Document", total_pages: int) -> int:
     """Convert headings that recur on >50% of pages into paragraphs.
 
     A real document section usually appears once. Headings that recur on
@@ -173,9 +173,15 @@ def _demote_running_headings(doc: "Document", total_pages: int) -> None:
     or per-page footers misclassified by the layout model. Convert them
     to paragraphs in place so downstream readers don't see fake section
     breaks.
+
+    Returns
+    -------
+    int
+        The number of heading nodes demoted (a structural-confidence signal).
+
     """
     if total_pages < 3:
-        return
+        return 0
 
     # First pass: count distinct pages each normalized heading appears on.
     pages_per_heading: dict[str, set[int]] = {}
@@ -191,9 +197,10 @@ def _demote_running_headings(doc: "Document", total_pages: int) -> None:
     threshold = max(2, total_pages // 2 + 1)
     running_headings = {norm for norm, pages in pages_per_heading.items() if len(pages) >= threshold}
     if not running_headings:
-        return
+        return 0
 
     # Second pass: rebuild children, demoting matched headings.
+    demoted = 0
     new_children: list[Node] = []
     for child in doc.children:
         if isinstance(child, Heading):
@@ -206,9 +213,11 @@ def _demote_running_headings(doc: "Document", total_pages: int) -> None:
                         source_location=child.source_location,
                     )
                 )
+                demoted += 1
                 continue
         new_children.append(child)
     doc.children = new_children
+    return demoted
 
 
 def _strip_leading_whitespace_in_place(nodes: list[Node]) -> None:
@@ -785,6 +794,11 @@ class PdfToAstConverter(BaseParser):
         # Count pages OCR was applied to this conversion (drives the doc-level
         # OCR safety net below).
         self._ocr_pages_applied = 0
+        # Reset per-conversion confidence collectors (degraded events accumulate
+        # via _record_degraded; _tables_rejected feeds the quality-card signals).
+        self._degraded_events: list[Any] = []
+        self._quality_signals: dict[str, Any] = {}
+        self._tables_rejected = 0
 
         total_pages = len(list(pages_to_use))
 
@@ -850,10 +864,37 @@ class PdfToAstConverter(BaseParser):
         # Demote headings that recur on more than half the document pages —
         # those are running titles or per-page form labels masquerading as
         # section headings, not real document structure.
+        headings_demoted = 0
         if self.options.dedup_running_headings and total_pages >= 3:
-            _demote_running_headings(ast_doc, total_pages)
+            headings_demoted = _demote_running_headings(ast_doc, total_pages)
+
+        self._record_pdf_quality_signals(ast_doc, total_pages, headings_demoted)
 
         return ast_doc
+
+    def _record_pdf_quality_signals(self, ast_doc: Document, total_pages: int, headings_demoted: int) -> None:
+        """Populate the confidence-report signals from the finished PDF conversion.
+
+        Derives the reference-free quality metrics — meaningful-text density,
+        OCR reliance, and detected/rejected table counts — that feed the
+        conversion :class:`~all2md.confidence.ConfidenceReport` assembled in
+        ``to_ast``. ``chars_per_page`` is the primary text-density signal (a
+        near-empty scanned page yields a low value); ``ocr_page_fraction``
+        captures how much of the document leaned on OCR.
+        """
+        meaningful_chars = self._count_meaningful_chars(ast_doc.children)
+        pages = max(1, total_pages)
+        tables_emitted = sum(1 for _ in extract_nodes(ast_doc, AstTable))
+        tables_rejected = getattr(self, "_tables_rejected", 0)
+
+        self._set_quality_signal("page_count", total_pages)
+        self._set_quality_signal("meaningful_chars", meaningful_chars)
+        self._set_quality_signal("chars_per_page", round(meaningful_chars / pages, 1))
+        self._set_quality_signal("ocr_page_fraction", round(self._ocr_pages_applied / pages, 3))
+        self._set_quality_signal("tables_detected", tables_emitted + tables_rejected)
+        self._set_quality_signal("tables_emitted", tables_emitted)
+        self._set_quality_signal("tables_rejected", tables_rejected)
+        self._set_quality_signal("running_headings_demoted", headings_demoted)
 
     def _render_pages(
         self,
@@ -922,6 +963,16 @@ class PdfToAstConverter(BaseParser):
         content_nodes = [n for n in children if not isinstance(n, Comment)]
         text = extract_node_text(content_nodes, joiner="")
         return sum(1 for char in text if char.isalnum())
+
+    def _record_table_rejection(self, reason: str) -> None:
+        """Note a detected "table" discarded as non-tabular (empty frame, TOC, ...).
+
+        Bumps the rejection counter used for the ``tables_rejected`` confidence
+        signal and records a degraded-content event carrying the reason, so the
+        quality card reflects structure the converter chose to drop.
+        """
+        self._tables_rejected = getattr(self, "_tables_rejected", 0) + 1
+        self._record_degraded("table_rejected", detail=reason, severity="warn")
 
     def _maybe_retry_with_ocr(
         self,
@@ -2479,6 +2530,7 @@ class PdfToAstConverter(BaseParser):
                 logger.debug(
                     f"Rejecting pymupdf table on page {page_num + 1}: {n_rows}x{n_cols} grid exceeds size caps"
                 )
+                self._record_table_rejection("oversized_grid")
                 return None
             n_empty = sum(1 for r in table_data for c in r if c is None or not str(c).strip())
             if n_empty / n_cells > MAX_TABLE_EMPTY_RATIO:
@@ -2486,6 +2538,7 @@ class PdfToAstConverter(BaseParser):
                     f"Rejecting pymupdf table on page {page_num + 1}: "
                     f"{n_empty}/{n_cells} ({n_empty / n_cells:.0%}) cells empty"
                 )
+                self._record_table_rejection("mostly_empty")
                 return None
             unique_texts = {str(c).strip() for r in table_data for c in r if c is not None and str(c).strip()}
             n_filled = n_cells - n_empty
@@ -2494,6 +2547,7 @@ class PdfToAstConverter(BaseParser):
                     f"Rejecting pymupdf table on page {page_num + 1}: "
                     f"all {n_filled} non-empty cells have identical content"
                 )
+                self._record_table_rejection("uniform_cells")
                 return None
             n_dot_leader = sum(1 for r in table_data for c in r if c is not None and is_dot_leader_cell(str(c)))
             if n_filled and n_dot_leader / n_filled > MAX_DOT_LEADER_CELL_RATIO:
@@ -2502,6 +2556,7 @@ class PdfToAstConverter(BaseParser):
                     f"{n_dot_leader}/{n_filled} ({n_dot_leader / n_filled:.0%}) cells are "
                     f"dot-leader noise (looks like TOC region)"
                 )
+                self._record_table_rejection("dot_leader_toc")
                 return None
 
             # Separate header row (first row) from data rows
@@ -2674,6 +2729,7 @@ class PdfToAstConverter(BaseParser):
                 f"Rejecting ruling-line table on page {page_num + 1}: "
                 f"{n_empty}/{n_cells} ({n_empty / n_cells:.0%}) cells empty"
             )
+            self._record_table_rejection("mostly_empty")
             return None
 
         # Uniformity guard: a "table" where every non-empty cell has the same
@@ -2685,6 +2741,7 @@ class PdfToAstConverter(BaseParser):
                 f"Rejecting ruling-line table on page {page_num + 1}: "
                 f"all {n_filled} non-empty cells have identical content"
             )
+            self._record_table_rejection("uniform_cells")
             return None
 
         if n_filled and n_dot_leader / n_filled > MAX_DOT_LEADER_CELL_RATIO:
@@ -2693,6 +2750,7 @@ class PdfToAstConverter(BaseParser):
                 f"{n_dot_leader}/{n_filled} ({n_dot_leader / n_filled:.0%}) cells are "
                 f"dot-leader noise (looks like TOC region)"
             )
+            self._record_table_rejection("dot_leader_toc")
             return None
 
         # Separate header and data rows

--- a/src/all2md/parsers/zip.py
+++ b/src/all2md/parsers/zip.py
@@ -331,6 +331,7 @@ class ZipToAstConverter(BaseParser):
                     if self.options.create_section_headings:
                         children.append(Heading(level=2, content=[Text(content=display_path)]))
                     children.append(Paragraph(content=[Text(content="(Could not parse this file)")]))
+                    self._record_degraded("unparsed_member", detail=display_path, severity="warn")
 
                 processed_count += 1
 
@@ -520,6 +521,7 @@ class ZipToAstConverter(BaseParser):
                 if self.options.create_section_headings:
                     children.append(Heading(level=2, content=[Text(content=display_path)]))
                 children.append(Paragraph(content=[Text(content="(Could not parse this file)")]))
+                self._record_degraded("unparsed_member", detail=display_path, severity="warn")
 
         # Add resource manifest if requested and resources were extracted
         if self.options.include_resource_manifest and self.options.extract_resource_files and self._extracted_resources:

--- a/tests/integration/test_confidence_report.py
+++ b/tests/integration/test_confidence_report.py
@@ -1,0 +1,153 @@
+#  Copyright (c) 2025 Tom Villani, Ph.D.
+"""Integration tests for conversion confidence reports (D1 quality card).
+
+Covers the parser producers (PDF, DOCX), the ``confidence_report`` API + the
+``Document.metadata['confidence']`` attachment, and the ``all2md report`` CLI.
+"""
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from all2md import confidence_report, to_ast
+from all2md.ast.nodes import Document
+from all2md.confidence import ConfidenceReport
+
+FIXTURES = Path(__file__).resolve().parent.parent / "fixtures" / "documents"
+BASIC_PDF = FIXTURES / "basic.pdf"
+COMPLEX_PDF = FIXTURES / "complex.pdf"
+BASIC_DOCX = FIXTURES / "basic.docx"
+COMPLEX_DOCX = FIXTURES / "complex.docx"
+
+
+@pytest.fixture
+def blank_pdf(tmp_path) -> Path:
+    """A single blank page — the near-empty / scanned-PDF shape (no text layer)."""
+    fitz = pytest.importorskip("fitz")
+    doc = fitz.open()
+    doc.new_page()
+    path = tmp_path / "blank.pdf"
+    doc.save(str(path))
+    doc.close()
+    return path
+
+
+@pytest.mark.integration
+@pytest.mark.pdf
+class TestPdfProducer:
+    def test_clean_pdf_scores_high_with_signals(self):
+        report = confidence_report(str(BASIC_PDF))
+        assert report.producer == "pdf"
+        assert report.score == 100
+        assert report.band == "high"
+        # The reference-free PDF signal set.
+        for key in ("page_count", "meaningful_chars", "chars_per_page", "ocr_page_fraction", "tables_detected"):
+            assert key in report.signals
+        assert report.signals["meaningful_chars"] > 0
+
+    def test_blank_pdf_scores_low_on_text_density(self, blank_pdf):
+        report = confidence_report(str(blank_pdf))
+        assert report.signals["chars_per_page"] < 200
+        assert report.score < 80  # not "high" — the card flags an empty extraction
+
+    def test_tables_detected_accounts_for_emitted_and_rejected(self):
+        report = confidence_report(str(COMPLEX_PDF))
+        signals = report.signals
+        assert signals["tables_detected"] == signals["tables_emitted"] + signals["tables_rejected"]
+
+
+@pytest.mark.integration
+@pytest.mark.docx
+class TestDocxProducer:
+    def test_clean_docx_scores_high(self):
+        report = confidence_report(str(BASIC_DOCX))
+        assert report.producer == "docx"
+        assert report.score == 100
+        assert not report.degraded_events
+
+    def test_dropped_chart_is_surfaced_and_penalized(self):
+        # complex.docx embeds a chart, which all2md has no Markdown form for.
+        report = confidence_report(str(COMPLEX_DOCX))
+        kinds = {event.kind for event in report.degraded_events}
+        assert "chart_dropped" in kinds
+        assert report.signals.get("chart_dropped", 0) >= 1
+        assert report.score < 100
+
+
+@pytest.mark.integration
+class TestConfidenceApi:
+    def test_to_ast_attaches_confidence_metadata(self):
+        doc = to_ast(str(BASIC_PDF))
+        assert "confidence" in doc.metadata
+        card = doc.metadata["confidence"]
+        assert set(card) >= {"score", "band", "producer", "signals", "degraded_events"}
+
+    def test_confidence_report_reads_prebuilt_document(self):
+        doc = to_ast(str(BASIC_PDF))
+        report = confidence_report(doc)
+        assert isinstance(report, ConfidenceReport)
+        assert report.score == doc.metadata["confidence"]["score"]
+
+    def test_confidence_metadata_survives_json_roundtrip(self):
+        from all2md.ast.serialization import ast_to_json
+
+        doc = to_ast(str(COMPLEX_DOCX))
+        # The card must serialize cleanly with the rest of the AST metadata.
+        payload = json.loads(ast_to_json(doc))
+        assert "confidence" in payload["metadata"]
+
+    def test_handbuilt_document_reports_clean(self):
+        report = confidence_report(Document(children=[]))
+        assert report.score == 100
+        assert report.band == "high"
+        assert report.degraded_events == []
+
+
+def _run_report(args: list[str]) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        [sys.executable, "-m", "all2md", "report", *args],
+        capture_output=True,
+        text=True,
+    )
+
+
+@pytest.mark.integration
+@pytest.mark.cli
+class TestReportCli:
+    def test_pretty_output(self):
+        result = _run_report([str(BASIC_PDF)])
+        assert result.returncode == 0
+        assert "confidence:" in result.stdout
+        assert "producer:" in result.stdout
+
+    def test_json_output_is_parseable(self):
+        result = _run_report([str(BASIC_PDF), "--json"])
+        assert result.returncode == 0
+        payload = json.loads(result.stdout)
+        assert payload["producer"] == "pdf"
+        assert payload["score"] == 100
+
+    def test_json_array_for_multiple_inputs(self):
+        result = _run_report([str(BASIC_PDF), str(BASIC_DOCX), "--json"])
+        assert result.returncode == 0
+        payload = json.loads(result.stdout)
+        assert isinstance(payload, list)
+        assert {entry["producer"] for entry in payload} == {"pdf", "docx"}
+
+    def test_fail_under_trips_exit_code(self):
+        # complex.docx scores below 100 (dropped chart); gate at 100 must fail.
+        result = _run_report([str(COMPLEX_DOCX), "--fail-under", "100"])
+        assert result.returncode != 0
+        assert "below --fail-under" in result.stderr
+
+    def test_fail_under_passes_when_met(self):
+        result = _run_report([str(BASIC_PDF), "--fail-under", "50"])
+        assert result.returncode == 0
+
+    def test_fail_under_rejects_out_of_range(self):
+        result = _run_report([str(BASIC_PDF), "--fail-under", "150"])
+        assert result.returncode != 0
+        assert "between 0 and 100" in result.stderr

--- a/tests/unit/test_confidence.py
+++ b/tests/unit/test_confidence.py
@@ -1,0 +1,162 @@
+#  Copyright (c) 2025 Tom Villani, Ph.D.
+"""Unit tests for the conversion-confidence scoring model (``all2md.confidence``)."""
+
+import pytest
+
+from all2md.confidence import (
+    BAND_HIGH_THRESHOLD,
+    BAND_MEDIUM_THRESHOLD,
+    DEGRADED_EVENT_PENALTY_CAP,
+    OCR_RELIANCE_MAX_PENALTY,
+    TEXT_DENSITY_FLOOR_CPP,
+    ConfidenceReport,
+    DegradedEvent,
+    band_for_score,
+    build_report,
+    coalesce_events,
+    score_conversion,
+)
+
+pytestmark = pytest.mark.unit
+
+
+class TestBands:
+    def test_band_thresholds(self):
+        assert band_for_score(100) == "high"
+        assert band_for_score(BAND_HIGH_THRESHOLD) == "high"
+        assert band_for_score(BAND_HIGH_THRESHOLD - 1) == "medium"
+        assert band_for_score(BAND_MEDIUM_THRESHOLD) == "medium"
+        assert band_for_score(BAND_MEDIUM_THRESHOLD - 1) == "low"
+        assert band_for_score(0) == "low"
+
+
+class TestScoreConversion:
+    def test_no_signals_no_events_is_perfect(self):
+        assert score_conversion({}, []) == (100, "high")
+
+    def test_healthy_pdf_signals_stay_perfect(self):
+        signals = {"chars_per_page": 800.0, "ocr_page_fraction": 0.0, "tables_rejected": 0}
+        assert score_conversion(signals, []) == (100, "high")
+
+    def test_text_density_floor_waives_penalty(self):
+        at_floor = {"chars_per_page": float(TEXT_DENSITY_FLOOR_CPP)}
+        above = {"chars_per_page": float(TEXT_DENSITY_FLOOR_CPP) + 500}
+        assert score_conversion(at_floor, [])[0] == 100
+        assert score_conversion(above, [])[0] == 100
+
+    def test_empty_page_image_pdf_scores_low(self):
+        # Near-zero text density + fully OCR-reliant: the classic scanned PDF.
+        score, band = score_conversion({"chars_per_page": 0.0, "ocr_page_fraction": 1.0}, [])
+        assert score < 50
+        assert band == "low"
+
+    def test_text_density_penalty_is_monotonic(self):
+        worse = score_conversion({"chars_per_page": 10.0}, [])[0]
+        better = score_conversion({"chars_per_page": 150.0}, [])[0]
+        assert worse < better < 100
+
+    def test_recovering_text_raises_score(self):
+        # The fitness-function property: extracting more text must improve the
+        # score even though OCR reliance rose (e.g. after enabling OCR).
+        before = score_conversion({"chars_per_page": 0.0, "ocr_page_fraction": 0.0}, [])[0]
+        after = score_conversion({"chars_per_page": 600.0, "ocr_page_fraction": 1.0}, [])[0]
+        assert after > before
+
+    def test_ocr_reliance_penalty_scales(self):
+        none = score_conversion({"ocr_page_fraction": 0.0}, [])[0]
+        half = score_conversion({"ocr_page_fraction": 0.5}, [])[0]
+        full = score_conversion({"ocr_page_fraction": 1.0}, [])[0]
+        assert none == 100
+        assert full == pytest.approx(100 - OCR_RELIANCE_MAX_PENALTY, abs=1)
+        assert none > half > full
+
+    def test_warn_events_penalize(self):
+        events = [DegradedEvent("pdf", "table_rejected", severity="warn")]
+        assert score_conversion({}, events)[0] == 96
+
+    def test_error_events_penalize_more_than_warn(self):
+        warn = score_conversion({}, [DegradedEvent("x", "k", severity="warn")])[0]
+        error = score_conversion({}, [DegradedEvent("x", "k", severity="error")])[0]
+        assert error < warn
+
+    def test_info_events_do_not_penalize(self):
+        assert score_conversion({}, [DegradedEvent("x", "k", count=9, severity="info")])[0] == 100
+
+    def test_event_count_multiplies_penalty(self):
+        one = score_conversion({}, [DegradedEvent("x", "k", count=1, severity="warn")])[0]
+        three = score_conversion({}, [DegradedEvent("x", "k", count=3, severity="warn")])[0]
+        assert 100 - three == 3 * (100 - one)
+
+    def test_event_penalty_is_capped(self):
+        many = [DegradedEvent("x", "k", count=1, detail=str(i), severity="error") for i in range(100)]
+        score = score_conversion({}, many)[0]
+        assert score == pytest.approx(100 - DEGRADED_EVENT_PENALTY_CAP, abs=1)
+
+    def test_score_never_negative(self):
+        signals = {"chars_per_page": 0.0, "ocr_page_fraction": 1.0}
+        events = [DegradedEvent("x", "k", count=50, severity="error")]
+        assert score_conversion(signals, events)[0] == 0
+
+
+class TestCoalesceEvents:
+    def test_merges_matching_events_and_sums_counts(self):
+        events = [
+            DegradedEvent("pdf", "table_rejected", detail="mostly_empty"),
+            DegradedEvent("pdf", "table_rejected", detail="mostly_empty"),
+            DegradedEvent("pdf", "table_rejected", detail="dot_leader_toc"),
+        ]
+        merged = coalesce_events(events)
+        assert len(merged) == 2
+        assert merged[0].detail == "mostly_empty"
+        assert merged[0].count == 2
+        assert merged[1].detail == "dot_leader_toc"
+        assert merged[1].count == 1
+
+    def test_distinct_severity_not_merged(self):
+        events = [
+            DegradedEvent("x", "k", severity="warn"),
+            DegradedEvent("x", "k", severity="error"),
+        ]
+        assert len(coalesce_events(events)) == 2
+
+    def test_preserves_first_seen_order(self):
+        events = [DegradedEvent("x", "b"), DegradedEvent("x", "a"), DegradedEvent("x", "b")]
+        merged = coalesce_events(events)
+        assert [e.kind for e in merged] == ["b", "a"]
+
+
+class TestSerialization:
+    def test_degraded_event_roundtrip(self):
+        event = DegradedEvent("pdf", "table_rejected", count=2, detail="mostly_empty", severity="warn")
+        assert DegradedEvent.from_dict(event.to_dict()) == event
+
+    def test_degraded_event_omits_none_detail(self):
+        assert "detail" not in DegradedEvent("pdf", "k").to_dict()
+
+    def test_report_roundtrip(self):
+        report = build_report(
+            "pdf",
+            {"chars_per_page": 12.0, "ocr_page_fraction": 1.0},
+            [DegradedEvent("pdf", "table_rejected", detail="mostly_empty")],
+        )
+        restored = ConfidenceReport.from_dict(report.to_dict())
+        assert restored == report
+
+    def test_report_dict_is_json_safe(self):
+        import json
+
+        report = build_report("pdf", {"chars_per_page": 12.0}, [DegradedEvent("pdf", "k")])
+        # Must not raise — the card rides on JSON-serialized AST metadata.
+        json.dumps(report.to_dict())
+
+
+class TestBuildReport:
+    def test_coalesces_before_scoring(self):
+        events = [DegradedEvent("pdf", "table_rejected", detail="x") for _ in range(3)]
+        report = build_report("pdf", {}, events)
+        assert len(report.degraded_events) == 1
+        assert report.degraded_events[0].count == 3
+        assert report.score == 100 - 3 * 4  # three warn events at 4 pts each
+
+    def test_producer_recorded(self):
+        assert build_report("docx", {}, []).producer == "docx"


### PR DESCRIPTION
## Summary

Introduces **D1** of Track D (trust & scoring): a reference-free **conversion confidence report** — a "quality card" — attached to every parsed document at `Document.metadata["confidence"]`.

It surfaces the sanity signals converters *already* computed as accept/reject guards and then discarded (surviving only as `logger.debug`): meaningful-text density, OCR reliance, rejected non-tabular "tables", silently-dropped embedded objects, and more. Each report carries a single **0–100 `score`** (with a `high`/`medium`/`low` band) that doubles as the reference-free fitness function the future `optimize` capstone (D3) will hill-climb on.

## What's in it

**Core** (`all2md/confidence.py`)
- `ConfidenceReport` + `DegradedEvent` dataclasses (JSON-safe, round-trip through AST serialization).
- `score_conversion()` — starts at 100; subtracts a text-density penalty, an OCR-reliance penalty, and a capped degraded-event penalty; clamped to `[0, 100]`. Weights are module constants so they stay tunable.

**Plumbing**
- Generic collector on `BaseParser` (`_record_degraded`, `_set_quality_signal`, `build_confidence_report`), lazily initialized so no parser `__init__` needs touching.
- `to_ast()` attaches the card **before the cache put**, so `to_markdown`/`convert`/`chunk` and cache hits all carry it.

**Producers (PDF + DOCX — the flagship formats)**
- **PDF**: `chars_per_page` (text density), `ocr_page_fraction`, tables detected/emitted/rejected (each rejected region recorded with its reason), running-heading demotions.
- **DOCX**: table/image counts + scans the source XML for silently-dropped embedded OLE objects, charts, and SmartArt.
- **Containers** (`zip`, archives): flag members that could not be parsed.

**Surface**
- `all2md.confidence_report(source | Document)` API (+ exported `ConfidenceReport` / `DegradedEvent`).
- New `all2md report <file>` CLI verb: aligned pretty card by default, `--json` for machine use, `--fail-under SCORE` as a CI gate, stdin (`-`), multi-input. Wired into dispatch, help, and config-section generation.

```
$ all2md report scan.pdf
scan.pdf
  confidence: 100/100  (HIGH)
  producer:   pdf

  signals
    page count                2
    meaningful chars          2,738
    chars per page            1369
    ...
```

## Scope note

Per discussion, **PDF and DOCX are the flagship producers**; the minor formats (html/ipynb/mbox/outlook/latex) were intentionally **not** wired — the generic `BaseParser._record_degraded` hook lets any of them opt in later. Container formats got the cheap, high-stakes `unparsed_member` signal since a failure there silently drops a whole sub-document.

## Tests

- **23 unit** (`tests/unit/test_confidence.py`): scoring model (monotonicity, penalty caps, band thresholds, the "recovering text raises score" fitness property), event coalescing, serialization round-trips.
- **15 integration** (`tests/integration/test_confidence_report.py`): PDF/DOCX producers (incl. a generated blank PDF hitting the low-score path), API attachment + JSON-metadata round-trip, and the CLI (pretty/json/multi-input/`--fail-under`).

ruff / black / mypy clean; PDF, DOCX, and CLI/config suites green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)