### PR TITLE
fix(pages): stop double-converting string page ranges to 0-based (#75)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -104,6 +104,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **String page ranges select the pages you asked for.** `validate_page_range()` converted
+  1-based page numbers to 0-based **twice** on the string path: `parse_page_ranges()` already
+  returns 0-based indices, and the result was then decremented again. So every string range
+  was wrong — one including page 1 (`pages="1-3"`) raised `Invalid page number: 0`, and every
+  other one *silently returned the wrong pages*, shifted by one: `PdfOptions(pages="2")` gave
+  you page 1. The list form (`pages=[2]`) was correct, and the tests only ever exercised
+  lists, so nothing caught it. The string path now returns the already-0-based parse directly.
+
+  Two adjacent failures went with it. **The CLI could not express the ranges the option
+  documents:** `--pdf-pages 1-3` was rejected with "Expected comma-separated integers",
+  because the builder resolved `pages: list[int] | str | None` to just `list[int]` — it takes
+  the first non-`None` member of a union — and ignored the field's own `"type": str` metadata,
+  which only `int` and `float` were honored. An explicit metadata type now overrides inference,
+  so the page spec reaches the converter verbatim. (`--pdf-pages` is the only option in the
+  library whose declared metadata type differs from its annotation, so nothing else changes.
+  `--save-config` now records the spec as written — `"pdf.pages": "1-3"` — and configs
+  carrying the older list form still load.) And **a range that selected nothing converted the
+  whole document**: `pages="99"` on a 10-page PDF parsed to an empty selection, which
+  `pdf.py` read as "no selection, use every page". It now raises.
 - **`all2md optimize` no longer recommends breaking words in half.** The objective's text
   signal was a count of whitespace-separated tokens, which *rewards* a parse that fragments
   words — chop one word into two and the document appears to contain more text. When

--- a/src/all2md/cli/builder.py
+++ b/src/all2md/cli/builder.py
@@ -462,6 +462,12 @@ class DynamicCLIBuilder:
         if "choices" in metadata:
             return {"choices": metadata["choices"]}, None
 
+        # An explicit metadata "type" overrides inference. Fields whose annotation is a union
+        # of several concrete types (e.g. pages: list[int] | str) rely on this to pick the one
+        # the CLI should accept, since inference cannot choose between them.
+        if metadata.get("type") in (int, float, str):
+            return {"type": metadata["type"]}, None
+
         # Handle Union types
         if get_origin(resolved_type) in (Union, types.UnionType):
             return self._handle_union_type(resolved_type)
@@ -584,10 +590,6 @@ class DynamicCLIBuilder:
 
         if help_suffix:
             kwargs["help"] = f"{kwargs['help']} {help_suffix}"
-
-        # Handle metadata-specified types that override type inference
-        if metadata.get("type") in (int, float):
-            kwargs["type"] = metadata["type"]
 
         # Honor metadata-specified action (e.g., append) if present
         # This allows fields to explicitly request append behavior

--- a/src/all2md/utils/inputs.py
+++ b/src/all2md/utils/inputs.py
@@ -138,13 +138,22 @@ def validate_page_range(pages: list[int] | str | None, max_pages: int | None = N
                 parameter_value=pages,
             )
         try:
-            # Use utility function to parse page range string
-            pages = parse_page_ranges(pages, max_pages)
+            # parse_page_ranges() already returns 0-based indices clamped to the document,
+            # so it needs no further conversion or bounds checking.
+            parsed = parse_page_ranges(pages, max_pages)
         except (ValueError, IndexError) as e:
             raise PageRangeError(
                 f"Invalid page range format: {str(e)}. Use format like '1-3,5,10-'",
                 parameter_value=pages,
             ) from e
+
+        if not parsed:
+            raise PageRangeError(
+                f"Page range '{pages}' selects no pages. Document has {max_pages} pages (1-{max_pages}).",
+                parameter_value=pages,
+            )
+
+        return parsed
 
     if not isinstance(pages, list):
         raise PageRangeError(
@@ -152,7 +161,7 @@ def validate_page_range(pages: list[int] | str | None, max_pages: int | None = N
             parameter_value=pages,
         )
 
-    # Convert from 1-based to 0-based and validate
+    # List input arrives 1-based: convert to 0-based and validate
     converted_pages = []
     for page_num in pages:
         if not isinstance(page_num, int):

--- a/tests/integration/test_page_selection.py
+++ b/tests/integration/test_page_selection.py
@@ -1,0 +1,122 @@
+"""End-to-end tests that a requested page is the page you actually get.
+
+The page-range unit tests only ever exercised ``validate_page_range`` with *lists*, which
+took a correct code path. The *string* path double-converted 1-based to 0-based -- once in
+``parse_page_ranges``, then again in ``validate_page_range`` -- so ``pages="1-3"`` raised
+and ``pages="2-3"`` silently returned the pages either side of the ones asked for. Nothing
+caught it, because no test ever asked "does the text of the page I requested come back?"
+
+These tests do exactly that: each page carries a unique marker word, so a conversion either
+contains the marker of the requested page or it does not. Every way of expressing a
+selection -- string range, list, and the CLI flag -- is checked against the same document.
+"""
+
+import fitz
+import pytest
+
+from all2md import to_markdown
+from all2md.exceptions import ValidationError
+from all2md.options.pdf import PdfOptions
+
+# One unmistakable marker per page. Distinct enough that no marker can be mistaken for
+# another, and no marker appears anywhere else in the document.
+MARKERS = ["Alpha", "Beta", "Gamma", "Delta", "Epsilon"]
+
+
+@pytest.fixture(scope="module")
+def marked_pdf(tmp_path_factory) -> str:
+    """A five-page PDF whose page N contains the marker word MARKERS[N-1] and nothing else."""
+    doc = fitz.open()
+    for marker in MARKERS:
+        page = doc.new_page()
+        page.insert_text((72, 100), marker, fontsize=14)
+
+    path = tmp_path_factory.mktemp("pages") / "marked.pdf"
+    doc.save(str(path))
+    doc.close()
+    return str(path)
+
+
+def _markers_in(markdown: str) -> list[str]:
+    """Which page markers survived into the converted output, in page order."""
+    return [m for m in MARKERS if m in markdown]
+
+
+@pytest.mark.integration
+@pytest.mark.pdf
+class TestStringPageRanges:
+    """The string form documented on PdfOptions.pages: '1-3,5,10-'."""
+
+    @pytest.mark.parametrize(
+        "spec,expected",
+        [
+            ("1", ["Alpha"]),
+            ("2", ["Beta"]),
+            ("1-3", ["Alpha", "Beta", "Gamma"]),
+            ("2-3", ["Beta", "Gamma"]),
+            ("2,4", ["Beta", "Delta"]),
+            ("4-", ["Delta", "Epsilon"]),
+            ("1-2,5", ["Alpha", "Beta", "Epsilon"]),
+        ],
+    )
+    def test_string_range_returns_exactly_those_pages(self, marked_pdf, spec, expected):
+        result = to_markdown(marked_pdf, parser_options=PdfOptions(pages=spec))
+        assert _markers_in(result) == expected
+
+    def test_range_including_page_one_does_not_raise(self, marked_pdf):
+        """'1-3' used to raise PageRangeError: Invalid page number: 0."""
+        result = to_markdown(marked_pdf, parser_options=PdfOptions(pages="1-3"))
+        assert "Alpha" in result
+
+    def test_out_of_range_selection_raises_rather_than_converting_everything(self, marked_pdf):
+        """A spec that selects no pages must fail loudly, not silently convert the whole document."""
+        with pytest.raises(ValidationError):
+            to_markdown(marked_pdf, parser_options=PdfOptions(pages="99"))
+
+
+@pytest.mark.integration
+@pytest.mark.pdf
+class TestListPageRanges:
+    """The list form, which always worked -- kept so a fix to one path cannot regress the other."""
+
+    @pytest.mark.parametrize(
+        "pages,expected",
+        [
+            ([1], ["Alpha"]),
+            ([2], ["Beta"]),
+            ([1, 2, 3], ["Alpha", "Beta", "Gamma"]),
+            ([2, 4], ["Beta", "Delta"]),
+        ],
+    )
+    def test_list_returns_exactly_those_pages(self, marked_pdf, pages, expected):
+        result = to_markdown(marked_pdf, parser_options=PdfOptions(pages=pages))
+        assert _markers_in(result) == expected
+
+    def test_string_and_list_forms_agree(self, marked_pdf):
+        """The two spellings of one selection must convert to the same Markdown."""
+        from_string = to_markdown(marked_pdf, parser_options=PdfOptions(pages="2-3"))
+        from_list = to_markdown(marked_pdf, parser_options=PdfOptions(pages=[2, 3]))
+        assert from_string == from_list
+
+
+@pytest.mark.integration
+@pytest.mark.pdf
+class TestCliPageFlag:
+    """--pdf-pages must accept every form the option documents."""
+
+    @pytest.mark.parametrize(
+        "flag,expected",
+        [
+            ("2", ["Beta"]),
+            ("1-3", ["Alpha", "Beta", "Gamma"]),
+            ("2,4", ["Beta", "Delta"]),
+            ("4-", ["Delta", "Epsilon"]),
+        ],
+    )
+    def test_cli_page_flag(self, marked_pdf, capsys, flag, expected):
+        from all2md.cli import main
+
+        exit_code = main([marked_pdf, "--pdf-pages", flag])
+
+        assert exit_code == 0
+        assert _markers_in(capsys.readouterr().out) == expected

--- a/tests/unit/cli/test_cli_builder.py
+++ b/tests/unit/cli/test_cli_builder.py
@@ -592,11 +592,16 @@ class TestCLIParser:
         """Test that dynamically generated arguments exist in the parser."""
         parser = create_parser()
 
-        # Test that PDF options exist
+        # Test that PDF options exist. The page spec is passed through verbatim -- PdfOptions
+        # accepts the documented string form, so the CLI must not coerce it to a list of ints
+        # (that coercion rejected every range: '1-3', '10-', ...).
         args = parser.parse_args(["test.pdf", "--pdf-pages", "1,2,3"])
         assert hasattr(args, "pdf.pages")
-        # Pages are now correctly parsed as a list of integers
-        assert getattr(args, "pdf.pages") == [1, 2, 3]
+        assert getattr(args, "pdf.pages") == "1,2,3"
+
+        # Ranges are accepted, not rejected as "expected comma-separated integers"
+        args = parser.parse_args(["test.pdf", "--pdf-pages", "1-3,5,10-"])
+        assert getattr(args, "pdf.pages") == "1-3,5,10-"
 
         # Test that HTML options exist
         args = parser.parse_args(["test.html", "--html-extract-title"])

--- a/tests/unit/cli/test_cli_main.py
+++ b/tests/unit/cli/test_cli_main.py
@@ -179,7 +179,8 @@ class TestCLIIntegration:
             kwargs = call_args[1]
 
             assert "pages" in kwargs
-            assert kwargs["pages"] == [1, 2]
+            # The spec reaches the converter verbatim; PdfOptions resolves both string and list forms
+            assert kwargs["pages"] == "1,2"
             assert kwargs["password"] == "secret"
             assert kwargs["detect_columns"] is False
 
@@ -1464,7 +1465,7 @@ class TestEnhancedCLIIntegration:
             config = json.load(f)
 
         assert "pdf.pages" in config
-        assert config["pdf.pages"] == [1, 2, 3]
+        assert config["pdf.pages"] == "1,2,3"
         assert "markdown.emphasis_symbol" in config
         assert config["markdown.emphasis_symbol"] == "_"
         assert "rich" in config
@@ -1649,7 +1650,7 @@ class TestEnhancedCLIIntegration:
             config = json.load(f)
 
         # Should include all relevant options
-        assert config["pdf.pages"] == [1, 3, 5]
+        assert config["pdf.pages"] == "1,3,5"
         assert config["pdf.password"] == "secret123"
         assert config["pdf.detect_columns"] is False
         assert config["markdown.emphasis_symbol"] == "_"

--- a/tests/unit/utils/test_inputs.py
+++ b/tests/unit/utils/test_inputs.py
@@ -144,32 +144,38 @@ class TestValidatePageRange:
 
     def test_string_range_simple(self):
         """Test parsing simple string range (1-based input, 0-based output)."""
-        result = validate_page_range("2-4", max_pages=10)
-        # "2-4" means pages 2,3,4 which map to 0-based indices 1,2,3
-        # But parse_page_ranges already returns 0-based, so we get [1,2,3]
-        assert result == [
-            0,
-            1,
-            2,
-        ]  # parse_page_ranges("2-4") returns pages at indices 1,2,3 but in 0-based that's actually 0,1,2
+        # Pages 2,3,4 (1-based) -> indices 1,2,3 (0-based)
+        assert validate_page_range("2-4", max_pages=10) == [1, 2, 3]
+
+    def test_string_range_including_first_page(self):
+        """A range starting at page 1 is valid and maps to index 0."""
+        assert validate_page_range("1-3", max_pages=10) == [0, 1, 2]
 
     def test_string_range_with_single_page(self):
         """Test parsing string with single page."""
-        result = validate_page_range("5", max_pages=10)
         # Page 5 (1-based) -> index 4 (0-based)
-        assert result == [3]  # parse_page_ranges returns 0-based already
+        assert validate_page_range("5", max_pages=10) == [4]
 
     def test_string_range_with_comma(self):
         """Test parsing string with comma-separated pages."""
-        result = validate_page_range("2-4,6", max_pages=10)
         # Pages 2-4,6 (1-based) -> indices 1,2,3,5 (0-based)
-        assert result == [0, 1, 2, 4]  # parse_page_ranges returns 0-based
+        assert validate_page_range("2-4,6", max_pages=10) == [1, 2, 3, 5]
 
     def test_string_range_open_ended(self):
         """Test parsing open-ended range (e.g., '8-')."""
-        result = validate_page_range("8-", max_pages=10)
         # Pages 8,9,10 (1-based) -> indices 7,8,9 (0-based)
-        assert result == [6, 7, 8]  # parse_page_ranges returns 0-based
+        assert validate_page_range("8-", max_pages=10) == [7, 8, 9]
+
+    def test_string_and_list_paths_agree(self):
+        """The string and list forms of the same selection must produce identical indices."""
+        assert validate_page_range("1-3,5", max_pages=10) == validate_page_range([1, 2, 3, 5], max_pages=10)
+        assert validate_page_range("2", max_pages=10) == validate_page_range([2], max_pages=10)
+
+    def test_string_range_selecting_no_pages_raises(self):
+        """A range that selects nothing must raise, not silently return an empty selection."""
+        with pytest.raises(PageRangeError) as excinfo:
+            validate_page_range("99", max_pages=10)
+        assert "selects no pages" in str(excinfo.value)
 
     def test_string_range_without_max_pages_raises(self):
         """Test that string range without max_pages raises error."""
@@ -616,11 +622,9 @@ class TestIntegration:
 
     def test_page_range_workflow(self):
         """Test complete page range workflow."""
-        # Parse string range - parse_page_ranges converts from 1-based to 0-based
+        # "2-4,6,9-" means pages 2,3,4,6,9,10 (1-based) -> indices 1,2,3,5,8,9 (0-based)
         pages = validate_page_range("2-4,6,9-", max_pages=10)
-        # "2-4,6,9-" means pages 2,3,4,6,9,10 -> 0-based: 1,2,3,5,8,9
-        # But parse_page_ranges("2-4") actually returns [0,1,2] not [1,2,3]
-        assert pages == [0, 1, 2, 4, 7, 8]
+        assert pages == [1, 2, 3, 5, 8, 9]
 
         # Validate list range - these are converted from 1-based to 0-based
         pages2 = validate_page_range([1, 5, 10], max_pages=10)


### PR DESCRIPTION
Fixes #75.

## The bug

`validate_page_range()` converted 1-based page numbers to 0-based **twice** on the string path — `parse_page_ranges()` already returns 0-based indices, and the result was decremented again. So every string page range was wrong:

- `pages="1-3"` (any range including page 1) raised `Invalid page number: 0`
- `pages="2"` **silently returned page 1**

The list form (`pages=[2]`) converted once and was correct. The tests only ever exercised lists, so nothing caught it — and the string-path tests that did exist had been written to match the buggy output, with comments noting the results looked wrong:

```python
result = validate_page_range("5", max_pages=10)
# Page 5 (1-based) -> index 4 (0-based)
assert result == [3]  # parse_page_ranges returns 0-based already
```

## The fix

Return the already-0-based parse directly; keep the 1-based→0-based conversion for the list path only.

Two adjacent failures came out with it:

**The CLI could not express the ranges the option documents.** `--pdf-pages 1-3` was rejected with "Expected comma-separated integers". The builder resolves a union to its *first non-`None` member* — `list[int]`, for `pages: list[int] | str | None` — and ignored the field's own `"type": str` metadata, because only `int` and `float` were honored there. An explicit metadata type now overrides inference, so the spec reaches the converter verbatim.

`pages` is the only option in the library whose declared metadata type differs from its annotation, so no other flag changes behavior. `--save-config` now records the spec as written (`"pdf.pages": "1-3"`), and configs carrying the older list form still load — both verified.

**A range that selected nothing converted the whole document.** `pages="99"` on a 10-page PDF parsed to an empty selection, which `pdf.py:517` read as "no selection given, use every page". It now raises.

## Tests

`tests/integration/test_page_selection.py` converts a PDF whose five pages each carry a distinct marker word, and asserts the page you asked for is the page you get — across the string form, the list form, and the CLI flag. That end-to-end question ("does the requested page's text come back?") is the one no existing test asked.

I ran the new tests against the pre-fix source to confirm they can actually fail: every string case fails, `--pdf-pages 1-3` and `4-` fail, and the list path stays green — exactly the profile the issue describes.

## Noticed, not fixed

`--pdf-header-sample-pages 1,2,3` is rejected even though its help text says "comma-separated list" — same root cause (`int | list[int] | None` collapses to `int`), separate option. Filing separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)