### PR TITLE
Fix loose multi-paragraph list roundtrip collapse

### DIFF
--- a/src/all2md/parsers/markdown.py
+++ b/src/all2md/parsers/markdown.py
@@ -742,7 +742,10 @@ class MarkdownToAstConverter(BaseParser):
 
         ordered = attrs.get("ordered", False)
         start = attrs.get("start", 1)
-        tight = attrs.get("tight", True)
+        # mistune 3.x carries the loose/tight flag on the token itself, not in
+        # attrs. Reading it only from attrs marked every list tight, collapsing
+        # the blank lines of a loose (multi-paragraph) list.
+        tight = token.get("tight", attrs.get("tight", True))
 
         children = token.get("children", [])
         # Guard against children not being a list

--- a/src/all2md/renderers/markdown.py
+++ b/src/all2md/renderers/markdown.py
@@ -166,6 +166,7 @@ class MarkdownRenderer(NodeVisitor, InlineContentMixin, BaseRenderer):
         self._output = []
         self._indent_level = 0
         self._in_list = False
+        self._list_tight = True
         self._list_marker_stack = []
         self._marker_width_stack = []
         self._link_references = {}
@@ -775,12 +776,14 @@ class MarkdownRenderer(NodeVisitor, InlineContentMixin, BaseRenderer):
 
         """
         was_in_list = self._in_list
+        was_tight = self._list_tight
 
         # Increment indent level for nested lists
         if self._in_list:
             self._indent_level += 1
 
         self._in_list = True
+        self._list_tight = node.tight
 
         for i, item in enumerate(node.items):
             if node.ordered:
@@ -801,6 +804,7 @@ class MarkdownRenderer(NodeVisitor, InlineContentMixin, BaseRenderer):
                     self._output.append("\n\n")
 
         self._in_list = was_in_list
+        self._list_tight = was_tight
 
         # Decrement indent level when exiting nested list
         if was_in_list:
@@ -858,8 +862,13 @@ class MarkdownRenderer(NodeVisitor, InlineContentMixin, BaseRenderer):
 
                 # Subsequent children are indented
                 # Both nested lists and other blocks (paragraphs, code blocks, etc.)
-                # will use _current_indent() which now includes the marker width
-                self._output.append("\n")
+                # will use _current_indent() which now includes the marker width.
+                # In a loose list, block-level siblings (paragraphs, code) are
+                # separated by a blank line; a nested list attaches directly.
+                if not self._list_tight and not isinstance(child, List):
+                    self._output.append("\n\n")
+                else:
+                    self._output.append("\n")
                 child.accept(self)
 
         # Pop marker width from stack if we pushed it

--- a/src/all2md/renderers/markdown.py
+++ b/src/all2md/renderers/markdown.py
@@ -642,11 +642,19 @@ class MarkdownRenderer(NodeVisitor, InlineContentMixin, BaseRenderer):
         fence = fence_char * fence_length
         lang = node.language or ""
 
-        self._output.append(f"{fence}{lang}\n")
-        self._output.append(node.content)
+        block = f"{fence}{lang}\n{node.content}"
         if not node.content.endswith("\n"):
-            self._output.append("\n")
-        self._output.append(fence)
+            block += "\n"
+        block += fence
+
+        # Honor the current indentation so a code block nested inside a list
+        # item stays under the item's margin instead of breaking out to column
+        # zero (which reparses as a sibling of the list). At the top level the
+        # indent is empty and the output is unchanged.
+        indent = self._current_indent()
+        if indent:
+            block = "\n".join(indent + line if line else line for line in block.split("\n"))
+        self._output.append(block)
 
         # Emit block references if using after_block placement
         if self.options.link_style == "reference" and self.options.reference_link_placement == "after_block":
@@ -757,8 +765,11 @@ class MarkdownRenderer(NodeVisitor, InlineContentMixin, BaseRenderer):
                     lines[i] = f"**{label}:** {line}"
                     break
 
-        # Quote all lines
-        quoted_lines = ["> " + line for line in lines]
+        # Quote all lines, honoring the current indentation so a block quote
+        # nested inside a list item stays under the item's margin instead of
+        # breaking out to column zero. At the top level the indent is empty.
+        indent = self._current_indent()
+        quoted_lines = [f"{indent}> " + line for line in lines]
 
         self._output.append("\n".join(quoted_lines))
 
@@ -820,15 +831,21 @@ class MarkdownRenderer(NodeVisitor, InlineContentMixin, BaseRenderer):
 
         """
         indent = self._current_indent()
