### PR TITLE
fix(docx): map Word 'Title' style back to a title heading on parse (#70)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -104,6 +104,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **DOCX: a document title survives the Markdown round trip.** Rendering to DOCX applies
+  `TitlePromotionTransform` — a leading `# H1` becomes Word's **Title** style and every
+  following heading is promoted one level (H2 → "Heading 1") so the document reads correctly
+  in Word. The parser had no inverse: it mapped the `Title` style to a plain paragraph and
+  left the promoted headings where they were, so `# Title` / `## Section` came back as body
+  text plus `# Section` — the title silently demoted to prose and every heading shifted up a
+  level (`all2md roundtrip … --via docx` scored `structure: 67`). The parser now maps Word's
+  `Title` back to `Heading(level=1, is_title=True)` and, when that title leads the document,
+  demotes the following headings one level to undo the promotion — making the transform
+  exactly invertible (`structure: 100`) while keeping the nice-looking Word output. Word's
+  `Title` is semantically the document title, so this also gives natively-authored Word
+  documents a sensible outline (Title → `#`, its Heading 1 → `##`).
 - **String page ranges select the pages you asked for.** `validate_page_range()` converted
   1-based page numbers to 0-based **twice** on the string path: `parse_page_ranges()` already
   returns 0-based indices, and the result was then decremented again. So every string range

--- a/src/all2md/parsers/docx.py
+++ b/src/all2md/parsers/docx.py
@@ -457,11 +457,38 @@ class DocxToAstConverter(BaseParser):
             metadata = self.extract_metadata(doc)
             metadata_dict = metadata.to_dict()
 
+        self._invert_title_promotion(children)
+
         document = Document(children=children, metadata=metadata_dict)
         self._record_docx_quality_signals(doc, document)
         self._footnote_collector = None
         self._comments_map = {}
         return document
+
+    def _invert_title_promotion(self, children: list[Node]) -> None:
+        """Undo :class:`TitlePromotionTransform`'s heading shift when a title leads.
+
+        The renderer promotes every heading after a leading title up one level
+        (H2 -> "Heading 1"); :meth:`_try_process_title` has already mapped the "Title"
+        paragraph back to a title heading, so here we demote the remaining headings one
+        level to restore the original outline. Mirrors the transform's leading-only rule:
+        nothing shifts unless the first real content node is the title heading. Mutates
+        ``children`` in place.
+        """
+        title_index: int | None = None
+        for i, child in enumerate(children):
+            if isinstance(child, AstParagraph) and self._is_effectively_empty(child.content):
+                continue  # skip blank spacer paragraphs, as the promotion did
+            if isinstance(child, Heading) and child.metadata.get("is_title"):
+                title_index = i
+            break  # only the first real content node can be the title
+
+        if title_index is None:
+            return
+
+        for child in children[title_index + 1 :]:
+            if isinstance(child, Heading):
+                child.level += 1
 
     # DrawingML ``graphicData/@uri`` values for content types all2md does not
     # render (and therefore drops): embedded charts and SmartArt diagrams.
@@ -514,6 +541,25 @@ class DocxToAstConverter(BaseParser):
                 elif uri == self._DOCX_DIAGRAM_URI:
                     counts["smartart_dropped"] += 1
         return counts
+
+    def _try_process_title(self, paragraph: "Paragraph", style_name: str) -> Heading | None:
+        """Try to process a Word ``Title`` paragraph as a title heading.
+
+        This is the inverse of :class:`TitlePromotionTransform`, which the DOCX
+        renderer applies to send a leading ``# H1`` to Word's ``Title`` style. Word's
+        ``Title`` is the document title -- semantically a level-1 heading -- so it maps
+        back to ``Heading(level=1, is_title=True)`` rather than a plain paragraph, which
+        dropped the title to body text and left every following heading shifted up a
+        level (#70). The subsequent-heading shift is undone document-wide by
+        :class:`TitleDemotionTransform` once the whole body is parsed.
+        """
+        if style_name != "Title":
+            return None
+        content = self._process_paragraph_runs_to_inline(paragraph)
+        heading = Heading(level=1, content=content)
+        heading.metadata["is_title"] = True
+        heading.metadata["source_style"] = style_name
+        return heading
 
     def _try_process_heading(self, paragraph: "Paragraph", style_name: str) -> Heading | None:
         """Try to process paragraph as a heading. Returns Heading or None."""
@@ -609,6 +655,8 @@ class DocxToAstConverter(BaseParser):
         style_name = paragraph.style.name if paragraph.style else ""
 
         # Try special paragraph types first
+        if title_result := self._try_process_title(paragraph, style_name):
+            return title_result
         if heading_result := self._try_process_heading(paragraph, style_name):
             return heading_result
         if code_result := self._try_process_code_block(paragraph, style_name):

--- a/tests/golden/__snapshots__/test_docx_golden.ambr
+++ b/tests/golden/__snapshots__/test_docx_golden.ambr
@@ -197,7 +197,7 @@
 # ---
 # name: TestDOCXGoldenFromFiles.test_footnotes_endnotes_docx_file
   '''
-  Advanced Document
+  # Advanced Document
   
   This document contains more advanced Microsoft word features. In this document, we will use some footnotes, endnotes, and leave comments.
   

--- a/tests/unit/parsers/test_docx_parser.py
+++ b/tests/unit/parsers/test_docx_parser.py
@@ -881,3 +881,67 @@ class TestMathExtraction:
         assert "=-1" in content
         assert math_nodes[0].notation == "latex"
         assert math_nodes[0].representations["latex"].replace(" ", "") == content
+
+
+@pytest.mark.unit
+class TestTitleRoundTrip:
+    """Tests for the Word 'Title' style inverse (issue #70)."""
+
+    def test_title_style_becomes_title_heading(self) -> None:
+        """A 'Title' paragraph maps back to a level-1 heading marked is_title."""
+        doc = docx.Document()
+        doc.add_paragraph("My Title", style="Title")
+
+        ast_doc = DocxToAstConverter().convert_to_ast(doc)
+
+        assert isinstance(ast_doc.children[0], Heading)
+        title = ast_doc.children[0]
+        assert title.level == 1
+        assert title.metadata.get("is_title") is True
+        assert _inline_text(title.content) == "My Title"
+
+    def test_headings_after_title_are_demoted(self) -> None:
+        """Headings following a leading title shift down one level to undo promotion."""
+        doc = docx.Document()
+        doc.add_paragraph("My Title", style="Title")
+        doc.add_heading("Section", level=1)
+        doc.add_heading("Subsection", level=2)
+
+        ast_doc = DocxToAstConverter().convert_to_ast(doc)
+        headings = [c for c in ast_doc.children if isinstance(c, Heading)]
+
+        # Title stays at 1; "Heading 1"/"Heading 2" become level 2/3.
+        assert [h.level for h in headings] == [1, 2, 3]
+        assert headings[0].metadata.get("is_title") is True
+
+    def test_non_leading_title_does_not_shift_headings(self) -> None:
+        """A title that is not the first content leaves following headings untouched."""
+        doc = docx.Document()
+        doc.add_paragraph("Intro paragraph.")
+        doc.add_paragraph("Mid Title", style="Title")
+        doc.add_heading("Section", level=1)
+
+        ast_doc = DocxToAstConverter().convert_to_ast(doc)
+        headings = [c for c in ast_doc.children if isinstance(c, Heading)]
+
+        # The non-leading title still becomes a heading, but no promotion was applied
+        # by the renderer in this shape, so the "Heading 1" must stay at level 1.
+        assert headings[0].metadata.get("is_title") is True
+        assert headings[0].level == 1
+        assert headings[1].level == 1
+
+    def test_markdown_docx_markdown_round_trip_preserves_outline(self) -> None:
+        """Md -> docx -> md keeps the title a heading and the outline intact (#70)."""
+        from all2md import from_ast, to_ast
+
+        source = "# Title\n\n## Section\n\nBody.\n"
+        ast = to_ast(source.encode(), source_format="markdown")
+        docx_bytes = from_ast(ast, target_format="docx")
+        back = to_ast(docx_bytes, source_format="docx")
+        rendered = from_ast(back, target_format="markdown")
+
+        assert "# Title" in rendered
+        assert "## Section" in rendered
+        # The title must not have decayed into body text, nor Section into an H1.
+        assert "\nTitle\n" not in rendered
+        assert "\n# Section" not in rendered


### PR DESCRIPTION
Fixes #70.

## The bug

Rendering to DOCX applies `TitlePromotionTransform`: a leading `# H1` becomes Word's **Title** style, and every subsequent heading is promoted one level (H2 → "Heading 1"). That is deliberate — it produces a good-looking Word document.

The DOCX **parser** had no inverse. It mapped the `Title` style to a plain `Paragraph` and did not un-shift the promoted headings, so the round trip was lossy by construction:

```markdown
# Title
## Section
Body.
```
came back as
```markdown
Title
# Section
Body.
```

The `# Title` was no longer a heading at all, and `## Section` had become `# Section`. `all2md roundtrip repro.md --via docx` scored **`structure: 67`** (`block_lost (heading(h2))`, `block_added (paragraph)`).

## The fix

Two parser-side changes, mirroring the render-side transform:

1. `_try_process_title` maps Word's `Title` style back to `Heading(level=1, metadata={"is_title": True})` instead of a paragraph.
2. `_invert_title_promotion` runs once the body is assembled: when the first real content node is that title heading, it demotes the following headings one level, undoing the promotion.

This makes `TitlePromotionTransform` **exactly invertible** — `all2md roundtrip repro.md --via docx` now reaches **`structure: 100`** — while keeping the nice Word output. Because Word's `Title` *is* semantically the document title, this also gives natively-authored Word documents a sensible Markdown outline (Title → `#`, its Heading 1 → `##`). The shift is gated on the title actually leading the document, exactly as the render-side transform is, so a document with no leading title is untouched.

## Verification

- `all2md roundtrip repro.md --via docx` → `structure: 100 / fidelity: 100` (was 67/81).
- New `TestTitleRoundTrip` (4 tests: title→heading mapping, subsequent-heading demotion, leading-only gating, full md→docx→md outline) — confirmed all **fail** against pre-fix code and pass with the fix.
- Full `test_docx_parser.py` + `test_docx_renderer.py` suites green; `mypy`, `ruff`, `black` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)