### PR TITLE
fix(html): stop double-wrapping loose list items in a nested paragraph (#72)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -104,6 +104,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **HTML: loose list items no longer grow a paragraph-inside-a-paragraph.** A *loose* item —
+  one whose `<li>` already holds a block, `<li><p>x</p></li>` — was parsed to
+  `ListItem > Paragraph > Paragraph > Text`, because `_process_list_item_to_ast` wrapped every
+  item's content in a freshly synthesized `Paragraph` whether or not that content was already a
+  block. No format represents a paragraph nested directly in a paragraph, so the inner node was
+  pure artifact: a consumer walking the AST saw a different `ListItem` shape depending on how the
+  source HTML happened to be written, and — because our own HTML renderer emits `<li><p>…</p></li>`
+  — an `html → html` round trip accreted one extra `Paragraph` per item on every pass. The parser
+  now adopts a `<li>`'s block children directly and only synthesizes a wrapping `Paragraph` for
+  loose inline runs, so `<li><p>x</p></li>` and `<li>x</li>` produce the identical AST and the
+  round trip is stable.
 - **String page ranges select the pages you asked for.** `validate_page_range()` converted
   1-based page numbers to 0-based **twice** on the string path: `parse_page_ranges()` already
   returns 0-based indices, and the result was then decremented again. So every string range

--- a/src/all2md/parsers/html.py
+++ b/src/all2md/parsers/html.py
@@ -1157,19 +1157,26 @@ class HtmlToAstConverter(BaseParser):
             List item node
 
         """
-        # Process children, separating inline content from nested lists
+        # Separate inline content (wrapped in a synthesized Paragraph) from block children,
+        # which are adopted directly. A block child includes a nested list but also a loose
+        # item's own <p>, <blockquote>, <table>, etc. Wrapping such a block in a Paragraph
+        # would nest a paragraph inside a paragraph -- an artifact no format represents, and
+        # the source of the <li><p>x</p></li> double-wrap (#72).
         children: list[Node] = []
         inline_content: list[Node] = []
 
         for child in node.children:
-            if hasattr(child, "name") and child.name in ["ul", "ol"]:
-                # Nested list - first add accumulated inline content as paragraph
+            if self._carries_block_content(child):
+                # Flush accumulated inline content as a paragraph before the block child.
                 if inline_content:
                     children.append(Paragraph(content=inline_content))
                     inline_content = []
-                # Add nested list
-                nested_list = self._process_list_to_ast(child)
-                children.append(nested_list)
+                block_nodes = self._process_node_to_ast(child)
+                if block_nodes:
+                    if isinstance(block_nodes, list):
+                        children.extend(block_nodes)
+                    else:
+                        children.append(block_nodes)
             else:
                 # Inline content
                 inline_nodes = self._process_node_to_ast(child)

--- a/tests/unit/parsers/test_html_parser.py
+++ b/tests/unit/parsers/test_html_parser.py
@@ -347,6 +347,37 @@ class TestLists:
         assert nested_list.ordered is False
         assert len(nested_list.items) == 2
 
+    def test_loose_item_not_double_wrapped(self) -> None:
+        """A loose <li><p>x</p></li> must not nest a Paragraph inside a Paragraph (#72)."""
+        converter = HtmlToAstConverter()
+        loose = converter.convert_to_ast("<ul><li><p>x</p></li></ul>")
+
+        item = loose.children[0].items[0]
+        assert len(item.children) == 1
+        para = item.children[0]
+        assert isinstance(para, Paragraph)
+        # The paragraph holds inline content directly, not another Paragraph.
+        assert isinstance(para.content[0], Text)
+        assert para.content[0].content == "x"
+
+    def test_loose_and_tight_items_agree(self) -> None:
+        """A loose item and its tight equivalent produce identical AST (#72)."""
+        converter = HtmlToAstConverter()
+        tight = converter.convert_to_ast("<ul><li>x</li></ul>")
+        loose = converter.convert_to_ast("<ul><li><p>x</p></li></ul>")
+        assert tight == loose
+
+    def test_loose_multi_paragraph_item(self) -> None:
+        """Multiple block paragraphs in one <li> are adopted as separate Paragraphs (#72)."""
+        converter = HtmlToAstConverter()
+        doc = converter.convert_to_ast("<ul><li><p>x</p><p>y</p></li></ul>")
+
+        item = doc.children[0].items[0]
+        assert len(item.children) == 2
+        assert all(isinstance(child, Paragraph) for child in item.children)
+        assert item.children[0].content[0].content == "x"
+        assert item.children[1].content[0].content == "y"
+
 
 @pytest.mark.unit
 class TestCodeBlocks:


### PR DESCRIPTION
Fixes #72.

## The bug

`_process_list_item_to_ast` wrapped every `<li>`'s content in a freshly synthesized `Paragraph`, whether or not that content was already a block. So a *loose* list item — one whose `<li>` already holds a block child, `<li><p>x</p></li>` — parsed to `ListItem > Paragraph > Paragraph > Text`:

```python
to_ast(b"<ul><li>x</li></ul>", source_format="html")
# Document > List > ListItem > Paragraph > Text 'x'              # correct

to_ast(b"<ul><li><p>x</p></li></ul>", source_format="html")
# Document > List > ListItem > Paragraph > Paragraph > Text 'x'  # extra Paragraph
```

No format represents a paragraph nested directly inside a paragraph, so the inner node is pure artifact. Two consequences:

- AST consumers saw an inconsistent `ListItem` shape depending on how the source HTML was written; and
- because our own HTML renderer emits `<li><p>…</p></li>`, an `html → html` round trip accreted one extra `Paragraph` per item on **every** pass.

## The fix

Classify each `<li>` child the same way `_process_block_container` already does: flush accumulated inline content into a `Paragraph`, but adopt block children (nested lists, `<p>`, `<blockquote>`, `<table>`, …) directly instead of wrapping them. A loose item and its tight equivalent now produce identical AST, and the round trip is stable across passes.

## Verification

- New regression tests in `TestLists` (`test_loose_item_not_double_wrapped`, `test_loose_and_tight_items_agree`, `test_loose_multi_paragraph_item`) — confirmed all three **fail** against pre-fix code and pass with the fix.
- Full `test_html_parser.py` suite green; `html → html` round trip verified stable (no paragraph growth across three passes).
- `mypy` and `ruff` clean on the changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)