### PR TITLE
fix: preserve markdown footnotes with mistune 3.x tokens

### DIFF
--- a/src/all2md/parsers/markdown.py
+++ b/src/all2md/parsers/markdown.py
@@ -568,6 +568,14 @@ class MarkdownToAstConverter(BaseParser):
         elif token_type == "footnote_def":
             self._process_footnote_def(token)
             return None
+        elif token_type == "footnotes":
+            # mistune 3.x groups definitions in a ``footnotes`` container whose
+            # children are ``footnote_item`` tokens; older versions emitted
+            # ``footnote_def`` directly. Handle both.
+            for item in token.get("children", []) or []:
+                if isinstance(item, dict):
+                    self._process_footnote_def(item)
+            return None
         elif token_type == "def_list":
             return self._process_definition_list(token)
         elif token_type == "admonition":
@@ -916,7 +924,11 @@ class MarkdownToAstConverter(BaseParser):
 
         """
         attrs = token.get("attrs", {})
-        identifier = attrs.get("label", "")
+        if not isinstance(attrs, dict):
+            attrs = {}
+        # mistune 3.x uses ``key`` on footnote_item tokens; older versions used
+        # ``label``. Fall back to the raw label text if neither is present.
+        identifier = attrs.get("key") or attrs.get("label") or token.get("raw", "")
         children = token.get("children", [])
         content = self._process_tokens(children)
 
@@ -1117,7 +1129,10 @@ class MarkdownToAstConverter(BaseParser):
         attrs = token.get("attrs", {})
         if not isinstance(attrs, dict):
             attrs = {}
-        identifier = attrs.get("label", "")
+        # mistune 3.x carries the label in the token's ``raw`` field (attrs only
+        # holds a numeric ``index``); older versions used ``attrs['label']``.
+        # Use the label text so references match their definitions' keys.
+        identifier = attrs.get("label") or token.get("raw", "")
         return FootnoteReference(identifier=identifier)
 
     def _process_inline_token(self, token: dict[str, Any]) -> Node | list[Node] | None:

--- a/src/all2md/renderers/markdown.py
+++ b/src/all2md/renderers/markdown.py
@@ -1598,11 +1598,21 @@ class MarkdownRenderer(NodeVisitor, InlineContentMixin, BaseRenderer):
                 child.accept(self)
                 child_content = "".join(self._output)
                 self._output = saved_output
+                lines = child_content.split("\n")
                 if i == 0:
-                    self._output.append(child_content)
+                    # First block starts right after the "[^id]: " marker; any
+                    # continuation lines align four spaces under it.
+                    self._output.append(lines[0])
+                    for line in lines[1:]:
+                        self._output.append("\n" + ("    " + line if line else ""))
                 else:
-                    indent_lines = child_content.split("\n")
-                    self._output.append("\n    " + "\n    ".join(indent_lines))
+                    # Later blocks are separate paragraphs. They need a blank
+                    # line before them and four-space indentation on every line,
+                    # otherwise a bare newline makes them lazily merge into the
+                    # previous paragraph when the footnote is reparsed.
+                    self._output.append("\n")
+                    for line in lines:
+                        self._output.append("\n" + ("    " + line if line else ""))
         else:
             mode = self.options.unsupported_inline_mode
             if mode == "drop":

--- a/tests/unit/parsers/test_markdown_parser_improvements.py
+++ b/tests/unit/parsers/test_markdown_parser_improvements.py
@@ -198,3 +198,69 @@ Second line"""
         assert isinstance(para.content[1], LineBreak)
         assert para.content[1].soft is True
         assert isinstance(para.content[2], Text)