-        marker = self._list_marker_stack[-1] if self._list_marker_stack else "* "
+        base_marker = self._list_marker_stack[-1] if self._list_marker_stack else "* "
+        marker = base_marker
 
         if node.task_status and self._flavor.supports_task_lists():
             checkbox = "[x]" if node.task_status == "checked" else "[ ]"
-            marker = f"{marker}{checkbox} "
+            marker = f"{base_marker}{checkbox} "
 
         self._output.append(f"{indent}{marker}")
 
-        marker_width = len(marker)
+        # Continuation blocks indent to the list-marker width. A task checkbox
+        # ("[ ] ") is inline content of the first line, not part of the marker,
+        # so it must not widen the indent: indenting continuations under the
+        # checkbox pushes them four-plus spaces past the content column, where
+        # they reparse as an indented code block instead of a paragraph.
+        marker_width = len(base_marker)
 
         # Render children - first child inline with marker, others indented
         for i, child in enumerate(node.children):

--- a/tests/unit/renderers/test_markdown_renderer.py
+++ b/tests/unit/renderers/test_markdown_renderer.py
@@ -588,15 +588,49 @@ class TestLists:
         renderer = MarkdownRenderer()
         result = renderer.render_to_string(doc)
         lines = result.split("\n")
-        # All markers are aligned properly
+        # Markers are aligned by width, and because the list is loose the two
+        # paragraphs inside each item are separated by a blank line (rendering
+        # them adjacent would lazily merge them into one paragraph on reparse).
         assert lines[0] == "8. Item 8"
-        assert lines[1] == "   Continuation 8"  # 3 spaces (marker "8. ")
-        assert lines[2] == ""  # blank line between items
-        assert lines[3] == "9. Item 9"
-        assert lines[4] == "   Continuation 9"  # 3 spaces (marker "9. ")
-        assert lines[5] == ""  # blank line
-        assert lines[6] == "10. Item 10"
-        assert lines[7] == "    Continuation 10"  # 4 spaces (marker "10. ")
+        assert lines[1] == ""
+        assert lines[2] == "   Continuation 8"  # 3 spaces (marker "8. ")
+        assert lines[3] == ""  # blank line between items
+        assert lines[4] == "9. Item 9"
+        assert lines[5] == ""
+        assert lines[6] == "   Continuation 9"  # 3 spaces (marker "9. ")
+        assert lines[7] == ""  # blank line
+        assert lines[8] == "10. Item 10"
+        assert lines[9] == ""
+        assert lines[10] == "    Continuation 10"  # 4 spaces (marker "10. ")
+
+    def test_loose_multiparagraph_list_roundtrips_without_collapsing(self):
+        """A loose list item with two paragraphs must survive a reparse.
+
+        Regression: the parser read the loose/tight flag only from ``attrs``,
+        where mistune 3.x never puts it, so every list was treated as tight and
+        the renderer emitted the item's second paragraph on the immediately
+        following line. On reparse that line is a lazy continuation, silently
+        merging the two paragraphs into one.
+        """
+        from all2md import convert, to_ast
+
+        source = "1. first\n\n   second para\n\n2. next\n"
+        opts = MarkdownRendererOptions(flavor="pandoc")
+
+        once = convert(source, source_format="markdown", target_format="markdown", renderer_options=opts)
+        twice = convert(once, source_format="markdown", target_format="markdown", renderer_options=opts)
+        assert once == twice, "loose multi-paragraph list is not idempotent"
+
+        # The two paragraphs stay separated by a blank line, never collapsed.
+        assert "first\n\n   second para" in once
+        assert "first\nsecond para" not in once
+
+        # The AST still carries a loose list whose first item has two paragraphs.
+        ast = to_ast(source, source_format="markdown")
+        lists = [c for c in ast.children if isinstance(c, List)]
+        assert lists and lists[0].tight is False
+        first_item_paragraphs = [c for c in lists[0].items[0].children if isinstance(c, Paragraph)]
+        assert len(first_item_paragraphs) == 2
 
 
 @pytest.mark.unit

