### PR TITLE
fix(pdf): stop inventing tables from prose, and stop deleting the prose

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **PDF table detection no longer invents tables out of prose — or deletes the prose
+  when it declines to.** `find_tables()` fires on plenty of things that are not tables,
+  and a grid with only one dimension is never one: a single column is prose wrapped in
+  pipes, and a single row is a line of text chopped at its word boundaries (on one
+  arXiv paper the sentence *"What is the capital of this country?"* was rendered as an
+  eight-column table). Those detections are now rejected — but rejecting them was not
+  simply a matter of dropping them. Text inside a detected table's bbox is removed from
+  the ordinary text stream *before* the table is validated, so a rejection path that
+  returned nothing did not demote the region to prose, it **deleted** it: doing that
+  silently cost 256 words of real body text across the corpus. Rejected regions now come
+  back as paragraphs. The same applied to regions the layout model predicted as tables
+  and which turned out not to be — a common misfire on academic PDFs, where suppressing
+  the fake tables also removed 530 words of body text with them. Measured across the PDF
+  corpus: junk tables `21 → 2`, real tables `37 → 37` (none lost), and body text strictly
+  *improves* — the junk grids had been shredding words into per-cell fragments
+  (`Gender` → `G` + `ender`), so ~500 real words come back.
 - **`merge_hyphenated_words` now actually works on text PDFs.** The option is on
   by default, but for any PDF that did not go through OCR it silently did
   nothing: the parser delegated the merge to PyMuPDF's `TEXT_DEHYPHENATE`

