### PR TITLE
fix: avoid leaking OSError when long content is mistaken for a file path

### DIFF
--- a/src/all2md/utils/input_sources.py
+++ b/src/all2md/utils/input_sources.py
@@ -285,10 +285,17 @@ class LocalPathRetriever(DocumentSourceRetriever):
 
         """
         value = request.raw_input
-        if isinstance(value, Path):
-            return value.exists() and value.is_file()
-        if isinstance(value, str) and "://" not in value and _looks_like_path(value):
-            return Path(value).exists()
+        # Stat calls on over-long or otherwise invalid strings raise OSError
+        # (e.g. ENAMETOOLONG when a path component exceeds NAME_MAX). An
+        # un-stattable path is not a handleable local file, so treat it as
+        # inline content rather than letting the OSError escape convert().
+        try:
+            if isinstance(value, Path):
+                return value.exists() and value.is_file()
+            if isinstance(value, str) and "://" not in value and _looks_like_path(value):
+                return Path(value).exists()
+        except OSError:
+            return False
         return False
 
     def load(self, request: DocumentSourceRequest) -> DocumentSource:

--- a/tests/unit/utils/test_input_sources.py
+++ b/tests/unit/utils/test_input_sources.py
@@ -113,6 +113,36 @@ def test_local_path_retriever_requires_existing_file(tmp_path, loader):
     assert source.payload == existing
 
 
+def test_local_path_retriever_handles_overlong_content_without_oserror():
+    """Long path-like content must not leak OSError (ENAMETOOLONG) from can_handle."""
+    retriever = LocalPathRetriever()
+    # Single-line string that _looks_like_path accepts (trailing ".md" suffix) but
+    # whose path component far exceeds NAME_MAX (255); Path.exists() would raise
+    # OSError [Errno 36] File name too long if the stat call were left unguarded.
+    overlong = "This is a perfectly normal long single line of prose that a user pasted " * 5 + " summary.md"
+    request = DocumentSourceRequest(raw_input=overlong, remote_options=None)
+
+    assert retriever.can_handle(request) is False
+
+
+def test_convert_overlong_content_raises_all2md_error_not_oserror():
+    """convert() must surface a library result/error, never a raw OSError, for long content."""
+    from all2md import convert
+    from all2md.exceptions import All2MdError
+
+    overlong = "This is a perfectly normal long single line of prose that a user pasted " * 5 + " summary.md"
+
+    try:
+        result = convert(overlong, source_format="markdown")
+    except OSError as exc:  # pragma: no cover - fails only on regression
+        pytest.fail(f"convert() leaked a raw OSError for long content: {exc!r}")
+    except All2MdError:
+        pass  # a wrapped library error is acceptable; a raw OSError is not
+    else:
+        assert isinstance(result, str)
+        assert "summary.md" in result
+
+
 def test_http_retriever_empty_allowlist_denies_all_hosts(monkeypatch, loader):
     """Test that an empty allowed_hosts list denies all remote hosts.
 


### PR DESCRIPTION
convert() can raise a raw OSError instead of the documented All2MdError when given ordinary long content:

```python
convert("This is a perfectly normal long single line of prose that a user pasted " * 5 + " summary.md",
        source_format="markdown")   # OSError: [Errno 36] File name too long
```

LocalPathRetriever.can_handle calls Path(value).exists() on the raw input during source resolution, before the parse error wrapper in convert(). Any single-line string that _looks_like_path accepts (starts with ~ or /, contains /, or ends in a .ext) and whose path component exceeds NAME_MAX makes the stat call raise OSError(ENAMETOOLONG), which escapes convert() entirely. It fires even when source_format is set explicitly.

parsers/base.py already guards this exact case (try/except OSError, "calling path.exists() on very long strings raises OSError - treat as content"); this just applies the same guard to can_handle so an un-stattable path is treated as inline content. Adds two regression tests.