--- a/tests/unit/renderers/test_markdown_renderer.py
+++ b/tests/unit/renderers/test_markdown_renderer.py
@@ -632,6 +632,53 @@ class TestLists:
         first_item_paragraphs = [c for c in lists[0].items[0].children if isinstance(c, Paragraph)]
         assert len(first_item_paragraphs) == 2
 
+    def test_list_item_block_children_stay_indented_on_roundtrip(self):
+        """A code block or quote inside a list item must not break out.
+
+        The code-block and block-quote renderers ignored the current
+        indentation, so as a later child of a list item they landed at column
+        zero. On reparse they became siblings of the list rather than children
+        of the item, dropping the trailing paragraph out of the item too.
+        """
+        from all2md import convert, to_ast
+
+        opts = MarkdownRendererOptions(flavor="pandoc")
+        for source in (
+            "- a\n\n  ```\n  x\n  ```\n\n  after\n",  # para, code, para
+            "- item\n\n  > quoted\n",  # para then block quote
+        ):
+            once = convert(source, source_format="markdown", target_format="markdown", renderer_options=opts)
+            twice = convert(once, source_format="markdown", target_format="markdown", renderer_options=opts)
+            assert once == twice, f"list item with a block child is not idempotent: {source!r}"
+
+            # The block child stays inside the single list, not beside it.
+            ast = to_ast(once, source_format="markdown")
+            assert sum(isinstance(c, List) for c in ast.children) == 1
+            assert len(ast.children) == 1
+
+    def test_task_list_item_continuation_is_not_indented_as_code(self):
+        """A task item's second paragraph must reparse as a paragraph.
+
+        The checkbox ("[ ] ") was counted into the marker width, so a
+        continuation paragraph indented six spaces and reparsed as an indented
+        code block. Continuations indent to the base marker width instead.
+        """
+        from all2md import convert, to_ast
+        from all2md.ast import CodeBlock
+
+        opts = MarkdownRendererOptions(flavor="pandoc")
+        source = "- [ ] task\n\n  more detail\n"
+
+        once = convert(source, source_format="markdown", target_format="markdown", renderer_options=opts)
+        twice = convert(once, source_format="markdown", target_format="markdown", renderer_options=opts)
+        assert once == twice, "task-list continuation is not idempotent"
+
+        ast = to_ast(once, source_format="markdown")
+        item = [c for c in ast.children if isinstance(c, List)][0].items[0]
+        assert item.task_status
+        assert not any(isinstance(c, CodeBlock) for c in item.children)
+        assert sum(isinstance(c, Paragraph) for c in item.children) == 2
+
 
 @pytest.mark.unit
 class TestTables:


### PR DESCRIPTION
A loose list whose items contain multiple paragraphs is corrupted on a markdown roundtrip: the paragraphs collapse onto adjacent lines and the second one lazily merges into the first (`1. first` / blank / `   second` → one paragraph on reparse).

Two causes: the parser read the loose/tight flag from `attrs`, but mistune 3.x carries `tight` on the list token itself, so every list parsed as tight; and `visit_list_item` emitted a single newline between an item's block children, so a loose item's second paragraph had no separating blank line.

Read the flag from the token (falling back to attrs, then True), and separate loose-list block siblings with a blank line. All six list-roundtrip shapes are now idempotent and marker-width alignment is unchanged. Added a regression test; updated one renderer test that asserted the old collapsed output.