### PR TITLE
fix(pdf): make auto_trim_headers_footers actually remove running furniture

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **`auto_trim_headers_footers` now removes running headers and footers.** It largely
+  did not. Three defects compounded, and each was hidden by the optional `pdf_layout`
+  extra, which labels headers and footers directly — so on a development machine with
+  the extra installed the feature looked fine, while a stock install got almost nothing.
+  (1) Candidates were keyed on their **exact text**, so `Page 1 of 12` and `Page 2 of 12`
+  looked like two unrelated blocks, neither ever repeated, and a footer carrying a page
+  number — very nearly every running footer there is — could never be detected at all.
+  Digit runs are now collapsed when keying, so a running footer is recognized as one.
+  (2) Detection refused to run on documents with fewer than **three pages**, making the
+  option a silent no-op on every two-page document; two pages are enough to show
+  repetition. (3) The zone filter dropped any block that *began* inside the header zone,
+  rather than one that lies **entirely** within it — so a body paragraph starting a few
+  points below the running head was deleted in full, taking the rest of the page with it.
+  On a real FCC filing whose body opened 4pt under the header, the opening paragraph of
+  every page was destroyed. Furniture is always fully contained in the zone (the zone is
+  derived from furniture's own far edge); body text merely pokes into it.
+
+  Because collapsing digits makes `Section 1` and `Section 2` key alike, a candidate must
+  now also **hold still**: real furniture is anchored to the page, whereas a heading that
+  merely recurs is anchored to the text flow and lands somewhere different on each page.
+  Verified against arXiv's HTML rendering of 29 papers as an external ground truth —
+  recall did not fall on a single one — and the feature now has tests, which it did not
+  before.
 - **`merge_hyphenated_words` now actually works on text PDFs.** The option is on
   by default, but for any PDF that did not go through OCR it silently did
   nothing: the parser delegated the merge to PyMuPDF's `TEXT_DEHYPHENATE`

--- a/src/all2md/parsers/pdf.py
+++ b/src/all2md/parsers/pdf.py
@@ -112,6 +112,38 @@ from all2md.utils.metadata import (
 
 logger = logging.getLogger(__name__)
 
+#: Fractions of the page height treated as the header and footer zones when
+#: auto-detecting running furniture.
+HEADER_ZONE_FRACTION = 0.2
+FOOTER_ZONE_FRACTION = 0.8
+
+#: Fewest pages that can show repetition. Two pages are enough: a block in the same
+#: place on both has repeated. (Three used to be required, which silently disabled
+#: ``auto_trim_headers_footers`` on every two-page document.)
+MIN_PAGES_FOR_RUNNING_DETECTION = 2
+
+#: How far, in points, a running header/footer may drift between pages and still count
+#: as the same one. Real furniture is anchored to the page; body text that happens to
+#: recur is anchored to the text flow and moves. The zone boundary is taken from the
+#: innermost matching block, so a false positive trims everything outside it on every
+#: page -- this tolerance is what keeps that aimed at furniture.
+RUNNING_POSITION_TOLERANCE = 5.0
+
+#: Runs of digits in a running header/footer, which differ from page to page precisely
+#: because it is running furniture.
+_RUNNING_DIGITS = re.compile(r"\d+")
+
+
+def _running_text_key(text: str) -> str:
+    """Key a header/footer candidate by what stays the same from page to page.
+
+    ``Page 1 of 12`` and ``Page 2 of 12`` are the same running footer, but keying on
+    raw text makes each of them unique, so neither ever reaches ``min_occurrences``
+    and the footer is never detected. Collapsing digit runs is what lets the most
+    common footer in existence -- one with a page number in it -- be recognized at all.
+    """
+    return _RUNNING_DIGITS.sub("#", text).strip()
+
 
 def _collapse_text_whitespace_in_place(node: Node) -> None:
     """Collapse 2+ horizontal-whitespace runs in every Text descendant.
@@ -505,10 +537,16 @@ class PdfToAstConverter(BaseParser):
         return self.convert_to_ast(doc, pages_to_use, base_filename)
 
     def _get_sample_pages(self, pages_to_use: range | list[int]) -> list[int] | None:
-        """Get evenly distributed sample pages for header/footer detection."""
+        """Get evenly distributed sample pages for header/footer detection.
+
+        Two pages are enough. Repetition is the entire signal, and a block that appears
+        at the same position on both pages of a two-page document has already repeated;
+        ``min_occurrences`` still requires it on every sampled page. The previous floor
+        of three made ``auto_trim_headers_footers`` a silent no-op on two-page documents.
+        """
         total_pages = len(list(pages_to_use))
-        if total_pages < 3:
-            return None  # Need at least 3 pages to detect patterns
+        if total_pages < MIN_PAGES_FOR_RUNNING_DETECTION:
+            return None  # A single page cannot show repetition.
 
         sample_size = min(10, total_pages)
         if isinstance(pages_to_use, range):
@@ -556,19 +594,25 @@ class PdfToAstConverter(BaseParser):
     def _classify_header_footer_candidates(
         self, page_blocks: dict[int, list[tuple[str, float, float]]], page_height: float
     ) -> tuple[dict[str, list[float]], dict[str, list[float]]]:
-        """Classify blocks into header/footer candidates based on position."""
+        """Classify blocks into header/footer candidates based on position.
+
+        Candidates are keyed on their text with digit runs collapsed (see
+        :func:`_running_text_key`), so ``Page 1 of 12`` and ``Page 2 of 12`` are
+        recognized as the same running footer rather than as two unrelated blocks.
+        """
         header_candidates: dict[str, list[float]] = {}
         footer_candidates: dict[str, list[float]] = {}
 
-        header_zone_threshold = page_height * 0.2
-        footer_zone_threshold = page_height * 0.8
+        header_zone_threshold = page_height * HEADER_ZONE_FRACTION
+        footer_zone_threshold = page_height * FOOTER_ZONE_FRACTION
 
         for blocks in page_blocks.values():
             for text, y_top, y_bottom in blocks:
+                key = _running_text_key(text)
                 if y_bottom < header_zone_threshold:
-                    header_candidates.setdefault(text, []).append(y_bottom)
+                    header_candidates.setdefault(key, []).append(y_bottom)
                 if y_top > footer_zone_threshold:
-                    footer_candidates.setdefault(text, []).append(y_top)
+                    footer_candidates.setdefault(key, []).append(y_top)
 
         return header_candidates, footer_candidates
 
@@ -579,16 +623,28 @@ class PdfToAstConverter(BaseParser):
         page_height: float,
         min_occurrences: int,
     ) -> tuple[float, float]:
-        """Find boundaries of repeating header/footer zones."""
+        """Find boundaries of repeating header/footer zones.
+
+        A candidate must repeat *and hold still*. The zone boundary is taken from the
+        innermost matching block, so a single false positive does not just drop its own
+        line -- it drops everything outside it, on every page. Requiring the block to
+        occupy the same vertical position on each page (within
+        :data:`RUNNING_POSITION_TOLERANCE`) is what keeps that blast radius aimed at
+        real furniture: a running head is anchored to the page, whereas a heading that
+        merely recurs sits wherever the text flow leaves it.
+        """
         max_header_y = 0.0
         max_footer_y = page_height
 
+        def anchored(y_values: list[float]) -> bool:
+            return len(y_values) >= min_occurrences and max(y_values) - min(y_values) <= RUNNING_POSITION_TOLERANCE
+
         for y_values in header_candidates.values():
-            if len(y_values) >= min_occurrences:
+            if anchored(y_values):
                 max_header_y = max(max_header_y, max(y_values))
 
         for y_values in footer_candidates.values():
-            if len(y_values) >= min_occurrences:
+            if anchored(y_values):
                 max_footer_y = min(max_footer_y, min(y_values))
 
         return max_header_y, max_footer_y
@@ -2915,12 +2971,16 @@ class PdfToAstConverter(BaseParser):
                 filtered_blocks.append(block)
                 continue
 
-            # Check if block is in header zone (top of page)
-            if header_zone > 0 and bbox[1] < header_zone:
+            # A block must lie ENTIRELY inside the zone to be furniture. Testing only the
+            # near edge -- does the block *start* above header_height -- deletes any body
+            # paragraph that happens to begin near the top margin, and takes the rest of
+            # the page with it: on an FCC filing whose body opened 4pt below the running
+            # head, the whole opening paragraph of every page was dropped. Real furniture
+            # is always fully contained, because the zone is derived from its own far edge.
+            if header_zone > 0 and bbox[3] <= header_zone:
                 continue  # Skip this block
 
-            # Check if block is in footer zone (bottom of page)
-            if footer_zone > 0 and bbox[3] > (page_height - footer_zone):
+            if footer_zone > 0 and bbox[1] >= (page_height - footer_zone):
                 continue  # Skip this block
 
             filtered_blocks.append(block)

--- a/tests/unit/formats/pdf/test_pdf_header_footer_trim.py
+++ b/tests/unit/formats/pdf/test_pdf_header_footer_trim.py
@@ -1,0 +1,179 @@
+#  Copyright (c) 2025 Tom Villani, Ph.D.
+#
+# tests/unit/formats/pdf/test_pdf_header_footer_trim.py
+"""Running header/footer removal, on a stock install.
+
+``auto_trim_headers_footers`` had no tests at all, and had quietly stopped working in
+the two cases that matter most:
+
+* it did nothing on a two-page document (detection required three pages), and
+* it never removed a footer containing a page number -- which is very nearly every
+  running footer there is -- because candidates were keyed on their exact text, so
+  ``Page 1 of 12`` and ``Page 2 of 12`` looked like two unrelated blocks and neither
+  ever repeated.
+
+Both failures were invisible in development because the optional layout model labels
+headers and footers directly, so the text-based path never ran. These tests force the
+layout model **off**, which is what a stock install and CI actually have.
+"""
+
+from __future__ import annotations
+
+import fitz
+import pytest
+
+from all2md import to_markdown
+from all2md.options.pdf import PdfOptions
+from all2md.parsers.pdf import PdfToAstConverter, _running_text_key
+
+pytestmark = [pytest.mark.unit, pytest.mark.pdf]
+
+
+class _StubPage:
+    """Just enough page for the zone filter: it only reads ``rect.height``."""
+
+    def __init__(self, height: float) -> None:
+        self.rect = fitz.Rect(0, 0, 612, height)
+
+
+HEADER = "ACME CONFIDENTIAL -- INTERNAL USE ONLY"
+
+#: Distinct prose per page. Body text that were *identical* on every page, in the same
+#: place, would be indistinguishable from a running header by any repetition rule --
+#: which is a statement about that document, not about the detector.
+BODIES = [
+    "The northern depot absorbed most of the seasonal surge without extra headcount.",
+    "Regulatory filings went in a fortnight early and cleared without comment.",
+    "Shipping delays pushed three launches into the following quarter.",
+    "Office consolidation freed an entire floor of the building.",
+    "A currency swing wiped out most of the overseas gain this period.",
+    "The legacy billing system was finally decommissioned in full.",
+]
+
+
+@pytest.fixture(autouse=True)
+def _no_layout_model(monkeypatch):
+    """A stock install has no ``pdf_layout`` extra, so the text-based path must work."""
+    monkeypatch.setattr("all2md.parsers.pdf.is_layout_available", lambda: False)
+
+
+def _make_pdf(tmp_path, n_pages: int, *, footer: str = "Page {n} of {total}") -> str:
+    doc = fitz.open()
+    for i in range(n_pages):
+        page = doc.new_page(width=612, height=792)
+        page.insert_text((72, 40), HEADER, fontsize=8)
+        page.insert_text((72, 760), footer.format(n=i + 1, total=n_pages), fontsize=8)
+        # Body sits clear of the header zone (the top 20% of the page).
+        page.insert_textbox(
+            fitz.Rect(72, 220, 540, 520), f"Section {i + 1} opens here. {BODIES[i % len(BODIES)]}", fontsize=11
+        )
+    path = tmp_path / f"doc{n_pages}.pdf"
+    doc.save(str(path))
+    doc.close()
+    return str(path)
+
+
+class TestRunningTextKey:
+    """Page numbers are the thing that makes a running footer look non-repeating."""
+
+    def test_page_numbers_collapse_to_one_key(self):
+        assert _running_text_key("Page 1 of 12") == _running_text_key("Page 2 of 12")
+
+    def test_different_text_keeps_different_keys(self):
+        assert _running_text_key("Chapter One") != _running_text_key("Appendix")
+
+    def test_prose_is_untouched(self):
+        assert _running_text_key("no digits here") == "no digits here"
+
+
+class TestAutoTrim:
+    @pytest.mark.parametrize("n_pages", [2, 3, 6])
+    def test_removes_the_running_header(self, tmp_path, n_pages):
+        md = to_markdown(_make_pdf(tmp_path, n_pages), parser_options=PdfOptions(auto_trim_headers_footers=True))
+        assert "INTERNAL USE ONLY" not in md
+
+    @pytest.mark.parametrize("n_pages", [2, 3, 6])
+    def test_removes_a_footer_that_carries_a_page_number(self, tmp_path, n_pages):
+        """The common case, and the one that never worked: the footer differs on every page."""
+        md = to_markdown(_make_pdf(tmp_path, n_pages), parser_options=PdfOptions(auto_trim_headers_footers=True))
+        assert "Page 1 of" not in md
+
+    @pytest.mark.parametrize("n_pages", [2, 3, 6])
+    def test_body_text_survives(self, tmp_path, n_pages):
+        """Trimming furniture must not cost body text.
+
+        The zone boundary comes from the innermost matching block, so an over-eager
+        detector does not lose one line, it loses everything outside that line.
+        """
+        md = to_markdown(_make_pdf(tmp_path, n_pages), parser_options=PdfOptions(auto_trim_headers_footers=True))
+        assert "seasonal surge" in md
+        for i in range(1, n_pages + 1):
+            assert f"Section {i} opens here" in md, "auto_trim ate a page's body text"
+
+    def test_two_pages_are_enough(self, tmp_path):
+        """A two-page document used to be ignored outright."""
+        md = to_markdown(_make_pdf(tmp_path, 2), parser_options=PdfOptions(auto_trim_headers_footers=True))
+        assert "INTERNAL USE ONLY" not in md
+
+    def test_a_single_page_is_left_alone(self, tmp_path):
+        """One page cannot show repetition, so nothing may be presumed furniture."""
+        md = to_markdown(_make_pdf(tmp_path, 1), parser_options=PdfOptions(auto_trim_headers_footers=True))
+        assert "INTERNAL USE ONLY" in md
+
+    def test_defaults_keep_everything(self, tmp_path):
+        """Trimming is opt-in: the default conversion is unchanged."""
+        md = to_markdown(_make_pdf(tmp_path, 3))
+        assert "INTERNAL USE ONLY" in md
+        assert "Page 1 of 3" in md
+
+
+class TestNonFurnitureIsSafe:
+    """What must *not* be trimmed. Digit-collapsing keys make this the live risk."""
+
+    def test_body_that_starts_inside_the_zone_survives(self):
+        """A paragraph that merely *begins* inside the header zone must not be eaten.
+
+        Taken from a real FCC filing: the running head's lower edge sat at y=73 and the
+        body opened at y=74.1, so the detected zone (furniture, plus a small margin)
+        reached a few points past the top of the body block. The filter tested only a
+        block's near edge -- does it *start* above ``header_height`` -- and so dropped
+        the opening paragraph of every page in its entirety, all the way down the page.
+
+        Furniture is always *fully* contained in the zone, because the zone is derived
+        from furniture's own far edge. Body text merely pokes into it.
+        """
+        page = _StubPage(height=792)
+        converter = PdfToAstConverter(PdfOptions(trim_headers_footers=True, header_height=78, footer_height=53))
+
+        running_head = {"bbox": (72, 36, 540, 73)}  # entirely inside the zone: furniture
+        body = {"bbox": (72, 74, 540, 700)}  # starts inside it, runs the page: content
+        page_number = {"bbox": (72, 743, 540, 755)}  # entirely inside the footer zone
+
+        kept = converter._filter_headers_footers([running_head, body, page_number], page)
+
+        assert body in kept, "a body block was trimmed because it began inside the header zone"
+        assert running_head not in kept, "the running head survived"
+        assert page_number not in kept, "the page number survived"
+
+    def test_a_heading_that_moves_down_the_page_is_not_furniture(self, tmp_path):
+        """``Section 1`` / ``Section 2`` share a digit-collapsed key -- position saves them.
+
+        Real furniture is anchored to the page. A heading that merely recurs is anchored
+        to the text flow, so it lands somewhere different on each page. Without the
+        position check these headings key alike, repeat often enough, and get trimmed --
+        taking every line above them with them.
+        """
+        doc = fitz.open()
+        for i in range(4):
+            page = doc.new_page(width=612, height=792)
+            # Same text shape, but it drifts down the page: not anchored, not furniture.
+            page.insert_text((72, 60 + i * 12), f"Section {i + 1}", fontsize=14)
+            page.insert_textbox(fitz.Rect(72, 200, 540, 400), f"Body of section {i + 1}.", fontsize=11)
+        path = tmp_path / "sections.pdf"
+        doc.save(str(path))
+        doc.close()
+
+        md = to_markdown(str(path), parser_options=PdfOptions(auto_trim_headers_footers=True))
+
+        for i in range(1, 5):
+            assert f"Section {i}" in md, "a drifting heading was mistaken for a running header"


### PR DESCRIPTION
## What

`auto_trim_headers_footers` largely **did not work**, and had **no tests**. Three defects
compounded, and each was hidden by the optional `pdf_layout` extra — that model labels
headers and footers directly, so on a dev machine with the extra installed the feature
looked healthy, while a stock install (and CI) got almost nothing.

Measured on a stock install, before this PR:

| setting | 2 pages | 3+ pages |
|---|---|---|
| `trim_headers_footers=True` | no-op | no-op |
| `auto_trim_headers_footers=True` | no-op | header only, **never the footer** |

## The three defects

1. **Page-numbered footers could never be detected.** Candidates were keyed on their exact
   text, so `Page 1 of 12` and `Page 2 of 12` were two unrelated blocks — neither ever
   repeated, so neither reached `min_occurrences`. That is very nearly *every* running
   footer there is. Digit runs are now collapsed when keying.
2. **Two-page documents were skipped outright** (detection required three pages). Two pages
   are enough: a block in the same place on both has repeated.
3. **The zone filter deleted body text.** It dropped any block that *began* inside the
   header zone rather than one lying **entirely** within it. So a body paragraph starting a
   few points below the running head was deleted in full — taking the rest of the page with
   it. On a real FCC filing whose body opened 4pt under the header, the opening paragraph of
   every page was destroyed.

## The risk this had to be designed against

The zone boundary is taken from the **innermost** match, so a single false positive doesn't
drop one line — it drops everything outside it, on every page. Collapsing digits widens that
exposure, because `Section 1` and `Section 2` now key alike.

So a candidate must also **hold still**: real furniture is anchored to the page, whereas a
heading that merely recurs is anchored to the text flow and lands somewhere different on
each page. (My own fixture caught a false positive before I did — the first version lost its
entire body.)

## Evidence, and its limits

Checked against **arXiv's HTML rendering of 29 papers** as external ground truth: recall did
not fall on a single paper (mean `-0.0001`), precision rose slightly.

I'm reporting that as *weak* evidence on purpose. I re-ran it against the known-buggy
behaviour and recall **still** didn't fall — no arXiv paper opens its body inside the header
zone, so the oracle has no teeth for defect (3). Two earlier line-level judges also lied
about this (one compared Markdown against raw PDF text; the other was defeated by reflow).
Defect (3) is therefore pinned by a direct test of the zone filter, verified to fail without
the fix.

17 new tests, where there were previously zero.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
