### PR TITLE
feat(roundtrip): structural fidelity scoring (`all2md roundtrip`)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Round-trip fidelity scoring (`all2md roundtrip`).** Converts a document to
+  another format, parses it straight back, and scores the structure that
+  survived. Unlike the confidence report this comparison has a ground truth —
+  the source document itself — so a lossless round trip scores exactly `100` and
+  anything less is a concrete, itemized loss. Five dimensions are scored against
+  independent alignments and combined: `structure` (0.40 — heading levels, list
+  nesting, table placement), `text` (0.30 — the document-wide word stream),
+  `inline` (0.15), `tables` (0.10) and `references` (0.05); dimensions the source
+  does not exercise are dropped and the rest renormalized, so a document with no
+  tables is neither rewarded nor punished for the tables it lacks. Alongside the
+  score the report lists concrete `StructuralDelta` incidents ("heading(h1) ->
+  paragraph", "table 1: 4x3 -> 4x2", "3 of 229 words") so a low score is
+  actionable. Tight/loose list items and nested-paragraph artifacts are
+  normalized away, so format-legal spelling differences do not read as loss.
+  Available from Python as `all2md.roundtrip_report(source, via=...)` (with
+  `roundtrippable_formats()` listing the 24 valid `via` formats) and from the
+  command line as `all2md roundtrip <file>` (aligned card by default, `--via` to
+  pick the intermediate format, `--json`, `--fail-under SCORE` as a CI gate,
+  `--max-deltas N`, `--format` to override source detection for stdin). The score
+  responds to converter options, which is what makes it usable as the fitness
+  function for the planned `all2md optimize`.
 - **Conversion confidence report ("quality card").** Every conversion now
   attaches a reference-free `ConfidenceReport` to `Document.metadata['confidence']`
   — a `0-100` `score`, a `high`/`medium`/`low` `band`, the signals behind it, and

--- a/docs/source/api/advanced.rst
+++ b/docs/source/api/advanced.rst
@@ -96,6 +96,22 @@ Document comparison and diff rendering:
    all2md.diff.text_diff
    all2md.diff.renderers
 
+Quality Scoring
+---------------
+
+Two complementary reads on conversion quality. :mod:`all2md.confidence` is
+*reference-free*: it scores a conversion from the sanity signals the parser
+observed, which is the only option for a document with no ground truth (a
+scanned PDF). :mod:`all2md.roundtrip` manufactures a reference by converting a
+document to another format and parsing it straight back, then scores the
+structure that survived.
+
+.. autosummary::
+   :nosignatures:
+
+   all2md.confidence
+   all2md.roundtrip
+
 MCP Server
 ----------
 
@@ -132,6 +148,8 @@ Complete References
    all2md.ast
    all2md.search
    all2md.diff
+   all2md.confidence
+   all2md.roundtrip
    all2md.mcp
    all2md.packagers
    all2md.packagers.arxiv

--- a/docs/source/api/all2md.confidence.rst
+++ b/docs/source/api/all2md.confidence.rst
@@ -1,0 +1,9 @@
+all2md.confidence
+=================
+
+.. automodule:: all2md.confidence
+   :members:
+   :show-inheritance:
+   :undoc-members:
+   :imported-members: False
+   :noindex:

--- a/docs/source/api/all2md.roundtrip.rst
+++ b/docs/source/api/all2md.roundtrip.rst
@@ -1,0 +1,9 @@
+all2md.roundtrip
+================
+
+.. automodule:: all2md.roundtrip
+   :members:
+   :show-inheritance:
+   :undoc-members:
+   :imported-members: False
+   :noindex:

--- a/docs/source/api/core.rst
+++ b/docs/source/api/core.rst
@@ -18,6 +18,15 @@ The primary functions for document conversion:
    all2md.from_markdown
    all2md.convert
 
+Quality scoring, for deciding how much to trust a conversion:
+
+.. autosummary::
+   :nosignatures:
+
+   all2md.confidence_report
+   all2md.roundtrip_report
+   all2md.roundtrippable_formats
+
 For full function signatures and detailed documentation, see :doc:`all2md.api`.
 
 Base Classes

--- a/docs/source/api/index.rst
+++ b/docs/source/api/index.rst
@@ -26,7 +26,7 @@ Quick Links
    * - :doc:`utilities`
      - Internal utilities for input handling, images, and security
    * - :doc:`advanced`
-     - AST nodes, search, diffing, and MCP integration
+     - AST nodes, search, diffing, quality scoring, and MCP integration
 
 .. toctree::
    :maxdepth: 2

--- a/docs/source/cli.rst
+++ b/docs/source/cli.rst
@@ -762,6 +762,91 @@ extra keyword arguments to the converter (e.g. ``attachment_mode="skip"``).
 For lower-level control over an AST you already hold, call
 ``all2md.chunking.chunk_ast(doc, strategy=..., max_tokens=...)`` directly.
 
+Roundtrip Command
+-----------------
+
+``all2md roundtrip`` converts a document to another format, parses it straight
+back, and scores the structure that survived. Because the source document is its
+own ground truth, a lossless round trip scores exactly ``100`` — anything less is
+a concrete, itemized loss.
+
+.. code-block:: bash
+
+   # How much does converting this DOCX to Markdown cost?
+   all2md roundtrip report.docx
+
+   # What would it cost to publish these notes as reStructuredText?
+   all2md roundtrip notes.md --via rst
+
+   # Gate a corpus in CI
+   all2md roundtrip docs/*.md --fail-under 95
+
+The card reports an overall score plus the five dimensions behind it. Here a real
+DOCX loses only its underlines, which Markdown cannot express:
+
+.. code-block:: text
+
+   $ all2md roundtrip basic.docx
+   basic.docx
+     fidelity:  97/100  (HIGH)
+     pipeline:  parse docx -> render markdown -> parse markdown
+
+     metrics
+       structure   100/100   headings, lists, tables, code blocks
+       text        100/100   the document's word stream
+       inline       82/100   bold, italic, code, links
+       tables      100/100   table dimensions and cell text
+       references  100/100   link and image targets
+
+     differences
+       warn  inline_lost  (underline)
+
+``structure`` carries the most weight (0.40), then ``text`` (0.30), ``inline``
+(0.15), ``tables`` (0.10) and ``references`` (0.05). Dimensions the source does
+not exercise are dropped and the rest renormalized, so a document with no tables
+is neither rewarded nor punished for the tables it does not have.
+
+Key Options
+~~~~~~~~~~~
+
+* ``--via FORMAT`` — the intermediate format (default ``markdown``). It must have
+  both a renderer and a parser; passing an unknown value prints the valid list.
+* ``--format FORMAT`` — the source format, overriding auto-detection. Worth
+  setting for stdin: piped Markdown sniffs as plaintext.
+* ``--fail-under SCORE`` — exit non-zero if any document scores below ``SCORE``.
+* ``--max-deltas N`` — show at most ``N`` differences per document (``0`` for all).
+* ``--json`` — emit the report(s) as JSON for machine consumption.
+
+Parser and renderer options come from the configuration file's converter sections
+(see :doc:`configuration`), not from flags on this subcommand.
+
+Python API
+~~~~~~~~~~
+
+.. code-block:: python
+
+   from all2md import roundtrip_report, roundtrippable_formats
+
+   report = roundtrip_report("report.docx", via="markdown")
+   print(report.score, report.band, report.metrics["structure"])
+   for delta in report.deltas:
+       print(delta.severity, delta.kind, delta.detail)
+
+   print(roundtrippable_formats())  # formats usable as `via`
+
+Because the score responds to converter options, it also prices a setting.
+``basic.md`` contains raw ``<u>`` tags, which the Markdown renderer escapes by
+default as a security posture — that costs two points, and turning the escape off
+recovers them:
+
+.. code-block:: python
+
+   roundtrip_report("basic.md").score                                  # 98
+   roundtrip_report("basic.md", html_passthrough_mode="pass-through").score  # 100
+
+This is exactly the property the planned ``all2md optimize`` capstone hill-climbs
+on: a scalar that improves as converter settings improve.
+
 Lint Command
 ------------
 

--- a/src/all2md/__init__.py
+++ b/src/all2md/__init__.py
@@ -127,6 +127,8 @@ from all2md.api import (
     convert,
     from_ast,
     from_markdown,
+    roundtrip_report,
+    roundtrippable_formats,
     to_ast,
     to_markdown,
 )
@@ -141,6 +143,7 @@ from all2md.exceptions import All2MdError, DependencyError, FormatError, Parsing
 from all2md.options.base import BaseParserOptions, BaseRendererOptions
 from all2md.options.common import LocalFileAccessOptions, NetworkFetchOptions
 from all2md.progress import ProgressCallback, ProgressEvent
+from all2md.roundtrip import RoundTripReport, StructuralDelta
 
 # Import parsers to trigger registration (must be eager, not lazy)
 from . import parsers  # noqa: F401
@@ -207,6 +210,11 @@ __all__ = [
     "confidence_report",
     "ConfidenceReport",
     "DegradedEvent",
+    # Round-trip fidelity scoring
+    "roundtrip_report",
+    "roundtrippable_formats",
+    "RoundTripReport",
+    "StructuralDelta",
     # Registry system
     "registry",
     # Type definitions

--- a/src/all2md/api.py
+++ b/src/all2md/api.py
@@ -28,6 +28,7 @@ from all2md.utils.io_utils import write_content
 if TYPE_CHECKING:
     from all2md.chunking import ProvenanceChunk
     from all2md.confidence import ConfidenceReport
+    from all2md.roundtrip import RoundTripReport
 
 logger = logging.getLogger(__name__)
 
@@ -970,6 +971,139 @@ def confidence_report(
         return ConfidenceReport.from_dict(raw)
     # No report attached (e.g. a hand-built Document): report a clean card.
     return ConfidenceReport(score=100, band="high", producer="", signals={}, degraded_events=[])
+
+
+def roundtrippable_formats() -> list[str]:
+    """Return the formats that can be both rendered to and parsed back from.
+
+    These are the formats accepted by :func:`roundtrip_report`'s ``via``
+    parameter: a round trip needs a renderer to get there and a parser to get
+    back.
+    """
+    formats = []
+    for name in registry.list_formats():
+        entries = registry.get_format_info(name) or []
+        if any(entry.parser_class and entry.renderer_class for entry in entries):
+            formats.append(name)
+    return sorted(formats)
+
+
+def roundtrip_report(
+    source: Union[str, Path, IO[bytes], bytes, Document],
+    *,
+    via: DocumentFormat = "markdown",
+    source_format: DocumentFormat = "auto",
+    parser_options: Optional[BaseParserOptions] = None,
+    renderer_options: Optional[BaseRendererOptions] = None,
+    progress_callback: Optional[ProgressCallback] = None,
+    remote_input_options: Optional[RemoteInputOptions] = None,
+    **kwargs: Any,
+) -> "RoundTripReport":
+    """Round-trip a document through ``via`` and score what survived.
+
+    Renders the parsed document to the ``via`` format, parses the result straight
+    back, and compares the two ASTs structurally. Unlike
+    :func:`confidence_report`, this has a ground truth to measure against -- the
+    source AST -- so a clean document round-tripping through a lossless format
+    scores exactly ``100`` and any drift is a real defect.
+
+    Parameters
+    ----------
+    source : str, Path, IO[bytes], bytes, or Document
+        Document to round-trip. A pre-parsed ``Document`` is used directly as the
+        ground truth, in which case ``source_format`` is only a label.
+    via : DocumentFormat, default "markdown"
+        Intermediate format to round-trip through. Must have both a renderer and
+        a parser -- see :func:`roundtrippable_formats`.
+    source_format : DocumentFormat, default "auto"
+        Explicit source format, or auto-detect.
+    parser_options : BaseParserOptions, optional
+        Options for parsing the source. The intermediate is always parsed with
+        that format's defaults, since it is machine-generated.
+    renderer_options : BaseRendererOptions, optional
+        Options for rendering to ``via``.
+    progress_callback : ProgressCallback, optional
+        Optional progress callback forwarded to the initial parse.
+    remote_input_options : RemoteInputOptions, optional
+        Controls remote retrieval behaviour. Defaults to None (disabled).
+    kwargs : Any
+        Individual options, split between the source parser and the ``via`` renderer.
+
+    Returns
+    -------
+    RoundTripReport
+        The ``0-100`` fidelity score, per-dimension metrics, and the concrete
+        structural differences found.
+
+    Raises
+    ------
+    FormatError
+        If ``via`` cannot be both rendered to and parsed back from.
+
+    Examples
+    --------
+        >>> from all2md import roundtrip_report
+        >>> report = roundtrip_report("report.docx")  # doctest: +SKIP
+        >>> report.score, report.metrics["structure"]  # doctest: +SKIP
+        (94, 91)
+
+    Check what a conversion to reStructuredText would cost:
+        >>> report = roundtrip_report("notes.md", via="rst")  # doctest: +SKIP
+
+    """
+    from all2md.roundtrip import build_report
+
+    if via not in roundtrippable_formats():
+        raise FormatError(
+            f"Cannot round-trip through {via!r}: it needs both a renderer and a parser. "
+            f"Available: {', '.join(roundtrippable_formats())}"
+        )
+
+    if isinstance(source, Document):
+        original = source
+        actual_source_format: str = source_format if source_format != "auto" else "ast"
+    else:
+        resolved_payload = _resolve_document_source(source, remote_input_options, progress_callback).payload
+        if source_format != "auto":
+            actual_source_format = source_format
+        elif isinstance(resolved_payload, (str, Path, bytes)) or (
+            hasattr(resolved_payload, "read") and hasattr(resolved_payload, "seek")
+        ):
+            actual_source_format = registry.detect_format(resolved_payload)  # type: ignore[arg-type]
+        else:
+            raise FormatError("Cannot auto-detect format from text-mode stream. Please specify source_format.")
+
+        parser_kwargs, _ = _split_kwargs_for_parser_and_renderer(
+            cast(DocumentFormat, actual_source_format), via, dict(kwargs)
+        )
+        original = to_ast(
+            cast(Union[str, Path, IO[bytes], bytes], resolved_payload),
+            parser_options=parser_options,
+            source_format=cast(DocumentFormat, actual_source_format),
+            progress_callback=progress_callback,
+            **parser_kwargs,
+        )
+
+    _, renderer_kwargs = _split_kwargs_for_parser_and_renderer(
+        cast(DocumentFormat, actual_source_format), via, dict(kwargs)
+    )
+    final_renderer_options: Optional[BaseRendererOptions]
+    if renderer_kwargs and renderer_options:
+        final_renderer_options = renderer_options.create_updated(**renderer_kwargs)
+    elif renderer_kwargs:
+        final_renderer_options = _create_renderer_options_from_kwargs(via, **renderer_kwargs)
+    else:
+        final_renderer_options = renderer_options
+
+    rendered = _transforms().render(original, renderer=via, options=final_renderer_options)
+    payload = rendered.encode("utf-8") if isinstance(rendered, str) else rendered
+
+    # The intermediate is machine-generated, so it is parsed with plain defaults:
+    # reusing the source's parser options would be a category error (they belong
+    # to a different format) and would let a parsing quirk mask a rendering loss.
+    roundtripped = to_ast(payload, source_format=via)
+
+    return build_report(original, roundtripped, source_format=actual_source_format, via=via)
 
 
 def _record_source_path(ast_doc: "Document", source: Any) -> None:

--- a/src/all2md/cli/commands/__init__.py
+++ b/src/all2md/cli/commands/__init__.py
@@ -120,6 +120,12 @@ def dispatch_command(args: list[str] | None = None) -> int | None:  # noqa: C901
 
         return handle_report_command(args[1:])
 
+    # Check for roundtrip command (structural fidelity score)
+    if args[0] == "roundtrip":
+        from all2md.cli.commands.roundtrip import handle_roundtrip_command
+
+        return handle_roundtrip_command(args[1:])
+
     # Check for lint command
     if args[0] == "lint":
         from all2md.cli.commands.lint import handle_lint_command

--- a/src/all2md/cli/commands/config.py
+++ b/src/all2md/cli/commands/config.py
@@ -137,6 +137,7 @@ def _subcommand_parser_factories() -> Dict[str, Any]:
     from all2md.cli.commands.edit import _create_edit_parser
     from all2md.cli.commands.generate_site import _create_generate_site_parser
     from all2md.cli.commands.report import _create_report_parser
+    from all2md.cli.commands.roundtrip import _create_roundtrip_parser
     from all2md.cli.commands.server import _create_serve_parser
     from all2md.cli.commands.view import _create_view_parser
 
@@ -149,6 +150,7 @@ def _subcommand_parser_factories() -> Dict[str, Any]:
         "generate-site": _create_generate_site_parser,
         "chunk": _create_chunk_parser,
         "report": _create_report_parser,
+        "roundtrip": _create_roundtrip_parser,
     }
 
 

--- a/src/all2md/cli/commands/report.py
+++ b/src/all2md/cli/commands/report.py
@@ -22,12 +22,10 @@ Examples
 from __future__ import annotations
 
 import argparse
-import contextlib
 import json
-import os
 import sys
 from pathlib import Path
-from typing import Any, Iterator, cast
+from typing import Any, cast
 
 from all2md.ast.nodes import Document
 from all2md.cli.builder import (
@@ -37,7 +35,7 @@ from all2md.cli.builder import (
     EXIT_SUCCESS,
     EXIT_VALIDATION_ERROR,
 )
-from all2md.cli.commands.shared import add_cache_arguments, conversion_cache_from_args
+from all2md.cli.commands.shared import add_cache_arguments, conversion_cache_from_args, protect_stdout
 from all2md.confidence import ConfidenceReport
 from all2md.exceptions import All2MdError, DependencyError
 
@@ -52,33 +50,6 @@ _INFO_SIGNALS = {
     "image_count",
     "running_headings_demoted",
 }
-
-
-@contextlib.contextmanager
-def _protect_stdout() -> Iterator[None]:
-    """Redirect OS-level stdout (fd 1) to stderr for the duration.
-
-    Some libraries in the conversion pipeline (notably PyMuPDF) print advisories
-    straight to stdout, which would corrupt the ``--json`` output stream. We
-    point fd 1 at stderr while parsing, then restore it before emitting the
-    report. This catches both Python-level ``print`` and C-level writes. Falls
-    back to a no-op if fd duplication is unavailable (e.g. a captured stdout with
-    no real file descriptor).
-    """
-    try:
-        saved_fd = os.dup(1)
-    except (OSError, ValueError):
-        yield
-        return
-    sys.stdout.flush()
-    sys.stderr.flush()
-    try:
-        os.dup2(2, 1)
-        yield
-    finally:
-        sys.stdout.flush()
-        os.dup2(saved_fd, 1)
-        os.close(saved_fd)
 
 
 def _create_report_parser() -> argparse.ArgumentParser:
@@ -264,7 +235,7 @@ def handle_report_command(args: list[str] | None = None) -> int:
     try:
         # Guard fd 1 so PyMuPDF (and friends) advisory prints during parsing
         # cannot corrupt the report — especially the machine-readable --json stream.
-        with _protect_stdout(), conversion_cache_from_args(parsed):
+        with protect_stdout(), conversion_cache_from_args(parsed):
             for source in parsed.inputs:
                 doc, label = _load_ast(source, converter_options)
                 results.append((label, confidence_report(doc)))

--- a/src/all2md/cli/commands/roundtrip.py
+++ b/src/all2md/cli/commands/roundtrip.py
@@ -1,0 +1,255 @@
+#  Copyright (c) 2025 Tom Villani, Ph.D.
+#
+# src/all2md/cli/commands/roundtrip.py
+"""Round-trip fidelity command.
+
+``all2md roundtrip`` converts a document to another format, converts it straight
+back, and scores what survived: a ``0-100`` structural fidelity score, the
+per-dimension metrics behind it (structure, text, inline formatting, tables,
+references), and the concrete differences it found. Unlike ``all2md report``,
+this comparison has a ground truth -- the source document itself -- so a lossless
+round trip scores exactly ``100`` and anything less is a real defect.
+
+Examples
+--------
+    all2md roundtrip report.docx
+    all2md roundtrip notes.md --via rst
+    all2md roundtrip *.docx --fail-under 90
+    all2md roundtrip paper.pdf --json
+    cat notes.md | all2md roundtrip - --format markdown
+
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any, cast
+
+from all2md.cli.builder import (
+    EXIT_DEPENDENCY_ERROR,
+    EXIT_ERROR,
+    EXIT_FILE_ERROR,
+    EXIT_SUCCESS,
+    EXIT_VALIDATION_ERROR,
+)
+from all2md.cli.commands.shared import add_cache_arguments, conversion_cache_from_args, protect_stdout
+from all2md.constants import DocumentFormat
+from all2md.exceptions import All2MdError, DependencyError
+from all2md.roundtrip import RoundTripReport
+
+#: How many deltas the pretty card lists before summarizing the rest. Deltas are
+#: coalesced and severity-ranked, so the first few are the ones worth reading.
+_DEFAULT_MAX_DELTAS = 10
+
+#: Human-readable gloss for each metric, shown beside its score.
+_METRIC_HELP = {
+    "structure": "headings, lists, tables, code blocks",
+    "text": "the document's word stream",
+    "inline": "bold, italic, code, links",
+    "tables": "table dimensions and cell text",
+    "references": "link and image targets",
+}
+
+
+def _create_roundtrip_parser() -> argparse.ArgumentParser:
+    """Build the argparse parser for ``all2md roundtrip``."""
+    parser = argparse.ArgumentParser(
+        prog="all2md roundtrip",
+        description="Convert a document through another format and back, scoring what survived.",
+        add_help=True,
+    )
+    parser.add_argument(
+        "inputs",
+        nargs="+",
+        help="One or more documents to round-trip (any supported format; use '-' for stdin).",
+    )
+    parser.add_argument(
+        "--via",
+        default="markdown",
+        metavar="FORMAT",
+        help="Intermediate format to round-trip through (default: markdown). "
+        "Must have both a renderer and a parser; see 'all2md list-formats'.",
+    )
+    parser.add_argument(
+        "--format",
+        "-f",
+        default="auto",
+        metavar="FORMAT",
+        help="Source format, overriding auto-detection. Worth setting for stdin, whose content "
+        "cannot always be told apart (Markdown piped in sniffs as plaintext).",
+    )
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Emit the report(s) as JSON (an array when multiple inputs are given).",
+    )
+    parser.add_argument(
+        "--fail-under",
+        type=int,
+        default=None,
+        metavar="SCORE",
+        help="Exit non-zero if any document scores below SCORE (0-100). Useful as a CI gate.",
+    )
+    parser.add_argument(
+        "--max-deltas",
+        type=int,
+        default=_DEFAULT_MAX_DELTAS,
+        metavar="N",
+        help=f"Show at most N differences per document (default: {_DEFAULT_MAX_DELTAS}; 0 for all).",
+    )
+    parser.add_argument("--out", "-o", help="Write output to a file (default: stdout).")
+    parser.add_argument(
+        "--config",
+        help="Path to a configuration file whose converter sections provide parsing defaults.",
+    )
+    parser.add_argument(
+        "--no-config",
+        action="store_true",
+        help="Disable configuration file loading for this command.",
+    )
+    add_cache_arguments(parser)
+    return parser
+
+
+def _load_report(source: str, via: str, source_format: str, converter_options: dict) -> tuple[str, RoundTripReport]:
+    """Round-trip one input, returning ``(label, report)``."""
+    from all2md import roundtrip_report
+    from all2md.cli.processors import prepare_options_for_execution
+
+    # argparse hands us plain strings; ``--via`` was validated against
+    # roundtrippable_formats() and ``--format`` is checked by the parser registry.
+    via_format = cast(DocumentFormat, via)
+    src_format = cast(DocumentFormat, source_format)
+
+    if source == "-":
+        data = sys.stdin.buffer.read()
+        if not data:
+            raise All2MdError("No data received from stdin")
+        kwargs = prepare_options_for_execution(converter_options, None, source_format)
+        return "stdin", roundtrip_report(data, via=via_format, source_format=src_format, **kwargs)
+
+    path = Path(source)
+    if not path.exists():
+        raise FileNotFoundError(f"Input file not found: {source}")
+    kwargs = prepare_options_for_execution(converter_options, path, source_format)
+    return path.as_posix(), roundtrip_report(source, via=via_format, source_format=src_format, **kwargs)
+
+
+def _render_pretty(label: str, report: RoundTripReport, max_deltas: int) -> str:
+    """Render a single report as a compact, human-readable fidelity card."""
+    lines: list[str] = [label]
+    lines.append(f"  fidelity:  {report.score}/100  ({report.band.upper()})")
+    lines.append(f"  pipeline:  parse {report.source_format} -> render {report.via} -> parse {report.via}")
+
+    if report.metrics:
+        lines.append("")
+        lines.append("  metrics")
+        width = max(len(name) for name in report.metrics)
+        for name, value in report.metrics.items():
+            gloss = _METRIC_HELP.get(name, "")
+            suffix = f"   {gloss}" if gloss else ""
+            lines.append(f"    {name.ljust(width)}  {value:>3}/100{suffix}")
+
+    if report.deltas:
+        shown = report.deltas if max_deltas <= 0 else report.deltas[:max_deltas]
+        lines.append("")
+        lines.append("  differences")
+        for delta in shown:
+            detail = f"  ({delta.detail})" if delta.detail else ""
+            times = f" x{delta.count}" if delta.count > 1 else ""
+            lines.append(f"    {delta.severity:<5} {delta.kind}{times}{detail}")
+        remaining = len(report.deltas) - len(shown)
+        if remaining > 0:
+            lines.append(f"    ... and {remaining} more (use --max-deltas 0 to show all)")
+
+    return "\n".join(lines)
+
+
+def handle_roundtrip_command(args: list[str] | None = None) -> int:
+    """Handle the ``roundtrip`` command.
+
+    Parameters
+    ----------
+    args : list[str], optional
+        Command line arguments (beyond 'roundtrip').
+
+    Returns
+    -------
+    int
+        Exit code. ``0`` on success; non-zero on load errors or when
+        ``--fail-under`` is tripped.
+
+    """
+    from all2md.cli.config import apply_config_to_parser
+
+    parser = _create_roundtrip_parser()
+    try:
+        pre_args, _ = parser.parse_known_args(args or [])
+        apply_config_to_parser(parser, "roundtrip", explicit_path=pre_args.config, no_config=pre_args.no_config)
+        parsed = parser.parse_args(args or [])
+    except SystemExit as e:
+        return e.code if isinstance(e.code, int) else 0
+
+    if parsed.fail_under is not None and not 0 <= parsed.fail_under <= 100:
+        print("Error: --fail-under must be between 0 and 100.", file=sys.stderr)
+        return EXIT_VALIDATION_ERROR
+
+    if sum(1 for src in parsed.inputs if src == "-") > 1:
+        print("Error: stdin ('-') may only be used once.", file=sys.stderr)
+        return EXIT_FILE_ERROR
+
+    from all2md import roundtrippable_formats
+
+    available = roundtrippable_formats()
+    if parsed.via not in available:
+        print(
+            f"Error: cannot round-trip through '{parsed.via}': it needs both a renderer and a parser.\n"
+            f"Available: {', '.join(available)}",
+            file=sys.stderr,
+        )
+        return EXIT_VALIDATION_ERROR
+
+    from all2md.cli.processors import load_converter_config_options
+
+    converter_options = load_converter_config_options(explicit_path=parsed.config, no_config=parsed.no_config)
+
+    results: list[tuple[str, RoundTripReport]] = []
+    try:
+        # Guard fd 1 so PyMuPDF (and friends) advisory prints during parsing
+        # cannot corrupt the report — especially the machine-readable --json stream.
+        with protect_stdout(), conversion_cache_from_args(parsed):
+            for source in parsed.inputs:
+                results.append(_load_report(source, parsed.via, parsed.format, converter_options))
+    except DependencyError as e:
+        print(f"Error: {e}", file=sys.stderr)
+        return EXIT_DEPENDENCY_ERROR
+    except FileNotFoundError as e:
+        print(f"Error: {e}", file=sys.stderr)
+        return EXIT_FILE_ERROR
+    except All2MdError as e:
+        print(f"Error during round trip: {e}", file=sys.stderr)
+        return EXIT_ERROR
+
+    if parsed.json:
+        payload: list[dict[str, Any]] = [{"input": label, **report.to_dict()} for label, report in results]
+        output = json.dumps(payload if len(payload) != 1 else payload[0], ensure_ascii=False, indent=2)
+    else:
+        output = "\n\n".join(_render_pretty(label, report, parsed.max_deltas) for label, report in results)
+
+    if parsed.out:
+        out_path = Path(parsed.out)
+        out_path.write_text(output + "\n", encoding="utf-8")
+        print(f"Wrote {len(results)} report(s) to {out_path}", file=sys.stderr)
+    elif output:
+        print(output)
+
+    if parsed.fail_under is not None:
+        worst = min((report.score for _, report in results), default=100)
+        if worst < parsed.fail_under:
+            print(f"Fidelity {worst} is below --fail-under {parsed.fail_under}.", file=sys.stderr)
+            return EXIT_ERROR
+
+    return EXIT_SUCCESS

--- a/src/all2md/cli/commands/shared.py
+++ b/src/all2md/cli/commands/shared.py
@@ -8,13 +8,15 @@ version information, system diagnostics, and batch file list parsing.
 """
 
 import argparse
+import contextlib
 import fnmatch
 import logging
+import os
 import platform
 import sys
 from importlib.metadata import version
 from pathlib import Path
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, Iterator, List, Optional
 from urllib.parse import unquote, urlparse
 
 from all2md.cli.input_items import CLIInputItem
@@ -22,6 +24,33 @@ from all2md.converter_registry import registry
 from all2md.utils.packages import check_version_requirement, get_package_version
 
 _GLOB_CHARS = "*?["
+
+
+@contextlib.contextmanager
+def protect_stdout() -> Iterator[None]:
+    """Redirect OS-level stdout (fd 1) to stderr for the duration.
+
+    Some libraries in the conversion pipeline (notably PyMuPDF) print advisories
+    straight to stdout, which would corrupt a command's own output stream --
+    especially a machine-readable ``--json`` one. We point fd 1 at stderr while
+    parsing, then restore it before emitting results. This catches both
+    Python-level ``print`` and C-level writes. Falls back to a no-op if fd
+    duplication is unavailable (e.g. a captured stdout with no real descriptor).
+    """
+    try:
+        saved_fd = os.dup(1)
+    except (OSError, ValueError):
+        yield
+        return
+    sys.stdout.flush()
+    sys.stderr.flush()
+    try:
+        os.dup2(2, 1)
+        yield
+    finally:
+        sys.stdout.flush()
+        os.dup2(saved_fd, 1)
+        os.close(saved_fd)
 
 
 def add_cache_arguments(parser: argparse.ArgumentParser) -> None:

--- a/src/all2md/cli/config.py
+++ b/src/all2md/cli/config.py
@@ -39,6 +39,7 @@ SUBCOMMAND_CONFIG_SECTIONS: tuple[str, ...] = (
     "generate-site",
     "chunk",
     "report",
+    "roundtrip",
 )
 
 

--- a/src/all2md/cli/help_formatter.py
+++ b/src/all2md/cli/help_formatter.py
@@ -167,6 +167,7 @@ _SUBCOMMAND_SUMMARIES: Sequence[tuple[str, str]] = (
     ("grep", "Search for text patterns in documents (like grep for any format)"),
     ("chunk", "Split documents into provenance-carrying chunks (JSONL) for RAG/LLM pipelines"),
     ("report", "Print a conversion confidence report ('quality card') scoring how much to trust a conversion"),
+    ("roundtrip", "Convert a document through another format and back, scoring the structure that survived"),
     ("lint", "Lint converted documents for structural, heading, link, list, table, and typography issues"),
     ("generate-site", "Generate Hugo, Jekyll, MkDocs, Zola, or Eleventy static site from documents"),
     ("arxiv", "Generate an ArXiv-ready LaTeX submission package from a document"),

--- a/src/all2md/roundtrip.py
+++ b/src/all2md/roundtrip.py
@@ -1,0 +1,732 @@
+#  Copyright (c) 2025 Tom Villani, Ph.D.
+# src/all2md/roundtrip.py
+"""Round-trip fidelity scoring — how much structure survives a conversion.
+
+Where :mod:`all2md.confidence` asks "how much should I trust this conversion?"
+*without* a reference, this module asks a question that *has* one: convert a
+document to another format, parse it straight back, and measure what changed.
+The source AST is the ground truth; the re-parsed AST is the candidate::
+
+    original --render--> via-format --parse--> round-tripped
+       |                                             |
+       +--------------- compared -------------------+
+
+That makes the score a genuine regression guard: a clean Markdown document
+round-trips through Markdown at exactly ``100``, so any drift is a real defect
+rather than measurement noise. It is also the second half of the substrate the
+``optimize`` capstone consumes -- :mod:`all2md.confidence` scores conversions
+where no reference exists (gnarly PDFs), this module scores the ones where a
+reference can be manufactured.
+
+The comparison is deliberately *structural* rather than textual. Two documents
+that serialize to different bytes may carry identical structure (Markdown is
+happy to write a bullet as ``*`` or ``-``), while two documents with identical
+text may have lost every heading. Five dimensions are scored independently and
+combined:
+
+* ``structure`` (weight 0.40) -- the block skeleton: heading levels, list
+  nesting and ordering, table placement, code blocks, quotes.
+* ``text`` (0.30) -- the document-wide word stream, in order.
+* ``inline`` (0.15) -- inline formatting: bold, italic, code, links, images.
+* ``tables`` (0.10) -- table dimensions and cell text.
+* ``references`` (0.05) -- hyperlink and image targets (URLs).
+
+Dimensions absent from the source are dropped and the remaining weights are
+renormalized, so a document with no tables is neither rewarded nor punished for
+the tables it does not have.
+
+``structure`` and ``text`` are scored against *independent* alignments, and that
+separation is load-bearing. An earlier design aligned blocks by shape and then
+compared the text of each aligned pair, which meant two paragraphs could pair up
+merely because both were paragraphs -- a demoted heading would shift every
+subsequent pairing and crater the text score for a document that had not lost a
+single word. Scoring the word stream document-wide keeps a structural change
+from being punished twice.
+
+Alongside the score, the report lists concrete :class:`StructuralDelta` incidents
+("2 headings became paragraphs", "table 1: 4x3 -> 4x2") so a low score is
+actionable rather than merely alarming.
+"""
+
+from __future__ import annotations
+
+from collections import Counter
+from dataclasses import dataclass, field
+from difflib import SequenceMatcher
+from typing import Any
+
+from all2md.ast.nodes import (
+    CodeBlock,
+    Document,
+    Heading,
+    Image,
+    Link,
+    List,
+    ListItem,
+    Node,
+    Paragraph,
+    Table,
+    Text,
+    get_node_children,
+)
+from all2md.confidence import Band, Severity, band_for_score
+
+# Pin the public surface. Without this, autodoc also documents the names this
+# module imports -- including ``difflib.SequenceMatcher``, whose docstring is not
+# valid reStructuredText and fails the ``-W`` docs build.
+__all__ = [
+    "DIMENSION_WEIGHTS",
+    "TEXT_INTACT_THRESHOLD",
+    "TEXT_MANGLED_THRESHOLD",
+    "TEXT_SIMILARITY_TOKEN_CAP",
+    "RoundTripReport",
+    "StructuralDelta",
+    "build_report",
+    "coalesce_deltas",
+    "net_block_deltas",
+    "score_roundtrip",
+]
+
+# --- Scoring model -----------------------------------------------------------
+#
+# Weights are exposed as module constants so tests (and the ``optimize`` capstone)
+# can reason about them. They are renormalized over the dimensions the source
+# document actually exercises -- see ``score_roundtrip``.
+
+#: Relative weight of each fidelity dimension in the composite score.
+DIMENSION_WEIGHTS: dict[str, float] = {
+    "structure": 0.40,
+    "text": 0.30,
+    "inline": 0.15,
+    "tables": 0.10,
+    "references": 0.05,
+}
+
+#: Text similarity at or above which the word stream is considered intact.
+#: Whitespace normalization can nudge a faithful document a hair under 1.0, so
+#: this is not exactly 1.
+TEXT_INTACT_THRESHOLD = 0.995
+
+#: Text similarity below which lost words are a ``warn`` rather than an ``info``.
+TEXT_MANGLED_THRESHOLD = 0.75
+
+#: Combined word count (original + round-tripped) above which the order-sensitive
+#: text comparison is abandoned for an order-insensitive multiset overlap.
+#:
+#: ``SequenceMatcher`` is quadratic in the worst case, and its worst case is not
+#: hypothetical: 10k+10k words drawn from a small vocabulary (an OCR-garbled
+#: page, a table of repeated cells) takes seconds, and 20k+20k takes half a
+#: minute. Word *order* is already the ``structure`` dimension's concern, so
+#: degrading to a bag-of-words overlap above the cap costs little and bounds the
+#: runtime of ``all2md roundtrip`` on a large corpus.
+TEXT_SIMILARITY_TOKEN_CAP = 20_000
+
+#: Inline node types. Everything else reachable from a Document is a block and
+#: contributes to the structural skeleton.
+_INLINE_TYPES: frozenset[str] = frozenset(
+    {
+        "Text",
+        "Emphasis",
+        "Strong",
+        "Code",
+        "Link",
+        "Image",
+        "LineBreak",
+        "Strikethrough",
+        "Mark",
+        "Underline",
+        "Superscript",
+        "Subscript",
+        "HTMLInline",
+        "FootnoteReference",
+        "MathInline",
+        "CommentInline",
+    }
+)
+
+#: Inline types whose presence is incidental to formatting fidelity. ``Text`` is
+#: scored by the ``text`` dimension; a ``LineBreak`` is a rendering artifact that
+#: most formats are free to add or drop.
+_UNSCORED_INLINE_TYPES: frozenset[str] = frozenset({"Text", "LineBreak"})
+
+
+@dataclass
+class StructuralDelta:
+    """A single concrete difference between the original and the round trip.
+
+    Parameters
+    ----------
+    kind : str
+        Machine-readable category (e.g. ``"block_lost"``, ``"block_changed"``,
+        ``"inline_lost"``, ``"table_changed"``, ``"reference_lost"``).
+    detail : str or None, default = None
+        Human-readable qualifier, e.g. ``"heading(h2) -> paragraph"``.
+    count : int, default = 1
+        How many times this delta occurred. Deltas sharing
+        ``(kind, detail, severity)`` are coalesced with their counts summed.
+    severity : {"info", "warn", "error"}, default = "warn"
+        How serious the difference is. Purely descriptive: the score comes from
+        the dimension metrics, not from summing delta penalties.
+
+    """
+
+    kind: str
+    detail: str | None = None
+    count: int = 1
+    severity: Severity = "warn"
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return a JSON-safe dict, omitting ``detail`` when unset."""
+        data: dict[str, Any] = {"kind": self.kind, "count": self.count, "severity": self.severity}
+        if self.detail is not None:
+            data["detail"] = self.detail
+        return data
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> "StructuralDelta":
+        """Reconstruct a :class:`StructuralDelta` from its :meth:`to_dict` form."""
+        return cls(
+            kind=str(data.get("kind", "")),
+            detail=data.get("detail"),
+            count=int(data.get("count", 1)),
+            severity=data.get("severity", "warn"),
+        )
+
+
+@dataclass
+class RoundTripReport:
+    """Structural fidelity of a ``parse -> render(via) -> parse`` round trip.
+
+    Parameters
+    ----------
+    score : int
+        Overall fidelity, ``0`` (nothing survived) to ``100`` (structurally identical).
+    band : {"high", "medium", "low"}
+        Coarse bucket derived from ``score``, using the same thresholds as
+        :class:`~all2md.confidence.ConfidenceReport`.
+    source_format : str
+        Format the original was parsed from (e.g. ``"docx"``).
+    via : str
+        Format the document was round-tripped through (e.g. ``"markdown"``).
+    metrics : dict
+        Per-dimension scores in ``0-100``, keyed by :data:`DIMENSION_WEIGHTS`.
+        Dimensions the source does not exercise are omitted entirely.
+    deltas : list of StructuralDelta
+        Concrete differences found, most severe and most structural first.
+
+    """
+
+    score: int
+    band: Band
+    source_format: str
+    via: str
+    metrics: dict[str, int] = field(default_factory=dict)
+    deltas: list[StructuralDelta] = field(default_factory=list)
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return a JSON-safe dict."""
+        return {
+            "score": self.score,
+            "band": self.band,
+            "source_format": self.source_format,
+            "via": self.via,
+            "metrics": dict(self.metrics),
+            "deltas": [delta.to_dict() for delta in self.deltas],
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> "RoundTripReport":
+        """Reconstruct a :class:`RoundTripReport` from its :meth:`to_dict` form."""
+        return cls(
+            score=int(data.get("score", 0)),
+            band=data.get("band", "low"),
+            source_format=str(data.get("source_format", "")),
+            via=str(data.get("via", "")),
+            metrics={str(key): int(value) for key, value in (data.get("metrics") or {}).items()},
+            deltas=[StructuralDelta.from_dict(delta) for delta in data.get("deltas", []) or []],
+        )
+
+
+def net_block_deltas(deltas: list[StructuralDelta]) -> list[StructuralDelta]:
+    """Cancel ``block_lost`` against ``block_added`` for the same block description.
+
+    Sequence alignment reports a moved block as one deleted and one inserted, so a
+    document that merely *gained* a paragraph can be described as having lost one
+    too. Netting the pair leaves the honest multiset statement -- "one heading
+    became a paragraph" -- and lets block *ordering* be judged by the ``structure``
+    score, which is what actually measures it.
+
+    Expects already-coalesced deltas, and drops any whose count nets to zero.
+    """
+    lost = {delta.detail: delta for delta in deltas if delta.kind == "block_lost"}
+    added = {delta.detail: delta for delta in deltas if delta.kind == "block_added"}
+    for detail in set(lost) & set(added):
+        overlap = min(lost[detail].count, added[detail].count)
+        lost[detail].count -= overlap
+        added[detail].count -= overlap
+    return [delta for delta in deltas if delta.count > 0]
+
+
+def coalesce_deltas(deltas: list[StructuralDelta]) -> list[StructuralDelta]:
+    """Merge deltas sharing ``(kind, detail, severity)``, summing counts.
+
+    Keeps first-seen order, which puts document-order structural findings first.
+    """
+    merged: dict[tuple[str, str | None, str], StructuralDelta] = {}
+    for delta in deltas:
+        key = (delta.kind, delta.detail, delta.severity)
+        existing = merged.get(key)
+        if existing is None:
+            merged[key] = StructuralDelta(
+                kind=delta.kind, detail=delta.detail, count=delta.count, severity=delta.severity
+            )
+        else:
+            existing.count += delta.count
+    return list(merged.values())
+
+
+# --- Feature extraction ------------------------------------------------------
+
+#: A block's structural signature: its kind plus whatever distinguishes it
+#: (heading level, list ordering, table dimensions, code language) and its
+#: nesting depth.
+Shape = tuple[Any, ...]
+
+
+def _is_inline(node: Node) -> bool:
+    return type(node).__name__ in _INLINE_TYPES
+
+
+def _own_words(node: Node) -> list[str]:
+    """Words from this node's inline content, ignoring nested blocks.
+
+    Descends through inline wrappers (``Strong``, ``Link``, ...) to reach ``Text``
+    but stops at any block child, whose words belong to that block instead.
+    """
+    if isinstance(node, Text):
+        return node.content.split()
+
+    words: list[str] = []
+
+    def walk(current: Node) -> None:
+        for child in get_node_children(current):
+            if isinstance(child, Text):
+                words.extend(child.content.split())
+            elif _is_inline(child):
+                walk(child)
+
+    walk(node)
+    return words
+
+
+def _all_words(node: Node) -> list[str]:
+    """Words from every ``Text`` descendant, crossing block boundaries.
+
+    Unlike :func:`_own_words` this does not stop at nested blocks, because a
+    table cell is free to wrap its content in a paragraph in one format and not
+    in another -- and a cell whose text vanished must not read as an empty cell
+    faithfully preserved.
+    """
+    words: list[str] = []
+
+    def walk(current: Node) -> None:
+        for child in get_node_children(current):
+            if isinstance(child, Text):
+                words.extend(child.content.split())
+            else:
+                walk(child)
+
+    if isinstance(node, Text):
+        return node.content.split()
+    walk(node)
+    return words
+
+
+def _unwrap(node: Node) -> Node:
+    """Collapse a ``Paragraph`` whose sole child is another ``Paragraph``.
+
+    Nested paragraphs are meaningless -- no format represents a paragraph inside
+    a paragraph -- so they are always a parser or renderer artifact rather than
+    content. Treating the chain as one paragraph keeps the artifact from reading
+    as an added block.
+    """
+    while isinstance(node, Paragraph):
+        blocks = [child for child in get_node_children(node) if not _is_inline(child)]
+        if len(blocks) == 1 and isinstance(blocks[0], Paragraph) and not _own_words(node):
+            node = blocks[0]
+        else:
+            break
+    return node
+
+
+def _table_dimensions(table: Table) -> tuple[int, int]:
+    """Return ``(rows, cols)``, counting the header as a row."""
+    rows = ([table.header] if table.header is not None else []) + list(table.rows)
+    cols = max((len(row.cells) for row in rows), default=0)
+    return len(rows), cols
+
+
+def _block_shape(node: Node, depth: int) -> Shape:
+    """Return the hashable structural signature of a block.
+
+    Depth is included so that a flattened nested list registers as a structural
+    change rather than passing as an equivalent flat one.
+    """
+    if isinstance(node, Heading):
+        return ("heading", node.level, depth)
+    if isinstance(node, List):
+        return ("list", node.ordered, depth)
+    if isinstance(node, ListItem):
+        return ("listitem", depth)
+    if isinstance(node, Table):
+        rows, cols = _table_dimensions(node)
+        return ("table", rows, cols)
+    if isinstance(node, CodeBlock):
+        return ("code", node.language or "")
+    if isinstance(node, Paragraph):
+        return ("paragraph", depth)
+    # Remaining blocks (BlockQuote, ThematicBreak, MathBlock, HTMLBlock,
+    # DefinitionList, FootnoteDefinition, Comment, ...) are identified by type
+    # and nesting alone.
+    return (type(node).__name__.lower(), depth)
+
+
+def _skeleton(doc: Document) -> list[Shape]:
+    """Flatten a document into a depth-annotated sequence of block shapes.
+
+    Two normalizations keep format-legal spelling differences from reading as
+    structural loss:
+
+    * A ``ListItem`` holding a single ``Paragraph`` is emitted as one block --
+      Markdown writes tight lists without the wrapping paragraph and HTML writes
+      loose ones with it, and neither has lost anything. A chain of singly-nested
+      paragraphs collapses the same way (see :func:`_unwrap`).
+    * ``TableRow`` / ``TableCell`` are not emitted; the ``Table`` shape already
+      carries its dimensions and the ``tables`` dimension scores cell text.
+    """
+    shapes: list[Shape] = []
+
+    def walk(node: Node, depth: int) -> None:
+        for raw_child in get_node_children(node):
+            if _is_inline(raw_child):
+                continue
+            child = _unwrap(raw_child)
+            if isinstance(child, Table):
+                shapes.append(_block_shape(child, depth))
+                continue  # do not descend: rows and cells are folded into the shape
+            if isinstance(child, ListItem):
+                shapes.append(("listitem", depth))
+                inner = [_unwrap(c) for c in get_node_children(child) if not _is_inline(c)]
+                if len(inner) == 1 and isinstance(inner[0], Paragraph):
+                    continue  # tight/loose equivalence: the lone paragraph is the item
+                walk(child, depth + 1)
+                continue
+            shapes.append(_block_shape(child, depth))
+            walk(child, depth + 1)
+
+    walk(doc, 0)
+    return shapes
+
+
+def _tables(doc: Document) -> list[tuple[int, int, list[str]]]:
+    """Every table as ``(rows, cols, cell_words)`` in document order."""
+    found: list[tuple[int, int, list[str]]] = []
+
+    def walk(node: Node) -> None:
+        for child in get_node_children(node):
+            if isinstance(child, Table):
+                rows, cols = _table_dimensions(child)
+                found.append((rows, cols, _all_words(child)))
+                continue
+            walk(child)
+
+    walk(doc)
+    return found
+
+
+def _inline_counts(doc: Document) -> Counter[str]:
+    """Multiset of scored inline node types across the whole document."""
+    counts: Counter[str] = Counter()
+
+    def walk(node: Node) -> None:
+        for child in get_node_children(node):
+            name = type(child).__name__
+            if name in _INLINE_TYPES and name not in _UNSCORED_INLINE_TYPES:
+                counts[name] += 1
+            walk(child)
+
+    walk(doc)
+    return counts
+
+
+def _references(doc: Document) -> Counter[str]:
+    """Multiset of hyperlink and image targets."""
+    refs: Counter[str] = Counter()
+
+    def walk(node: Node) -> None:
+        for child in get_node_children(node):
+            if isinstance(child, (Link, Image)):
+                url = (getattr(child, "url", "") or "").strip()
+                if url:
+                    refs[url] += 1
+            walk(child)
+
+    walk(doc)
+    return refs
+
+
+# --- Similarity primitives ---------------------------------------------------
+
+
+def _bag_similarity(left: Counter[str], right: Counter[str]) -> float:
+    """Multiset overlap in ``[0, 1]`` (Bray-Curtis), ``1.0`` when both are empty."""
+    total = sum(left.values()) + sum(right.values())
+    if total == 0:
+        return 1.0
+    overlap = sum((left & right).values())
+    return 2.0 * overlap / total
+
+
+def _sequence_similarity(left: list[Any], right: list[Any]) -> float:
+    """Order-sensitive similarity in ``[0, 1]``, ``1.0`` when both are empty.
+
+    ``autojunk`` is disabled: its heuristic treats any element appearing in more
+    than 1% of a 200+ element sequence as noise, which would silently discard the
+    most common block shape (``paragraph``) in exactly the long documents whose
+    structure we most want to check.
+    """
+    if not left and not right:
+        return 1.0
+    if not left or not right:
+        return 0.0
+    return SequenceMatcher(None, left, right, autojunk=False).ratio()
+
+
+def _word_similarity(left: list[str], right: list[str]) -> float:
+    """Similarity of two word streams, order-sensitive below the token cap.
+
+    Above :data:`TEXT_SIMILARITY_TOKEN_CAP` combined words this degrades to an
+    order-insensitive multiset overlap to bound the quadratic worst case.
+    """
+    if len(left) + len(right) > TEXT_SIMILARITY_TOKEN_CAP:
+        return _bag_similarity(Counter(left), Counter(right))
+    return _sequence_similarity(left, right)
+
+
+def _table_similarity(left: tuple[int, int, list[str]], right: tuple[int, int, list[str]]) -> float:
+    """Similarity of two tables: half their dimensions, half their cell text."""
+    rows_sim = min(left[0], right[0]) / max(left[0], right[0]) if max(left[0], right[0]) else 1.0
+    cols_sim = min(left[1], right[1]) / max(left[1], right[1]) if max(left[1], right[1]) else 1.0
+    return 0.5 * (rows_sim * cols_sim) + 0.5 * _word_similarity(left[2], right[2])
+
+
+def _describe(shape: Shape) -> str:
+    """Render a block shape as a compact human-readable label."""
+    kind = str(shape[0])
+    if kind == "heading":
+        return f"heading(h{shape[1]})"
+    if kind == "list":
+        return "ordered list" if shape[1] else "bullet list"
+    if kind == "table":
+        return f"table({shape[1]}x{shape[2]})"
+    if kind == "code":
+        return f"code({shape[1]})" if shape[1] else "code"
+    return kind
+
+
+# --- Dimension scoring -------------------------------------------------------
+
+
+def _score_structure(original: list[Shape], roundtripped: list[Shape], deltas: list[StructuralDelta]) -> float:
+    """Score the block skeleton and record which blocks were lost or reshaped."""
+    matcher = SequenceMatcher(None, original, roundtripped, autojunk=False)
+    for tag, i1, i2, j1, j2 in matcher.get_opcodes():
+        if tag == "equal":
+            continue
+        if tag == "replace":
+            # Pair positionally as far as both runs go: the shapes differ, but it
+            # is almost certainly the same content, reshaped.
+            paired = min(i2 - i1, j2 - j1)
+            for offset in range(paired):
+                deltas.append(
+                    StructuralDelta(
+                        "block_changed",
+                        f"{_describe(original[i1 + offset])} -> {_describe(roundtripped[j1 + offset])}",
+                        severity="warn",
+                    )
+                )
+            for offset in range(paired, i2 - i1):
+                deltas.append(StructuralDelta("block_lost", _describe(original[i1 + offset]), severity="warn"))
+            for offset in range(paired, j2 - j1):
+                deltas.append(StructuralDelta("block_added", _describe(roundtripped[j1 + offset]), severity="info"))
+        elif tag == "delete":
+            for offset in range(i2 - i1):
+                deltas.append(StructuralDelta("block_lost", _describe(original[i1 + offset]), severity="warn"))
+        elif tag == "insert":
+            for offset in range(j2 - j1):
+                deltas.append(StructuralDelta("block_added", _describe(roundtripped[j1 + offset]), severity="info"))
+
+    return _sequence_similarity(original, roundtripped)
+
+
+def _score_text(original: list[str], roundtripped: list[str], deltas: list[StructuralDelta]) -> float:
+    """Score the document-wide word stream and report how many words went missing."""
+    similarity = _word_similarity(original, roundtripped)
+    missing = sum((Counter(original) - Counter(roundtripped)).values())
+    if missing:
+        deltas.append(
+            StructuralDelta(
+                "text_lost",
+                f"{missing:,} of {len(original):,} words",
+                severity="warn" if similarity < TEXT_MANGLED_THRESHOLD else "info",
+            )
+        )
+    elif similarity < TEXT_INTACT_THRESHOLD:
+        # Every original word survived, so the shortfall is words the round trip
+        # invented (a rendered caption, a footnote marker) or words it moved.
+        added = sum((Counter(roundtripped) - Counter(original)).values())
+        if added:
+            deltas.append(StructuralDelta("text_added", f"{added:,} words", severity="info"))
+        else:
+            deltas.append(StructuralDelta("text_reordered", severity="info"))
+    return similarity
+
+
+def _score_inline(original: Counter[str], roundtripped: Counter[str], deltas: list[StructuralDelta]) -> float:
+    """Score inline-formatting preservation and record what went missing."""
+    for name, count in original.items():
+        lost = count - roundtripped.get(name, 0)
+        if lost > 0:
+            deltas.append(StructuralDelta("inline_lost", name.lower(), count=lost, severity="warn"))
+    return _bag_similarity(original, roundtripped)
+
+
+def _score_tables(
+    original: list[tuple[int, int, list[str]]],
+    roundtripped: list[tuple[int, int, list[str]]],
+    deltas: list[StructuralDelta],
+) -> float:
+    """Score table preservation pairwise in document order."""
+    if not original:
+        return 1.0
+    total = 0.0
+    for index, table_a in enumerate(original):
+        if index >= len(roundtripped):
+            deltas.append(
+                StructuralDelta("table_lost", f"table {index + 1} ({table_a[0]}x{table_a[1]})", severity="error")
+            )
+            continue
+        table_b = roundtripped[index]
+        if (table_a[0], table_a[1]) != (table_b[0], table_b[1]):
+            deltas.append(
+                StructuralDelta(
+                    "table_changed",
+                    f"table {index + 1}: {table_a[0]}x{table_a[1]} -> {table_b[0]}x{table_b[1]}",
+                    severity="warn",
+                )
+            )
+        total += _table_similarity(table_a, table_b)
+    return total / len(original)
+
+
+def _score_references(original: Counter[str], roundtripped: Counter[str], deltas: list[StructuralDelta]) -> float:
+    """Score hyperlink/image target preservation."""
+    for url, count in original.items():
+        lost = count - roundtripped.get(url, 0)
+        if lost > 0:
+            deltas.append(StructuralDelta("reference_lost", url, count=lost, severity="warn"))
+    return _bag_similarity(original, roundtripped)
+
+
+# --- Public entry point ------------------------------------------------------
+
+_KIND_RANK: dict[str, int] = {
+    "table_lost": 0,
+    "block_lost": 1,
+    "block_changed": 2,
+    "table_changed": 3,
+    "text_lost": 4,
+    "inline_lost": 5,
+    "reference_lost": 6,
+    "text_reordered": 7,
+    "text_added": 8,
+    "block_added": 9,
+}
+_SEVERITY_RANK: dict[str, int] = {"error": 0, "warn": 1, "info": 2}
+
+
+def _rank(delta: StructuralDelta) -> tuple[int, int]:
+    """Sort key putting the most severe, most structural findings first."""
+    return (_SEVERITY_RANK.get(delta.severity, 1), _KIND_RANK.get(delta.kind, 9))
+
+
+def score_roundtrip(original: Document, roundtripped: Document) -> tuple[int, dict[str, int], list[StructuralDelta]]:
+    """Compare two ASTs and return ``(score, per-dimension metrics, deltas)``.
+
+    Only the dimensions the *original* actually exercises are scored; their
+    weights are renormalized to sum to 1. A document with no tables therefore
+    neither gains nor loses points for its (absent) tables, and an empty document
+    scores a vacuous ``100``.
+
+    Parameters
+    ----------
+    original : Document
+        The ground-truth AST, parsed from the source document.
+    roundtripped : Document
+        The AST re-parsed after rendering ``original`` to the intermediate format.
+
+    Returns
+    -------
+    tuple of (int, dict, list)
+        The ``0-100`` score, the per-dimension ``0-100`` metrics, and the
+        coalesced, severity-ranked structural deltas.
+
+    """
+    deltas: list[StructuralDelta] = []
+
+    shapes_a, shapes_b = _skeleton(original), _skeleton(roundtripped)
+    words_a, words_b = _all_words(original), _all_words(roundtripped)
+    inline_a, inline_b = _inline_counts(original), _inline_counts(roundtripped)
+    tables_a, tables_b = _tables(original), _tables(roundtripped)
+    refs_a, refs_b = _references(original), _references(roundtripped)
+
+    raw = {
+        "structure": _score_structure(shapes_a, shapes_b, deltas),
+        "text": _score_text(words_a, words_b, deltas),
+        "inline": _score_inline(inline_a, inline_b, deltas),
+        "tables": _score_tables(tables_a, tables_b, deltas),
+        "references": _score_references(refs_a, refs_b, deltas),
+    }
+    # A dimension is "exercised" only if the source has something to lose there.
+    present = {
+        "structure": bool(shapes_a),
+        "text": bool(words_a),
+        "inline": bool(inline_a),
+        "tables": bool(tables_a),
+        "references": bool(refs_a),
+    }
+
+    active = {name: value for name, value in raw.items() if present[name]}
+    if not active:
+        return 100, {}, []
+
+    total_weight = sum(DIMENSION_WEIGHTS[name] for name in active)
+    composite = sum(DIMENSION_WEIGHTS[name] * value for name, value in active.items()) / total_weight
+    score = int(round(max(0.0, min(1.0, composite)) * 100))
+
+    metrics = {name: int(round(value * 100)) for name, value in active.items()}
+    ranked = sorted(net_block_deltas(coalesce_deltas(deltas)), key=_rank)
+    return score, metrics, ranked
+
+
+def build_report(original: Document, roundtripped: Document, *, source_format: str, via: str) -> RoundTripReport:
+    """Assemble a scored :class:`RoundTripReport` from two ASTs."""
+    score, metrics, deltas = score_roundtrip(original, roundtripped)
+    return RoundTripReport(
+        score=score,
+        band=band_for_score(score),
+        source_format=source_format,
+        via=via,
+        metrics=metrics,
+        deltas=deltas,
+    )

--- a/tests/integration/test_roundtrip.py
+++ b/tests/integration/test_roundtrip.py
@@ -1,0 +1,220 @@
+#  Copyright (c) 2025 Tom Villani, Ph.D.
+"""Integration tests for round-trip fidelity scoring (D2).
+
+Covers the ``roundtrip_report`` API against real converters and the
+``all2md roundtrip`` CLI.
+"""
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from all2md import roundtrip_report, roundtrippable_formats, to_ast
+from all2md.exceptions import FormatError
+from all2md.roundtrip import RoundTripReport
+
+FIXTURES = Path(__file__).resolve().parent.parent / "fixtures" / "documents"
+BASIC_MD = FIXTURES / "basic.md"
+
+#: A document exercising every scored dimension: headings, nested lists, a table,
+#: a code block, a blockquote, inline formatting, a link and an image.
+RICH_MARKDOWN = """# Title
+
+Intro with **bold**, *italic*, `code`, and a [link](https://example.com).
+
+## Section
+
+- bullet one
+- bullet two
+  - nested
+
+1. first
+2. second
+
+| a | b |
+|---|---|
+| 1 | 2 |
+
+> quote
+
+```python
+print("hi")
+```
+
+![img](pic.png)
+"""
+
+
+@pytest.fixture
+def rich_md(tmp_path) -> Path:
+    path = tmp_path / "rich.md"
+    path.write_text(RICH_MARKDOWN, encoding="utf-8")
+    return path
+
+
+def _run_cli(*args: str, stdin: bytes | None = None) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        [sys.executable, "-m", "all2md", "roundtrip", *args],
+        capture_output=True,
+        text=stdin is None,
+        input=stdin,
+    )
+
+
+@pytest.mark.integration
+class TestRoundTripApi:
+    def test_markdown_through_markdown_is_lossless(self, rich_md):
+        """The anchor of the whole metric: a clean document must score exactly 100.
+
+        If this drifts, the score is measuring noise rather than fidelity.
+        """
+        report = roundtrip_report(rich_md)
+        assert report.score == 100
+        assert report.band == "high"
+        assert report.deltas == []
+        assert set(report.metrics) == {"structure", "text", "inline", "tables", "references"}
+
+    @pytest.mark.html
+    def test_markdown_through_html_is_lossless(self, rich_md):
+        assert roundtrip_report(rich_md, via="html").score == 100
+
+    def test_report_labels_the_pipeline(self, rich_md):
+        report = roundtrip_report(rich_md, via="rst")
+        assert report.source_format == "markdown"
+        assert report.via == "rst"
+
+    def test_accepts_a_prebuilt_document(self):
+        source = to_ast(RICH_MARKDOWN.encode(), source_format="markdown")
+        assert roundtrip_report(source).score == 100
+
+    def test_accepts_raw_bytes_with_explicit_format(self):
+        report = roundtrip_report(RICH_MARKDOWN.encode(), source_format="markdown")
+        assert report.score == 100
+
+    def test_escaped_inline_html_is_priced_as_a_real_loss(self):
+        """Escaped raw HTML costs fidelity, and the score says so.
+
+        ``basic.md`` contains ``<u>...</u>``, and the Markdown renderer escapes raw
+        HTML by default (``html_passthrough_mode="escape"``, a security posture).
+        The round trip therefore cannot be perfect, and the score reports that
+        rather than quietly forgiving it.
+        """
+        report = roundtrip_report(BASIC_MD)
+        assert report.score < 100
+        assert {delta.kind for delta in report.deltas} == {"inline_lost", "text_lost"}
+        assert any(delta.detail == "htmlinline" for delta in report.deltas)
+
+    def test_score_responds_to_converter_options(self):
+        """The score must move when converter options move.
+
+        This is what makes it usable as the ``optimize`` capstone's fitness
+        function: flipping one renderer option recovers the lost points.
+        """
+        escaped = roundtrip_report(BASIC_MD)
+        passed_through = roundtrip_report(BASIC_MD, html_passthrough_mode="pass-through")
+
+        assert passed_through.score == 100
+        assert passed_through.deltas == []
+        assert passed_through.score > escaped.score
+
+    def test_unknown_via_format_is_rejected(self, rich_md):
+        with pytest.raises(FormatError, match="needs both a renderer and a parser"):
+            roundtrip_report(rich_md, via="not-a-format")
+
+    def test_render_only_via_format_is_rejected(self, rich_md):
+        """``via`` needs a parser to come back through, not just a renderer."""
+        assert "xlsx" not in roundtrippable_formats()
+        with pytest.raises(FormatError):
+            roundtrip_report(rich_md, via="xlsx")
+
+    def test_roundtrippable_formats_are_sorted_and_bidirectional(self):
+        formats = roundtrippable_formats()
+        assert formats == sorted(formats)
+        assert {"markdown", "html", "docx", "rst"} <= set(formats)
+
+    @pytest.mark.docx
+    def test_docx_round_trip_reports_the_title_demotion(self, rich_md):
+        """A DOCX round trip loses structure, and the score surfaces it.
+
+        Rendering to DOCX promotes a leading H1 to Word's Title style, and the DOCX
+        parser has no inverse for it, so the heading comes back as a paragraph.
+        This asymmetry is the kind of thing the score exists to find; the assertion
+        pins the *detection*, not the (currently lossy) behaviour.
+        """
+        report = roundtrip_report(rich_md, via="docx")
+        assert report.score < 100
+        assert report.metrics["structure"] < report.metrics["text"]
+        assert any(delta.kind in {"block_lost", "block_changed"} for delta in report.deltas)
+
+    def test_json_round_trip_of_the_report(self, rich_md):
+        report = roundtrip_report(rich_md, via="rst")
+        assert RoundTripReport.from_dict(json.loads(json.dumps(report.to_dict()))) == report
+
+
+@pytest.mark.integration
+@pytest.mark.cli
+class TestRoundTripCli:
+    def test_pretty_card_reports_perfect_fidelity(self, rich_md):
+        result = _run_cli(str(rich_md))
+        assert result.returncode == 0
+        assert "fidelity:  100/100  (HIGH)" in result.stdout
+        assert "parse markdown -> render markdown -> parse markdown" in result.stdout
+
+    def test_json_output_is_machine_readable(self, rich_md):
+        result = _run_cli(str(rich_md), "--via", "rst", "--json")
+        assert result.returncode == 0
+        payload = json.loads(result.stdout)
+        assert payload["via"] == "rst"
+        assert 0 <= payload["score"] <= 100
+        assert "structure" in payload["metrics"]
+
+    def test_multiple_inputs_emit_a_json_array(self, rich_md):
+        result = _run_cli(str(rich_md), str(BASIC_MD), "--json")
+        assert result.returncode == 0
+        payload = json.loads(result.stdout)
+        assert isinstance(payload, list) and len(payload) == 2
+
+    def test_fail_under_gates_on_the_worst_score(self, rich_md):
+        clean = _run_cli(str(rich_md), "--fail-under", "100")
+        assert clean.returncode == 0
+
+        strict = _run_cli(str(rich_md), "--via", "latex", "--fail-under", "100")
+        assert strict.returncode == 1
+        assert "below --fail-under" in strict.stderr
+
+    def test_out_of_range_fail_under_is_a_validation_error(self, rich_md):
+        result = _run_cli(str(rich_md), "--fail-under", "150")
+        assert result.returncode == 3
+
+    def test_unknown_via_names_the_available_formats(self, rich_md):
+        result = _run_cli(str(rich_md), "--via", "nope")
+        assert result.returncode == 3
+        assert "markdown" in result.stderr
+
+    def test_missing_file_is_a_file_error(self, tmp_path):
+        result = _run_cli(str(tmp_path / "absent.md"))
+        assert result.returncode == 4
+
+    def test_stdin_needs_an_explicit_format_to_be_markdown(self):
+        """Piped Markdown sniffs as plaintext; --format is how a caller says otherwise."""
+        sniffed = _run_cli("-", stdin=RICH_MARKDOWN.encode())
+        assert sniffed.returncode == 0
+        assert b"parse plaintext" in sniffed.stdout
+
+        told = _run_cli("-", "--format", "markdown", stdin=RICH_MARKDOWN.encode())
+        assert told.returncode == 0
+        assert b"fidelity:  100/100" in told.stdout
+
+    def test_max_deltas_truncates_and_says_so(self, rich_md):
+        result = _run_cli(str(rich_md), "--via", "latex", "--max-deltas", "2")
+        assert result.returncode == 0
+        assert "... and" in result.stdout and "more" in result.stdout
+
+    def test_out_writes_to_a_file(self, rich_md, tmp_path):
+        target = tmp_path / "card.txt"
+        result = _run_cli(str(rich_md), "--out", str(target))
+        assert result.returncode == 0
+        assert "fidelity:" in target.read_text(encoding="utf-8")

--- a/tests/unit/test_roundtrip.py
+++ b/tests/unit/test_roundtrip.py
@@ -1,0 +1,383 @@
+#  Copyright (c) 2025 Tom Villani, Ph.D.
+"""Unit tests for the round-trip fidelity scoring model (``all2md.roundtrip``)."""
+
+import pytest
+
+from all2md.ast.nodes import (
+    CodeBlock,
+    Document,
+    Emphasis,
+    Heading,
+    Image,
+    Link,
+    List,
+    ListItem,
+    Paragraph,
+    Strong,
+    Table,
+    TableCell,
+    TableRow,
+    Text,
+)
+from all2md.roundtrip import (
+    DIMENSION_WEIGHTS,
+    TEXT_SIMILARITY_TOKEN_CAP,
+    RoundTripReport,
+    StructuralDelta,
+    build_report,
+    coalesce_deltas,
+    net_block_deltas,
+    score_roundtrip,
+)
+
+pytestmark = pytest.mark.unit
+
+
+# --- Builders ----------------------------------------------------------------
+
+
+def para(text):
+    return Paragraph(content=[Text(content=text)])
+
+
+def heading(level, text):
+    return Heading(level=level, content=[Text(content=text)])
+
+
+def tight_item(text):
+    """A list item holding inline content directly, as tight Markdown lists do."""
+    return ListItem(children=[para(text)])
+
+
+def bullet_list(*texts):
+    return List(ordered=False, items=[tight_item(t) for t in texts])
+
+
+def table(rows):
+    """Build a Table whose first row is the header."""
+    header = TableRow(cells=[TableCell(content=[Text(content=c)]) for c in rows[0]], is_header=True)
+    body = [TableRow(cells=[TableCell(content=[Text(content=c)]) for c in row]) for row in rows[1:]]
+    return Table(rows=body, header=header)
+
+
+def doc(*children):
+    return Document(children=list(children))
+
+
+def kinds(deltas):
+    return {d.kind for d in deltas}
+
+
+def by_kind(deltas, kind):
+    return [d for d in deltas if d.kind == kind]
+
+
+# --- Endpoints ---------------------------------------------------------------
+
+
+class TestEndpoints:
+    def test_identity_scores_perfect_with_no_deltas(self):
+        source = doc(heading(1, "Title"), para("Hello world"), bullet_list("a", "b"))
+        score, metrics, deltas = score_roundtrip(source, source)
+        assert score == 100
+        assert deltas == []
+        assert metrics["structure"] == 100
+        assert metrics["text"] == 100
+
+    def test_empty_document_scores_vacuous_perfect(self):
+        score, metrics, deltas = score_roundtrip(doc(), doc())
+        assert (score, metrics, deltas) == (100, {}, [])
+
+    def test_everything_lost_scores_zero(self):
+        source = doc(heading(1, "Title"), para("Hello world"), table([["a", "b"], ["1", "2"]]))
+        score, metrics, _ = score_roundtrip(source, doc())
+        assert score == 0
+        assert set(metrics.values()) == {0}
+
+    def test_score_is_clamped_to_0_100(self):
+        source = doc(para("one two three"))
+        for candidate in (doc(), source, doc(para("one two three four five"))):
+            score, _, _ = score_roundtrip(source, candidate)
+            assert 0 <= score <= 100
+
+
+# --- Normalization -----------------------------------------------------------
+
+
+class TestNormalization:
+    def test_loose_list_item_matches_tight_list_item(self):
+        """A ListItem wrapping its text in a Paragraph is the same item.
+
+        Markdown writes tight lists without the wrapping paragraph, HTML writes
+        loose ones with it, and neither has lost anything.
+        """
+        tight = doc(List(ordered=False, items=[ListItem(children=[para("x")])]))
+        loose = doc(List(ordered=False, items=[ListItem(children=[Paragraph(content=[para("x")])])]))
+        score, _, deltas = score_roundtrip(tight, loose)
+        assert score == 100
+        assert deltas == []
+
+    def test_nested_paragraph_chain_collapses(self):
+        """Paragraph-inside-paragraph is always an artifact, never content."""
+        flat = doc(para("hello world"))
+        nested = doc(Paragraph(content=[Paragraph(content=[para("hello world")])]))
+        score, _, deltas = score_roundtrip(flat, nested)
+        assert score == 100
+        assert deltas == []
+
+    def test_table_rows_are_not_counted_as_blocks(self):
+        """Table dimensions ride on the Table shape; rows/cells are not blocks."""
+        source = doc(table([["a", "b"], ["1", "2"]]))
+        score, metrics, _ = score_roundtrip(source, source)
+        assert score == 100
+        assert metrics["tables"] == 100
+
+    def test_table_cell_text_survives_paragraph_wrapping(self):
+        """A cell that wraps content in a paragraph has not lost its text."""
+        plain = doc(table([["a"], ["1"]]))
+        wrapped = Table(
+            rows=[TableRow(cells=[TableCell(content=[para("1")])])],
+            header=TableRow(cells=[TableCell(content=[para("a")])], is_header=True),
+        )
+        score, _, _ = score_roundtrip(plain, doc(wrapped))
+        assert score == 100
+
+
+# --- Structure / text independence -------------------------------------------
+
+
+class TestStructureTextIndependence:
+    def test_demoted_heading_costs_structure_but_not_text(self):
+        """The regression this design exists to prevent.
+
+        Aligning text through the structural match let one demoted heading shift
+        every later pairing, so a document that lost no words scored near zero on
+        text. Structure and text are now scored against independent alignments.
+        """
+        source = doc(heading(1, "Title"), para("alpha beta gamma"), heading(2, "Section"))
+        demoted = doc(para("Title"), para("alpha beta gamma"), heading(1, "Section"))
+
+        _, metrics, deltas = score_roundtrip(source, demoted)
+
+        assert metrics["text"] == 100, "no word was lost, so text must be perfect"
+        assert metrics["structure"] < 100
+        assert deltas, "the demotion must still be reported"
+
+    def test_single_block_reshape_reports_block_changed(self):
+        source = doc(heading(1, "Title"))
+        _, _, deltas = score_roundtrip(source, doc(para("Title")))
+        changed = by_kind(deltas, "block_changed")
+        assert changed and changed[0].detail == "heading(h1) -> paragraph"
+
+    def test_reordered_text_is_reported_but_loses_no_words(self):
+        source = doc(para("alpha beta"), para("gamma delta"))
+        swapped = doc(para("gamma delta"), para("alpha beta"))
+        _, metrics, deltas = score_roundtrip(source, swapped)
+        assert metrics["structure"] == 100
+        assert metrics["text"] < 100
+        assert "text_reordered" in kinds(deltas)
+
+    def test_added_text_is_reported_as_info(self):
+        source = doc(para("alpha beta"))
+        padded = doc(para("alpha beta gamma"))
+        _, _, deltas = score_roundtrip(source, padded)
+        added = by_kind(deltas, "text_added")
+        assert added and added[0].severity == "info"
+
+    def test_lost_words_are_counted(self):
+        source = doc(para("alpha beta gamma delta"))
+        trimmed = doc(para("alpha beta"))
+        _, metrics, deltas = score_roundtrip(source, trimmed)
+        assert metrics["text"] < 100
+        lost = by_kind(deltas, "text_lost")
+        assert lost and "2 of 4 words" in (lost[0].detail or "")
+
+    def test_large_documents_fall_back_to_bag_similarity(self):
+        """Above the token cap, order-sensitivity is traded for bounded runtime."""
+        words = " ".join(f"w{i % 50}" for i in range(TEXT_SIMILARITY_TOKEN_CAP))
+        source = doc(para(words))
+        reversed_words = doc(para(" ".join(reversed(words.split()))))
+        _, metrics, _ = score_roundtrip(source, reversed_words)
+        # A bag comparison cannot see the reordering, so text reads as intact.
+        assert metrics["text"] == 100
+
+
+# --- Per-dimension deltas ----------------------------------------------------
+
+
+class TestDeltas:
+    def test_lost_block_is_reported(self):
+        source = doc(para("a"), CodeBlock(content="x = 1", language="python"))
+        _, _, deltas = score_roundtrip(source, doc(para("a")))
+        lost = by_kind(deltas, "block_lost")
+        assert lost and lost[0].detail == "code(python)"
+
+    def test_added_block_is_info_not_warn(self):
+        source = doc(para("a"))
+        _, _, deltas = score_roundtrip(source, doc(para("a"), para("b")))
+        added = by_kind(deltas, "block_added")
+        assert added and added[0].severity == "info"
+
+    def test_gaining_a_block_never_reports_losing_one(self):
+        """Alignment reports a moved block as delete+insert; netting cancels them.
+
+        Without netting, demoting a heading makes the paragraph count go *up* while
+        the deltas claim a paragraph was lost.
+        """
+        source = doc(heading(1, "T"), para("body text"), heading(2, "S"))
+        demoted = doc(para("T"), para("body text"), heading(1, "S"))
+        _, _, deltas = score_roundtrip(source, demoted)
+
+        assert "paragraph" not in {d.detail for d in by_kind(deltas, "block_lost")}
+        assert by_kind(deltas, "block_lost"), "the lost h2 must still be reported"
+
+    def test_netting_leaves_unmatched_losses_intact(self):
+        merged = net_block_deltas(
+            coalesce_deltas(
+                [
+                    StructuralDelta("block_lost", "paragraph", count=3),
+                    StructuralDelta("block_added", "paragraph", count=1),
+                    StructuralDelta("block_lost", "table(2x2)", count=1),
+                ]
+            )
+        )
+        assert {(d.kind, d.detail, d.count) for d in merged} == {
+            ("block_lost", "paragraph", 2),
+            ("block_lost", "table(2x2)", 1),
+        }
+
+    def test_flattened_nested_list_is_a_structural_change(self):
+        nested = doc(
+            List(
+                ordered=False,
+                items=[ListItem(children=[para("outer"), bullet_list("inner")])],
+            )
+        )
+        flat = doc(bullet_list("outer", "inner"))
+        _, metrics, deltas = score_roundtrip(nested, flat)
+        assert metrics["structure"] < 100
+        assert kinds(deltas) & {"block_lost", "block_changed"}
+
+    def test_dropped_table_is_an_error(self):
+        source = doc(table([["a", "b"], ["1", "2"]]))
+        _, metrics, deltas = score_roundtrip(source, doc(para("a b 1 2")))
+        assert metrics["tables"] == 0
+        lost = by_kind(deltas, "table_lost")
+        assert lost and lost[0].severity == "error"
+
+    def test_resized_table_reports_old_and_new_shape(self):
+        source = doc(table([["a", "b"], ["1", "2"]]))
+        narrowed = doc(table([["a"], ["1"]]))
+        _, metrics, deltas = score_roundtrip(source, narrowed)
+        assert metrics["tables"] < 100
+        changed = by_kind(deltas, "table_changed")
+        assert changed and "2x2 -> 2x1" in (changed[0].detail or "")
+
+    def test_lost_inline_formatting_is_reported(self):
+        source = doc(Paragraph(content=[Strong(content=[Text(content="bold")])]))
+        _, metrics, deltas = score_roundtrip(source, doc(para("bold")))
+        assert metrics["inline"] == 0
+        lost = by_kind(deltas, "inline_lost")
+        assert lost and lost[0].detail == "strong"
+
+    def test_inline_counts_are_a_multiset(self):
+        source = doc(Paragraph(content=[Strong(content=[Text(content="a")]), Strong(content=[Text(content="b")])]))
+        kept_one = doc(Paragraph(content=[Strong(content=[Text(content="a")]), Text(content="b")]))
+        _, _, deltas = score_roundtrip(source, kept_one)
+        lost = by_kind(deltas, "inline_lost")
+        assert lost and lost[0].count == 1
+
+    def test_lost_reference_names_the_url(self):
+        source = doc(Paragraph(content=[Link(url="https://example.com", content=[Text(content="x")])]))
+        _, metrics, deltas = score_roundtrip(source, doc(para("x")))
+        assert metrics["references"] == 0
+        lost = by_kind(deltas, "reference_lost")
+        assert lost and lost[0].detail == "https://example.com"
+
+    def test_image_targets_count_as_references(self):
+        source = doc(Paragraph(content=[Image(url="pic.png", alt_text="p")]))
+        _, metrics, _ = score_roundtrip(source, doc(para("")))
+        assert metrics["references"] == 0
+
+    def test_deltas_are_ranked_most_severe_first(self):
+        source = doc(table([["a"], ["1"]]), para("x"), Paragraph(content=[Emphasis(content=[Text(content="y")])]))
+        _, _, deltas = score_roundtrip(source, doc(para("x")))
+        severities = [d.severity for d in deltas]
+        assert severities == sorted(severities, key=["error", "warn", "info"].index)
+
+
+# --- Weighting ---------------------------------------------------------------
+
+
+class TestWeighting:
+    def test_absent_dimensions_are_omitted_not_scored(self):
+        """A document with no tables is neither rewarded nor punished for them."""
+        source = doc(para("plain text"))
+        _, metrics, _ = score_roundtrip(source, source)
+        assert "tables" not in metrics
+        assert "references" not in metrics
+        assert "inline" not in metrics
+        assert set(metrics) == {"structure", "text"}
+
+    def test_weights_are_renormalized_over_present_dimensions(self):
+        """With only structure and text present, their weights must still sum to 1.
+
+        Structure is perfect and text is destroyed, so the score is exactly the
+        renormalized text weight away from 100.
+        """
+        source = doc(para("alpha beta gamma delta"))
+        gutted = doc(para(""))
+        score, metrics, _ = score_roundtrip(source, gutted)
+
+        assert metrics["structure"] == 100 and metrics["text"] == 0
+        total = DIMENSION_WEIGHTS["structure"] + DIMENSION_WEIGHTS["text"]
+        expected = round(100 * DIMENSION_WEIGHTS["structure"] / total)
+        assert score == expected
+
+    def test_structure_carries_the_most_weight(self):
+        assert DIMENSION_WEIGHTS["structure"] == max(DIMENSION_WEIGHTS.values())
+        assert sum(DIMENSION_WEIGHTS.values()) == pytest.approx(1.0)
+
+
+# --- Report plumbing ---------------------------------------------------------
+
+
+class TestReport:
+    def test_build_report_labels_the_pipeline_and_bands_the_score(self):
+        source = doc(heading(1, "T"), para("a b c"))
+        report = build_report(source, source, source_format="docx", via="markdown")
+        assert (report.score, report.band) == (100, "high")
+        assert (report.source_format, report.via) == ("docx", "markdown")
+
+    def test_low_score_bands_low(self):
+        source = doc(heading(1, "T"), para("alpha beta gamma"))
+        report = build_report(source, doc(), source_format="docx", via="latex")
+        assert report.score == 0
+        assert report.band == "low"
+
+    def test_report_survives_a_json_round_trip(self):
+        source = doc(heading(1, "T"), para("a b"), table([["x"], ["1"]]))
+        report = build_report(source, doc(para("a b")), source_format="docx", via="rst")
+        assert RoundTripReport.from_dict(report.to_dict()) == report
+
+    def test_delta_omits_detail_when_unset(self):
+        assert "detail" not in StructuralDelta(kind="text_reordered").to_dict()
+
+    def test_coalesce_sums_counts_and_keeps_first_seen_order(self):
+        merged = coalesce_deltas(
+            [
+                StructuralDelta("block_lost", "paragraph"),
+                StructuralDelta("inline_lost", "strong", count=2),
+                StructuralDelta("block_lost", "paragraph", count=3),
+            ]
+        )
+        assert [(d.kind, d.count) for d in merged] == [("block_lost", 4), ("inline_lost", 2)]
+
+    def test_coalesce_keeps_distinct_severities_apart(self):
+        merged = coalesce_deltas(
+            [
+                StructuralDelta("text_lost", "x", severity="warn"),
+                StructuralDelta("text_lost", "x", severity="info"),
+            ]
+        )
+        assert len(merged) == 2


### PR DESCRIPTION
Closes **D2** in the Fidelity & Trust batch (`todo.md` Track D). Unblocks **D3** (`all2md optimize`).

## What

`all2md roundtrip doc.docx` converts a document to another format, parses it straight back, and scores the structure that survived.

Where `all2md report` (D1) is *reference-free* — it scores a conversion from signals the parser observed, the only option for a scanned PDF — this **manufactures a reference**: the source AST is the ground truth, the re-parsed AST is the candidate. So a lossless round trip scores exactly `100`, and any drift is a real defect rather than measurement noise.

```
$ all2md roundtrip basic.docx
basic.docx
  fidelity:  97/100  (HIGH)
  pipeline:  parse docx -> render markdown -> parse markdown

  metrics
    structure   100/100   headings, lists, tables, code blocks
    text        100/100   the document's word stream
    inline       82/100   bold, italic, code, links
    tables      100/100   table dimensions and cell text
    references  100/100   link and image targets

  differences
    warn  inline_lost  (underline)
```

Five dimensions, weights renormalized over the ones the source actually exercises — a document with no tables is neither rewarded nor punished for the tables it lacks.

Built on the AST rather than `all2md.diff`, which is a text `difflib` engine and cannot see a demoted heading.

## Two design corrections that came out of spiking against the real converters

**1. `structure` and `text` must use independent alignments.** The first version aligned blocks by shape and compared the text of each aligned pair. Two paragraphs then pair up merely because both are paragraphs — so one demoted heading shifted every later pairing and cratered `text` to **20** on a document that had not lost a single word. Text is now scored document-wide.

**2. `SequenceMatcher` is quadratic, and the worst case is not hypothetical.** 20k words drawn from a small vocabulary (OCR garble, a repetitive table) took **32 seconds**. Above `TEXT_SIMILARITY_TOKEN_CAP` the word comparison degrades to a bag-of-words overlap — which costs only order-sensitivity, already `structure`'s job.

Format-legal spelling differences are normalized, not scored as loss (tight vs. loose list items; nested single-child paragraphs), and `block_lost` is netted against `block_added` so a moved block isn't reported as both.

## Why this unblocks the optimizer

The score responds to converter options. `basic.md` contains raw `<u>` tags, which the Markdown renderer escapes by default as a security posture:

```python
roundtrip_report("basic.md").score                                       # 98
roundtrip_report("basic.md", html_passthrough_mode="pass-through").score # 100
```

That is precisely the fitness function `all2md optimize` hill-climbs on. Pinned by a test.

## Surface

- **API**: `roundtrip_report(source, via=...)`, `roundtrippable_formats()` (24 formats)
- **CLI**: `--via`, `--format` (stdin sniffs Markdown as plaintext), `--json`, `--fail-under SCORE` as a CI gate, `--max-deltas N`
- Wired into dispatch, help, config sections, and `config generate`
- `_protect_stdout` hoisted from `report.py` into `commands/shared.py` now that two commands need it
- Docs: `cli.rst` section + module page — plus the module page `confidence` (D1) never got, since the two are halves of one substrate

## Bugs this immediately found

Not fixed here (one branch, one change), filed for follow-up:

1. **HTML parser double-wraps loose list items** — `<li><p>x</p></li>` parses to `ListItem > Paragraph > Paragraph > Text`.
2. **DOCX `Title` style has no inverse in the parser** — rendering applies `TitlePromotionTransform` (leading H1 → Word "Title", later headings shifted up one), but the parser maps "Title" → `Paragraph`. So `md → docx → md` demotes the title *and* shifts H2→H1. Repro: `all2md roundtrip notes.md --via docx`.
3. **DOCX round trip drops inline `Code`** and turns a `BlockQuote` into a bullet list. Verified: `> a quoted line` comes back as `* a quoted line`.

## Verification

- 35 unit + 22 integration tests, all passing
- `black --check`, `ruff check`, `mypy src/` clean (only the pre-existing `_pdf_layout.py` extras-only error remains)
- Sphinx `-W --keep-going` builds clean (needed an explicit `__all__` on the new module — autodoc was otherwise pulling in `difflib.SequenceMatcher`, whose docstring isn't valid RST)
- `report`/`confidence` suites re-run green after the `shared.py` move

🤖 Generated with [Claude Code](https://claude.com/claude-code)