### PR TITLE
fix(docx): forward-port bullet/template fix from v1.8.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,11 +4,13 @@ on:
   push:
     branches:
       - main
+      - 'release/**'
     tags:
       - 'v*'
   pull_request:
     branches:
       - main
+      - 'release/**'
 
 permissions:
   contents: write  # Required for `gh release create` in the release job

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   hits. The index now records a fingerprint of the documents and index-relevant
   options at save time and is rebuilt when they no longer match.
 
+## [1.8.2] - 2026-07-09
+
+### Fixed
+
+- **Bullet lists no longer disappear when rendering DOCX with a custom template.**
+  When a template lacked the `List Bullet` / `List Number` styles, the generated
+  numbering part interleaved `w:abstractNum` and `w:num` elements. `CT_Numbering`
+  requires every `w:abstractNum` to precede every `w:num`; Word does not reject the
+  malformed part but silently mis-associates the stray definition, so bulleted lists
+  rendered as plain paragraphs. Numbering definitions are now spliced in ahead of any
+  existing `w:num`, which also fixes templates that already ship a numbering part
+  (`--docx-renderer-template-path`, `DocxRendererOptions.template_path`).
+- **Generated bullets use the correct glyph.** The bullet level specified `U+00B7`
+  (MIDDLE DOT) while pinning the run font to Symbol, yielding the wrong character.
+  It now uses `U+F0B7`, the Symbol font's bullet, matching Word's own output.
+- **Generated list styles keep their names.** `List Bullet` / `List Number` were
+  created as custom styles, colliding with Word's latent built-ins and getting
+  renamed to `List Bullet1` / `List Number1` — so any styling a template applied to
+  `List Bullet` never took effect. They are now created as built-in styles.
+
+### Changed
+
+- CI now runs on pushes to and pull requests against `release/**` branches, so patch
+  releases cut from a release tag get a full lint/type/test run before merge.
+
 ## [1.8.1] - 2026-07-06
 
 ### Added
@@ -680,7 +705,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - NumPy-style docstrings
 - Modular architecture with clear separation of concerns
 
-[Unreleased]: https://github.com/thomas-villani/all2md/compare/v1.8.1...HEAD
+[Unreleased]: https://github.com/thomas-villani/all2md/compare/v1.8.2...HEAD
+[1.8.2]: https://github.com/thomas-villani/all2md/releases/tag/v1.8.2
 [1.8.1]: https://github.com/thomas-villani/all2md/releases/tag/v1.8.1
 [1.8.0]: https://github.com/thomas-villani/all2md/releases/tag/v1.8.0
 [1.7.1]: https://github.com/thomas-villani/all2md/releases/tag/v1.7.1

--- a/src/all2md/renderers/docx.py
+++ b/src/all2md/renderers/docx.py
@@ -321,12 +321,20 @@ class DocxRenderer(NodeVisitor, BaseRenderer):
         # ------------------------------------------------------------------
         W = "http://schemas.openxmlformats.org/wordprocessingml/2006/main"
 
+        # CT_Numbering is a strict sequence: every w:abstractNum must precede every
+        # w:num.  Collect the new definitions here and splice them into the right
+        # positions once both are built (see step 3 below).
+        new_abstract_nums = []
+        new_nums = []
+
         if need_bullet:
             abs_id = next_abstract_id
             num_id = next_num_id
             next_abstract_id += 1
             next_num_id += 1
 
