### PR TITLE
Fix definition-list roundtrip collapse

### DIFF
--- a/src/all2md/renderers/markdown.py
+++ b/src/all2md/renderers/markdown.py
@@ -1662,24 +1662,34 @@ class MarkdownRenderer(NodeVisitor, InlineContentMixin, BaseRenderer):
             # else: mode == "force", continue with markdown rendering below
         for i, (term, descriptions) in enumerate(node.items):
             if i > 0:
-                self._output.append("\n")
+                # A blank line separates definition groups; a single newline
+                # would make the next term lazily merge into the previous
+                # description when the list is reparsed.
+                self._output.append("\n\n")
             term_content = self._render_inline_content(term.content)
             self._output.append(term_content)
             for desc in descriptions:
                 self._output.append("\n: ")
                 for j, child in enumerate(desc.content):
-                    if j > 0:
-                        self._output.append("\n    ")
                     saved_output = self._output
                     self._output = []
                     child.accept(self)
                     child_content = "".join(self._output)
                     self._output = saved_output
-                    if j > 0:
-                        indent_lines = child_content.split("\n")
-                        self._output.append("\n    ".join(indent_lines))
+                    lines = child_content.split("\n")
+                    if j == 0:
+                        self._output.append(lines[0])
+                        for line in lines[1:]:
+                            self._output.append("\n" + ("    " + line if line else ""))
                     else:
-                        self._output.append(child_content)
+                        # Later blocks in a description are separate paragraphs:
+                        # they need a blank line before them and four-space
+                        # indentation on every line, otherwise a bare newline
+                        # makes them lazily merge into the previous paragraph
+                        # when the definition list is reparsed.
+                        self._output.append("\n")
+                        for line in lines:
+                            self._output.append("\n" + ("    " + line if line else ""))
 
     def visit_definition_term(self, node: "DefinitionTerm") -> None:
         """Render a DefinitionTerm node.

--- a/tests/golden/__snapshots__/test_other_formats_golden.ambr
+++ b/tests/golden/__snapshots__/test_other_formats_golden.ambr
@@ -205,9 +205,12 @@
   
   Developer
   : Implements core features and fixes bugs.
+  
   Designer
   : Crafts the user experience, visuals, and accessibility guidance.
+  
   QA Engineer
+  
   :
   : * Creates regression suites
   : * Automates smoke checks

--- a/tests/golden/__snapshots__/test_renderer_outputs_golden.ambr
+++ b/tests/golden/__snapshots__/test_renderer_outputs_golden.ambr
@@ -91,6 +91,7 @@
   
   Pipeline
   : Processes sources into a shared AST for rendering.
+  
   Renderer
   : Produces target format while honoring **comments** and math.
   

--- a/tests/golden/__snapshots__/test_textual_formats_golden.ambr
+++ b/tests/golden/__snapshots__/test_textual_formats_golden.ambr
@@ -76,8 +76,10 @@
   
   CPU
   : The brain of the computer
+  
   RAM
   : Random Access Memory
+  
   GPU
   : Graphics Processing Unit
   

--- a/tests/unit/renderers/test_markdown_renderer.py
+++ b/tests/unit/renderers/test_markdown_renderer.py
@@ -1155,3 +1155,32 @@ class TestDefinitionListRendering:
         assert "Example" in result
         assert "Here's how to use it:" in result
         assert "code example" in result
+
+    def test_definition_list_roundtrips_without_collapsing(self):
+        """Multi-paragraph descriptions and multiple terms survive a roundtrip.
+
+        Two regressions in one place: a description's paragraphs were joined by
+        a single newline (so the second lazily merged into the first on
+        reparse), and consecutive term/description groups were separated by a
+        single newline (so the next term merged into the previous description).
+        Both need a blank-line separator; continuation lines are indented four
+        spaces.
+        """
+        from all2md import convert, to_ast
+        from all2md.ast import DefinitionList
+
+        opts = MarkdownRendererOptions(flavor="pandoc")
+        markdown = "term one\n\n:   first para\n\n    second para\n\nterm two\n\n:   only para\n"
+
+        once = convert(markdown, source_format="markdown", target_format="markdown", renderer_options=opts)
+        twice = convert(once, source_format="markdown", target_format="markdown", renderer_options=opts)
+        assert once == twice, "definition list is not idempotent"
+
+        # Blank line kept between the two paragraphs of the first description.
+        assert "first para\n\n    second para" in once
+
+        # Both terms survive as two separate definition items.
+        ast = to_ast(once, source_format="markdown")
+        dls = [n for n in ast.children if isinstance(n, DefinitionList)]
+        assert len(dls) == 1
+        assert len(dls[0].items) == 2


### PR DESCRIPTION
A definition list is corrupted on a markdown roundtrip in two ways.

A description's paragraphs were joined with a single newline, so a second paragraph landed directly under the first and lazily merged into it on reparse. And consecutive term/description groups were separated by a single newline, so the next term merged into the previous description (`t1\n: d1\nt2\n: d2` parses as a single item).

Separate description blocks and term groups with a blank line, and indent continuation lines four spaces. Multi-paragraph descriptions and multiple terms now survive a roundtrip. Added a regression test; existing definition-list and roundtrip tests still pass.