--- a/src/all2md/parsers/_pdf_tables.py
+++ b/src/all2md/parsers/_pdf_tables.py
@@ -19,6 +19,8 @@ if TYPE_CHECKING:
 __all__ = [
     "MAX_DOT_LEADER_CELL_RATIO",
     "MAX_TABLE_COLS",
+    "MIN_TABLE_COLS",
+    "MIN_TABLE_ROWS",
     "MAX_TABLE_EMPTY_RATIO",
     "MAX_TABLE_ROWS",
     "MIN_FILLED_FOR_UNIFORMITY_CHECK",
@@ -36,6 +38,13 @@ __all__ = [
 # on the same false-positive shapes.
 MAX_TABLE_COLS = 25
 MAX_TABLE_ROWS = 200
+# A grid needs two dimensions to mean anything. A one-column "table" is prose wrapped
+# in pipes; a one-row "table" is a single line of text chopped at its word boundaries.
+# find_tables() emits both on academic PDFs -- on one paper it rendered the sentence
+# "What is the capital of this country?" as an eight-column table -- and both are
+# strictly worse than leaving the text as text.
+MIN_TABLE_COLS = 2
+MIN_TABLE_ROWS = 2
 MAX_TABLE_EMPTY_RATIO = 0.70
 MIN_FILLED_FOR_UNIFORMITY_CHECK = 5
 # When more than this fraction of non-empty cells are dot-leader cells

--- a/src/all2md/parsers/pdf.py
+++ b/src/all2md/parsers/pdf.py
@@ -88,6 +88,8 @@ from all2md.parsers._pdf_tables import (
     MAX_TABLE_EMPTY_RATIO,
     MAX_TABLE_ROWS,
     MIN_FILLED_FOR_UNIFORMITY_CHECK,
+    MIN_TABLE_COLS,
+    MIN_TABLE_ROWS,
     detect_tables_by_ruling_lines,
     is_dot_leader_cell,
     page_has_table_signals,
@@ -2481,7 +2483,7 @@ class PdfToAstConverter(BaseParser):
             return ""
         return str(cell_text).strip()
 
-    def _process_table_to_ast(self, table: Any, page: "fitz.Page", page_num: int) -> AstTable | None:
+    def _process_table_to_ast(self, table: Any, page: "fitz.Page", page_num: int) -> Node | None:
         """Process a PyMuPDF table to AST Table node.
 
         Directly accesses table cell data from PyMuPDF table object instead of
@@ -2492,18 +2494,21 @@ class PdfToAstConverter(BaseParser):
         table : PyMuPDF Table
             Table object from find_tables()
         page : fitz.Page
-            Page containing the table (accepted for API symmetry with the
-            ruling-line and layout extraction paths).
+            Page containing the table. Used to recover the region's text when the
+            detection is rejected as a degenerate grid.
         page_num : int
             Page number for source tracking
 
         Returns
         -------
-        AstTable or None
-            Table node if table has content
+        Node or None
+            A table when the detection is a real grid; a paragraph carrying the
+            region's text when it is a degenerate (1xN / Nx1) grid; ``None`` when
+            the region has no usable content.
 
         """
-        del page  # accepted for API symmetry with other extraction paths
+        import fitz
+
         try:
             # Try to extract cells directly from PyMuPDF table object
             # PyMuPDF tables have a `extract()` method that returns cell data
@@ -2521,6 +2526,24 @@ class PdfToAstConverter(BaseParser):
             n_cells = sum(len(r) for r in table_data)
             if n_cells == 0:
                 return None
+            # A grid needs two dimensions to be a table. One column is prose wrapped in
+            # pipes; one row is a single line of text chopped at its word boundaries --
+            # find_tables() emits both, and on an academic paper it turned the sentence
+            # "What is the capital of this country?" into an eight-column table. Neither
+            # shape can carry tabular meaning, and rendering them as tables is strictly
+            # worse than leaving the text alone.
+            #
+            # Return the region's text as a paragraph rather than None: the text inside a
+            # table bbox has already been excluded from the ordinary text blocks, so
+            # returning None here would delete it, not demote it.
+            if n_rows < MIN_TABLE_ROWS or n_cols < MIN_TABLE_COLS:
+                logger.debug(
+                    f"Rejecting pymupdf table on page {page_num + 1}: "
+                    f"{n_rows}x{n_cols} is not a grid (needs at least "
+                    f"{MIN_TABLE_ROWS}x{MIN_TABLE_COLS})"
+                )
+                self._record_table_rejection("degenerate_grid")
+                return self._region_text_as_paragraph(page, fitz.Rect(table.bbox), page_num)
             if n_cols > MAX_TABLE_COLS or n_rows > MAX_TABLE_ROWS:
                 logger.debug(
                     f"Rejecting pymupdf table on page {page_num + 1}: {n_rows}x{n_cols} grid exceeds size caps"
@@ -2758,17 +2781,30 @@ class PdfToAstConverter(BaseParser):
 
     def _extract_table_from_layout_region(
         self, page: "fitz.Page", table_rect: "fitz.Rect", page_num: int
-    ) -> AstTable | None:
-        """Extract a table from a region identified by layout analysis.
+    ) -> Node | None:
+        """Extract the content of a region the layout model predicted to be a table.
 
-        Uses ``page.find_tables()`` scoped to the predicted region. Falls back
-        to extracting the raw text as a single-cell table if no structured
-        table is found.
+        Uses ``page.find_tables()`` scoped to the predicted region. When no structured
+        table can be recovered there, the region's text is returned as a **paragraph**.
+
+        It used to be returned as a single-column table -- one row per line of text --
+        and that was wrong twice over. A one-column table is not a table: it is prose
+        wrapped in pipes, so the output was *worse* than plain text, not better. And
+        because these tables are the only copy of the region's text (it is excluded
+        from the ordinary text blocks to avoid duplication), the mangling could not
+        simply be dropped either: suppressing them on a real arXiv paper removed 144
+        junk table rows and 530 words of body text along with them.
+
+        The layout model over-fires on academic PDFs -- on one paper it predicted six
+        "table" regions and none of them held a table -- so this path is common, and
+        every one of those six became a fake table. No converter option changed that;
+        the same six appeared under every ``table_detection_mode``, because they never
+        came from the table detector at all.
 
         Parameters
         ----------
         page : fitz.Page
-            PDF page containing the table.
+            PDF page containing the region.
         table_rect : fitz.Rect
             Bounding box predicted by the layout model.
         page_num : int
@@ -2776,22 +2812,47 @@ class PdfToAstConverter(BaseParser):
 
         Returns
         -------
-        AstTable or None
-            Table node if extraction succeeded.
+        Node or None
+            A table when the region really holds one, otherwise a paragraph carrying
+            its text. ``None`` only when the region is empty.
 
         """
-        # Try PyMuPDF's find_tables within the predicted region
+        # Try PyMuPDF's find_tables within the predicted region. Only a real table is
+        # accepted here: a rejected detection may hand back a paragraph covering just
+        # the grid's bbox, which can be narrower than the region the layout model
+        # predicted. Falling through instead keeps the whole region's text.
         try:
             tabs = page.find_tables(clip=table_rect)
             if tabs.tables:
-                return self._process_table_to_ast(tabs.tables[0], page, page_num)
+                table = self._process_table_to_ast(tabs.tables[0], page, page_num)
+                if isinstance(table, AstTable):
+                    return table
         except Exception:
-            # PyMuPDF table detection is best-effort; fall through to the
-            # caller's fallback handling on any error.
+            # PyMuPDF table detection is best-effort; fall through to the text path.
             pass
 
-        # Fallback: extract raw text from the region as a simple table
-        text = page.get_textbox(table_rect)
+        # No table here -- the layout model was wrong. Keep the text, drop the pipes.
+        paragraph = self._region_text_as_paragraph(page, table_rect, page_num)
+        if paragraph is not None:
+            self._record_table_rejection("layout_region_not_tabular")
+        return paragraph
+
+    def _region_text_as_paragraph(self, page: "fitz.Page", region: "fitz.Rect", page_num: int) -> AstParagraph | None:
+        """Return a region's text as a paragraph, for regions rejected as tables.
+
+        Text inside a detected table's bbox is removed from the ordinary text blocks so
+        it is not emitted twice, and that removal happens *before* the table is validated.
+        So a rejection path that simply returns ``None`` does not fall back to prose --
+        it deletes the region's text outright. Rejecting degenerate grids this way cost
+        256 words of real body text across the corpus.
+
+        Returns
+        -------
+        AstParagraph or None
+            The region's text as a paragraph, or ``None`` if the region holds no text.
+
+        """
+        text = page.get_textbox(region)
         if not text or not text.strip():
             return None
 
@@ -2799,11 +2860,9 @@ class PdfToAstConverter(BaseParser):
         if not lines:
             return None
 
-        # Build a single-column table from the lines
-        header_row = TableRow(cells=[TableCell(content=[Text(content=lines[0])])], is_header=True)
-        data_rows = [TableRow(cells=[TableCell(content=[Text(content=line)])]) for line in lines[1:]]
-        return AstTable(
-            header=header_row, rows=data_rows, source_location=SourceLocation(format="pdf", page=page_num + 1)
+        return AstParagraph(
+            content=[Text(content=" ".join(lines))],
+            source_location=SourceLocation(format="pdf", page=page_num + 1),
         )
 
     def _parse_markdown_table_row(self, row_line: str) -> list[str]:

--- a/tests/unit/formats/pdf/test_pdf_table_guards.py
+++ b/tests/unit/formats/pdf/test_pdf_table_guards.py
@@ -1,0 +1,153 @@
+#  Copyright (c) 2025 Tom Villani, Ph.D.
+#
+# tests/unit/formats/pdf/test_pdf_table_guards.py
+"""Guards that reject non-tabular detections must never cost a word of text.
+
+``find_tables()`` fires on things that are not tables. A one-column "table" is prose
+wrapped in pipes; a one-row "table" is a line of text chopped at its word boundaries.
+Rejecting those is easy. Rejecting them *without deleting their text* is the part that
+bit us, and is what these tests pin down.
+
+The trap is an ordering one, and it is invisible from the guard's own code: text blocks
+that fall inside a detected table's bbox are removed from the ordinary text stream
+**before** the table is validated, so they will not be emitted twice. A rejection path
+that simply returns ``None`` therefore does not demote the region to prose -- it deletes
+it. Across the PDF corpus, rejecting degenerate grids that way silently cost 256 words
+of real body text while every table-shaped assertion still passed.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from all2md.ast import Paragraph as AstParagraph
+from all2md.ast import Table as AstTable
+from all2md.ast.nodes import Text, get_node_children
+from all2md.parsers.pdf import PdfToAstConverter
+
+pytestmark = [pytest.mark.unit, pytest.mark.pdf, pytest.mark.table]
+
+
+class _FakeTable:
+    """The shape of a PyMuPDF table: an ``extract()`` grid and a ``bbox``."""
+
+    def __init__(self, grid: list[list[str | None]], bbox: tuple[float, float, float, float]) -> None:
+        self._grid = grid
+        self.bbox = bbox
+
+    def extract(self) -> list[list[str | None]]:
+        return self._grid
+
+
+class _FakePage:
+    """A page that can only do what the rejection path needs: hand back a region's text."""
+
+    def __init__(self, text: str) -> None:
+        self._text = text
+        self.asked_for: list[tuple] = []
+
+    def get_textbox(self, rect) -> str:
+        self.asked_for.append(tuple(rect))
+        return self._text
+
+
+def _text_of(node) -> str:
+    parts: list[str] = []
+
+    def walk(current) -> None:
+        if isinstance(current, Text):
+            parts.append(current.content)
+            return
+        for child in get_node_children(current):
+            walk(child)
+
+    walk(node)
+    return " ".join(parts)
+
+
+@pytest.fixture
+def converter() -> PdfToAstConverter:
+    conv = PdfToAstConverter()
+    conv._tables_rejected = 0
+    return conv
+
+
+# A real grid: two dimensions, so it can carry tabular meaning.
+REAL_GRID = [["Model", "Score"], ["baseline", "0.62"], ["ours", "0.81"]]
+
+# The shapes find_tables() invents. Both are text, not tables.
+SINGLE_COLUMN = [["Retrieval augments the decoder."], ["Each layer attends to the graph."]]
+SINGLE_ROW = [["What", "is", "the", "capital", "of", "this", "country", "?"]]
+
+
+@pytest.mark.parametrize(
+    ("grid", "region_text"),
+    [
+        pytest.param(SINGLE_COLUMN, "Retrieval augments the decoder.\nEach layer attends to the graph.", id="1xN"),
+        pytest.param(SINGLE_ROW, "What is the capital of this country?", id="Nx1"),
+    ],
+)
+def test_degenerate_grid_becomes_a_paragraph_not_a_table(converter, grid, region_text):
+    """A grid with only one dimension is demoted to prose rather than rendered as a table."""
+    page = _FakePage(region_text)
+    node = converter._process_table_to_ast(_FakeTable(grid, (0, 0, 100, 50)), page, page_num=0)
+
+    assert not isinstance(node, AstTable), "a 1xN / Nx1 detection is text, not a table"
+    assert isinstance(node, AstParagraph)
+
+
+@pytest.mark.parametrize(
+    ("grid", "region_text"),
+    [
+        pytest.param(SINGLE_COLUMN, "Retrieval augments the decoder.\nEach layer attends to the graph.", id="1xN"),
+        pytest.param(SINGLE_ROW, "What is the capital of this country?", id="Nx1"),
+    ],
+)
+def test_rejecting_a_degenerate_grid_keeps_every_word(converter, grid, region_text):
+    """The whole point: rejection must demote the region's text, never delete it.
+
+    Returning ``None`` here would drop the text on the floor -- it has already been
+    excluded from the ordinary text blocks by the time this runs.
+    """
+    page = _FakePage(region_text)
+    node = converter._process_table_to_ast(_FakeTable(grid, (0, 0, 100, 50)), page, page_num=0)
+
+    assert node is not None, "returning None deletes the region's text: it is not emitted anywhere else"
+    recovered = _text_of(node).split()
+    for word in region_text.split():
+        assert word in recovered, f"rejecting the junk table lost the word {word!r}"
+
+
+def test_degenerate_rejection_reads_the_tables_own_region(converter):
+    """The paragraph is built from the rejected table's bbox, not some other region."""
+    page = _FakePage("some text")
+    converter._process_table_to_ast(_FakeTable(SINGLE_ROW, (10, 20, 110, 70)), page, page_num=0)
+
+    assert page.asked_for == [(10, 20, 110, 70)]
+
+
+def test_degenerate_rejection_is_recorded(converter):
+    """The demotion is counted, so the quality card can report it."""
+    page = _FakePage("What is the capital of this country?")
+    converter._process_table_to_ast(_FakeTable(SINGLE_ROW, (0, 0, 100, 50)), page, page_num=0)
+
+    assert converter._tables_rejected == 1
+
+
+def test_a_real_grid_is_still_a_table(converter):
+    """The guard must not touch tables that have two dimensions. It is the whole corpus's worth of them."""
+    page = _FakePage("Model Score baseline 0.62 ours 0.81")
+    node = converter._process_table_to_ast(_FakeTable(REAL_GRID, (0, 0, 100, 50)), page, page_num=0)
+
+    assert isinstance(node, AstTable)
+    assert converter._tables_rejected == 0
+    assert [c.content[0].content for c in node.header.cells] == ["Model", "Score"]
+    assert len(node.rows) == 2
+
+
+def test_empty_region_yields_nothing(converter):
+    """A degenerate grid over a region with no text has nothing to preserve."""
+    page = _FakePage("   \n  ")
+    node = converter._process_table_to_ast(_FakeTable(SINGLE_ROW, (0, 0, 100, 50)), page, page_num=0)
+
+    assert node is None


### PR DESCRIPTION
## What

`find_tables()` fires on plenty of things that are not tables. A grid with only one
dimension is never one: a single column is prose wrapped in pipes, and a single row is a
line of text chopped at its word boundaries. On one arXiv paper it rendered the sentence
*"What is the capital of this country?"* as an eight-column table.

This rejects both shapes — and, more importantly, rejects them **without losing the text**.

## The part that is easy to get wrong

Text inside a detected table's bbox is stripped from the ordinary text stream *before* the
table is validated, so it isn't emitted twice. A rejection path that simply returns `None`
therefore does **not** demote the region to prose — it deletes it.

The first version of this guard did exactly that, and it looked completely healthy: every
table-shaped assertion passed, junk tables fell from 21 to 2, and no real table was lost.
It was also silently destroying **256 words of real body text** across the corpus. Rejected
regions now come back as paragraphs.

The layout-region path had the same defect in a louder form. When the layout model predicts
a table where there is none — a common misfire on academic PDFs; six on a single paper —
the region was emitted as a one-column table. Because that table was the *only* copy of the
region's text, suppressing the junk also removed **530 words** of body text. No converter
option changed this, because those tables never came from the table detector at all.

## Evidence

The main PyMuPDF path is well-travelled, so this was measured against the whole PDF corpus
rather than argued for:

| | before | after |
|---|---|---|
| real tables (2+ rows **and** 2+ cols) | 37 | **37** (none lost) |
| degenerate tables (1×N / N×1) | 21 | **2** |
| real words lost | — | **0** |

Body text does not merely survive, it *improves*. The junk grids had been shredding words
into per-cell fragments — `Gender` → `G` + `ender`, plus debris like `EncQ`, `odu` — so
rejecting them puts roughly **500 real words back**.

The custom ruling-line detector (the non-PyMuPDF path) is **untouched** and keeps its own
guards.

## Tests

8 new tests in `tests/unit/formats/pdf/test_pdf_table_guards.py`, verified to fail against
the old behaviour (5 failures, including both `keeps_every_word` cases). The property they
pin is not "junk is rejected" but "rejecting junk never costs a word".

🤖 Generated with [Claude Code](https://claude.com/claude-code)
