### PR TITLE
fix(docs): make the options reference regenerate reproducibly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **The options reference regenerates reproducibly.** Two `MarkdownRendererOptions`
+  fields default to an `UNSET` sentinel, and the generator rendered it with
+  `repr()` — emitting `<object object at 0x...>`, a memory address that changed on
+  every run. `docs/source/options.rst` therefore showed a spurious diff after any
+  documentation build, burying real option changes in noise. Those fields now
+  render as `unset`, matching the wording `all2md --help` already used. Running
+  `scripts/generate_options_doc.py` standalone also works now: its `--output` and
+  `--narrative` defaults resolved against `scripts/` rather than the `docs/source/`
+  tree they named, so a hand-run always failed on a missing narrative file.
 - **DOCX no longer opens with a stray blank line.** A Word document whose first
   paragraph is empty (a common template artifact) produced a leading blank line
   in the Markdown output — including when that empty paragraph carried a list

--- a/docs/source/options.rst
+++ b/docs/source/options.rst
@@ -5266,7 +5266,7 @@ The Markdown format has no dedicated CLI flags. The common Markdown formatting f
    How to handle tables when flavor doesn't support them: drop (skip entirely), ascii (render as ASCII art), force (render as pipe tables anyway), html (render as HTML table)
 
    :Type: ``Literal['drop', 'ascii', 'force', 'html'] | object``
-   :Default: ``<object object at 0x00000231462C0D50>``
+   :Default: ``unset`` (resolved from ``flavor`` at construction)
    :Choices: ``drop``, ``ascii``, ``force``, ``html``
    :Importance: advanced
 
@@ -5275,7 +5275,7 @@ The Markdown format has no dedicated CLI flags. The common Markdown formatting f
    How to handle inline elements unsupported by flavor: plain (render content without formatting), force (use markdown syntax anyway), html (use HTML tags)
 
    :Type: ``Literal['plain', 'force', 'html'] | object``
-   :Default: ``<object object at 0x00000231462C0D50>``
+   :Default: ``unset`` (resolved from ``flavor`` at construction)
    :Choices: ``plain``, ``force``, ``html``
    :Importance: advanced
 
@@ -11252,7 +11252,7 @@ modules to ensure consistent Markdown generation.
 
    :Type: ``Literal['drop', 'ascii', 'force', 'html'] | object``
    :CLI flag: ``--markdown-unsupported-table-mode``
-   :Default: ``<object object at 0x00000231462C0D50>``
+   :Default: ``unset`` (resolved from ``flavor`` at construction)
    :Choices: ``drop``, ``ascii``, ``force``, ``html``
    :Importance: advanced
 
@@ -11262,7 +11262,7 @@ modules to ensure consistent Markdown generation.
 
    :Type: ``Literal['plain', 'force', 'html'] | object``
    :CLI flag: ``--markdown-unsupported-inline-mode``
-   :Default: ``<object object at 0x00000231462C0D50>``
+   :Default: ``unset`` (resolved from ``flavor`` at construction)
    :Choices: ``plain``, ``force``, ``html``
    :Importance: advanced
 

--- a/scripts/generate_options_doc.py
+++ b/scripts/generate_options_doc.py
@@ -31,7 +31,7 @@ if str(SRC_PATH) not in sys.path:
     sys.path.insert(0, str(SRC_PATH))
 
 from all2md.converter_registry import registry  # noqa: E402
-from all2md.options.base import BaseParserOptions, BaseRendererOptions  # noqa: E402
+from all2md.options.base import UNSET, BaseParserOptions, BaseRendererOptions  # noqa: E402
 from all2md.options.common import LocalFileAccessOptions, NetworkFetchOptions  # noqa: E402
 from all2md.options.markdown import MarkdownRendererOptions  # noqa: E402
 from all2md.utils.input_sources import RemoteInputOptions  # noqa: E402
@@ -410,7 +410,12 @@ class OptionsRenderer:
             lines.append(f"   :CLI flag: ``{cli_flag}``")
 
         default_value, factory_name = get_field_default(field)
-        if default_value is not None:
+        if default_value is UNSET:
+            # repr(object()) embeds the sentinel's memory address, which changes
+            # every run and made options.rst impossible to regenerate reproducibly.
+            # Match the wording the CLI help already uses for these fields.
+            lines.append("   :Default: ``unset`` (resolved from ``flavor`` at construction)")
+        elif default_value is not None:
             lines.append(f"   :Default: ``{default_value!r}``")
         elif factory_name:
             lines.append(f"   :Default factory: ``{factory_name}``")
@@ -610,19 +615,23 @@ def generate_options_document(output_path: Path, narrative_path: Optional[Path] 
 
 def parse_args(argv: Optional[list[str]] = None) -> argparse.Namespace:
     """Parse command line arguments."""
+    # The Sphinx build passes both paths explicitly; these defaults only serve a
+    # standalone run, and they resolved against ``scripts/`` rather than the docs
+    # tree they name -- so running the script by hand always failed.
+    docs_source = Path(__file__).resolve().parent.parent / "docs" / "source"
     parser = argparse.ArgumentParser(description="Generate options.rst documentation.")
     parser.add_argument(
         "-o",
         "--output",
         type=Path,
-        default=Path(__file__).resolve().parent / "options.rst",
+        default=docs_source / "options.rst",
         help="Output .rst path (defaults to docs/source/options.rst)",
     )
     parser.add_argument(
         "-n",
         "--narrative",
         type=Path,
-        default=Path(__file__).resolve().parent / "_templates" / "_options-narrative.rst",
+        default=docs_source / "_templates" / "_options-narrative.rst",
         help="Narrative preface file",
     )
     return parser.parse_args(argv)


### PR DESCRIPTION
Two `MarkdownRendererOptions` fields (`unsupported_table_mode`, `unsupported_inline_mode`) default to the `UNSET = object()` sentinel, and `generate_options_doc.py` rendered it with `repr()`:

```
-   :Default: ``<object object at 0x00000231462C0D50>``
+   :Default: ``unset`` (resolved from ``flavor`` at construction)
```

That memory address changes on every interpreter run, so **any** documentation build left `docs/source/options.rst` dirty with a diff carrying no information — burying real option changes in noise and making the file impossible to review. It's why the file seemed to churn on every build.

The new wording matches what the CLI already prints. `help_formatter.py:267` maps `UNSET` → `"unset"`, and `all2md help markdown` shows `default: unset`, so the CLI and the docs now agree instead of contradicting each other.

## Also fixed

The script's standalone `--output` / `--narrative` defaults resolved against `scripts/` rather than the `docs/source/` tree their help text names:

```
FileNotFoundError: ...\scripts\_templates\_options-narrative.rst
```

So running the generator by hand always failed. The Sphinx build passes both paths explicitly (`conf.py:163`) and never hit it. Now `uv run python scripts/generate_options_doc.py` just works — which is what made the reproducibility check below possible.

## Verification

- Two independent interpreter runs now produce **byte-identical** output (`cmp` clean)
- A full `sphinx-build -W --keep-going` leaves `options.rst` **unchanged** — no more phantom diff
- Zero `object at 0x...` remain anywhere in the 11,632-line generated reference
- The committed diff is exactly the 4 intended lines
- `black` / `ruff` clean; docs build passes with warnings-as-errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)