+            # U+F0B7 is the Symbol font's bullet glyph; a literal U+00B7 renders as
+            # the wrong character once w:rFonts pins the run to Symbol.
             bullet_abstract_xml = (
                 f'<w:abstractNum xmlns:w="{W}" w:abstractNumId="{abs_id}">'
                 f'  <w:multiLevelType w:val="singleLevel"/>'
@@ -334,21 +342,24 @@ class DocxRenderer(NodeVisitor, BaseRenderer):
                 f'    <w:start w:val="1"/>'
                 f'    <w:numFmt w:val="bullet"/>'
                 f'    <w:pStyle w:val="ListBullet"/>'
-                f'    <w:lvlText w:val="\u00b7"/>'
+                f'    <w:lvlText w:val="\uf0b7"/>'
                 f'    <w:lvlJc w:val="left"/>'
                 f'    <w:pPr><w:ind w:left="360" w:hanging="360"/></w:pPr>'
                 f'    <w:rPr><w:rFonts w:ascii="Symbol" w:hAnsi="Symbol" w:hint="default"/></w:rPr>'
                 f"  </w:lvl>"
                 f"</w:abstractNum>"
             ).encode("utf-8")
-            numbering_el.append(parse_xml(bullet_abstract_xml))
+            new_abstract_nums.append(parse_xml(bullet_abstract_xml))
 
             num_xml = (f'<w:num xmlns:w="{W}" w:numId="{num_id}">  <w:abstractNumId w:val="{abs_id}"/></w:num>').encode(
                 "utf-8"
             )
-            numbering_el.append(parse_xml(num_xml))
+            new_nums.append(parse_xml(num_xml))
 
-            bullet_style = self.document.styles.add_style("List Bullet", WD_STYLE_TYPE.PARAGRAPH)
+            # builtin=True keeps the name as "List Bullet"; a custom style of that name
+            # collides with Word's latent built-in and gets renamed to "List Bullet1",
+            # so any styling the template applies to "List Bullet" would never take.
+            bullet_style = self.document.styles.add_style("List Bullet", WD_STYLE_TYPE.PARAGRAPH, builtin=True)
             bullet_style.base_style = self.document.styles["Normal"]
             pPr = bullet_style._element.get_or_add_pPr()
             numPr = OxmlElement("w:numPr")
@@ -376,14 +387,14 @@ class DocxRenderer(NodeVisitor, BaseRenderer):
                 f"  </w:lvl>"
                 f"</w:abstractNum>"
             ).encode("utf-8")
-            numbering_el.append(parse_xml(number_abstract_xml))
+            new_abstract_nums.append(parse_xml(number_abstract_xml))
 
             num_xml = (f'<w:num xmlns:w="{W}" w:numId="{num_id}">  <w:abstractNumId w:val="{abs_id}"/></w:num>').encode(
                 "utf-8"
             )
-            numbering_el.append(parse_xml(num_xml))
+            new_nums.append(parse_xml(num_xml))
 
-            number_style = self.document.styles.add_style("List Number", WD_STYLE_TYPE.PARAGRAPH)
+            number_style = self.document.styles.add_style("List Number", WD_STYLE_TYPE.PARAGRAPH, builtin=True)
             number_style.base_style = self.document.styles["Normal"]
             pPr2 = number_style._element.get_or_add_pPr()
             numPr2 = OxmlElement("w:numPr")
@@ -393,6 +404,26 @@ class DocxRenderer(NodeVisitor, BaseRenderer):
             pPr2.append(numPr2)
             pPr2.append(OxmlElement("w:contextualSpacing"))
             self._available_styles.add("List Number")
