### PR TITLE
chore(release): let bump-my-version manage uv.lock

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -505,3 +505,18 @@ replace = 'version = "{new_version}"'
 filename = "mcpb/pyproject.toml"
 search = '>={current_version}'
 replace = '>={new_version}'
+
+# uv.lock records the project's own version. Anchor the match on the preceding
+# `name = "all2md"` line: a bare version search would also match any dependency
+# that happens to be pinned at the same version. Without this, a release tag
+# ships a lock recording the previous version (v1.8.1 shipped one saying 1.8.0),
+# and the next `uv run` rewrites it -- which makes the format-sync pre-commit
+# hook report modified files and abort every commit on a fresh release branch.
+[[tool.bumpversion.files]]
+filename = "uv.lock"
+search = '''
+name = "all2md"
+version = "{current_version}"'''
+replace = '''
+name = "all2md"
+version = "{new_version}"'''


### PR DESCRIPTION
## Summary

`uv.lock` records the project's own version, but it wasn't in `[tool.bumpversion]`. So a release tag shipped a lock recording the **previous** version unless someone remembered `uv lock` by hand — `v1.8.1` shipped a lock saying `1.8.0`.

This isn't cosmetic. The `format-sync-update` pre-commit hook runs `uv run`, which rewrites the stale lock; pre-commit then reports modified files and aborts the commit. That blocks **every commit** on a release branch freshly cut from such a tag. It bit `release/1.8` during the 1.8.2 patch and cost a dedicated `chore(lock)` commit to unblock.

Discovered while cutting v1.8.2 (#65). `v1.8.2` itself ships a correct lock because we ran `uv lock` manually; this makes that automatic.

## The anchoring detail

The match is anchored on the preceding `name = "all2md"` line:

```toml
search = '''
name = "all2md"
version = "{current_version}"'''
```

A bare `version = "{current_version}"` search would also rewrite any **dependency** pinned at the same version. Today `1.8.1` happens to be unique in `uv.lock`, but that's luck — a future `1.9.0` or `2.0.0` could easily collide with a transitive dep.

## Verification

Ran the real bump against a dirty tree (`--no-commit --no-tag --allow-dirty`) and inspected the result:

- `uv.lock` changed by exactly **one line** (`1 1 uv.lock` per `--numstat`), inside the `all2md` package block.
- `bump-my-version` stages it: `Would add changes in file 'uv.lock' to repository`.
- Reverted the test bump; this PR contains the config change only (`pyproject.toml`, +15 lines).

## Note for future patch lines

`release/1.8` does **not** have this config (it predates it). If a `1.8.3` is ever cut, `bump-my-version` there still won't touch `uv.lock` — either cherry-pick this commit onto `release/1.8`, or run `uv lock` manually as we did for 1.8.2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
