### PR TITLE
fix(pdf): dehyphenate natively-extracted text, not just OCR output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **`merge_hyphenated_words` now actually works on text PDFs.** The option is on
+  by default, but for any PDF that did not go through OCR it silently did
+  nothing: the parser delegated the merge to PyMuPDF's `TEXT_DEHYPHENATE`
+  extraction flag, and that flag is inert — on PyMuPDF 1.28 / MuPDF 1.29 it does
+  not change `get_text()` output in any extraction mode. A word split at a line
+  break came back as `"hyphen- ation"` instead of `"hyphenation"` in every
+  ordinary text PDF. The merge is now performed directly on the extracted text
+  blocks (`dehyphenate_blocks()`), moving the continuation word up into the
+  preceding line so the joined word survives the line-to-paragraph join that
+  callers perform. The existing capitalization rule is unchanged and now applies
+  to native text too: an uppercase continuation keeps the hyphen
+  (`"Anglo-\nSaxon"` → `"Anglo-Saxon"`), a lowercase one drops it
+  (`"be-\nwusst"` → `"bewusst"`), and hyphens not between two letters
+  (`"10-\n20"`) are left alone. This is the other half of the fix for #51, which
+  addressed only the OCR path — on the explicit assumption that the flag already
+  covered native extraction.
 - **The options reference regenerates reproducibly.** Two `MarkdownRendererOptions`
   fields default to an `UNSET` sentinel, and the generator rendered it with
   `repr()` — emitting `<object object at 0x...>`, a memory address that changed on

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -80,12 +80,6 @@ obvious.
     - *TensorFlow* — `tf.data.from_generator` for live use, but the real story is
       pre-sharded TFRecords from the batch engine.
 
-**Reuse note (resolved):** `localvectordb` is PolyForm Noncommercial-licensed. We took the
-recommended path — the fine-grained chunking primitives were **vendored** into `all2md`
-(self-contained, `tiktoken`-based) rather than added as a hard dependency, and BPE counting
-lives behind the optional `[chunk]` extra. License posture settled; no runtime dependency
-on the noncommercial package.
-
 ---
 
 ## Theme 2 — Conversion fidelity (deepen the core moat)

--- a/src/all2md/parsers/_pdf_ocr.py
+++ b/src/all2md/parsers/_pdf_ocr.py
@@ -12,7 +12,7 @@ from __future__ import annotations
 
 import logging
 import re
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from all2md.constants import DEPS_PDF_LANGDETECT
 from all2md.options.common import OCROptions
@@ -28,6 +28,7 @@ __all__ = [
     "detect_page_language",
     "calculate_image_coverage",
     "dehyphenate_text",
+    "dehyphenate_blocks",
 ]
 
 logger = logging.getLogger(__name__)
@@ -93,6 +94,71 @@ def dehyphenate_text(text: str) -> str:
     if not text:
         return text
     return _HYPHEN_LINEBREAK_RE.sub(_merge_hyphenation, text)