+
+        # ------------------------------------------------------------------
+        # 3. Splice the definitions in, preserving CT_Numbering's element order.
+        #    Word doesn't reject an out-of-order numbering part outright -- it
+        #    silently mis-associates the stray w:abstractNum, so the affected list
+        #    loses its numbering and renders as plain paragraphs.
+        # ------------------------------------------------------------------
+        first_num = numbering_el.find(qn("w:num"))
+        for abstract_el in new_abstract_nums:
+            if first_num is None:
+                numbering_el.append(abstract_el)
+            else:
+                first_num.addprevious(abstract_el)
+
+        trailing = numbering_el.find(qn("w:numIdMacAtCleanup"))
+        for num_el in new_nums:
+            if trailing is None:
+                numbering_el.append(num_el)
+            else:
+                trailing.addprevious(num_el)
 
         logger.debug(
             "Created missing list styles: %s",

--- a/tests/unit/renderers/test_docx_renderer.py
+++ b/tests/unit/renderers/test_docx_renderer.py
@@ -364,6 +364,106 @@ class TestListRendering:
         assert "Second" in text_content
 
 
+def _template_lacking_list_styles(tmp_path, *, drop_numbering_part: bool):
+    """Build a template with no List Bullet/List Number styles.
+
+    Real-world templates omit these styles; some also ship without a numbering part
+    at all, which exercises a different branch of ``_ensure_list_styles``.
+    """
+    import re
+    import zipfile
+
+    template = tmp_path / "template.docx"
+    doc = DocxDocument()
+    for name in ("List Bullet", "List Number"):
+        doc.styles[name].delete()
+    doc.save(str(template))
+
+    if not drop_numbering_part:
+        return template
+
+    stripped = tmp_path / "template_no_numbering.docx"
+    with zipfile.ZipFile(template) as zin, zipfile.ZipFile(stripped, "w", zipfile.ZIP_DEFLATED) as zout:
+        for item in zin.infolist():
+            if item.filename == "word/numbering.xml":
+                continue
+            data = zin.read(item.filename)
+            if item.filename == "[Content_Types].xml":
+                data = re.sub(rb"<Override PartName=\"/word/numbering\.xml\"[^/]*/>", b"", data)
+            elif item.filename == "word/_rels/document.xml.rels":
+                data = re.sub(rb"<Relationship [^>]*Target=\"numbering\.xml\"[^>]*/>", b"", data)
+            zout.writestr(item, data)
+    return stripped
+
+
+@pytest.mark.unit
+@pytest.mark.docx
+@pytest.mark.parametrize("drop_numbering_part", [False, True], ids=["existing-numbering", "no-numbering"])
+def test_template_numbering_keeps_schema_element_order(tmp_path, drop_numbering_part):
+    """Regression: interleaved w:abstractNum/w:num silently killed bullets in Word.
+
+    CT_Numbering is a strict sequence -- every w:abstractNum must precede every
+    w:num.  Word does not reject an out-of-order part; it mis-associates the stray
+    definition, so bulleted lists render as plain paragraphs.
+    """
+    from docx.oxml.ns import qn
+
+    from all2md.options.docx import DocxRendererOptions
+    from all2md.renderers.docx import DocxRenderer
+
+    template = _template_lacking_list_styles(tmp_path, drop_numbering_part=drop_numbering_part)
+    doc = Document(
+        children=[
+            List(ordered=False, items=[ListItem(children=[Paragraph(content=[Text(content="Bullet")])])]),
+            List(ordered=True, items=[ListItem(children=[Paragraph(content=[Text(content="Number")])])]),
+        ]
+    )
+    output_file = tmp_path / "out.docx"
+    DocxRenderer(options=DocxRendererOptions(template_path=str(template))).render(doc, output_file)
+
+    rendered = DocxDocument(str(output_file))
+    numbering = rendered.part.numbering_part._element
+    order = [child.tag.split("}")[-1] for child in numbering if child.tag in (qn("w:abstractNum"), qn("w:num"))]
+    assert "abstractNum" in order and "num" in order
+    last_abstract = len(order) - 1 - order[::-1].index("abstractNum")
+    assert last_abstract < order.index("num"), f"w:num precedes a w:abstractNum: {order}"
+
+    # Each recreated style must resolve to a numbering definition that exists.
+    styles = {s.name for s in rendered.styles}
+    assert {"List Bullet", "List Number"} <= styles
+
+    defined_num_ids = {int(n.get(qn("w:numId"))) for n in numbering.findall(qn("w:num"))}
+    for style_name in ("List Bullet", "List Number"):
+        num_pr = rendered.styles[style_name]._element.find(qn("w:pPr")).find(qn("w:numPr"))
+        num_id = int(num_pr.find(qn("w:numId")).get(qn("w:val")))
+        assert num_id in defined_num_ids, f"{style_name} references undefined numId {num_id}"
+
+
+@pytest.mark.unit
+@pytest.mark.docx
+def test_template_bullet_uses_symbol_font_codepoint(tmp_path):
+    """The Symbol font's bullet is U+F0B7; U+00B7 renders as the wrong glyph."""
+    from docx.oxml.ns import qn
+
+    from all2md.options.docx import DocxRendererOptions
+    from all2md.renderers.docx import DocxRenderer
+
+    template = _template_lacking_list_styles(tmp_path, drop_numbering_part=True)
+    doc = Document(
+        children=[List(ordered=False, items=[ListItem(children=[Paragraph(content=[Text(content="Bullet")])])])]
+    )
+    output_file = tmp_path / "out.docx"
+    DocxRenderer(options=DocxRendererOptions(template_path=str(template))).render(doc, output_file)
+
+    numbering = DocxDocument(str(output_file)).part.numbering_part._element
+    bullet_lvl = next(
+        lvl
+        for lvl in numbering.iter(qn("w:lvl"))
+        if lvl.find(qn("w:numFmt")) is not None and lvl.find(qn("w:numFmt")).get(qn("w:val")) == "bullet"
+    )
+    assert bullet_lvl.find(qn("w:lvlText")).get(qn("w:val")) == ""
+
+
 @pytest.mark.unit
 @pytest.mark.docx
 class TestTableRendering:


### PR DESCRIPTION
## Summary

Forward-ports the DOCX bullet fix released in **v1.8.2** onto `main`, so 1.9.0 doesn't regress it. Cherry-picked from `release/1.8` with `-x` (provenance lines record the source SHAs).

Released via #65 → `release/1.8` → `v1.8.2`.

## What's here

- `fix(docx)` (`cd7a206`) — the fix and its three regression tests.
- `ci` (`90c6e5d`) — run CI on `release/**` branches. Needed on `main` too, or the next patch line loses it.

Deliberately **not** cherry-picked:

- `chore(lock): sync uv.lock to 1.8.1` — `main` already has the equivalent (`279ddf4`).
- `chore(mypy): fix mbox type errors` — `main` already has it (`5ad6a47`); it was back-ported *to* the release branch, not from it.
- `Bump version: 1.8.1 → 1.8.2` — `main` keeps its own version until 1.9.0 is cut.

## The bug

`_ensure_list_styles()` appended each `w:abstractNum` immediately followed by its `w:num`. `CT_Numbering` is a strict sequence — every `w:abstractNum` must precede every `w:num`. Word doesn't reject the malformed part; it silently mis-associates the out-of-sequence definition, so the bullet list lost its numbering and rendered as plain paragraphs while the numbered list survived. Only reproduced with `template_path`, since python-docx's default skeleton already defines both list styles and the function early-returns.

Also fixed: the bullet used `U+00B7` while pinning the run font to Symbol (Word's bullet is `U+F0B7`), and the styles were created as custom, colliding with Word's latent built-ins and being renamed to `List Bullet1` — so template styling of `List Bullet` never applied.

## Conflict resolution

`CHANGELOG.md` conflicted, as expected: `main` has an `[Unreleased]` section (confidence report, conversion cache, run-style round-trip) and a `[1.8.1]` section that the release branch never had. Resolved to `Unreleased → 1.8.2 → 1.8.1 → 1.8.0`, with all three link refs present and `[Unreleased]` now comparing from `v1.8.2`. Verified main's three unreleased feature entries survived and no 1.8.2 content leaked into `[Unreleased]`.

## Testing

Re-verified against `main`'s code, not just the release branch — `main` carries the run-level character-style round-trip (`33a81d7`) that touches the same renderer:

- 183 docx tests pass; `black --check`, `ruff check`, `mypy` clean.
- Drove the original repro through **real Word over COM**: 6/6 list items, bullet marker `U+F0B7`, styles named `List Bullet` / `List Number` (not `List Bullet1`).
- Confirmed no version bump leaked onto `main` (`pyproject.toml` and `__init__.py` still `1.8.1`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