+
+
+class TestMarkdownFootnotes:
+    """Regression tests for footnote reference/definition parsing.
+
+    mistune 3.x groups definitions in a ``footnotes`` container of
+    ``footnote_item`` tokens (label in ``attrs['key']`` / the ref's ``raw``),
+    not the legacy ``footnote_def`` token with ``attrs['label']``. When the
+    parser only handled the legacy shape, every reference identifier came back
+    empty and every definition was silently dropped from the AST.
+    """
+
+    @staticmethod
+    def _collect(node, out):
+        name = type(node).__name__
+        if name in ("FootnoteReference", "FootnoteDefinition"):
+            out.setdefault(name, []).append(node)
+        for child in getattr(node, "children", None) or []:
+            TestMarkdownFootnotes._collect(child, out)
+        content = getattr(node, "content", None)
+        if isinstance(content, list):
+            for child in content:
+                TestMarkdownFootnotes._collect(child, out)
+
+    def test_footnote_reference_keeps_identifier(self) -> None:
+        markdown = "See this[^1].\n\n[^1]: the note\n"
+        doc = MarkdownToAstConverter().parse(markdown)
+
+        found: dict = {}
+        self._collect(doc, found)
+        refs = found.get("FootnoteReference", [])
+
+        assert len(refs) == 1
+        assert refs[0].identifier == "1"
+
+    def test_footnote_definitions_are_not_dropped(self) -> None:
+        markdown = "A[^1] B[^2] C[^foo].\n\n[^1]: first\n[^2]: second\n[^foo]: third\n"
+        doc = MarkdownToAstConverter().parse(markdown)
+
+        found: dict = {}
+        self._collect(doc, found)
+        defs = found.get("FootnoteDefinition", [])
+        refs = found.get("FootnoteReference", [])
+
+        ref_ids = [r.identifier for r in refs]
+        def_ids = {d.identifier for d in defs}
+
+        assert ref_ids == ["1", "2", "FOO"]
+        # All three definitions survive with distinct identifiers matching the refs.
+        assert def_ids == {"1", "2", "FOO"}
+
+    def test_footnotes_roundtrip_on_supporting_flavor(self) -> None:
+        from all2md import convert
+        from all2md.options.markdown import MarkdownRendererOptions
+
+        markdown = "A[^1] and B[^foo].\n\n[^1]: first note\n[^foo]: second note\n"
+        out = convert(
+            markdown,
+            source_format="markdown",
+            target_format="markdown",
+            renderer_options=MarkdownRendererOptions(flavor="pandoc"),
+        )
+
+        assert "[^1]" in out
+        assert "[^1]: first note" in out
+        assert "[^FOO]: second note" in out

--- a/tests/unit/parsers/test_markdown_parser_improvements.py
+++ b/tests/unit/parsers/test_markdown_parser_improvements.py
@@ -264,3 +264,33 @@ class TestMarkdownFootnotes:
         assert "[^1]" in out
         assert "[^1]: first note" in out
         assert "[^FOO]: second note" in out
+
+    def test_multiparagraph_footnote_definition_survives_roundtrip(self) -> None:
+        """A footnote whose body has several paragraphs must not collapse.
+
+        The renderer separated a definition's paragraphs with a single newline,
+        so ``[^1]: first`` and ``    second`` landed on adjacent lines. On
+        reparse that indented line is a lazy continuation and the two
+        paragraphs silently merge into one; the fix emits a blank line between
+        them and indents every continuation line four spaces.
+        """
+        from all2md import convert, to_ast
+        from all2md.ast import FootnoteDefinition, Paragraph
+        from all2md.options.markdown import MarkdownRendererOptions
+
+        opts = MarkdownRendererOptions(flavor="pandoc")
+        markdown = "text[^1]\n\n[^1]: first\n\n    second\n"
+
+        once = convert(markdown, source_format="markdown", target_format="markdown", renderer_options=opts)
+        twice = convert(once, source_format="markdown", target_format="markdown", renderer_options=opts)
+        assert once == twice, "multi-paragraph footnote is not idempotent"
+
+        # The blank line between the two paragraphs is preserved.
+        assert "[^1]: first\n\n    second" in once
+
+        # After a full roundtrip the definition still carries two paragraphs.
+        ast = to_ast(once, source_format="markdown")
+        defs = [n for n in ast.children if isinstance(n, FootnoteDefinition)]
+        assert len(defs) == 1
+        paragraphs = [c for c in defs[0].content if isinstance(c, Paragraph)]
+        assert len(paragraphs) == 2


### PR DESCRIPTION
Markdown footnotes are silently dropped: `text[^1]` with a `[^1]: note` definition round-trips to `text<sup></sup>`, losing both the identifier and the note body.

The parser handled only the legacy `footnote_def` token and read the identifier from `attrs["label"]`. mistune 3.x instead groups definitions in a `footnotes` container of `footnote_item` tokens (label in `attrs["key"]`, and the reference carries it in `raw` while `attrs` holds only a numeric `index`). So every definition was dropped from the AST and every reference identifier came back empty.

Fix handles the `footnotes` container and reads `key`/`raw` with a `label` fallback (backward compatible). After it, references keep their ids and all definitions survive; footnote-supporting flavors (pandoc/multimarkdown/kramdown) round-trip natively. Adds a `TestMarkdownFootnotes` regression class (the markdown parser had no footnote identifier test, unlike org/dokuwiki).