+
+
+# A hyphen ending a line: a letter, a hyphen character, then only trailing blanks.
+_LINE_END_HYPHEN_RE = re.compile(r"([^\W\d_])[-­‐][ \t]*$", re.UNICODE)
+# The continuation word: the leading letters of the following line.
+_CONTINUATION_RE = re.compile(r"^([^\W\d_]+)", re.UNICODE)
+
+
+def dehyphenate_blocks(blocks: list[dict[str, Any]]) -> None:
+    r"""Merge line-break hyphenation across the lines of PyMuPDF text blocks, in place.
+
+    PyMuPDF exposes a ``TEXT_DEHYPHENATE`` extraction flag, and the PDF parser used
+    to rely on it for natively-extracted text. It is inert — on PyMuPDF 1.28 /
+    MuPDF 1.29 it does not alter ``get_text()`` output in any extraction mode — so
+    ``merge_hyphenated_words`` silently did nothing for every non-OCR PDF. This
+    reproduces the intended behaviour structurally instead of trusting the flag.
+
+    Blocks are dicts from ``page.get_text("dict")``. A word split at a line break
+    lives in two different ``lines``, so merging the *text* is not enough: callers
+    join lines with a space, which would leave "hyphen- ation". The continuation
+    word is therefore moved up into the preceding line's final span, and removed
+    from the following line, so every downstream consumer sees the joined word.
+
+    The hyphen/capitalization rules match :func:`dehyphenate_text` exactly — an
+    uppercase continuation keeps the hyphen ("Anglo-\\nSaxon" → "Anglo-Saxon"),
+    a lowercase one drops it ("be-\\nwusst" → "bewusst"), and hyphens not sitting
+    between two letters are left alone.
+
+    Parameters
+    ----------
+    blocks : list of dict
+        Text blocks from ``page.get_text("dict")["blocks"]``. Mutated in place.
+
+    """
+    for block in blocks:
+        if block.get("type") != 0:
+            continue
+        lines = block.get("lines") or []
+        index = 0
+        while index < len(lines) - 1:
+            spans = lines[index].get("spans") or []
+            next_spans = lines[index + 1].get("spans") or []
+            if not spans or not next_spans:
+                index += 1
+                continue
+
+            last, first = spans[-1], next_spans[0]
+            hyphen = _LINE_END_HYPHEN_RE.search(last.get("text", ""))
+            continuation = _CONTINUATION_RE.match(first.get("text", "").lstrip())
+            if not hyphen or not continuation:
+                index += 1
+                continue
+
+            word = continuation.group(1)
+            # An uppercase continuation signals a real compound: keep the hyphen.
+            joiner = "-" if word[0].isupper() else ""
+            last["text"] = _LINE_END_HYPHEN_RE.sub(rf"\1{joiner}{word}", last["text"])
+            first["text"] = first["text"].lstrip()[len(word) :].lstrip()
+
+            if not first["text"]:
+                next_spans.pop(0)
+            if not next_spans:
+                lines.pop(index + 1)
+                continue  # the line vanished; re-test this line against the new next one
+            index += 1
 
 
 def calculate_image_coverage(page: "fitz.Page") -> float:

--- a/src/all2md/parsers/pdf.py
+++ b/src/all2md/parsers/pdf.py
@@ -76,6 +76,7 @@ from all2md.parsers._pdf_layout import (
 )
 from all2md.parsers._pdf_numbering import parse_numbering_prefix
 from all2md.parsers._pdf_ocr import (
+    dehyphenate_blocks,
     dehyphenate_text,
 )
 from all2md.parsers._pdf_ocr import (
@@ -1195,10 +1196,9 @@ class PdfToAstConverter(BaseParser):
                 logger.warning("OCR returned empty text, keeping original extraction")
                 return all_blocks, False
 
-            # PyMuPDF's TEXT_DEHYPHENATE flag only affects its native extraction,
-            # not OCR output, so line-break hyphenation ("be-\nwusst") survives in
-            # OCR text. Merge it here so merge_hyphenated_words behaves the same
-            # regardless of whether a page went through OCR.
+            # OCR returns a flat string rather than the span structure
+            # dehyphenate_blocks() walks, so line-break hyphenation ("be-\nwusst")
+            # is merged here on the text instead. Same rules, same option.
             if self.options.merge_hyphenated_words:
                 ocr_text = dehyphenate_text(ocr_text)
 
@@ -1462,11 +1462,9 @@ class PdfToAstConverter(BaseParser):
 
         # Extract all text blocks from the page
         try:
-            text_flags = fitz.TEXTFLAGS_TEXT
+            all_blocks = page.get_text("dict", flags=fitz.TEXTFLAGS_TEXT, sort=False)["blocks"]
             if self.options.merge_hyphenated_words:
-                text_flags |= fitz.TEXT_DEHYPHENATE
-
-            all_blocks = page.get_text("dict", flags=text_flags, sort=False)["blocks"]
+                dehyphenate_blocks(all_blocks)
         except (AttributeError, KeyError, Exception):
             return []
 
@@ -1774,17 +1772,14 @@ class PdfToAstConverter(BaseParser):
 
         # Extract text blocks
         try:
-            # Build flags: always include TEXTFLAGS_TEXT, conditionally add TEXT_DEHYPHENATE
-            text_flags = fitz.TEXTFLAGS_TEXT
-            if self.options.merge_hyphenated_words:
-                text_flags |= fitz.TEXT_DEHYPHENATE
-
             blocks = page.get_text(
                 "dict",
                 clip=clip,
-                flags=text_flags,
+                flags=fitz.TEXTFLAGS_TEXT,
                 sort=False,
             )["blocks"]
+            if self.options.merge_hyphenated_words:
+                dehyphenate_blocks(blocks)
         except (AttributeError, KeyError, Exception):
             # If extraction fails (e.g., in tests), return empty
             return []

--- a/tests/unit/formats/pdf/test_pdf_dehyphenation.py
+++ b/tests/unit/formats/pdf/test_pdf_dehyphenation.py
@@ -1,0 +1,137 @@
+"""Dehyphenation on the *native* (non-OCR) PDF text path.
+
+The parser used to delegate this entirely to PyMuPDF's ``TEXT_DEHYPHENATE``
+extraction flag, which is inert (it does not change ``get_text()`` output in any
+mode on PyMuPDF 1.28 / MuPDF 1.29). ``merge_hyphenated_words`` — a default-on
+option — therefore did nothing at all for any PDF that did not go through OCR.
+
+It went unnoticed because every existing test either called ``dehyphenate_text()``
+as a pure function or drove the OCR path; none ran a real text PDF through the
+parser and asserted the word came back joined. These do.
+"""
+
+import fitz
+import pytest
+
+from all2md import to_markdown
+from all2md.options.pdf import PdfOptions
+from all2md.parsers._pdf_ocr import dehyphenate_blocks
+
+
+def _pdf_with_lines(tmp_path, text: str, name: str = "h.pdf") -> str:
+    """Render ``text`` into one text block, honouring its explicit line breaks.
+
+    The hyphen must fall at the end of a line *inside a single block* — that is the
+    only place line-break hyphenation can occur. Separate ``insert_text`` calls put
+    each line in its own block, where no dehyphenator (ours or PyMuPDF's) can join
+    them; that is a property of the fixture, not of the parser.
+    """
+    doc = fitz.open()
+    page = doc.new_page()
+    page.insert_textbox(fitz.Rect(50, 50, 400, 300), text, fontsize=10)
+    path = tmp_path / name
+    doc.save(str(path))
+    doc.close()
+    return str(path)
+
+
+@pytest.mark.unit
+@pytest.mark.pdf
+class TestNativePdfDehyphenation:
+    """End-to-end: a text PDF, through the parser, with no OCR involved."""
+
+    def test_merges_line_break_hyphenation_by_default(self, tmp_path):
+        """The regression: merge_hyphenated_words defaults on and must actually merge."""
+        path = _pdf_with_lines(tmp_path, "This paragraph demonstrates hyphen-\nation across a break.")
+
+        markdown = to_markdown(path)
+
+        assert "hyphenation across a break." in markdown
+        assert "hyphen- ation" not in markdown
+
+    def test_preserves_hyphenation_when_disabled(self, tmp_path):
+        """Turning the option off has to be observable, or it is not a real knob."""
+        path = _pdf_with_lines(tmp_path, "This paragraph demonstrates hyphen-\nation across a break.")
+
+        markdown = to_markdown(path, parser_options=PdfOptions(merge_hyphenated_words=False))
+
+        assert "hyphenation" not in markdown
+        assert "hyphen- ation" in markdown
+
+    def test_uppercase_continuation_keeps_the_hyphen(self, tmp_path):
+        """A genuine compound survives: "Anglo-\\nSaxon" is a hyphenated word, not a split one."""
+        path = _pdf_with_lines(tmp_path, "The Anglo-\nSaxon and the be-\nwusst cases.")
+
+        markdown = to_markdown(path)
+
+        assert "Anglo-Saxon" in markdown
+        assert "bewusst" in markdown
+        assert "AngloSaxon" not in markdown
+
+    def test_numeric_continuation_is_left_alone(self, tmp_path):
+        """A number range is not hyphenation: "10-\\n20" must stay "10- 20", not "1020"."""
+        path = _pdf_with_lines(tmp_path, "Values in the range 10-\n20 are valid.")
+
+        markdown = to_markdown(path)
+
+        assert "1020" not in markdown
+
+
+@pytest.mark.unit
+@pytest.mark.pdf
+class TestDehyphenateBlocks:
+    """Span-level behaviour of the block rewriter."""
+
+    @staticmethod
+    def _block(*lines: list[str]) -> dict:
+        return {"type": 0, "lines": [{"spans": [{"text": t} for t in line]} for line in lines]}
+
+    def test_moves_continuation_word_into_the_previous_line(self):
+        """The continuation must MOVE, not just lose its hyphen.
+
+        Callers join a block's lines with a space, so merely stripping the hyphen
+        would still render "hyphen ation". The word has to migrate up a line.
+        """
+        blocks = [self._block(["demonstrates hyphen-"], ["ation across a break."])]
+
+        dehyphenate_blocks(blocks)
+
+        lines = blocks[0]["lines"]
+        assert lines[0]["spans"][0]["text"] == "demonstrates hyphenation"
+        assert lines[1]["spans"][0]["text"] == "across a break."
+
+    def test_drops_a_line_the_continuation_emptied(self):
+        """When the continuation was the whole line, the now-empty line goes away."""
+        blocks = [self._block(["spanning hyphen-"], ["ation"], ["and more text"])]
+
+        dehyphenate_blocks(blocks)
+
+        lines = blocks[0]["lines"]
+        assert len(lines) == 2
+        assert lines[0]["spans"][0]["text"] == "spanning hyphenation"
+        assert lines[1]["spans"][0]["text"] == "and more text"
+
+    def test_leaves_ordinary_line_breaks_untouched(self):
+        blocks = [self._block(["no hyphen here"], ["second line"])]
+
+        dehyphenate_blocks(blocks)
+
+        lines = blocks[0]["lines"]
+        assert lines[0]["spans"][0]["text"] == "no hyphen here"
+        assert lines[1]["spans"][0]["text"] == "second line"
+
+    def test_ignores_non_text_blocks(self):
+        """Image blocks (type 1) have no "lines" and must not raise."""
+        blocks = [{"type": 1, "bbox": (0, 0, 1, 1)}]
+
+        dehyphenate_blocks(blocks)  # must not raise
+
+        assert blocks == [{"type": 1, "bbox": (0, 0, 1, 1)}]
+
+    def test_hyphen_at_end_of_the_final_line_is_kept(self):
+        """Nothing follows, so there is nothing to join it to."""
+        blocks = [self._block(["a trailing hyphen-"])]
+
+        dehyphenate_blocks(blocks)
+
+        assert blocks[0]["lines"][0]["spans"][0]["text"] == "a trailing hyphen-"


### PR DESCRIPTION
## The bug

`merge_hyphenated_words` is **on by default**, and for every PDF that did not go through OCR it **silently did nothing**. A word split across a line break came back as `"hyphen- ation"` instead of `"hyphenation"` in ordinary text PDFs.

The parser delegated the merge to PyMuPDF's `TEXT_DEHYPHENATE` extraction flag. That flag is **inert** — on PyMuPDF 1.28 / MuPDF 1.29 it does not change `get_text()` output in *any* extraction mode:

```
PRECONDITIONS
  hyphen at a line end?       True -> 'This paragraph demonstrates hyphen-'
  next line continues it?     'ation across a line break.'
  same block?                 yes (block 3, lines 7 & 8)

RESULT
  TEXT_DEHYPHENATE joins it?  False
  flag changed output at all? False
  all2md dehyphenate_text()?  True
```

## Why #51 didn't catch it

This is the missing half of #51. That issue was framed as *"OCR **bypasses** the flag"*, so the fix (`eeb7823`) patched only the OCR path — explicitly reasoning that *"PyMuPDF's TEXT_DEHYPHENATE flag only affects native text extraction"*. That assumption was never tested. It's false, so the common case (any text PDF) stayed broken while the rare case (OCR) got fixed.

It survived because **no test ever drove a real non-OCR PDF through the parser** and asserted the word came back joined — existing coverage either called `dehyphenate_text()` as a pure function or exercised the OCR path.

## The fix

Merge structurally instead of trusting the flag. `dehyphenate_blocks()` walks the spans from `page.get_text("dict")` and **moves the continuation word up** into the preceding line's final span. Stripping the hyphen alone is not enough: callers join a block's lines with a space, so that would still render `"hyphen ation"`.

The capitalization rule is shared with `dehyphenate_text()` so the OCR and native paths can't drift:

| input | output |
|---|---|
| `be-\nwusst` | `bewusst` (lowercase → drop hyphen) |
| `Anglo-\nSaxon` | `Anglo-Saxon` (uppercase → keep hyphen, real compound) |
| `10-\n20` | unchanged (not between two letters) |

## Verification

- 9 new tests, including 4 that drive a **real non-OCR PDF end-to-end** — the coverage gap that let this through. Confirmed to fail against the old parser (`joined=False`, `"hyphen- ation"` present) and pass with the fix.
- Full PDF suite green (160 tests), plus the confidence/round-trip integration suites.

Found while building `all2md optimize`: sweeping PDF options against ground truth showed `merge_hyphenated_words` had **zero effect in all 32 combinations**, which is what led to the flag.

Also drops a resolved licensing note from the roadmap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)