### PR TITLE
feat(optimize): auto-tune converter options against a reference-free objective

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Conversion optimizer (`all2md optimize`).** Converts a document many times under
+  different converter settings and reports the ones that recover the most well-formed
+  structure — emitted both as a runnable command and as a `.all2md.toml` snippet.
+  Built for the documents that need it most (the gnarly PDF with no known-good output
+  to diff against), so the objective is reference-free — and it is deliberately
+  neither of the two existing scores. The **confidence** score is a saturating
+  breakage detector: on anything not visibly broken it pins to `100` regardless of
+  settings, so it has no gradient to search (measured: 16 option combinations on a
+  two-column PDF produced *one* distinct confidence score while the parsed AST
+  produced *four* distinct outcomes). The **round-trip** score measures the renderer,
+  not the parser — a garbled table round-trips through Markdown perfectly. So
+  `all2md.optimize` scores the parsed AST directly: body text recovered, table
+  well-formedness (fill density and column regularity, so a hallucinated table scores
+  near zero rather than being rewarded for its extra cells), structure, and how much
+  repeated furniture the setting left behind. The search is cheap by construction —
+  the named presets first, then coordinate descent, which costs `sum(len(values))`
+  conversions instead of a full grid's `prod(len(values))`. `--sample-pages` tunes
+  against a slice of a long document and `--cache` makes repeat runs nearly free
+  (18.5s → 0.3s warm, on a 31-candidate run). Available from Python as
+  `all2md.optimize_options(source, ...)` (with `optimizable_formats()`), and from the
+  command line as `all2md optimize <file>` (`--rounds`, `--sample-pages`,
+  `--no-presets`, `--top`, `--out`, `--json`). Tunable formats: `pdf`, `html`, `docx`.
+  The reported fitness ranks candidates *against each other* and is not an absolute
+  quality score — `all2md report` and `all2md roundtrip` remain the scores for that.
 - **Round-trip fidelity scoring (`all2md roundtrip`).** Converts a document to
   another format, parses it straight back, and scores the structure that
   survived. Unlike the confidence report this comparison has a ground truth —

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,19 +20,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   two-column PDF produced *one* distinct confidence score while the parsed AST
   produced *four* distinct outcomes). The **round-trip** score measures the renderer,
   not the parser — a garbled table round-trips through Markdown perfectly. So
-  `all2md.optimize` scores the parsed AST directly: body text recovered, table
-  well-formedness (fill density and column regularity, so a hallucinated table scores
-  near zero rather than being rewarded for its extra cells), structure, and how much
-  repeated furniture the setting left behind. The search is cheap by construction —
-  the named presets first, then coordinate descent, which costs `sum(len(values))`
-  conversions instead of a full grid's `prod(len(values))`. `--sample-pages` tunes
-  against a slice of a long document and `--cache` makes repeat runs nearly free
-  (18.5s → 0.3s warm, on a 31-candidate run). Available from Python as
-  `all2md.optimize_options(source, ...)` (with `optimizable_formats()`), and from the
-  command line as `all2md optimize <file>` (`--rounds`, `--sample-pages`,
-  `--no-presets`, `--top`, `--out`, `--json`). Tunable formats: `pdf`, `html`, `docx`.
-  The reported fitness ranks candidates *against each other* and is not an absolute
-  quality score — `all2md report` and `all2md roundtrip` remain the scores for that.
+  `all2md.optimize` scores the parsed AST directly.
+
+  **Body text gates the score rather than contributing to it.** Losing a paragraph is
+  data loss; leaving a running header in is an annoyance, and the two are not
+  interchangeable at any exchange rate — so a candidate's body-text retention
+  *multiplies* its fitness (cubed), and no amount of tidiness buys back deleted
+  content. The weighted dimensions are the ones that are genuinely tradeable: tables
+  (scored as quality-weighted *recall* — filled cells discounted by shape regularity,
+  so a hallucinated table earns almost nothing while a missed real one still costs its
+  cells), structure, and cleanliness (how much repeated furniture the setting left
+  behind, where furniture is content that repeats across a substantial fraction of the
+  document's pages).
+
+  The search is cheap by construction — the named presets first, then coordinate
+  descent, which costs `sum(len(values))` conversions instead of a full grid's
+  `prod(len(values))`. It is still tens of full conversions, though, and a PDF page
+  costs about a second to parse, so `--sample-pages` tunes against a slice of a long
+  document and `--cache` makes repeat runs nearly free (18.5s → 0.3s warm, on a
+  31-candidate run); the command warns up front when it is about to tune a whole
+  document. Available from Python as `all2md.optimize_options(source, ...)` (with
+  `optimizable_formats()`), and from the command line as `all2md optimize <file>`
+  (`--rounds`, `--sample-pages`, `--no-presets`, `--top`, `--out`, `--json`). Tunable
+  formats: `pdf`, `html`, `docx`. The reported fitness ranks candidates *against each
+  other* and is not an absolute quality score — `all2md report` and `all2md roundtrip`
+  remain the scores for that.
 - **Round-trip fidelity scoring (`all2md roundtrip`).** Converts a document to
   another format, parses it straight back, and scores the structure that
   survived. Unlike the confidence report this comparison has a ground truth —

--- a/docs/source/api/advanced.rst
+++ b/docs/source/api/advanced.rst
@@ -99,18 +99,30 @@ Document comparison and diff rendering:
 Quality Scoring
 ---------------
 
-Two complementary reads on conversion quality. :mod:`all2md.confidence` is
-*reference-free*: it scores a conversion from the sanity signals the parser
-observed, which is the only option for a document with no ground truth (a
-scanned PDF). :mod:`all2md.roundtrip` manufactures a reference by converting a
-document to another format and parsing it straight back, then scores the
-structure that survived.
+Three reads on conversion quality, answering three different questions.
+
+:mod:`all2md.confidence` answers *"can I trust this conversion?"* It is
+**reference-free**, scoring from the sanity signals the parser observed, which is
+the only option for a document with no ground truth (a scanned PDF).
+
+:mod:`all2md.roundtrip` answers *"what did this conversion lose?"* It **manufactures
+a reference** by converting a document to another format and parsing it straight
+back, then scores the structure that survived.
+
+:mod:`all2md.optimize` answers *"which of these settings is best?"* — a distinct
+question, and it needs a distinct objective. The confidence score cannot be used to
+search: it saturates at ``100`` on anything not visibly broken, so across a sweep of
+converter options it is flat and there is no gradient to climb. The round-trip score
+cannot be used either, because re-parsing rendered output measures the *renderer* —
+a garbled table round-trips through Markdown perfectly. So the optimizer scores the
+parsed AST directly, on how much *well-formed* structure each setting recovers.
 
 .. autosummary::
    :nosignatures:
 
    all2md.confidence
    all2md.roundtrip
+   all2md.optimize
 
 MCP Server
 ----------
@@ -150,6 +162,7 @@ Complete References
    all2md.diff
    all2md.confidence
    all2md.roundtrip
+   all2md.optimize
    all2md.mcp
    all2md.packagers
    all2md.packagers.arxiv

--- a/docs/source/api/all2md.optimize.rst
+++ b/docs/source/api/all2md.optimize.rst
@@ -1,0 +1,9 @@
+all2md.optimize
+===============
+
+.. automodule:: all2md.optimize
+   :members:
+   :show-inheritance:
+   :undoc-members:
+   :imported-members: False
+   :noindex:

--- a/docs/source/api/core.rst
+++ b/docs/source/api/core.rst
@@ -26,6 +26,8 @@ Quality scoring, for deciding how much to trust a conversion:
    all2md.confidence_report
    all2md.roundtrip_report
    all2md.roundtrippable_formats
+   all2md.optimize_options
+   all2md.optimizable_formats
 
 For full function signatures and detailed documentation, see :doc:`all2md.api`.
 

--- a/docs/source/cli.rst
+++ b/docs/source/cli.rst
@@ -844,8 +844,91 @@ recovers them:
    roundtrip_report("basic.md").score                                  # 98
    roundtrip_report("basic.md", html_passthrough_mode="pass-through").score  # 100
 
-This is exactly the property the planned ``all2md optimize`` capstone hill-climbs
-on: a scalar that improves as converter settings improve.
+That makes this score a good way to *price a renderer setting*. It is not, however,
+what ``all2md optimize`` searches on — re-parsing rendered output measures the
+renderer, so it is blind to a parser that garbled the document in the first place (a
+mangled table round-trips through Markdown perfectly). See :ref:`optimize-command`.
+
+.. _optimize-command:
+
+Optimize Command
+----------------
+
+``all2md optimize`` converts a document many times under different converter
+settings and reports the ones that recover the most well-formed structure — as a
+command you can run and a ``.all2md.toml`` snippet you can paste.
+
+It is built for the documents that need it most: the gnarly PDF with no known-good
+output to compare against. So the objective is **reference-free**, and it is
+deliberately *neither* of the other two scores:
+
+* The **confidence** score (``all2md report``) is a saturating breakage detector. On
+  anything not visibly broken it pins to ``100`` regardless of settings — across a
+  16-combination sweep on a two-column PDF it produced **one** distinct score while
+  the parsed AST produced **four** distinct outcomes. A flat objective cannot be
+  searched.
+* The **round-trip** score measures the renderer, not the parser (see above).
+
+So the optimizer scores the parsed AST directly: how much body text, how many
+well-formed tables, how much structure each setting recovers — and how much repeated
+furniture it left behind.
+
+.. code-block:: console
+
+   $ all2md optimize scanned.pdf
+   scanned.pdf
+     format:     pdf
+     evaluated:  31 candidates
+     fitness:    98.93  (defaults scored 97.84, +1.09)
+
+     command
+       all2md scanned.pdf --pdf-trim-headers-footers
+
+     .all2md.toml
+       [pdf]
+       trim_headers_footers = true
+
+The reported fitness ranks candidates **against each other**; it is not an absolute
+quality score. For that, use ``all2md report`` (trust) or ``all2md roundtrip``
+(fidelity).
+
+This is not cheap — it is tens of conversions. ``--sample-pages`` tunes against a
+slice of a long document, and ``--cache`` makes repeat runs nearly free (a warm
+cache cut a 31-candidate run from 18.5s to 0.3s).
+
+Key Options
+~~~~~~~~~~~
+
+* ``--sample-pages N`` — tune against only the first ``N`` pages. Use at least 2:
+  running headers and footers are identified by the fact that they *repeat*, so a
+  single-page sample cannot detect them at all.
+* ``--rounds N`` — coordinate-descent passes over the knobs (default ``1``). More
+  rounds can find knobs that only pay off in combination, at proportionally more
+  conversions.
+* ``--no-presets`` — skip scoring the named presets and refine from the defaults only.
+* ``--top N`` — how many ranked candidates to show (``0`` for all).
+* ``--out FILE`` — write the TOML snippet to ``FILE``.
+* ``--json`` — emit the full report, including ``command`` and ``toml``, as JSON.
+* ``--cache`` — reuse conversions across runs.
+
+Tunable formats are ``pdf``, ``html``, and ``docx``. The searched knobs are curated,
+not derived from every option: an optimizer has no business flipping a security
+posture such as ``strip_dangerous_elements``.
+
+Python API
+~~~~~~~~~~
+
+.. code-block:: python
+
+   from all2md import optimize_options, optimizable_formats
+
+   report = optimize_options("scanned.pdf", sample_pages=5)
+   print(report.best_options)      # {'trim_headers_footers': True}
+   print(report.gain)              # +1.09 over the defaults
+   for candidate in report.candidates[:5]:
+       print(candidate.fitness, candidate.origin, candidate.options)
+
+   print(optimizable_formats())    # ['docx', 'html', 'pdf']
 
 Lint Command
 ------------

--- a/docs/source/cli.rst
+++ b/docs/source/cli.rst
@@ -869,9 +869,15 @@ deliberately *neither* of the other two scores:
   searched.
 * The **round-trip** score measures the renderer, not the parser (see above).
 
-So the optimizer scores the parsed AST directly: how much body text, how many
-well-formed tables, how much structure each setting recovers — and how much repeated
-furniture it left behind.
+So the optimizer scores the parsed AST directly: how many well-formed tables, how much
+structure each setting recovers, and how much repeated furniture it left behind.
+
+**Body text is not one of those dimensions — it gates them.** Losing a paragraph is
+data loss; leaving a running header in is an annoyance, and the two are not
+interchangeable at any exchange rate. A candidate's body-text retention *multiplies*
+its score (cubed), so shedding 1% of the document costs roughly 3% of fitness and no
+amount of tidiness buys it back. The optimizer is deliberately conservative: advice
+that can silently delete text is not advice worth taking.
 
 .. code-block:: console
 
@@ -892,9 +898,17 @@ The reported fitness ranks candidates **against each other**; it is not an absol
 quality score. For that, use ``all2md report`` (trust) or ``all2md roundtrip``
 (fidelity).
 
-This is not cheap — it is tens of conversions. ``--sample-pages`` tunes against a
-slice of a long document, and ``--cache`` makes repeat runs nearly free (a warm
-cache cut a 31-candidate run from 18.5s to 0.3s).
+This is not cheap, and it is worth being concrete about why: the search runs **tens of
+full conversions**, and a PDF page costs roughly a second to parse. A 12-page paper is
+about 10 seconds per candidate, so a full run is **~5 minutes**; a 100-page report is
+far worse. Two levers make that manageable:
+
+* ``--sample-pages N`` tunes against a slice rather than the whole document.
+* ``--cache`` makes repeat runs nearly free — a warm cache cut a 31-candidate run from
+  18.5s to 0.3s.
+
+Without ``--sample-pages`` the command says so on stderr before it starts, rather than
+leaving you watching a blank terminal.
 
 Key Options
 ~~~~~~~~~~~

--- a/src/all2md/__init__.py
+++ b/src/all2md/__init__.py
@@ -127,6 +127,8 @@ from all2md.api import (
     convert,
     from_ast,
     from_markdown,
+    optimizable_formats,
+    optimize_options,
     roundtrip_report,
     roundtrippable_formats,
     to_ast,
@@ -138,6 +140,7 @@ from all2md.constants import DocumentFormat
 # Extensions lists moved to constants.py - keep references for backward compatibility
 from all2md.converter_registry import registry
 from all2md.exceptions import All2MdError, DependencyError, FormatError, ParsingError
+from all2md.optimize import Candidate, DocumentMetrics, OptimizationReport
 
 # Keep only base and common option classes that are lightweight and frequently used
 from all2md.options.base import BaseParserOptions, BaseRendererOptions
@@ -215,6 +218,12 @@ __all__ = [
     "roundtrippable_formats",
     "RoundTripReport",
     "StructuralDelta",
+    # Conversion optimizer
+    "optimize_options",
+    "optimizable_formats",
+    "OptimizationReport",
+    "Candidate",
+    "DocumentMetrics",
     # Registry system
     "registry",
     # Type definitions

--- a/src/all2md/api.py
+++ b/src/all2md/api.py
@@ -12,7 +12,7 @@ from all2md.ast.nodes import Document
 from all2md.constants import DocumentFormat
 from all2md.conversion_cache import get_active_cache, make_cache_key
 from all2md.converter_registry import registry
-from all2md.exceptions import All2MdError, FormatError, ParsingError
+from all2md.exceptions import All2MdError, FormatError, ParsingError, ValidationError
 from all2md.options.base import BaseParserOptions, BaseRendererOptions
 from all2md.options.markdown import MarkdownParserOptions, MarkdownRendererOptions
 from all2md.progress import ProgressCallback
@@ -28,6 +28,7 @@ from all2md.utils.io_utils import write_content
 if TYPE_CHECKING:
     from all2md.chunking import ProvenanceChunk
     from all2md.confidence import ConfidenceReport
+    from all2md.optimize import OptimizationReport
     from all2md.roundtrip import RoundTripReport
 
 logger = logging.getLogger(__name__)
@@ -1104,6 +1105,153 @@ def roundtrip_report(
     roundtripped = to_ast(payload, source_format=via)
 
     return build_report(original, roundtripped, source_format=actual_source_format, via=via)
+
+
+def optimizable_formats() -> list[str]:
+    """Return the formats :func:`optimize_options` knows how to tune."""
+    from all2md.optimize import KNOBS
+
+    return sorted(KNOBS)
+
+
+def optimize_options(
+    source: Union[str, Path, IO[bytes], bytes],
+    *,
+    source_format: DocumentFormat = "auto",
+    parser_options: Optional[BaseParserOptions] = None,
+    rounds: int = 1,
+    include_presets: bool = True,
+    sample_pages: Optional[int] = None,
+    remote_input_options: Optional[RemoteInputOptions] = None,
+) -> "OptimizationReport":
+    """Search converter options for the settings that convert ``source`` best.
+
+    Converts the document many times under different settings and ranks them by a
+    reference-free fidelity objective (see :mod:`all2md.optimize`), so this works on
+    the documents that need it most: the ones with no known-good output to compare
+    against. Returns the winning options as a diff from the defaults, ready to drop
+    into an ``.all2md.toml``.
+
+    This is *not* cheap — it is tens of conversions. Use ``sample_pages`` to tune on
+    a slice of a long document, and enable the conversion cache
+    (:func:`all2md.conversion_cache.use_conversion_cache`) to skip re-converting
+    option sets already tried.
+
+    Parameters
+    ----------
+    source : str or Path or file-like or bytes
+        The document to tune against.
+    source_format : str, default "auto"
+        Override format detection.
+    parser_options : BaseParserOptions, optional
+        Starting point for the search. Options outside the searched knobs are held
+        fixed at whatever this specifies, so it doubles as a way to pin settings the
+        optimizer must not touch.
+    rounds : int, default 1
+        Coordinate-descent passes over the knobs. More rounds can recover knobs that
+        only pay off in combination, at proportionally more conversions.
+    include_presets : bool, default True
+        Score the named presets (``quality``, ``complete``, ...) before refining.
+    sample_pages : int, optional
+        Tune against only the first N pages, so a 400-page document does not have to
+        be reconverted in full for every candidate. Paginated formats only. Use at
+        least 2 (ideally 3+): running headers and footers are recognized by the fact
+        that they *repeat*, so a single-page sample cannot see them at all.
+    remote_input_options : RemoteInputOptions, optional
+        Controls retrieval when ``source`` is a URL.
+
+    Returns
+    -------
+    OptimizationReport
+        The winning options, the fitness they scored, what the defaults scored, and
+        every candidate evaluated.
+
+    Raises
+    ------
+    FormatError
+        If the detected format has no tunable knobs.
+
+    Examples
+    --------
+        >>> from all2md import optimize_options
+        >>> report = optimize_options("scanned.pdf")  # doctest: +SKIP
+        >>> report.best_options  # doctest: +SKIP
+        {'table_detection_mode': 'ruling', 'detect_columns': True}
+
+    """
+    from all2md.cli.presets import PRESETS
+    from all2md.optimize import DocumentMetrics, extract_metrics, search, tunable_knobs
+
+    resolved = _resolve_document_source(source, remote_input_options, None).payload
+
+    # The search parses the same source dozens of times, so a stream -- which can
+    # only be read once -- has to be materialized up front.
+    if hasattr(resolved, "read"):
+        resolved = resolved.read()
+
+    if source_format != "auto":
+        actual_format: str = source_format
+    elif isinstance(resolved, (str, Path, bytes)):
+        actual_format = registry.detect_format(resolved)
+    else:
+        raise FormatError("Cannot auto-detect format from this source. Please specify source_format.")
+
+    knobs = tunable_knobs(actual_format)
+    if not knobs:
+        raise FormatError(
+            f"No tunable options for format {actual_format!r}. "
+            f"Optimizable formats: {', '.join(optimizable_formats())}"
+        )
+
+    options_class = _get_parser_options_class_for_format(cast(DocumentFormat, actual_format))
+    if options_class is None:
+        raise FormatError(f"No parser options class for format {actual_format!r}")
+
+    base = parser_options if parser_options is not None else options_class()
+    if sample_pages is not None:
+        if not hasattr(base, "pages"):
+            raise FormatError(f"Format {actual_format!r} is not paginated; sample_pages does not apply.")
+        if sample_pages < 1:
+            raise ValidationError("sample_pages must be >= 1", parameter_name="sample_pages")
+        if sample_pages < 2:
+            # Running headers and footers are identified by the fact that they
+            # *repeat*. One page has nothing to repeat against, so the furniture
+            # dimension goes blind and header/footer trimming looks free.
+            logger.warning(
+                "sample_pages=1 leaves no repetition signal, so running headers and footers "
+                "cannot be detected. Sample at least 2 pages (3+ is better)."
+            )
+        # A 1-based list, not the "1-N" string form: string page ranges are
+        # double-converted to 0-based and come back off by one (see #75).
+        base = base.create_updated(pages=list(range(1, sample_pages + 1)))
+
+    def evaluate(overrides: dict[str, Any]) -> DocumentMetrics:
+        candidate_options = base.create_updated(**overrides) if overrides else base
+        document = to_ast(
+            cast(Union[str, Path, IO[bytes], bytes], resolved),
+            parser_options=candidate_options,
+            source_format=cast(DocumentFormat, actual_format),
+        )
+        return extract_metrics(document)
+
+    presets: dict[str, dict[str, Any]] = {}
+    if include_presets:
+        for name, preset in PRESETS.items():
+            # Presets are nested by format; only this format's section is relevant.
+            section = preset.get("config", {}).get(actual_format, {})
+            if section:
+                presets[name] = section
+
+    report = search(knobs, evaluate, presets=presets, rounds=rounds)
+    report.source_format = actual_format
+
+    # Coordinate descent accumulates whatever it walked through, so the winner can
+    # carry knobs it set to the value they already had. Those are no-ops: drop them
+    # so "recommended settings" means settings you actually have to change.
+    report.best_options = {
+        name: value for name, value in report.best_options.items() if getattr(base, name, object()) != value
+    }
+    return report
 
 
 def _record_source_path(ast_doc: "Document", source: Any) -> None:

--- a/src/all2md/cli/commands/__init__.py
+++ b/src/all2md/cli/commands/__init__.py
@@ -126,6 +126,12 @@ def dispatch_command(args: list[str] | None = None) -> int | None:  # noqa: C901
 
         return handle_roundtrip_command(args[1:])
 
+    # Check for optimize command (converter option auto-tuning)
+    if args[0] == "optimize":
+        from all2md.cli.commands.optimize import handle_optimize_command
+
+        return handle_optimize_command(args[1:])
+
     # Check for lint command
     if args[0] == "lint":
         from all2md.cli.commands.lint import handle_lint_command

--- a/src/all2md/cli/commands/config.py
+++ b/src/all2md/cli/commands/config.py
@@ -136,6 +136,7 @@ def _subcommand_parser_factories() -> Dict[str, Any]:
     from all2md.cli.commands.diff import _create_diff_parser
     from all2md.cli.commands.edit import _create_edit_parser
     from all2md.cli.commands.generate_site import _create_generate_site_parser
+    from all2md.cli.commands.optimize import _create_optimize_parser
     from all2md.cli.commands.report import _create_report_parser
     from all2md.cli.commands.roundtrip import _create_roundtrip_parser
     from all2md.cli.commands.server import _create_serve_parser
@@ -151,6 +152,7 @@ def _subcommand_parser_factories() -> Dict[str, Any]:
         "chunk": _create_chunk_parser,
         "report": _create_report_parser,
         "roundtrip": _create_roundtrip_parser,
+        "optimize": _create_optimize_parser,
     }
 
 

--- a/src/all2md/cli/commands/optimize.py
+++ b/src/all2md/cli/commands/optimize.py
@@ -1,0 +1,364 @@
+#  Copyright (c) 2025 Tom Villani, Ph.D.
+#
+# src/all2md/cli/commands/optimize.py
+"""Conversion optimizer command.
+
+``all2md optimize`` converts a document many times under different converter
+settings and reports the ones that recover the most well-formed structure -- as a
+``.all2md.toml`` snippet you can paste straight into a config file.
+
+It is built for the documents that need it most: the gnarly PDF with no known-good
+output to compare against. The objective is therefore reference-free (see
+:mod:`all2md.optimize`) -- it does not need a ground truth, and it is deliberately
+*not* the ``all2md report`` confidence score, which saturates at 100 on anything not
+visibly broken and so has no gradient to search.
+
+This costs tens of conversions. ``--sample-pages`` tunes on a slice of a long
+document and ``--cache`` makes repeat runs nearly free.
+
+Examples
+--------
+    all2md optimize scanned.pdf
+    all2md optimize report.pdf --sample-pages 5 --cache
+    all2md optimize page.html --json
+    all2md optimize paper.pdf --rounds 2 --out .all2md.toml
+
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any, cast
+
+from all2md.cli.builder import (
+    EXIT_DEPENDENCY_ERROR,
+    EXIT_ERROR,
+    EXIT_FILE_ERROR,
+    EXIT_SUCCESS,
+    EXIT_VALIDATION_ERROR,
+)
+from all2md.cli.commands.shared import add_cache_arguments, conversion_cache_from_args, protect_stdout
+from all2md.constants import DocumentFormat
+from all2md.exceptions import All2MdError, DependencyError
+from all2md.optimize import OptimizationReport
+
+#: How many ranked candidates the pretty output lists by default.
+_DEFAULT_TOP = 5
+
+
+def _create_optimize_parser() -> argparse.ArgumentParser:
+    """Build the argparse parser for ``all2md optimize``."""
+    from all2md.optimize import KNOBS
+
+    parser = argparse.ArgumentParser(
+        prog="all2md optimize",
+        description="Search converter options for the settings that convert a document best.",
+        add_help=True,
+    )
+    parser.add_argument(
+        "inputs",
+        nargs="+",
+        help=f"Documents to tune ({', '.join(sorted(KNOBS))}; use '-' for stdin).",
+    )
+    parser.add_argument(
+        "--format",
+        "-f",
+        default="auto",
+        help="Override source format detection (required for stdin of an ambiguous type).",
+    )
+    parser.add_argument(
+        "--rounds",
+        type=int,
+        default=1,
+        help=(
+            "Coordinate-descent passes over the knobs (default: 1). More rounds can find knobs "
+            "that only pay off together, at proportionally more conversions."
+        ),
+    )
+    parser.add_argument(
+        "--sample-pages",
+        type=int,
+        metavar="N",
+        help=(
+            "Tune against only the first N pages of a paginated document. Use at least 2: "
+            "running headers/footers are found by their repetition, so one page cannot reveal them."
+        ),
+    )
+    parser.add_argument(
+        "--no-presets",
+        action="store_true",
+        help="Skip scoring the named presets; refine from the defaults only.",
+    )
+    parser.add_argument(
+        "--top",
+        type=int,
+        default=_DEFAULT_TOP,
+        metavar="N",
+        help=f"How many ranked candidates to show (default: {_DEFAULT_TOP}; 0 for all).",
+    )
+    parser.add_argument("--json", action="store_true", help="Emit the full report as JSON.")
+    parser.add_argument(
+        "--out",
+        "-o",
+        metavar="FILE",
+        help="Write the recommended settings to FILE as a TOML snippet instead of stdout.",
+    )
+    parser.add_argument("--config", help="Path to a configuration file.")
+    parser.add_argument(
+        "--no-config",
+        action="store_true",
+        help="Disable configuration file loading for this command.",
+    )
+    add_cache_arguments(parser)
+    return parser
+
+
+def _toml_value(value: Any) -> str:
+    """Render a Python option value as a TOML literal."""
+    if isinstance(value, bool):
+        return "true" if value else "false"
+    if isinstance(value, (int, float)):
+        return str(value)
+    if isinstance(value, (list, tuple)):
+        return "[" + ", ".join(_toml_value(item) for item in value) + "]"
+    return json.dumps(str(value))
+
+
+def _toml_snippet(report: OptimizationReport) -> str:
+    """Render the winning options as a pasteable ``.all2md.toml`` section."""
+    if not report.best_options:
+        return ""
+    lines = [f"[{report.source_format}]"]
+    for name, value in sorted(report.best_options.items()):
+        lines.append(f"{name} = {_toml_value(value)}")
+    return "\n".join(lines)
+
+
+def _cli_command(label: str, report: OptimizationReport) -> str:
+    """Render the winning options as a runnable ``all2md`` command line.
+
+    Flag names are read from the CLI builder's own ``dest -> flag`` map rather than
+    re-derived from the field names here. The naming rules are not mechanical -- a
+    boolean that defaults to *True* is exposed as its negation
+    (``detect_columns`` -> ``--pdf-no-detect-columns``) -- and a second hand-written
+    copy of those rules would be free to drift out of sync with the real parser.
+
+    Because the boolean flags *flip* the default, a value that already equals the
+    default needs no flag at all; ``optimize_options`` has already pruned those.
+    """
+    import dataclasses
+
+    from all2md.cli.builder import DynamicCLIBuilder
+    from all2md.converter_registry import registry
+
+    if not report.best_options:
+        return ""
+
+    builder = DynamicCLIBuilder()
+    builder.build_parser()
+    flag_for_dest = builder.dest_to_cli_flag
+
+    options_class = registry.get_parser_options_class(report.source_format)
+    defaults: dict[str, Any] = {}
+    if options_class is not None:
+        defaults = {
+            f.name: f.default for f in dataclasses.fields(options_class) if f.default is not dataclasses.MISSING
+        }
+
+    parts: list[str] = []
+    unmapped: list[str] = []
+    for name, value in sorted(report.best_options.items()):
+        flag = flag_for_dest.get(f"{report.source_format}.{name}")
+        if flag is None:
+            unmapped.append(name)
+            continue
+        if isinstance(value, bool):
+            # The flag inverts the default, so its mere presence sets this value.
+            if value == defaults.get(name):
+                continue
+            parts.append(flag)
+        else:
+            parts.append(f"{flag} {value}")
+
+    if not parts:
+        return ""
+
+    quoted = f'"{label}"' if " " in label else label
+    command = f"all2md {quoted} " + " ".join(parts)
+    if unmapped:
+        command += f"\n# no CLI flag for: {', '.join(unmapped)} (use the TOML snippet)"
+    return command
+
+
+def _optimize_one(
+    source: str,
+    source_format: str,
+    rounds: int,
+    sample_pages: int | None,
+    include_presets: bool,
+) -> tuple[str, OptimizationReport]:
+    """Tune one input, returning ``(label, report)``."""
+    from all2md import optimize_options
+
+    src_format = cast(DocumentFormat, source_format)
+
+    if source == "-":
+        data = sys.stdin.buffer.read()
+        if not data:
+            raise All2MdError("No data received from stdin")
+        return "stdin", optimize_options(
+            data,
+            source_format=src_format,
+            rounds=rounds,
+            sample_pages=sample_pages,
+            include_presets=include_presets,
+        )
+
+    path = Path(source)
+    if not path.exists():
+        raise FileNotFoundError(f"Input file not found: {source}")
+    return path.as_posix(), optimize_options(
+        source,
+        source_format=src_format,
+        rounds=rounds,
+        sample_pages=sample_pages,
+        include_presets=include_presets,
+    )
+
+
+def _render_pretty(label: str, report: OptimizationReport, top: int) -> str:
+    """Render one optimization result as a human-readable card."""
+    lines: list[str] = [label]
+    lines.append(f"  format:     {report.source_format}")
+    lines.append(f"  evaluated:  {report.evaluated} candidates")
+
+    if report.improved:
+        lines.append(
+            f"  fitness:    {report.best_fitness:.2f}  "
+            f"(defaults scored {report.baseline_fitness:.2f}, {report.gain:+.2f})"
+        )
+        command = _cli_command(label, report)
+        if command:
+            lines.append("")
+            lines.append("  command")
+            for line in command.splitlines():
+                lines.append(f"    {line}")
+        lines.append("")
+        lines.append("  .all2md.toml")
+        for line in _toml_snippet(report).splitlines():
+            lines.append(f"    {line}")
+    else:
+        lines.append(f"  fitness:    {report.baseline_fitness:.2f}")
+        lines.append("")
+        lines.append("  The defaults are already the best settings found. Nothing to change.")
+
+    ranked = report.candidates if top <= 0 else report.candidates[:top]
+    if ranked:
+        lines.append("")
+        lines.append("  ranked candidates")
+        for candidate in ranked:
+            options = (
+                ", ".join(f"{k}={v}" for k, v in sorted(candidate.options.items()))
+                if candidate.options
+                else "(defaults)"
+            )
+            lines.append(f"    {candidate.fitness:6.2f}  {options}")
+
+    # The fitness is pool-relative, so an absolute number would be misleading.
+    lines.append("")
+    lines.append("  Fitness ranks candidates against each other; it is not an absolute quality score.")
+    lines.append("  For that, use `all2md report` (trust) or `all2md roundtrip` (fidelity).")
+    return "\n".join(lines)
+
+
+def handle_optimize_command(args: list[str] | None = None) -> int:
+    """Handle the ``optimize`` command.
+
+    Parameters
+    ----------
+    args : list[str], optional
+        Command line arguments (beyond 'optimize').
+
+    Returns
+    -------
+    int
+        Exit code. ``0`` on success; non-zero on load or validation errors.
+
+    """
+    from all2md.cli.config import apply_config_to_parser
+
+    parser = _create_optimize_parser()
+    try:
+        pre_args, _ = parser.parse_known_args(args or [])
+        apply_config_to_parser(parser, "optimize", explicit_path=pre_args.config, no_config=pre_args.no_config)
+        parsed = parser.parse_args(args or [])
+    except SystemExit as e:
+        return e.code if isinstance(e.code, int) else 0
+
+    if parsed.rounds < 1:
+        print("Error: --rounds must be at least 1.", file=sys.stderr)
+        return EXIT_VALIDATION_ERROR
+
+    if parsed.sample_pages is not None and parsed.sample_pages < 1:
+        print("Error: --sample-pages must be at least 1.", file=sys.stderr)
+        return EXIT_VALIDATION_ERROR
+
+    if sum(1 for src in parsed.inputs if src == "-") > 1:
+        print("Error: stdin ('-') may only be used once.", file=sys.stderr)
+        return EXIT_FILE_ERROR
+
+    results: list[tuple[str, OptimizationReport]] = []
+    try:
+        # Guard fd 1 so PyMuPDF advisories during the (many) parses cannot corrupt
+        # the report -- especially the machine-readable --json stream.
+        with protect_stdout(), conversion_cache_from_args(parsed):
+            for source in parsed.inputs:
+                results.append(
+                    _optimize_one(
+                        source,
+                        parsed.format,
+                        parsed.rounds,
+                        parsed.sample_pages,
+                        not parsed.no_presets,
+                    )
+                )
+    except DependencyError as e:
+        print(f"Error: {e}", file=sys.stderr)
+        return EXIT_DEPENDENCY_ERROR
+    except FileNotFoundError as e:
+        print(f"Error: {e}", file=sys.stderr)
+        return EXIT_FILE_ERROR
+    except All2MdError as e:
+        print(f"Error during optimization: {e}", file=sys.stderr)
+        return EXIT_ERROR
+
+    if parsed.json:
+        payload: list[dict[str, Any]] = [
+            {
+                "input": label,
+                **report.to_dict(),
+                "command": _cli_command(label, report),
+                "toml": _toml_snippet(report),
+            }
+            for label, report in results
+        ]
+        output = json.dumps(payload if len(payload) != 1 else payload[0], ensure_ascii=False, indent=2)
+    elif parsed.out:
+        snippets = [snippet for _, report in results if (snippet := _toml_snippet(report))]
+        if not snippets:
+            print("The defaults are already the best settings found; nothing to write.", file=sys.stderr)
+            return EXIT_SUCCESS
+        output = "\n\n".join(snippets)
+    else:
+        output = "\n\n".join(_render_pretty(label, report, parsed.top) for label, report in results)
+
+    if parsed.out:
+        Path(parsed.out).write_text(output + "\n", encoding="utf-8")
+        print(f"Wrote recommended settings to {parsed.out}", file=sys.stderr)
+    else:
+        print(output)
+
+    return EXIT_SUCCESS

--- a/src/all2md/cli/commands/optimize.py
+++ b/src/all2md/cli/commands/optimize.py
@@ -310,6 +310,18 @@ def handle_optimize_command(args: list[str] | None = None) -> int:
         print("Error: stdin ('-') may only be used once.", file=sys.stderr)
         return EXIT_FILE_ERROR
 
+    # Say up front what this is about to cost. The search is tens of full conversions,
+    # and a PDF page costs roughly a second to parse -- so a 20-page report is minutes
+    # of silence, and a 100-page one is far worse. Users should not have to discover
+    # --sample-pages by waiting.
+    if parsed.sample_pages is None and not parsed.json:
+        print(
+            "Tuning against the whole document: this runs tens of full conversions, "
+            "and a PDF page costs about a second to parse.\n"
+            "  --sample-pages 5  tunes on a slice instead;  --cache  makes repeat runs near-instant.",
+            file=sys.stderr,
+        )
+
     results: list[tuple[str, OptimizationReport]] = []
     try:
         # Guard fd 1 so PyMuPDF advisories during the (many) parses cannot corrupt

--- a/src/all2md/cli/config.py
+++ b/src/all2md/cli/config.py
@@ -40,6 +40,7 @@ SUBCOMMAND_CONFIG_SECTIONS: tuple[str, ...] = (
     "chunk",
     "report",
     "roundtrip",
+    "optimize",
 )
 
 

--- a/src/all2md/cli/help_formatter.py
+++ b/src/all2md/cli/help_formatter.py
@@ -168,6 +168,7 @@ _SUBCOMMAND_SUMMARIES: Sequence[tuple[str, str]] = (
     ("chunk", "Split documents into provenance-carrying chunks (JSONL) for RAG/LLM pipelines"),
     ("report", "Print a conversion confidence report ('quality card') scoring how much to trust a conversion"),
     ("roundtrip", "Convert a document through another format and back, scoring the structure that survived"),
+    ("optimize", "Search converter options for the settings that convert a document best"),
     ("lint", "Lint converted documents for structural, heading, link, list, table, and typography issues"),
     ("generate-site", "Generate Hugo, Jekyll, MkDocs, Zola, or Eleventy static site from documents"),
     ("arxiv", "Generate an ArXiv-ready LaTeX submission package from a document"),

--- a/src/all2md/optimize.py
+++ b/src/all2md/optimize.py
@@ -1,0 +1,561 @@
+#  Copyright (c) 2025 Tom Villani, Ph.D.
+#
+# src/all2md/optimize.py
+"""Auto-tune converter options against a reference-free fidelity objective.
+
+Difficult documents — the scanned PDF, the three-column report, the table with no
+ruling lines — rarely come with a reference to diff against, so the settings that
+convert them well cannot be found by comparing to a known-good output. This module
+searches the option space directly and ranks candidates by how much *well-formed*
+structure each one recovers.
+
+Why not reuse an existing score
+-------------------------------
+Neither shipped score works as a search objective:
+
+* :mod:`all2md.confidence` is a saturating *breakage detector*
+  (``100 - text_density - ocr_reliance - degraded_events``). It answers "can I
+  trust this conversion?", and on any document that is not visibly broken it pins
+  to ``100`` regardless of the settings used. Measured across 16 option
+  combinations on a two-column fixture it produced **one** distinct score while
+  the parsed AST produced **four** distinct outcomes: no gradient to climb.
+* :mod:`all2md.roundtrip` needs a ground truth. It manufactures one by re-parsing
+  rendered output, which measures the *renderer*, not the parser — a garbled table
+  round-trips through Markdown perfectly. It is the right objective for tuning
+  renderer options and the wrong one for tuning a PDF parser.
+
+So the objective here is computed from the parsed AST, which is where the gradient
+actually lives. The confidence report is still used, but for its *penalties* — the
+degraded-content incidents it records are a genuine signal that a conversion broke.
+
+The over-detection trap
+-----------------------
+"More structure is better" is the obvious objective and it is wrong twice over.
+
+**It rewards keeping the boilerplate.** Leaving a running header and page footer in
+yields strictly more text than trimming them, so a naive text-volume objective
+prefers the worse conversion. Measured against a fixture whose correct parse is
+known, that objective was *anti*-correlated with the truth (Pearson r = -0.88): it
+picked the worst candidate nearly every time. Text is therefore scored over body
+content only, with repeated furniture excluded — see :func:`_boilerplate_words`,
+and note that block-level deduplication is *not* sufficient, because the parser
+frequently glues a footer into an adjacent body block where no block comparison can
+ever see it.
+
+**It rewards an over-eager table detector**, because any junk region promoted to a
+table adds cells. Tables are therefore scored on **well-formedness** — cell fill
+density and column regularity — not on count. A hallucinated table is sparse and
+ragged, and scores near zero.
+
+With furniture excluded, a trimmed and an untrimmed conversion *tie* on text, which
+frees the ``cleanliness`` dimension to break the tie in favour of the one that
+actually removed it. On the same fixture that took the objective from r = -0.88 to
+r = +1.00.
+
+Fitness is *relative to the candidate pool*, not absolute: the best text recovery
+observed across the candidates stands in for the reference we do not have. This is
+deliberate. The job is to *rank* candidates, and inventing an absolute 0-100 quality
+number would both duplicate :mod:`all2md.confidence` and imply a precision these
+signals do not support.
+
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from collections import Counter
+from collections.abc import Callable
+from dataclasses import dataclass, field
+from typing import Any
+
+from all2md.ast.nodes import Document, Heading, Link, ListItem, Node, Table, Text, get_node_children
+
+# Pin the public surface. Without this, autodoc also documents the names this
+# module imports, and their docstrings are not valid reStructuredText.
+__all__ = [
+    "BOILERPLATE_NGRAM",
+    "DIMENSION_WEIGHTS",
+    "KNOBS",
+    "Candidate",
+    "DocumentMetrics",
+    "OptimizationReport",
+    "extract_metrics",
+    "score_candidates",
+    "search",
+    "tunable_knobs",
+]
+
+logger = logging.getLogger(__name__)
+
+#: How the fitness dimensions are combined. Dimensions the candidate pool does not
+#: exercise (no candidate found a table) are dropped and the rest renormalized, so a
+#: table-free document is neither rewarded nor punished for the tables it lacks.
+DIMENSION_WEIGHTS: dict[str, float] = {
+    "text": 0.45,
+    "tables": 0.25,
+    "structure": 0.15,
+    "cleanliness": 0.15,
+}
+
+#: The option values worth searching, per format. Deliberately curated rather than
+#: derived from the dataclass fields: most options are irrelevant to fidelity
+#: (``password``), or are a security posture that an optimizer has no business
+#: flipping (``strip_dangerous_elements``), or would explode the search space for no
+#: gain. Only knobs that plausibly change *what structure is recovered* belong here.
+KNOBS: dict[str, dict[str, list[Any]]] = {
+    "pdf": {
+        "table_detection_mode": ["pymupdf", "ruling", "both", "none"],
+        "detect_columns": [True, False],
+        "column_detection_mode": ["auto", "force_single", "force_multi"],
+        "enable_table_fallback_detection": [True, False],
+        "table_fallback_extraction_mode": ["none", "grid", "text_clustering"],
+        "detect_merged_cells": [True, False],
+        "trim_headers_footers": [True, False],
+        "auto_trim_headers_footers": [True, False],
+        "dedup_running_headings": [True, False],
+        "merge_hyphenated_words": [True, False],
+        "consolidate_inline_formatting": [True, False],
+    },
+    "html": {
+        "extract_readable": [True, False],
+        "detect_table_alignment": [True, False],
+        "collapse_whitespace": [True, False],
+        "figures_parsing": ["figure", "image", "skip"],
+        "details_parsing": ["details", "content", "skip"],
+        "extract_microdata": [True, False],
+    },
+    "docx": {
+        "preserve_tables": [True, False],
+        "include_footnotes": [True, False],
+        "include_endnotes": [True, False],
+        "include_comments": [True, False],
+        "include_image_captions": [True, False],
+    },
+}
+
+
+@dataclass
+class DocumentMetrics:
+    """The reference-free structural yield of one conversion.
+
+    Everything here is read off the parsed AST, except ``breakage``, which comes
+    from the confidence report's degraded-content incidents.
+    """
+
+    blocks: int = 0
+    #: Words in the document, counting every block.
+    words: int = 0
+    #: Words belonging to repeated furniture (running headers, page footers), whether
+    #: they sit in their own block or were glued into a body block.
+    boilerplate_words: int = 0
+    #: ``words`` minus the furniture: the body content actually recovered. This, not
+    #: ``words``, is what the text dimension scores.
+    unique_words: int = 0
+    #: Blocks whose text is entirely a repeat of another block.
+    duplicate_blocks: int = 0
+    headings: int = 0
+    list_items: int = 0
+    links: int = 0
+    tables: int = 0
+    table_cells: int = 0
+    #: Fraction of table cells that are non-empty. A hallucinated table is sparse.
+    table_fill: float = 0.0
+    #: Fraction of table rows whose column count matches the table's modal count.
+    #: A hallucinated table is ragged.
+    table_regularity: float = 0.0
+    #: ``100 - confidence.score``: how much real breakage the converter reported.
+    breakage: float = 0.0
+
+    @property
+    def table_quality(self) -> float:
+        """Well-formedness of the tables found, ``0.0``-``1.0``. Zero if there are none."""
+        if not self.tables:
+            return 0.0
+        return self.table_fill * self.table_regularity
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return a JSON-serializable view, including the derived table quality."""
+        data = {
+            "blocks": self.blocks,
+            "words": self.words,
+            "boilerplate_words": self.boilerplate_words,
+            "unique_words": self.unique_words,
+            "duplicate_blocks": self.duplicate_blocks,
+            "headings": self.headings,
+            "list_items": self.list_items,
+            "links": self.links,
+            "tables": self.tables,
+            "table_cells": self.table_cells,
+            "table_fill": round(self.table_fill, 4),
+            "table_regularity": round(self.table_regularity, 4),
+            "table_quality": round(self.table_quality, 4),
+            "breakage": round(self.breakage, 2),
+        }
+        return data
+
+
+@dataclass
+class Candidate:
+    """One point in the option space, with its measured yield and fitness."""
+
+    #: The options that differ from the parser's defaults, e.g. ``{"detect_columns": True}``.
+    options: dict[str, Any] = field(default_factory=dict)
+    #: Where the candidate came from: ``"default"``, ``"preset:quality"``, ``"refine:detect_columns"``.
+    origin: str = "default"
+    metrics: DocumentMetrics = field(default_factory=DocumentMetrics)
+    #: Pool-relative fitness, ``0``-``100``. Only comparable within one run.
+    fitness: float = 0.0
+    #: Per-dimension contributions, for explaining *why* a candidate won.
+    dimensions: dict[str, float] = field(default_factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return a JSON-serializable view."""
+        return {
+            "options": self.options,
+            "origin": self.origin,
+            "fitness": round(self.fitness, 2),
+            "dimensions": {k: round(v, 4) for k, v in self.dimensions.items()},
+            "metrics": self.metrics.to_dict(),
+        }
+
+
+@dataclass
+class OptimizationReport:
+    """The outcome of a search: what won, what it beat, and by how much."""
+
+    source_format: str = ""
+    #: The winning options, as a flat ``{option: value}`` diff from the defaults.
+    best_options: dict[str, Any] = field(default_factory=dict)
+    best_fitness: float = 0.0
+    #: Fitness of the parser's stock defaults, so the gain is legible.
+    baseline_fitness: float = 0.0
+    #: Every candidate evaluated, best first.
+    candidates: list[Candidate] = field(default_factory=list)
+    evaluated: int = 0
+
+    @property
+    def gain(self) -> float:
+        """How much fitness the winning options add over the stock defaults."""
+        return self.best_fitness - self.baseline_fitness
+
+    @property
+    def improved(self) -> bool:
+        """Whether the search beat the defaults at all."""
+        return self.gain > 0.005
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return a JSON-serializable view."""
+        return {
+            "source_format": self.source_format,
+            "best_options": self.best_options,
+            "best_fitness": round(self.best_fitness, 2),
+            "baseline_fitness": round(self.baseline_fitness, 2),
+            "gain": round(self.gain, 2),
+            "improved": self.improved,
+            "evaluated": self.evaluated,
+            "candidates": [c.to_dict() for c in self.candidates],
+        }
+
+
+def tunable_knobs(source_format: str) -> dict[str, list[Any]]:
+    """Return the searchable option values for ``source_format`` (empty if untuned)."""
+    return KNOBS.get(source_format, {})
+
+
+def _iter_nodes(node: Node) -> list[Node]:
+    """Walk every node in the tree.
+
+    ``get_node_children`` already descends into table rows and cells, so this must
+    not also walk them by hand or every cell would be counted twice.
+    """
+    found: list[Node] = [node]
+    for child in get_node_children(node):
+        found.extend(_iter_nodes(child))
+    return found
+
+
+def _node_text(node: Node) -> str:
+    """Concatenate the text carried by a node and everything beneath it.
+
+    Text lives in ``Text.content`` as a string, while every other node uses
+    ``content``/``children``/``rows`` as a *container*. ``get_node_children``
+    normalizes that difference; reading ``.content`` directly does not.
+    """
+    if isinstance(node, Text):
+        return node.content
+    parts = [_node_text(child) for child in get_node_children(node)]
+    return " ".join(p for p in parts if p)
+
+
+_DIGITS = re.compile(r"\d+")
+
+#: Length of the word window used to spot repeated furniture. Long enough that
+#: ordinary prose does not collide by chance, short enough to catch a page footer.
+BOILERPLATE_NGRAM = 5
+
+
+def _boilerplate_key(text: str) -> str:
+    """Normalize text so page-varying furniture still compares equal.
+
+    A running footer is not byte-identical across pages -- "Page 1 of 12" and
+    "Page 2 of 12" differ -- so digits are masked before comparing. Without this the
+    header dedupes and the footer does not, and keeping the footer still pays.
+    """
+    return _DIGITS.sub("#", " ".join(text.lower().split()))
+
+
+def _boilerplate_words(texts: list[str]) -> int:
+    """Count the words that are repeated furniture rather than body content.
+
+    Furniture is detected two ways, because one alone is not enough:
+
+    * **A whole block that repeats** -- a running heading, an unglued header.
+    * **A repeated word sequence spanning blocks** -- because a header or footer is
+      frequently *glued into an adjacent body block* by the parser, producing a
+      block like "Page 1 of 2 | ACME CONFIDENTIAL Beta sentence B1 ...". That block
+      is unique (it contains body text), so no amount of block-level comparison will
+      ever flag it, and its footer words get counted as body. Measured against ground
+      truth, that one leak was enough to make keeping the boilerplate outscore
+      trimming it.
+
+    Only sequences appearing in **two or more distinct blocks** count, so a single
+    block that happens to repeat a phrase internally is not mistaken for furniture.
+
+    Repetition is the only reference-free evidence that content is furniture, so a
+    one-page document offers no signal and its header cannot be recognized. That is
+    a real limit of the objective, not a bug.
+    """
+    tokens = [_boilerplate_key(text).split() for text in texts]
+
+    whole_block: Counter[str] = Counter(_boilerplate_key(t) for t in texts if t.strip())
+    covered = [[False] * len(block) for block in tokens]
+
+    # Where does each n-gram appear? Furniture shows up in more than one block.
+    seen: dict[tuple[str, ...], set[int]] = {}
+    for index, block in enumerate(tokens):
+        for start in range(len(block) - BOILERPLATE_NGRAM + 1):
+            seen.setdefault(tuple(block[start : start + BOILERPLATE_NGRAM]), set()).add(index)
+
+    for index, block in enumerate(tokens):
+        # A short running heading ("Quarterly Report") is below the n-gram window,
+        # so catch it as a whole-block repeat instead.
+        if texts[index].strip() and whole_block[_boilerplate_key(texts[index])] > 1:
+            covered[index] = [True] * len(block)
+            continue
+        for start in range(len(block) - BOILERPLATE_NGRAM + 1):
+            if len(seen[tuple(block[start : start + BOILERPLATE_NGRAM])]) > 1:
+                for offset in range(start, start + BOILERPLATE_NGRAM):
+                    covered[index][offset] = True
+
+    return sum(sum(block) for block in covered)
+
+
+def _table_shape(table: Table) -> tuple[int, int, int]:
+    """Return ``(cells, filled_cells, regular_rows)`` for one table."""
+    counts = [len(row.cells) for row in table.rows]
+    if not counts:
+        return 0, 0, 0
+    modal = Counter(counts).most_common(1)[0][0]
+    cells = sum(counts)
+    filled = sum(1 for row in table.rows for cell in row.cells if _node_text(cell).strip())
+    regular = sum(1 for count in counts if count == modal)
+    return cells, filled, regular
+
+
+def extract_metrics(document: Document) -> DocumentMetrics:
+    """Measure the structural yield of a parsed document.
+
+    Reads the AST rather than the confidence report's signal vector: measured on a
+    two-column fixture the signals collapsed 6 option combinations into 2 distinct
+    vectors (and the score into 1), while the AST kept 4 distinct outcomes. The
+    signals are a summary built for a different purpose; the AST is the evidence.
+    """
+    metrics = DocumentMetrics()
+
+    top_level = list(document.children or [])
+    metrics.blocks = len(top_level)
+
+    # Boilerplate is text that *repeats*. Identify it, then exclude every occurrence
+    # from the word count -- not just the second and later ones.
+    #
+    # This is load-bearing. Scoring text as "more is better" makes leaving the running
+    # header in strictly better than trimming it, because the boilerplate is extra
+    # words. Measured against ground truth that objective was anti-correlated
+    # (r = -0.88): it reliably picked the *worst* conversion. Excluding furniture makes
+    # a trimmed and an untrimmed conversion tie on text, so `cleanliness` -- which
+    # counts the furniture still present -- decides, and the trimmed one wins.
+    texts = [_node_text(block).strip() for block in top_level]
+    metrics.words = sum(len(text.split()) for text in texts)
+    metrics.boilerplate_words = _boilerplate_words(texts)
+    metrics.unique_words = metrics.words - metrics.boilerplate_words
+
+    repeats = Counter(_boilerplate_key(text) for text in texts if text)
+    metrics.duplicate_blocks = sum(1 for text in texts if text and repeats[_boilerplate_key(text)] > 1)
+
+    cells = filled = regular = rows = 0
+    for node in _iter_nodes(document):
+        if isinstance(node, Heading):
+            metrics.headings += 1
+        elif isinstance(node, ListItem):
+            metrics.list_items += 1
+        elif isinstance(node, Link):
+            metrics.links += 1
+        elif isinstance(node, Table):
+            metrics.tables += 1
+            table_cells, table_filled, table_regular = _table_shape(node)
+            cells += table_cells
+            filled += table_filled
+            regular += table_regular
+            rows += len(node.rows)
+
+    metrics.table_cells = cells
+    metrics.table_fill = filled / cells if cells else 0.0
+    metrics.table_regularity = regular / rows if rows else 0.0
+
+    confidence = (document.metadata or {}).get("confidence")
+    if isinstance(confidence, dict):
+        metrics.breakage = max(0.0, 100.0 - float(confidence.get("score", 100)))
+
+    return metrics
+
+
+def score_candidates(candidates: list[Candidate]) -> None:
+    """Assign each candidate a pool-relative fitness, in place.
+
+    Fitness is relative because the objective is reference-free: with no ground
+    truth, the best text recovery *observed across the pool* is the closest thing to
+    one. A candidate recovering fewer unique words than the best candidate lost text.
+
+    Dimensions the pool does not exercise are dropped and the weights renormalized
+    over the rest — if no candidate found a table, the ``tables`` dimension says
+    nothing about this document and must not drag every score down.
+    """
+    if not candidates:
+        return
+
+    best_words = max(c.metrics.unique_words for c in candidates)
+    best_structure = max(c.metrics.headings + c.metrics.list_items + c.metrics.links for c in candidates)
+    any_tables = any(c.metrics.tables for c in candidates)
+
+    active = dict(DIMENSION_WEIGHTS)
+    if not any_tables:
+        active.pop("tables")
+    if not best_words:
+        active.pop("text", None)
+    if not best_structure:
+        active.pop("structure", None)
+    total_weight = sum(active.values()) or 1.0
+
+    for candidate in candidates:
+        metrics = candidate.metrics
+        dimensions: dict[str, float] = {}
+
+        if "text" in active:
+            dimensions["text"] = metrics.unique_words / best_words
+
+        if "tables" in active:
+            # Well-formedness, not count: a junk table is sparse and ragged.
+            dimensions["tables"] = metrics.table_quality
+
+        if "structure" in active:
+            structure = metrics.headings + metrics.list_items + metrics.links
+            dimensions["structure"] = structure / best_structure
+
+        # Furniture still sitting in the output is boilerplate the converter failed
+        # to trim. Measured in words, not blocks, so a footer glued into a paragraph
+        # counts just as much as one left in a block of its own.
+        boilerplate_ratio = metrics.boilerplate_words / metrics.words if metrics.words else 0.0
+        dimensions["cleanliness"] = 1.0 - boilerplate_ratio
+
+        weighted = sum(dimensions[name] * active[name] for name in active if name in dimensions)
+        # Breakage is a real defect the converter itself reported: subtract it.
+        candidate.fitness = max(0.0, (weighted / total_weight) * 100.0 - metrics.breakage)
+        candidate.dimensions = dimensions
+
+
+def search(
+    knobs: dict[str, list[Any]],
+    evaluate: Callable[[dict[str, Any]], DocumentMetrics],
+    *,
+    presets: dict[str, dict[str, Any]] | None = None,
+    rounds: int = 1,
+) -> OptimizationReport:
+    """Search ``knobs`` for the option set with the best fitness.
+
+    Takes an ``evaluate`` callable rather than a document, so the search is pure and
+    can be tested against a synthetic objective with no parsing at all.
+
+    The shape is deliberately cheap. A full grid over the PDF knobs alone is tens of
+    thousands of conversions; instead:
+
+    1. Score the stock defaults, then each named preset. These are interpretable,
+       few, and often already contain the answer.
+    2. **Coordinate descent** from the best of those: walk one knob at a time, try
+       each of its values holding the rest fixed, and keep any improvement. That is
+       ``sum(len(values))`` conversions per round rather than ``prod(len(values))``.
+
+    Coordinate descent finds a local optimum, not a global one — it cannot discover
+    that two knobs only pay off when flipped *together*. That is an accepted trade:
+    the alternative costs orders of magnitude more conversions, and the knobs here
+    are largely independent in practice. ``rounds > 1`` re-walks the knobs from the
+    new best point, which recovers some interactions.
+
+    Every distinct option set is evaluated at most once.
+    """
+    seen: dict[tuple[tuple[str, Any], ...], Candidate] = {}
+
+    def signature(options: dict[str, Any]) -> tuple[tuple[str, Any], ...]:
+        return tuple(sorted(options.items()))
+
+    def consider(options: dict[str, Any], origin: str) -> Candidate:
+        key = signature(options)
+        if key not in seen:
+            seen[key] = Candidate(options=dict(options), origin=origin, metrics=evaluate(options))
+        return seen[key]
+
+    def rank() -> None:
+        """Fitness is pool-relative, so it must be recomputed as the pool grows."""
+        score_candidates(list(seen.values()))
+
+    baseline = consider({}, "default")
+    rank()
+
+    best = baseline
+    for name, config in (presets or {}).items():
+        # A preset that sets nothing for this format is the default under another
+        # name; evaluating it would just be a duplicate.
+        overrides = {k: v for k, v in config.items() if k in knobs}
+        if not overrides:
+            continue
+        consider(overrides, f"preset:{name}")
+    rank()
+    best = max(seen.values(), key=lambda c: c.fitness)
+
+    for _ in range(max(1, rounds)):
+        improved = False
+        for knob, values in knobs.items():
+            for value in values:
+                if best.options.get(knob) == value:
+                    continue
+                trial = dict(best.options)
+                trial[knob] = value
+                consider(trial, f"refine:{knob}")
+            rank()
+            leader = max(seen.values(), key=lambda c: c.fitness)
+            if leader.fitness > best.fitness:
+                best, improved = leader, True
+        if not improved:
+            break  # a full pass changed nothing; another one cannot either
+
+    rank()
+    ranked = sorted(seen.values(), key=lambda c: -c.fitness)
+    best = ranked[0]
+
+    return OptimizationReport(
+        best_options=dict(best.options),
+        best_fitness=best.fitness,
+        baseline_fitness=baseline.fitness,
+        candidates=ranked,
+        evaluated=len(seen),
+    )

--- a/src/all2md/optimize.py
+++ b/src/all2md/optimize.py
@@ -54,21 +54,49 @@ Getting that exclusion right took two corrections, both forced by measurement:
    PyMuPDF versions, so a per-candidate rule can look perfectly correct locally and
    invert the ranking somewhere else.
 
-**It rewards an over-eager table detector**, because any junk region promoted to a
-table adds cells. Tables are therefore scored on **well-formedness** — cell fill
-density and column regularity — not on count. A hallucinated table is sparse and
-ragged, and scores near zero.
-
 With furniture excluded, a trimmed and an untrimmed conversion *tie* on text, which
 frees the ``cleanliness`` dimension to break the tie in favour of the one that
 actually removed it. On the same fixture that took the objective from r = -0.88 to
 r = +1.00.
+
+**It rewards an over-eager table detector**, because any junk region promoted to a
+table adds cells. But scoring well-formedness *alone* — the obvious correction —
+simply inverts the bias into rewarding an **under**-eager one: finding five clean
+tables and missing the sixth then beats finding all six with one messy. That is not
+theoretical; on a real arXiv paper ``table_detection_mode="ruling"`` scored 0.98 on
+well-formedness against ``"pymupdf"``'s 0.68 while recovering *fewer* tables. Tables
+are therefore scored on **quality-weighted recall** (:func:`_table_shape`): filled
+cells, discounted by shape regularity. A hallucinated table is sparse and ragged and
+contributes almost nothing; a missed real one costs its cells.
+
+**And furniture must repeat like furniture.** A sequence counted as boilerplate if it
+appeared in merely *two* blocks — correct only for the two-page fixture it was written
+against. On a 21-page paper it fired on ordinary recurring academic phrasing and
+flagged 746 words of real body text as boilerplate (against 131 with the corrected
+rule). False furniture is not harmless: it makes body text look like clutter, so a
+setting that *deletes* that text scores as if it had tidied up. The bar now scales
+with page count — :func:`furniture_threshold`.
+
+Body text is not a dimension at all
+-----------------------------------
+It **gates** the others. Losing a paragraph is data loss; leaving a running header in
+is an annoyance, and no exchange rate between them is defensible. As a weighted
+dimension the two were interchangeable at 0.45 versus 0.15, which means a setting
+that destroyed 1% of the body could buy its way back with a 3% tidiness gain. That is
+the wrong trade at any exchange rate, so retention instead *multiplies* the score,
+raised to :data:`TEXT_RETENTION_EXPONENT`: shedding 1% of the body costs ~3% of
+fitness and no amount of polish buys it back. This is a deliberately conservative
+posture — the optimizer's advice is only worth taking if it cannot destroy content.
 
 Fitness is *relative to the candidate pool*, not absolute: the best text recovery
 observed across the candidates stands in for the reference we do not have. This is
 deliberate. The job is to *rank* candidates, and inventing an absolute 0-100 quality
 number would both duplicate :mod:`all2md.confidence` and imply a precision these
 signals do not support.
+
+Every correction above was forced by measurement, and several of them by documents
+from the wild, which broke an objective that looked perfectly healthy on a synthetic
+fixture. Changing the scoring without re-running that evaluation is not advisable.
 
 """
 
@@ -92,6 +120,10 @@ from all2md.roundtrip import _INLINE_TYPES
 __all__ = [
     "BOILERPLATE_NGRAM",
     "DIMENSION_WEIGHTS",
+    "MINIMIZE_TOLERANCE",
+    "MIN_STRUCTURE_ELEMENTS",
+    "MIN_TABLE_CELLS",
+    "TEXT_RETENTION_EXPONENT",
     "KNOBS",
     "Candidate",
     "DocumentMetrics",
@@ -99,6 +131,7 @@ __all__ = [
     "OptimizationReport",
     "extract_metrics",
     "find_furniture",
+    "furniture_threshold",
     "score_candidates",
     "search",
     "tunable_knobs",
@@ -109,12 +142,45 @@ logger = logging.getLogger(__name__)
 #: How the fitness dimensions are combined. Dimensions the candidate pool does not
 #: exercise (no candidate found a table) are dropped and the rest renormalized, so a
 #: table-free document is neither rewarded nor punished for the tables it lacks.
+#:
+#: Body text is deliberately **not** here. It is not a dimension to be traded against
+#: the others; it is a multiplicative gate -- see :data:`TEXT_RETENTION_EXPONENT`.
 DIMENSION_WEIGHTS: dict[str, float] = {
-    "text": 0.45,
-    "tables": 0.25,
-    "structure": 0.15,
-    "cleanliness": 0.15,
+    "tables": 0.45,
+    "structure": 0.25,
+    "cleanliness": 0.30,
 }
+
+#: How steeply losing body text is punished. Retention (this candidate's body words
+#: over the best candidate's) multiplies the whole score raised to this power, so
+#: shedding 1% of the body costs roughly 3% of fitness.
+#:
+#: This exists because losing a paragraph and keeping a running header are not
+#: commensurable defects. As a mere weighted dimension, body text was interchangeable
+#: with tidiness, so a setting that destroyed content could buy its way back by
+#: removing clutter. A conservative posture is the point: advice that can silently
+#: delete text is not advice worth taking.
+TEXT_RETENTION_EXPONENT = 3.0
+
+#: How much fitness a recommended setting must be worth to survive the minimization
+#: pass. Anything that can be removed without dropping below this is a passenger the
+#: search happened to pick up, not a finding, and reporting it as advice is worse than
+#: saying nothing: the user cannot tell the difference.
+MINIMIZE_TOLERANCE = 1e-9
+
+#: How much of a dimension the best candidate must actually find before that dimension
+#: is allowed to influence the ranking.
+#:
+#: Every dimension is normalized against the best candidate in the pool, which turns a
+#: *trivial* absolute difference into a *total* relative one. On a real arXiv paper
+#: with no real tables at all, one setting happened to find a single two-column table
+#: worth four cells while the default found none: the tables dimension read 1.0 against
+#: 0.0 -- a maximal swing, worth its full weight -- and the optimizer reported a **45
+#: point** gain for a change that measurably did nothing. A dimension the document
+#: barely exercises carries no information about it, and must not be allowed to decide
+#: the ranking. Below these floors it is dropped, exactly as it already is at zero.
+MIN_TABLE_CELLS = 8.0
+MIN_STRUCTURE_ELEMENTS = 3
 
 #: The option values worth searching, per format. Deliberately curated rather than
 #: derived from the dataclass fields: most options are irrelevant to fidelity
@@ -177,6 +243,11 @@ class DocumentMetrics:
     links: int = 0
     tables: int = 0
     table_cells: int = 0
+    #: Filled cells discounted by shape regularity, summed over tables with 2+ columns.
+    #: Quality-weighted *recall*: this, not ``table_quality``, is what the objective
+    #: scores. Well-formedness alone rewards missing real tables; count alone rewards
+    #: inventing them.
+    good_cells: float = 0.0
     #: Fraction of table cells that are non-empty. A hallucinated table is sparse.
     table_fill: float = 0.0
     #: Fraction of table rows whose column count matches the table's modal count.
@@ -190,6 +261,9 @@ class DocumentMetrics:
     block_texts: list[str] = field(default_factory=list, repr=False, compare=False)
     #: The repeated content this parse revealed.
     furniture: Furniture = field(default_factory=lambda: Furniture(set(), set()), repr=False, compare=False)
+    #: How many distinct blocks a sequence must span before it counts as furniture.
+    #: Scales with page count: furniture repeats page after page, ordinary prose does not.
+    min_furniture_blocks: int = 2
 
     @property
     def table_quality(self) -> float:
@@ -211,6 +285,7 @@ class DocumentMetrics:
             "links": self.links,
             "tables": self.tables,
             "table_cells": self.table_cells,
+            "good_cells": round(self.good_cells, 2),
             "table_fill": round(self.table_fill, 4),
             "table_regularity": round(self.table_regularity, 4),
             "table_quality": round(self.table_quality, 4),
@@ -369,11 +444,28 @@ class Furniture(NamedTuple):
         return Furniture(self.sequences | other.sequences, self.blocks | other.blocks)
 
 
-def find_furniture(texts: list[str]) -> Furniture:
+def furniture_threshold(page_count: int | None) -> int:
+    """How many distinct blocks a sequence must appear in before it is furniture.
+
+    Furniture is content that repeats on *page after page*, so the bar has to scale
+    with the document. A flat "appears twice" rule is only correct for a two-page
+    document -- which is exactly the fixture it was written against. On a 21-page
+    arXiv paper it fired on ordinary recurring academic phrasing and flagged 746 words
+    of real body text as boilerplate, against 131 once the bar scaled with the page
+    count. False furniture is not harmless: it makes body text look like clutter, so a
+    setting that *deletes* that text scores as if it had tidied up.
+    """
+    if not page_count or page_count < 2:
+        return 2
+    return max(2, round(page_count / 2))
+
+
+def find_furniture(texts: list[str], min_blocks: int = 2) -> Furniture:
     """Identify the repeated furniture in one parse of a document.
 
-    Only sequences appearing in **two or more distinct blocks** count, so a single
-    block that happens to repeat a phrase internally is not mistaken for furniture.
+    A sequence must appear in at least ``min_blocks`` distinct blocks -- see
+    :func:`furniture_threshold`. Counting *distinct blocks* (not occurrences) means a
+    single block that repeats a phrase internally is never mistaken for furniture.
 
     Repetition is the only reference-free evidence that content is furniture, so a
     one-page document offers no signal and its header cannot be recognized. That is
@@ -382,14 +474,14 @@ def find_furniture(texts: list[str]) -> Furniture:
     tokens = [_boilerplate_key(text).split() for text in texts]
 
     counts: Counter[str] = Counter(_boilerplate_key(t) for t in texts if t.strip())
-    blocks = {key for key, count in counts.items() if count > 1}
+    blocks = {key for key, count in counts.items() if count >= min_blocks}
 
     where: dict[tuple[str, ...], set[int]] = {}
     for index, block in enumerate(tokens):
         for start in range(len(block) - BOILERPLATE_NGRAM + 1):
             where.setdefault(tuple(block[start : start + BOILERPLATE_NGRAM]), set()).add(index)
 
-    sequences = {gram for gram, seen_in in where.items() if len(seen_in) > 1}
+    sequences = {gram for gram, seen_in in where.items() if len(seen_in) >= min_blocks}
     return Furniture(sequences, blocks)
 
 
@@ -421,16 +513,34 @@ def _boilerplate_words(texts: list[str], furniture: Furniture) -> int:
     return total
 
 
-def _table_shape(table: Table) -> tuple[int, int, int]:
-    """Return ``(cells, filled_cells, regular_rows)`` for one table."""
+def _table_shape(table: Table) -> tuple[int, int, int, float]:
+    """Return ``(cells, filled_cells, regular_rows, good_cells)`` for one table.
+
+    ``good_cells`` is the table's contribution to the objective: its filled cells,
+    discounted by how regular its shape is. It is *quality-weighted recall*, and both
+    halves are load-bearing:
+
+    * Scoring quality **alone** rewards under-detection — finding five clean tables
+      and missing the sixth beats finding all six with one messy. Measured on a real
+      arXiv paper, ``table_detection_mode="ruling"`` scored 0.98 on well-formedness
+      against ``"pymupdf"``'s 0.68 while recovering *fewer* tables.
+    * Scoring count **alone** rewards hallucination — any junk region promoted to a
+      table adds cells.
+
+    A single-column "table" is not tabular: it is a paragraph the detector captured,
+    and counting it would let an aggressive detector bank body text as table content.
+    """
     counts = [len(row.cells) for row in table.rows]
     if not counts:
-        return 0, 0, 0
+        return 0, 0, 0, 0.0
     modal = Counter(counts).most_common(1)[0][0]
     cells = sum(counts)
     filled = sum(1 for row in table.rows for cell in row.cells if _node_text(cell).strip())
     regular = sum(1 for count in counts if count == modal)
-    return cells, filled, regular
+
+    regularity = regular / len(counts)
+    good = 0.0 if modal < 2 else filled * regularity
+    return cells, filled, regular, good
 
 
 def extract_metrics(document: Document) -> DocumentMetrics:
@@ -455,17 +565,25 @@ def extract_metrics(document: Document) -> DocumentMetrics:
     # (r = -0.88): it reliably picked the *worst* conversion. Excluding furniture makes
     # a trimmed and an untrimmed conversion tie on text, so `cleanliness` -- which
     # counts the furniture still present -- decides, and the trimmed one wins.
+    confidence = (document.metadata or {}).get("confidence") or {}
+    signals = confidence.get("signals") or {} if isinstance(confidence, dict) else {}
+    page_count = signals.get("page_count")
+    metrics.min_furniture_blocks = furniture_threshold(page_count if isinstance(page_count, int) else None)
+
     texts = [_node_text(block).strip() for block in top_level]
     metrics.block_texts = texts
-    metrics.furniture = find_furniture(texts)
+    metrics.furniture = find_furniture(texts, metrics.min_furniture_blocks)
     metrics.words = sum(len(text.split()) for text in texts)
     metrics.boilerplate_words = _boilerplate_words(texts, metrics.furniture)
     metrics.unique_words = metrics.words - metrics.boilerplate_words
 
     repeats = Counter(_boilerplate_key(text) for text in texts if text)
-    metrics.duplicate_blocks = sum(1 for text in texts if text and repeats[_boilerplate_key(text)] > 1)
+    metrics.duplicate_blocks = sum(
+        1 for text in texts if text and repeats[_boilerplate_key(text)] >= metrics.min_furniture_blocks
+    )
 
     cells = filled = regular = rows = 0
+    good = 0.0
     for node in _iter_nodes(document):
         if isinstance(node, Heading):
             metrics.headings += 1
@@ -475,17 +593,18 @@ def extract_metrics(document: Document) -> DocumentMetrics:
             metrics.links += 1
         elif isinstance(node, Table):
             metrics.tables += 1
-            table_cells, table_filled, table_regular = _table_shape(node)
+            table_cells, table_filled, table_regular, table_good = _table_shape(node)
             cells += table_cells
             filled += table_filled
             regular += table_regular
             rows += len(node.rows)
+            good += table_good
 
     metrics.table_cells = cells
+    metrics.good_cells = good
     metrics.table_fill = filled / cells if cells else 0.0
     metrics.table_regularity = regular / rows if rows else 0.0
 
-    confidence = (document.metadata or {}).get("confidence")
     if isinstance(confidence, dict):
         metrics.breakage = max(0.0, 100.0 - float(confidence.get("score", 100)))
 
@@ -525,14 +644,17 @@ def score_candidates(candidates: list[Candidate]) -> None:
 
     best_words = max(c.metrics.unique_words for c in candidates)
     best_structure = max(c.metrics.headings + c.metrics.list_items + c.metrics.links for c in candidates)
-    any_tables = any(c.metrics.tables for c in candidates)
+    best_cells = max(c.metrics.good_cells for c in candidates)
 
+    # A dimension the document barely exercises says nothing about it. Because every
+    # dimension is normalized against the pool's best, a trivial absolute difference
+    # (four table cells against none, on a paper with no real tables) would otherwise
+    # read as a total one -- 1.0 against 0.0 -- and swing the ranking by its full
+    # weight. Drop it, exactly as we already do when it is entirely absent.
     active = dict(DIMENSION_WEIGHTS)
-    if not any_tables:
-        active.pop("tables")
-    if not best_words:
-        active.pop("text", None)
-    if not best_structure:
+    if best_cells < MIN_TABLE_CELLS:
+        active.pop("tables", None)
+    if best_structure < MIN_STRUCTURE_ELEMENTS:
         active.pop("structure", None)
     total_weight = sum(active.values()) or 1.0
 
@@ -540,12 +662,10 @@ def score_candidates(candidates: list[Candidate]) -> None:
         metrics = candidate.metrics
         dimensions: dict[str, float] = {}
 
-        if "text" in active:
-            dimensions["text"] = metrics.unique_words / best_words
-
         if "tables" in active:
-            # Well-formedness, not count: a junk table is sparse and ragged.
-            dimensions["tables"] = metrics.table_quality
+            # Quality-weighted *recall*: filled cells discounted by shape regularity.
+            # Quality alone rewards under-detection; count alone rewards hallucination.
+            dimensions["tables"] = metrics.good_cells / best_cells
 
         if "structure" in active:
             structure = metrics.headings + metrics.list_items + metrics.links
@@ -557,9 +677,20 @@ def score_candidates(candidates: list[Candidate]) -> None:
         boilerplate_ratio = metrics.boilerplate_words / metrics.words if metrics.words else 0.0
         dimensions["cleanliness"] = 1.0 - boilerplate_ratio
 
+        # Body text is not a dimension to be traded against the others -- it GATES
+        # them. Losing a paragraph is data loss; leaving a running header in is an
+        # annoyance, and the two must not be interchangeable at any exchange rate.
+        # As a weighted dimension they were, so a candidate that destroyed body text
+        # could buy its way back with a tidiness gain. Retention is therefore a
+        # multiplier raised to TEXT_RETENTION_EXPONENT: shedding 1% of the body costs
+        # ~3% of fitness and no amount of polish can buy it back.
+        retention = metrics.unique_words / best_words if best_words else 1.0
+        dimensions["retention"] = retention
+
         weighted = sum(dimensions[name] * active[name] for name in active if name in dimensions)
+        gated = (weighted / total_weight) * (retention**TEXT_RETENTION_EXPONENT)
         # Breakage is a real defect the converter itself reported: subtract it.
-        candidate.fitness = max(0.0, (weighted / total_weight) * 100.0 - metrics.breakage)
+        candidate.fitness = max(0.0, gated * 100.0 - metrics.breakage)
         candidate.dimensions = dimensions
 
 
@@ -638,8 +769,33 @@ def search(
             break  # a full pass changed nothing; another one cannot either
 
     rank()
+    best = max(seen.values(), key=lambda c: c.fitness)
+
+    # Drop passengers. Coordinate descent accumulates whatever it walked through, so
+    # the winner can carry settings that merely *tied* rather than won -- on a real
+    # arXiv paper it reported ``table_detection_mode="none"`` for a document whose only
+    # "table" was a one-column artifact, so the knob could not affect fitness at all.
+    # A setting we have no evidence for is not a finding, and printing it as advice
+    # invites the user to believe it matters. Try removing each one; if fitness does
+    # not fall, it was never earning its place.
+    #
+    # This also makes the recommendation strictly more conservative -- everything
+    # dropped reverts to the shipped default.
+    shrinking = True
+    while shrinking:
+        shrinking = False
+        for knob in list(best.options):
+            trial = {name: value for name, value in best.options.items() if name != knob}
+            candidate = consider(trial, f"minimize:{knob}")
+            rank()
+            if candidate.fitness >= best.fitness - MINIMIZE_TOLERANCE:
+                best = candidate
+                shrinking = True
+                break
+
+    rank()
     ranked = sorted(seen.values(), key=lambda c: -c.fitness)
-    best = ranked[0]
+    best = seen[signature(best.options)]
 
     return OptimizationReport(
         best_options=dict(best.options),

--- a/src/all2md/optimize.py
+++ b/src/all2md/optimize.py
@@ -137,7 +137,7 @@ __all__ = [
     "tunable_knobs",
 ]
 
-logger = logging.getLogger(__name__)
+_unused_logger = logging.getLogger(__name__)
 
 #: How the fitness dimensions are combined. Dimensions the candidate pool does not
 #: exercise (no candidate found a table) are dropped and the rest renormalized, so a

--- a/src/all2md/optimize.py
+++ b/src/all2md/optimize.py
@@ -741,7 +741,6 @@ def search(
     baseline = consider({}, "default")
     rank()
 
-    best = baseline
     for name, config in (presets or {}).items():
         # A preset that sets nothing for this format is the default under another
         # name; evaluating it would just be a duplicate.

--- a/src/all2md/optimize.py
+++ b/src/all2md/optimize.py
@@ -37,10 +37,22 @@ yields strictly more text than trimming them, so a naive text-volume objective
 prefers the worse conversion. Measured against a fixture whose correct parse is
 known, that objective was *anti*-correlated with the truth (Pearson r = -0.88): it
 picked the worst candidate nearly every time. Text is therefore scored over body
-content only, with repeated furniture excluded — see :func:`_boilerplate_words`,
-and note that block-level deduplication is *not* sufficient, because the parser
-frequently glues a footer into an adjacent body block where no block comparison can
-ever see it.
+content only, with repeated furniture excluded.
+
+Getting that exclusion right took two corrections, both forced by measurement:
+
+1. **Block-level deduplication is not enough.** The parser frequently glues a footer
+   into an adjacent body block ("Page 1 of 2 | ACME CONFIDENTIAL Beta sentence
+   B1 ..."). That block is unique, so no block comparison can ever see it. Furniture
+   must be found as a repeated *word sequence* spanning blocks — :func:`find_furniture`.
+2. **Furniture is a property of the document, not of one parse of it.** Deriving it
+   per-candidate lets a candidate whose block segmentation happens to hide the
+   repetition escape detection and bank its running header as recovered body text.
+   The candidates then stop tying on text and keeping the boilerplate wins again.
+   :func:`score_candidates` therefore pools what *every* candidate revealed and
+   applies the union to all of them. This one bit differs between platforms and
+   PyMuPDF versions, so a per-candidate rule can look perfectly correct locally and
+   invert the ranking somewhere else.
 
 **It rewards an over-eager table detector**, because any junk region promoted to a
 table adds cells. Tables are therefore scored on **well-formedness** — cell fill
@@ -67,9 +79,13 @@ import re
 from collections import Counter
 from collections.abc import Callable
 from dataclasses import dataclass, field
-from typing import Any
+from typing import Any, NamedTuple
 
 from all2md.ast.nodes import Document, Heading, Link, ListItem, Node, Table, Text, get_node_children
+
+# One definition of "inline", shared with the round-trip scorer. A second copy here
+# would be free to drift, and getting this set wrong silently corrupts word counts.
+from all2md.roundtrip import _INLINE_TYPES
 
 # Pin the public surface. Without this, autodoc also documents the names this
 # module imports, and their docstrings are not valid reStructuredText.
@@ -79,8 +95,10 @@ __all__ = [
     "KNOBS",
     "Candidate",
     "DocumentMetrics",
+    "Furniture",
     "OptimizationReport",
     "extract_metrics",
+    "find_furniture",
     "score_candidates",
     "search",
     "tunable_knobs",
@@ -166,6 +184,12 @@ class DocumentMetrics:
     table_regularity: float = 0.0
     #: ``100 - confidence.score``: how much real breakage the converter reported.
     breakage: float = 0.0
+
+    #: The document's top-level block texts. Kept so the furniture found by *any*
+    #: candidate can be re-applied to *this* one -- see :func:`score_candidates`.
+    block_texts: list[str] = field(default_factory=list, repr=False, compare=False)
+    #: The repeated content this parse revealed.
+    furniture: Furniture = field(default_factory=lambda: Furniture(set(), set()), repr=False, compare=False)
 
     @property
     def table_quality(self) -> float:
@@ -281,11 +305,29 @@ def _node_text(node: Node) -> str:
     Text lives in ``Text.content`` as a string, while every other node uses
     ``content``/``children``/``rows`` as a *container*. ``get_node_children``
     normalizes that difference; reading ``.content`` directly does not.
+
+    Inline siblings are joined with **no separator**, because they are contiguous
+    character runs, not separate words: a bolded middle of a word arrives as three
+    runs and must come back as one word. Joining them with a space instead turns
+    "hello" into "hel lo" and conjures a word out of nothing — which is not merely
+    inaccurate, it is *exploitable*. The optimizer scores recovered text, so on real
+    papers it learned to recommend ``consolidate_inline_formatting=False`` purely
+    because leaving runs unmerged inflated the word count (2325 -> 2412 words on an
+    arXiv paper, with no more text on the page). Blocks still get a separator: they
+    are genuinely distinct runs of prose.
     """
     if isinstance(node, Text):
         return node.content
-    parts = [_node_text(child) for child in get_node_children(node)]
-    return " ".join(p for p in parts if p)
+
+    result = ""
+    for child in get_node_children(node):
+        part = _node_text(child)
+        if not part:
+            continue
+        if result and type(child).__name__ not in _INLINE_TYPES:
+            result += " "
+        result += part
+    return result
 
 
 _DIGITS = re.compile(r"\d+")
@@ -305,19 +347,30 @@ def _boilerplate_key(text: str) -> str:
     return _DIGITS.sub("#", " ".join(text.lower().split()))
 
 
-def _boilerplate_words(texts: list[str]) -> int:
-    """Count the words that are repeated furniture rather than body content.
+class Furniture(NamedTuple):
+    """The repeated content of a document: running headers, footers, watermarks.
 
-    Furniture is detected two ways, because one alone is not enough:
+    Two shapes, because one alone is not enough:
 
-    * **A whole block that repeats** -- a running heading, an unglued header.
-    * **A repeated word sequence spanning blocks** -- because a header or footer is
-      frequently *glued into an adjacent body block* by the parser, producing a
-      block like "Page 1 of 2 | ACME CONFIDENTIAL Beta sentence B1 ...". That block
-      is unique (it contains body text), so no amount of block-level comparison will
-      ever flag it, and its footer words get counted as body. Measured against ground
-      truth, that one leak was enough to make keeping the boilerplate outscore
-      trimming it.
+    * ``sequences`` -- word windows appearing in two or more distinct blocks. Needed
+      because a header or footer is frequently *glued into an adjacent body block* by
+      the parser ("Page 1 of 2 | ACME CONFIDENTIAL Beta sentence B1 ..."). Such a
+      block is unique -- it contains body text -- so no block-level comparison can
+      ever flag it, and its footer words would count as recovered body content.
+    * ``blocks`` -- whole blocks that repeat. Needed because a short running heading
+      ("Quarterly Report") is below the n-gram window and no sequence can catch it.
+    """
+
+    sequences: set[tuple[str, ...]]
+    blocks: set[str]
+
+    def union(self, other: Furniture) -> Furniture:
+        """Combine what two parses each revealed about the document's furniture."""
+        return Furniture(self.sequences | other.sequences, self.blocks | other.blocks)
+
+
+def find_furniture(texts: list[str]) -> Furniture:
+    """Identify the repeated furniture in one parse of a document.
 
     Only sequences appearing in **two or more distinct blocks** count, so a single
     block that happens to repeat a phrase internally is not mistaken for furniture.
@@ -328,27 +381,44 @@ def _boilerplate_words(texts: list[str]) -> int:
     """
     tokens = [_boilerplate_key(text).split() for text in texts]
 
-    whole_block: Counter[str] = Counter(_boilerplate_key(t) for t in texts if t.strip())
-    covered = [[False] * len(block) for block in tokens]
+    counts: Counter[str] = Counter(_boilerplate_key(t) for t in texts if t.strip())
+    blocks = {key for key, count in counts.items() if count > 1}
 
-    # Where does each n-gram appear? Furniture shows up in more than one block.
-    seen: dict[tuple[str, ...], set[int]] = {}
+    where: dict[tuple[str, ...], set[int]] = {}
     for index, block in enumerate(tokens):
         for start in range(len(block) - BOILERPLATE_NGRAM + 1):
-            seen.setdefault(tuple(block[start : start + BOILERPLATE_NGRAM]), set()).add(index)
+            where.setdefault(tuple(block[start : start + BOILERPLATE_NGRAM]), set()).add(index)
 
-    for index, block in enumerate(tokens):
-        # A short running heading ("Quarterly Report") is below the n-gram window,
-        # so catch it as a whole-block repeat instead.
-        if texts[index].strip() and whole_block[_boilerplate_key(texts[index])] > 1:
-            covered[index] = [True] * len(block)
+    sequences = {gram for gram, seen_in in where.items() if len(seen_in) > 1}
+    return Furniture(sequences, blocks)
+
+
+def _boilerplate_words(texts: list[str], furniture: Furniture) -> int:
+    """Count how many of ``texts``' words belong to ``furniture``.
+
+    ``furniture`` is passed in rather than derived here, because *what counts as
+    furniture is a property of the document, not of one parse of it*. Deriving it
+    per-candidate lets a candidate whose block segmentation happens to hide the
+    repetition escape detection -- its furniture words then read as recovered body
+    text, and keeping the boilerplate starts paying again. That is exactly how the
+    over-detection trap came back on a document where every local run looked fine:
+    the candidates stopped tying on text, and the untrimmed one won.
+    """
+    total = 0
+    for text in texts:
+        block = _boilerplate_key(text).split()
+        if not block:
             continue
+        if _boilerplate_key(text) in furniture.blocks:
+            total += len(block)
+            continue
+        covered = [False] * len(block)
         for start in range(len(block) - BOILERPLATE_NGRAM + 1):
-            if len(seen[tuple(block[start : start + BOILERPLATE_NGRAM])]) > 1:
+            if tuple(block[start : start + BOILERPLATE_NGRAM]) in furniture.sequences:
                 for offset in range(start, start + BOILERPLATE_NGRAM):
-                    covered[index][offset] = True
-
-    return sum(sum(block) for block in covered)
+                    covered[offset] = True
+        total += sum(covered)
+    return total
 
 
 def _table_shape(table: Table) -> tuple[int, int, int]:
@@ -386,8 +456,10 @@ def extract_metrics(document: Document) -> DocumentMetrics:
     # a trimmed and an untrimmed conversion tie on text, so `cleanliness` -- which
     # counts the furniture still present -- decides, and the trimmed one wins.
     texts = [_node_text(block).strip() for block in top_level]
+    metrics.block_texts = texts
+    metrics.furniture = find_furniture(texts)
     metrics.words = sum(len(text.split()) for text in texts)
-    metrics.boilerplate_words = _boilerplate_words(texts)
+    metrics.boilerplate_words = _boilerplate_words(texts, metrics.furniture)
     metrics.unique_words = metrics.words - metrics.boilerplate_words
 
     repeats = Counter(_boilerplate_key(text) for text in texts if text)
@@ -433,6 +505,23 @@ def score_candidates(candidates: list[Candidate]) -> None:
     """
     if not candidates:
         return
+
+    # What counts as furniture is a property of the DOCUMENT, not of one parse of it.
+    # Pool every candidate's findings and re-apply the union to all of them, so a
+    # candidate whose block segmentation happened to hide the repetition does not get
+    # to bank its running header as recovered body text. Without this the candidates
+    # stop tying on text and keeping the boilerplate wins again -- which is precisely
+    # what happened on a document where every local run had looked correct.
+    pooled = Furniture(set(), set())
+    for candidate in candidates:
+        pooled = pooled.union(candidate.metrics.furniture)
+
+    for candidate in candidates:
+        metrics = candidate.metrics
+        if not metrics.block_texts:
+            continue
+        metrics.boilerplate_words = _boilerplate_words(metrics.block_texts, pooled)
+        metrics.unique_words = metrics.words - metrics.boilerplate_words
 
     best_words = max(c.metrics.unique_words for c in candidates)
     best_structure = max(c.metrics.headings + c.metrics.list_items + c.metrics.links for c in candidates)

--- a/tests/integration/test_optimize.py
+++ b/tests/integration/test_optimize.py
@@ -1,0 +1,272 @@
+"""End-to-end tests for ``all2md optimize``, against a document whose correct parse we know.
+
+The whole feature rests on one claim: the settings it recommends really do produce a
+better conversion. That cannot be tested against the shipped fixtures -- they are
+clean enough to score perfectly under every setting -- so we *synthesize* a document
+and therefore know exactly what a correct extraction must contain.
+
+``_truth()`` below scores a conversion against that ground truth. The optimizer never
+sees it; it only sees its own reference-free objective. The tests assert the two
+agree, which is the only thing that makes the objective trustworthy.
+
+That agreement was hard-won. The first objective scored text as "more words is
+better", which made *keeping* the running header strictly better than trimming it.
+Measured here it was anti-correlated with the truth (Pearson r = -0.88): it reliably
+recommended the worst settings available.
+"""
+
+import fitz
+import pytest
+
+from all2md import optimizable_formats, optimize_options, to_markdown
+from all2md.options.pdf import PdfOptions
+
+# Each page gets its own prose. If the pages shared sentences, the body text itself
+# would repeat and a repetition detector would rightly call it furniture -- which
+# would destroy the very signal under test.
+BODIES = {
+    "Alpha": [
+        "revenue climbed sharply after the spring reorganisation",
+        "margins held despite unusually volatile freight costs",
+        "the northern depot absorbed most of the seasonal surge",
+        "headcount fell by nine without affecting throughput",
+    ],
+    "Beta": [
+        "regulatory filings were submitted a fortnight early",
+        "customer churn dropped to its lowest level since inception",
+        "the pilot programme exceeded every retention target",
+        "warehouse automation paid back its investment in months",
+    ],
+    "Gamma": [
+        "shipping delays pushed three launches into the next quarter",
+        "the legacy billing system was finally decommissioned",
+        "a currency swing wiped out most of the overseas gain",
+        "recruitment reopened for the vacant analyst positions",
+    ],
+    "Delta": [
+        "office consolidation freed up an entire floor",
+        "training completion rates finally cleared the mandated bar",
+        "one contractor overran its budget by a wide margin",
+        "the new dashboard cut reporting time to a single morning",
+    ],
+}
+
+
+@pytest.fixture(scope="module")
+def gnarly_pdf(tmp_path_factory) -> str:
+    """A two-page PDF with a running header/footer, two columns, and a ruled table.
+
+    We place every element, so the correct parse is known: the header and footer are
+    furniture and should be trimmed; both columns and every table cell must survive.
+    """
+    doc = fitz.open()
+    for page_no in range(2):
+        left_tag = "Alpha" if page_no == 0 else "Gamma"
+        right_tag = "Beta" if page_no == 0 else "Delta"
+        page = doc.new_page(width=612, height=792)
+
+        # Furniture: identical on every page apart from the page number.
+        page.insert_text((72, 40), "ACME CONFIDENTIAL -- INTERNAL USE ONLY", fontsize=8)
+        page.insert_text((72, 760), f"Page {page_no + 1} of 2  |  ACME CONFIDENTIAL", fontsize=8)
+        page.insert_text((72, 80), "Quarterly Report", fontsize=18)
+
+        col_left = " ".join(f"{left_tag} sentence A{i}: {t}." for i, t in enumerate(BODIES[left_tag], 1))
+        col_right = " ".join(f"{right_tag} sentence B{i}: {t}." for i, t in enumerate(BODIES[right_tag], 1))
+        page.insert_textbox(fitz.Rect(72, 100, 280, 290), col_left, fontsize=9)
+        page.insert_textbox(fitz.Rect(320, 100, 540, 290), col_right, fontsize=9)
+
+        # A ruled 4x3 table with known cell text.
+        top, left, row_h, col_w = 320, 72, 20, 150
+        for r in range(5):
+            page.draw_line((left, top + r * row_h), (left + 3 * col_w, top + r * row_h))
+        for c in range(4):
+            page.draw_line((left + c * col_w, top), (left + c * col_w, top + 4 * row_h))
+        for r in range(4):
+            for c in range(3):
+                page.insert_text((left + c * col_w + 5, top + r * row_h + 14), f"{left_tag[0]}R{r}C{c}", fontsize=9)
+
+    path = tmp_path_factory.mktemp("optimize") / "gnarly.pdf"
+    doc.save(str(path))
+    doc.close()
+    return str(path)
+
+
+def _truth(markdown: str) -> int:
+    """Score a conversion against what we KNOW is on the page. ``0``-``100``."""
+    checks = {
+        # The running header and footer are furniture and should not survive.
+        "no_header": "INTERNAL USE ONLY" not in markdown,
+        "no_footer": "Page 1 of 2" not in markdown,
+        # Every cell of the ruled table must be present.
+        "table_intact": all(f"AR{r}C{c}" in markdown for r in range(4) for c in range(3)),
+    }
+    left = [markdown.find(f"sentence A{i}:") for i in range(1, 5)]
+    right = [markdown.find(f"sentence B{i}:") for i in range(1, 5)]
+    # No body sentence may be dropped, and the left column must be read before the right.
+    checks["no_text_loss"] = all(pos > 0 for pos in left + right)
+    checks["column_order"] = checks["no_text_loss"] and max(left) < min(right)
+    return round(100 * sum(checks.values()) / len(checks))
+
+
+@pytest.mark.integration
+@pytest.mark.pdf
+class TestOptimizerAgainstGroundTruth:
+    """The claim that matters: the recommended settings convert the document better."""
+
+    def test_the_fixture_is_actually_hard(self, gnarly_pdf):
+        """If the defaults already nailed it there would be nothing to optimize."""
+        assert _truth(to_markdown(gnarly_pdf)) < 100
+
+    def test_recommended_settings_beat_the_defaults_on_ground_truth(self, gnarly_pdf):
+        """The headline property. The optimizer never sees ``_truth``."""
+        report = optimize_options(gnarly_pdf)
+
+        assert report.improved, "optimizer found nothing on a document the defaults get wrong"
+
+        baseline = _truth(to_markdown(gnarly_pdf))
+        tuned = _truth(to_markdown(gnarly_pdf, parser_options=PdfOptions(**report.best_options)))
+
+        assert tuned > baseline
+        assert tuned == 100
+
+    def test_it_recovers_the_header_footer_trimming(self, gnarly_pdf):
+        """The one thing wrong with the default conversion of this document."""
+        report = optimize_options(gnarly_pdf)
+
+        trims = {"trim_headers_footers", "auto_trim_headers_footers"}
+        assert trims & set(report.best_options), f"expected a trim setting, got {report.best_options}"
+
+    def test_fitness_ranking_agrees_with_ground_truth(self, gnarly_pdf):
+        """Not just the winner: the whole ranking must track the truth.
+
+        A winner that is right by luck is indistinguishable from an objective that
+        works, until the day it is not. This pins the correlation.
+        """
+        report = optimize_options(gnarly_pdf)
+
+        scored = [
+            (c.fitness, _truth(to_markdown(gnarly_pdf, parser_options=PdfOptions(**c.options))))
+            for c in report.candidates
+        ]
+        best_fit_truth = max(scored, key=lambda pair: pair[0])[1]
+        worst_fit_truth = min(scored, key=lambda pair: pair[0])[1]
+
+        assert best_fit_truth >= worst_fit_truth
+        assert best_fit_truth == max(truth for _, truth in scored)
+
+    def test_reported_options_are_real_changes(self, gnarly_pdf):
+        """Never recommend a setting that already holds; that is noise, not advice."""
+        report = optimize_options(gnarly_pdf)
+        defaults = PdfOptions()
+
+        for name, value in report.best_options.items():
+            assert getattr(defaults, name) != value, f"{name}={value} is already the default"
+
+
+@pytest.mark.integration
+@pytest.mark.pdf
+class TestOptimizeApi:
+    """Surface behaviour of ``optimize_options``."""
+
+    def test_baseline_is_the_stock_defaults(self, gnarly_pdf):
+        report = optimize_options(gnarly_pdf)
+
+        default_candidates = [c for c in report.candidates if c.origin == "default"]
+        assert len(default_candidates) == 1
+        assert default_candidates[0].options == {}
+        assert report.baseline_fitness == default_candidates[0].fitness
+
+    def test_every_candidate_is_distinct(self, gnarly_pdf):
+        report = optimize_options(gnarly_pdf)
+
+        signatures = [tuple(sorted(c.options.items())) for c in report.candidates]
+        assert len(signatures) == len(set(signatures))
+        assert report.evaluated == len(report.candidates)
+
+    def test_sample_pages_limits_the_work(self, gnarly_pdf):
+        """Tuning a slice must still produce a usable report."""
+        report = optimize_options(gnarly_pdf, sample_pages=2)
+
+        assert report.source_format == "pdf"
+        assert report.evaluated > 0
+
+    def test_rejects_a_format_with_no_knobs(self, tmp_path):
+        from all2md.exceptions import FormatError
+
+        target = tmp_path / "notes.md"
+        target.write_text("# hello\n", encoding="utf-8")
+
+        with pytest.raises(FormatError, match="No tunable options"):
+            optimize_options(target)
+
+    def test_optimizable_formats_are_advertised(self):
+        assert "pdf" in optimizable_formats()
+        assert optimizable_formats() == sorted(optimizable_formats())
+
+
+@pytest.mark.integration
+@pytest.mark.pdf
+class TestOptimizeCli:
+    """The command line, including the settings it tells you to run."""
+
+    def test_emits_a_runnable_command_and_a_toml_snippet(self, gnarly_pdf, capsys):
+        from all2md.cli.commands.optimize import handle_optimize_command
+
+        assert handle_optimize_command([gnarly_pdf]) == 0
+
+        out = capsys.readouterr().out
+        assert "all2md" in out
+        assert "--pdf-" in out
+        assert "[pdf]" in out
+
+    def test_the_emitted_command_actually_improves_the_document(self, gnarly_pdf, tmp_path):
+        """A wrong flag would be worse than no flag at all.
+
+        Flag names are not mechanical -- a boolean defaulting to True is exposed as
+        its *negation* (``detect_columns`` -> ``--pdf-no-detect-columns``) -- so this
+        runs the emitted flags back through the real CLI and scores the result against
+        ground truth, rather than trusting that the flag string was built correctly.
+        """
+        from all2md.cli import main
+        from all2md.cli.commands.optimize import _cli_command
+
+        report = optimize_options(gnarly_pdf)
+        command = _cli_command(gnarly_pdf, report)
+        assert command, "optimizer improved the document but emitted no command"
+
+        flags = command.split()[2:]  # drop the leading "all2md <path>"
+        assert flags
+
+        out = tmp_path / "tuned.md"
+        assert main([gnarly_pdf, "--out", str(out), *flags]) == 0
+
+        tuned = out.read_text(encoding="utf-8")
+        assert _truth(tuned) > _truth(to_markdown(gnarly_pdf))
+        assert _truth(tuned) == 100
+
+    def test_json_output_carries_the_command_and_toml(self, gnarly_pdf, capsys):
+        import json
+
+        from all2md.cli.commands.optimize import handle_optimize_command
+
+        assert handle_optimize_command([gnarly_pdf, "--json"]) == 0
+
+        payload = json.loads(capsys.readouterr().out)
+        assert payload["source_format"] == "pdf"
+        assert payload["best_options"]
+        assert payload["command"].startswith("all2md ")
+        assert payload["toml"].startswith("[pdf]")
+
+    def test_writes_a_toml_file(self, gnarly_pdf, tmp_path):
+        from all2md.cli.commands.optimize import handle_optimize_command
+
+        target = tmp_path / "out.toml"
+        assert handle_optimize_command([gnarly_pdf, "--out", str(target)]) == 0
+
+        assert target.read_text(encoding="utf-8").startswith("[pdf]")
+
+    def test_rejects_bad_rounds(self, gnarly_pdf, capsys):
+        from all2md.cli.commands.optimize import handle_optimize_command
+
+        assert handle_optimize_command([gnarly_pdf, "--rounds", "0"]) != 0
+        assert "--rounds" in capsys.readouterr().err

--- a/tests/unit/test_optimize.py
+++ b/tests/unit/test_optimize.py
@@ -1,0 +1,283 @@
+"""Unit tests for the conversion optimizer's objective and search.
+
+The objective is the whole ballgame here: a search that hill-climbs the wrong
+function finds the wrong settings faster. These tests pin the two ways the obvious
+objective goes wrong -- rewarding kept boilerplate, and rewarding hallucinated
+tables -- because both were real, both were measured, and both would silently come
+back if someone "simplified" the scoring.
+"""
+
+import pytest
+
+from all2md.ast.nodes import Document, Heading, Paragraph, Table, TableCell, TableRow, Text
+from all2md.optimize import (
+    DIMENSION_WEIGHTS,
+    Candidate,
+    DocumentMetrics,
+    extract_metrics,
+    score_candidates,
+    search,
+    tunable_knobs,
+)
+
+
+def _para(text: str) -> Paragraph:
+    return Paragraph(content=[Text(content=text)])
+
+
+def _table(rows: list[list[str]]) -> Table:
+    return Table(
+        rows=[TableRow(cells=[TableCell(content=[Text(content=c)]) for c in row]) for row in rows],
+    )
+
+
+def _doc(*children) -> Document:
+    return Document(children=list(children))
+
+
+@pytest.mark.unit
+class TestExtractMetrics:
+    """Reading structural yield off the AST."""
+
+    def test_counts_words_headings_and_tables(self):
+        doc = _doc(Heading(level=1, content=[Text(content="Title")]), _para("one two three"), _table([["a", "b"]]))
+
+        metrics = extract_metrics(doc)
+
+        assert metrics.headings == 1
+        assert metrics.tables == 1
+        assert metrics.table_cells == 2
+        assert "one two three".split() == ["one", "two", "three"]
+        assert metrics.words >= 3
+
+    def test_text_is_found_through_inline_wrappers(self):
+        """Text lives in Text.content; every other node uses content as a container.
+
+        Reading ``.content`` directly instead of walking children yields zero words,
+        which silently flattens the whole text dimension to a constant.
+        """
+        doc = _doc(_para("alpha beta gamma"))
+
+        assert extract_metrics(doc).words == 3
+
+    def test_table_cells_are_not_double_counted(self):
+        """get_node_children already descends into rows and cells."""
+        doc = _doc(_table([["a", "b"], ["c", "d"]]))
+
+        assert extract_metrics(doc).table_cells == 4
+
+    def test_a_sparse_ragged_table_scores_poorly(self):
+        """A hallucinated table is mostly empty and has inconsistent column counts."""
+        good = extract_metrics(_doc(_table([["a", "b"], ["c", "d"]])))
+        junk = extract_metrics(_doc(_table([["x", "", ""], ["", ""], [""]])))
+
+        assert good.table_quality == pytest.approx(1.0)
+        assert junk.table_quality < 0.2
+
+    def test_no_tables_means_zero_table_quality(self):
+        assert extract_metrics(_doc(_para("no tables here"))).table_quality == 0.0
+
+
+@pytest.mark.unit
+class TestBoilerplateDetection:
+    """Repeated furniture must not read as recovered body text."""
+
+    def test_a_repeated_block_is_boilerplate(self):
+        doc = _doc(_para("ACME CONFIDENTIAL"), _para("real body text here"), _para("ACME CONFIDENTIAL"))
+
+        metrics = extract_metrics(doc)
+
+        assert metrics.duplicate_blocks == 2
+        assert metrics.boilerplate_words == 4  # both copies, not just the second
+        assert metrics.unique_words == 4  # "real body text here"
+
+    def test_page_numbers_do_not_defeat_the_match(self):
+        """A footer reading 'Page 1 of 9' and 'Page 2 of 9' is one footer: digits are masked."""
+        doc = _doc(_para("Page 1 of 9 confidential draft"), _para("body"), _para("Page 2 of 9 confidential draft"))
+
+        assert extract_metrics(doc).boilerplate_words == 12
+
+    def test_furniture_glued_into_a_body_block_is_still_caught(self):
+        """The regression that made the objective anti-correlated with the truth.
+
+        The PDF parser routinely glues a running footer onto the front of the next
+        body block. That block is unique -- it contains body text -- so no block-level
+        comparison can ever flag it, and its footer words get counted as recovered
+        content. Only a repeated *word sequence* spanning blocks finds it.
+        """
+        doc = _doc(
+            _para("Page 1 of 2 ACME CONFIDENTIAL alpha revenue climbed sharply this spring"),
+            _para("Page 2 of 2 ACME CONFIDENTIAL beta margins held despite volatile costs"),
+        )
+
+        metrics = extract_metrics(doc)
+
+        assert metrics.duplicate_blocks == 0  # neither block repeats as a whole
+        assert metrics.boilerplate_words > 0  # ...but the footer sequence does
+
+    def test_a_block_repeating_itself_internally_is_not_furniture(self):
+        """Furniture repeats across blocks. One block echoing a phrase is just prose."""
+        doc = _doc(_para("the same five words here the same five words here"))
+
+        assert extract_metrics(doc).boilerplate_words == 0
+
+
+@pytest.mark.unit
+class TestScoreCandidates:
+    """Pool-relative fitness."""
+
+    def test_keeping_boilerplate_does_not_beat_trimming_it(self):
+        """The load-bearing property.
+
+        Naive "more text is better" makes the untrimmed conversion win, because the
+        boilerplate is extra words. Measured against ground truth that objective was
+        anti-correlated (r = -0.88) -- it picked the worst candidate. Excluding
+        furniture makes the two tie on text, so cleanliness decides for the trimmed one.
+        """
+        untrimmed = Candidate(
+            options={"trim": False},
+            metrics=extract_metrics(
+                _doc(
+                    _para("ACME CONFIDENTIAL header"),
+                    _para("alpha revenue climbed sharply after the spring reorganisation"),
+                    _para("ACME CONFIDENTIAL header"),
+                    _para("beta margins held despite unusually volatile freight costs"),
+                )
+            ),
+        )
+        trimmed = Candidate(
+            options={"trim": True},
+            metrics=extract_metrics(
+                _doc(
+                    _para("alpha revenue climbed sharply after the spring reorganisation"),
+                    _para("beta margins held despite unusually volatile freight costs"),
+                )
+            ),
+        )
+
+        score_candidates([untrimmed, trimmed])
+
+        assert trimmed.fitness > untrimmed.fitness
+
+    def test_a_hallucinated_table_does_not_beat_finding_none(self):
+        """More tables is not better; well-formed tables are better."""
+        junk = Candidate(
+            options={"mode": "aggressive"},
+            metrics=extract_metrics(_doc(_para("body text"), _table([["x", "", ""], ["", ""], [""]]))),
+        )
+        clean = Candidate(
+            options={"mode": "strict"},
+            metrics=extract_metrics(_doc(_para("body text"), _table([["a", "b"], ["c", "d"]]))),
+        )
+
+        score_candidates([junk, clean])
+
+        assert clean.fitness > junk.fitness
+
+    def test_dimensions_the_pool_never_exercises_are_dropped(self):
+        """A document with no tables must not be dragged down by the tables it lacks."""
+        only = Candidate(metrics=extract_metrics(_doc(_para("just some prose here"))))
+
+        score_candidates([only])
+
+        assert "tables" not in only.dimensions
+        assert only.fitness == pytest.approx(100.0)
+
+    def test_breakage_is_subtracted(self):
+        clean = Candidate(metrics=DocumentMetrics(blocks=1, words=10, unique_words=10))
+        broken = Candidate(metrics=DocumentMetrics(blocks=1, words=10, unique_words=10, breakage=30.0))
+
+        score_candidates([clean, broken])
+
+        assert clean.fitness - broken.fitness == pytest.approx(30.0)
+
+    def test_empty_pool_does_not_raise(self):
+        score_candidates([])  # must not raise
+
+    def test_weights_cover_every_dimension_once(self):
+        assert set(DIMENSION_WEIGHTS) == {"text", "tables", "structure", "cleanliness"}
+        assert sum(DIMENSION_WEIGHTS.values()) == pytest.approx(1.0)
+
+
+@pytest.mark.unit
+class TestSearch:
+    """The search loop, driven by a synthetic objective so no parsing is involved."""
+
+    def test_finds_the_option_the_objective_rewards(self):
+        knobs = {"alpha": [True, False], "beta": ["x", "y", "z"]}
+
+        def evaluate(options):
+            # Only alpha=True and beta="z" pay, and they pay independently.
+            words = 10 + (5 if options.get("alpha") else 0) + (5 if options.get("beta") == "z" else 0)
+            return DocumentMetrics(blocks=1, words=words, unique_words=words)
+
+        report = search(knobs, evaluate)
+
+        assert report.best_options == {"alpha": True, "beta": "z"}
+        assert report.improved
+
+    def test_reports_no_improvement_when_defaults_already_win(self):
+        knobs = {"alpha": [True, False]}
+
+        def evaluate(options):
+            return DocumentMetrics(blocks=1, words=10, unique_words=10)
+
+        report = search(knobs, evaluate)
+
+        assert not report.improved
+        assert report.gain == pytest.approx(0.0)
+
+    def test_each_option_set_is_evaluated_only_once(self):
+        calls: list[dict] = []
+
+        def evaluate(options):
+            calls.append(dict(options))
+            return DocumentMetrics(blocks=1, words=10, unique_words=10)
+
+        search({"alpha": [True, False], "beta": [1, 2]}, evaluate, rounds=3)
+
+        signatures = [tuple(sorted(c.items())) for c in calls]
+        assert len(signatures) == len(set(signatures))
+
+    def test_search_is_far_cheaper_than_a_full_grid(self):
+        """Coordinate descent costs sum(len(values)), not prod(len(values))."""
+        knobs = {f"k{i}": [0, 1, 2] for i in range(6)}  # a full grid would be 3**6 = 729
+        calls = 0
+
+        def evaluate(options):
+            nonlocal calls
+            calls += 1
+            return DocumentMetrics(blocks=1, words=10, unique_words=10)
+
+        search(knobs, evaluate)
+
+        assert calls < 30
+
+    def test_presets_are_scored_and_attributed(self):
+        knobs = {"alpha": [True, False]}
+
+        def evaluate(options):
+            words = 20 if options.get("alpha") else 10
+            return DocumentMetrics(blocks=1, words=words, unique_words=words)
+
+        report = search(knobs, evaluate, presets={"quality": {"alpha": True}})
+
+        origins = {c.origin for c in report.candidates}
+        assert "preset:quality" in origins
+
+    def test_a_preset_touching_no_searched_knob_is_skipped(self):
+        """It would just be the defaults under another name."""
+        knobs = {"alpha": [True, False]}
+
+        def evaluate(options):
+            return DocumentMetrics(blocks=1, words=10, unique_words=10)
+
+        report = search(knobs, evaluate, presets={"irrelevant": {"something_else": 1}})
+
+        assert not any(c.origin.startswith("preset:") for c in report.candidates)
+
+
+@pytest.mark.unit
+def test_tunable_knobs_is_empty_for_an_untuned_format():
+    assert tunable_knobs("pdf")
+    assert tunable_knobs("nonexistent-format") == {}

--- a/tests/unit/test_optimize.py
+++ b/tests/unit/test_optimize.py
@@ -261,8 +261,104 @@ class TestScoreCandidates:
         score_candidates([])  # must not raise
 
     def test_weights_cover_every_dimension_once(self):
-        assert set(DIMENSION_WEIGHTS) == {"text", "tables", "structure", "cleanliness"}
+        """Body text is deliberately absent: it gates the score, it is not weighted in."""
+        assert set(DIMENSION_WEIGHTS) == {"tables", "structure", "cleanliness"}
         assert sum(DIMENSION_WEIGHTS.values()) == pytest.approx(1.0)
+        assert "text" not in DIMENSION_WEIGHTS
+
+
+@pytest.mark.unit
+class TestBodyTextGatesEverything:
+    """Losing content and keeping a header are not commensurable defects."""
+
+    def test_cleanliness_cannot_buy_back_lost_body_text(self):
+        """Body text gates the score; it is not tradeable against tidiness.
+
+        As a weighted dimension the two were interchangeable (0.45 vs 0.15), so a
+        setting that destroyed body text could buy its way back by removing clutter.
+        That is the wrong trade at any exchange rate: a perfectly clean conversion that
+        lost 10% of the document must lose to a slightly dirty one that kept everything.
+        """
+        lossy_but_spotless = Candidate(
+            options={"trim": True},
+            metrics=DocumentMetrics(blocks=10, words=90, unique_words=90, boilerplate_words=0),
+        )
+        intact_but_dirty = Candidate(
+            options={},
+            metrics=DocumentMetrics(blocks=10, words=105, unique_words=100, boilerplate_words=5),
+        )
+
+        score_candidates([lossy_but_spotless, intact_but_dirty])
+
+        assert intact_but_dirty.fitness > lossy_but_spotless.fitness
+
+    def test_trimming_furniture_still_wins_when_no_text_is_lost(self):
+        """The gate must not make the optimizer inert: free wins are still taken."""
+        trimmed = Candidate(
+            options={"trim": True},
+            metrics=DocumentMetrics(blocks=10, words=100, unique_words=100, boilerplate_words=0),
+        )
+        untrimmed = Candidate(
+            options={},
+            metrics=DocumentMetrics(blocks=12, words=120, unique_words=100, boilerplate_words=20),
+        )
+
+        score_candidates([trimmed, untrimmed])
+
+        assert trimmed.fitness > untrimmed.fitness
+
+
+@pytest.mark.unit
+class TestTablesScoreRecallNotJustQuality:
+    """Well-formedness alone rewards missing real tables."""
+
+    def test_finding_more_real_tables_beats_finding_fewer_clean_ones(self):
+        """The under-detection trap, from a real arXiv paper.
+
+        Scoring well-formedness alone made ``table_detection_mode="ruling"`` score 0.98
+        against ``"pymupdf"``'s 0.68 while recovering *fewer* tables: missing a real
+        table cost nothing, so the objective preferred the detector that found less.
+        """
+        found_all = Candidate(
+            options={"mode": "pymupdf"},
+            metrics=extract_metrics(
+                _doc(_para("body"), _table([["a", "b"], ["c", "d"]]), _table([["e", "f"], ["g", "h"]]))
+            ),
+        )
+        missed_one = Candidate(
+            options={"mode": "ruling"},
+            metrics=extract_metrics(_doc(_para("body"), _table([["a", "b"], ["c", "d"]]))),
+        )
+
+        score_candidates([found_all, missed_one])
+
+        assert found_all.dimensions["tables"] > missed_one.dimensions["tables"]
+        assert found_all.fitness > missed_one.fitness
+
+    def test_a_hallucinated_table_still_loses(self):
+        """The original trap must not reopen: junk cells must not outscore real ones."""
+        junk = Candidate(
+            options={"mode": "aggressive"},
+            metrics=extract_metrics(_doc(_para("body"), _table([["x", "", "", ""], ["", "", ""], [""], ["", ""]]))),
+        )
+        real = Candidate(
+            options={"mode": "strict"},
+            metrics=extract_metrics(_doc(_para("body"), _table([["a", "b"], ["c", "d"]]))),
+        )
+
+        score_candidates([junk, real])
+
+        assert real.fitness > junk.fitness
+
+    def test_a_single_column_table_is_not_a_table(self):
+        """A one-column 'table' is a paragraph the detector captured.
+
+        Counting it would let an aggressive detector bank body text as table content.
+        """
+        metrics = extract_metrics(_doc(_table([["just"], ["some"], ["lines"]])))
+
+        assert metrics.tables == 1
+        assert metrics.good_cells == 0.0
 
 
 @pytest.mark.unit
@@ -330,6 +426,39 @@ class TestSearch:
 
         origins = {c.origin for c in report.candidates}
         assert "preset:quality" in origins
+
+    def test_settings_that_do_not_pay_for_themselves_are_dropped(self):
+        """Coordinate descent picks up passengers; they must not be reported as advice.
+
+        The winner accumulates whatever the walk went through, including knobs that
+        merely *tied*. On a real arXiv paper that surfaced as a recommendation to set
+        ``table_detection_mode="none"`` for a document whose only "table" was a
+        one-column artifact -- the knob could not affect fitness at all. A setting we
+        have no evidence for is not a finding, and printing it invites the user to
+        believe it matters.
+        """
+        knobs = {"real": [True, False], "irrelevant": [True, False]}
+
+        def evaluate(options):
+            # "irrelevant" changes nothing; only "real" pays.
+            words = 20 if options.get("real") else 10
+            return DocumentMetrics(blocks=1, words=words, unique_words=words)
+
+        report = search(knobs, evaluate)
+
+        assert report.best_options == {"real": True}
+        assert "irrelevant" not in report.best_options
+
+    def test_minimization_never_gives_up_a_real_gain(self):
+        knobs = {"a": [True, False], "b": [True, False]}
+
+        def evaluate(options):
+            words = 10 + (5 if options.get("a") else 0) + (5 if options.get("b") else 0)
+            return DocumentMetrics(blocks=1, words=words, unique_words=words)
+
+        report = search(knobs, evaluate)
+
+        assert report.best_options == {"a": True, "b": True}
 
     def test_a_preset_touching_no_searched_knob_is_skipped(self):
         """It would just be the defaults under another name."""

--- a/tests/unit/test_optimize.py
+++ b/tests/unit/test_optimize.py
@@ -9,7 +9,7 @@ back if someone "simplified" the scoring.
 
 import pytest
 
-from all2md.ast.nodes import Document, Heading, Paragraph, Table, TableCell, TableRow, Text
+from all2md.ast.nodes import Document, Heading, Paragraph, Strong, Table, TableCell, TableRow, Text
 from all2md.optimize import (
     DIMENSION_WEIGHTS,
     Candidate,
@@ -120,6 +120,72 @@ class TestBoilerplateDetection:
         doc = _doc(_para("the same five words here the same five words here"))
 
         assert extract_metrics(doc).boilerplate_words == 0
+
+    def test_furniture_is_pooled_across_candidates(self):
+        """Furniture is a property of the DOCUMENT, not of one parse of it.
+
+        A parse whose block segmentation happens to hide the repetition finds no
+        furniture *in itself* -- and would then bank its running header as recovered
+        body text, breaking the tie on text and letting "keep the boilerplate" win
+        again. This is the failure that got through local testing and only showed up
+        on another platform, where the blocks happened to segment differently.
+        """
+        foot_a, foot_b = "Page 1 of 2 ACME CONFIDENTIAL", "Page 2 of 2 ACME CONFIDENTIAL"
+        body_a = "alpha revenue climbed sharply after the spring reorganisation"
+        body_b = "beta margins held despite unusually volatile freight costs"
+
+        # This parse glued the footer onto each body block: the repeat spans two blocks.
+        glued = Candidate(
+            options={"trim": False},
+            metrics=extract_metrics(_doc(_para(f"{foot_a} {body_a}"), _para(f"{foot_b} {body_b}"))),
+        )
+        # This parse merged everything into ONE block, so nothing repeats *within it*.
+        merged = Candidate(
+            options={"trim": False, "other": 1},
+            metrics=extract_metrics(_doc(_para(f"{foot_a} {body_a} {foot_b} {body_b}"))),
+        )
+        trimmed = Candidate(options={"trim": True}, metrics=extract_metrics(_doc(_para(body_a), _para(body_b))))
+
+        # On its own the merged parse sees no furniture at all...
+        assert merged.metrics.boilerplate_words == 0
+
+        score_candidates([glued, merged, trimmed])
+
+        # ...but pooled with the others, its furniture is found and discounted, so all
+        # three agree on how much body text the document actually has.
+        assert merged.metrics.boilerplate_words > 0
+        assert glued.metrics.unique_words == merged.metrics.unique_words == trimmed.metrics.unique_words
+        assert trimmed.fitness > glued.fitness
+        assert trimmed.fitness > merged.fitness
+
+
+@pytest.mark.unit
+class TestTextIsNotInflatable:
+    """The word count must not be gameable by a setting that adds no text."""
+
+    def test_inline_runs_join_without_a_space(self):
+        """Adjacent inline runs are contiguous characters, not separate words.
+
+        A bolded middle of a word arrives as three runs. Joining them with a space
+        turns "hello" into "hel lo" and conjures a word out of nothing -- and because
+        the optimizer scores recovered text, that is *exploitable*: on real arXiv
+        papers it learned to recommend ``consolidate_inline_formatting=False``, which
+        leaves runs unmerged and inflated the count from 2325 to 2412 words with no
+        more text on the page. Fragmenting a word must not pay.
+        """
+        whole = _doc(Paragraph(content=[Text(content="hello world")]))
+        fragmented = _doc(
+            Paragraph(content=[Text(content="hel"), Strong(content=[Text(content="lo")]), Text(content=" world")])
+        )
+
+        assert extract_metrics(whole).words == 2
+        assert extract_metrics(fragmented).words == 2
+
+    def test_separate_blocks_still_get_a_separator(self):
+        """Blocks are genuinely distinct runs of prose and must not be run together."""
+        doc = _doc(_para("alpha"), _para("beta"))
+
+        assert extract_metrics(doc).words == 2
 
 
 @pytest.mark.unit


### PR DESCRIPTION
## What

`all2md optimize` converts a document many times under different converter settings and
reports the ones that recover the most well-formed structure — emitted both as a runnable
command and as an `.all2md.toml` snippet.

Built for the documents that need it most (the gnarly PDF with no known-good output to diff
against), so the objective is **reference-free** — and deliberately *neither* of the two
scores we already have:

- **Confidence** is a saturating breakage detector. On anything not visibly broken it pins
  to `100` regardless of settings, so it has no gradient to search. Measured: 16 option
  combinations on a two-column PDF produced **one** distinct confidence score while the
  parsed AST produced **four** distinct outcomes.
- **Round-trip** measures the *renderer*, not the parser — a garbled table round-trips
  through Markdown perfectly.

So the optimizer scores the parsed AST directly.

## Validated against documents from the wild

The objective looked healthy on a synthetic fixture and was **wrong in four ways** on real
documents. It was evaluated against **29 arXiv papers using the publisher's HTML rendering
as ground truth**, and every correction below was forced by measurement:

- **Tables were scored on well-formedness alone**, which just inverts the over-detection bias
  into rewarding an *under*-eager detector: five clean tables plus a miss beats six with one
  messy. On a real paper `table_detection_mode="ruling"` scored `0.98` against `"pymupdf"`'s
  `0.68` while recovering *fewer* tables. Now scored as quality-weighted **recall**.
- **Body text was a weighted dimension**, making it interchangeable with tidiness: at `0.45`
  vs `0.15`, a setting that destroyed 1% of the body could buy its way back with a 3%
  cleanliness gain. Retention now **gates** the score multiplicatively (cubed). The optimizer
  must not be able to recommend deleting content.
- **Furniture counted as boilerplate after only two blocks** — true only of the two-page
  fixture it was written against. On a 21-page paper it flagged **746 words of real body
  text** as furniture. The bar now scales with page count.
- **Pool-relative normalization turned trivial differences into total ones.** On a paper with
  no real tables, one setting found a single four-cell table where the default found none →
  the dimension read `1.0` vs `0.0` → a reported **45-point gain** for a change that
  measurably did nothing. Dimensions the document barely exercises are now dropped.

**Final result on the 29-paper evaluation: zero regressions**, mean delta `-0.0003`, worst
`-0.0032`.

## An honest word about value

On clean arXiv papers the optimizer finds **nothing** — because the defaults are already
right for them. That is the correct outcome, not a null one: the tool earns its keep on
documents the defaults mishandle, and it must be *safe* on the ones they don't.

Chasing this PR's CI failure is what uncovered why it found so little: **the furniture knobs
it was searching over barely worked.** `trim_headers_footers=True` was a silent no-op, and
`auto_trim_headers_footers` could never remove a footer containing a page number. That is
fixed in #78.

## Depends on #78

This PR's ground-truth integration test asserts the recommendation takes the fixture from
`60 → 100`, which requires header/footer trimming to actually work on a stock install (CI has
no `pdf_layout` extra). **CI here stays red until #78 lands**; with #78 merged locally, all 15
integration tests pass with the layout model force-disabled — the exact CI configuration.

## Cost

The search is `sum(len(values))` conversions (coordinate descent), not a grid's
`prod(len(values))` — but it is still tens of full conversions, and a PDF page costs ~1s to
parse, so a 12-page paper is ~5 minutes. `--sample-pages` tunes on a slice; `--cache` makes
repeat runs near-instant (18.5s → 0.3s warm). The command now says so up front rather than
leaving you watching a blank terminal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
