### PR TITLE
fix(docx): round-trip inline code and block quotes via named styles (#71)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -104,6 +104,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **DOCX: inline code and block quotes survive the Markdown round trip.** Two independent
+  renderer/parser asymmetries on the `md → docx → md` path, both filed as #71:
+
+  *Inline code was dropped.* The renderer emitted a `` `code` `` run with a monospace font
+  but no named character style, so the parser — which recovers inline styling from run
+  *styles*, not fonts — had nothing to key on, and `` `inline code` `` came back as plain
+  `inline code`. The renderer now tags inline-code runs with a `Verbatim Char` character
+  style (matching pandoc's name; created on demand and only when `use_styles` is on), and the
+  parser maps that style back to a `Code` node. Recognized style names are configurable via
+  the new `code_char_style_names` DOCX parser option.
+
+  *A block quote came back as a bullet list.* The renderer wrote the quoted paragraph as a
+  `Normal` paragraph with a left indent, and the parser read that indent as list nesting — so
+  `> a quoted line` silently became `* a quoted line`, which looks intentional and is arguably
+  worse than dropping it. The renderer now applies Word's built-in `Quote` paragraph style
+  (which also makes the generated document look right in Word) and, for a single level, no
+  longer sets a bare indent that the parser would misread; the parser maps `Quote` /
+  `Intense Quote` back to a `BlockQuote`, coalescing adjacent quote paragraphs into one quote.
+  Recognized style names are configurable via the new `quote_style_names` DOCX parser option.
+
+  Together these take `all2md roundtrip … --via docx` on a document with inline code and a
+  quote from `structure: 33 / inline: 0` to `100 / 100`. Both recoveries require styles
+  (`use_styles=True`, the default); with styles disabled the render still falls back to
+  font-and-indent as before.
 - **String page ranges select the pages you asked for.** `validate_page_range()` converted
   1-based page numbers to 0-based **twice** on the string path: `parse_page_ranges()` already
   returns 0-based indices, and the result was then decremented again. So every string range

--- a/src/all2md/options/docx.py
+++ b/src/all2md/options/docx.py
@@ -264,3 +264,18 @@ class DocxOptions(BaseParserOptions, AttachmentOptionsMixin):
             "importance": "advanced",
         },
     )
+    code_char_style_names: list[str] = field(
+        default_factory=lambda: ["Verbatim Char", "Code Char"],
+        metadata={
+            "help": "List of run character style names to treat as inline code (case-insensitive exact match). "
+            "The DOCX renderer writes inline code with the 'Verbatim Char' style; pandoc uses the same name.",
+            "importance": "advanced",
+        },
+    )
+    quote_style_names: list[str] = field(
+        default_factory=lambda: ["Quote", "Intense Quote"],
+        metadata={
+            "help": "List of paragraph style names to treat as block quotes (case-insensitive exact match)",
+            "importance": "advanced",
+        },
+    )

--- a/src/all2md/parsers/docx.py
+++ b/src/all2md/parsers/docx.py
@@ -33,6 +33,8 @@ if TYPE_CHECKING:
     from docx.text.paragraph import Paragraph
 
 from all2md.ast import (
+    BlockQuote,
+    Code,
     CodeBlock,
     Comment,
     CommentInline,
@@ -457,11 +459,32 @@ class DocxToAstConverter(BaseParser):
             metadata = self.extract_metadata(doc)
             metadata_dict = metadata.to_dict()
 
+        self._coalesce_blockquotes(children)
+
         document = Document(children=children, metadata=metadata_dict)
         self._record_docx_quality_signals(doc, document)
         self._footnote_collector = None
         self._comments_map = {}
         return document
+
+    def _coalesce_blockquotes(self, children: list[Node]) -> None:
+        """Merge consecutive top-level :class:`BlockQuote` siblings into one.
+
+        Each Word ``Quote`` paragraph parses to its own single-paragraph block quote;
+        a multi-paragraph quote is therefore several adjacent block quotes. Merge them
+        so the round trip yields one quote with several paragraphs rather than several
+        one-paragraph quotes. The parser produces block quotes only from quote-styled
+        paragraphs, so adjacent ones are always safe to join. Mutates ``children``.
+        """
+        i = 0
+        while i < len(children) - 1:
+            current = children[i]
+            following = children[i + 1]
+            if isinstance(current, BlockQuote) and isinstance(following, BlockQuote):
+                current.children.extend(following.children)
+                del children[i + 1]
+            else:
+                i += 1
 
     # DrawingML ``graphicData/@uri`` values for content types all2md does not
     # render (and therefore drops): embedded charts and SmartArt diagrams.
@@ -526,6 +549,39 @@ class DocxToAstConverter(BaseParser):
                 heading.metadata["source_style"] = style_name
             return heading
         return None
+
+    def _is_code_char_style(self, style_name: str) -> bool:
+        """Whether a run character style name marks inline code (case-insensitive)."""
+        lowered = style_name.lower()
+        return any(lowered == name.lower() for name in self.options.code_char_style_names)
+
+    def _is_quote_style(self, style_name: str) -> bool:
+        """Whether a paragraph style name marks a block quote (case-insensitive)."""
+        lowered = style_name.lower()
+        return any(lowered == name.lower() for name in self.options.quote_style_names)
+
+    def _process_quote_paragraph(self, paragraph: "Paragraph", style_name: str) -> Node | list[Node] | None:
+        """Map a Word ``Quote``-styled paragraph back to a :class:`BlockQuote`.
+
+        The inverse of the renderer, which sends a ``BlockQuote`` to Word's ``Quote``
+        style (#71). Before this existed the parser saw only the quote style's left
+        indent and mis-read it as a list item, turning ``> a quoted line`` into
+        ``* a quoted line``. Each quote paragraph becomes its own single-paragraph
+        ``BlockQuote``; adjacent ones are merged by :meth:`_coalesce_blockquotes`.
+        Any list still accumulating is finalized first, since a quote ends it.
+        """
+        content = self._process_paragraph_runs_to_inline(paragraph)
+        nodes: list[Node] = []
+        if self._list_stack:
+            accumulated_list = self._finalize_current_list()
+            self._list_stack = []
+            if accumulated_list:
+                nodes.append(accumulated_list)
+        if not self._is_effectively_empty(content):
+            nodes.append(BlockQuote(children=[AstParagraph(content=content)]))
+        if not nodes:
+            return None
+        return nodes[0] if len(nodes) == 1 else nodes
 
     def _try_process_code_block(self, paragraph: "Paragraph", style_name: str) -> CodeBlock | None:
         """Try to process paragraph as a code block. Returns CodeBlock or None."""
@@ -615,6 +671,11 @@ class DocxToAstConverter(BaseParser):
             return code_result
         if break_result := self._try_process_thematic_break(paragraph):
             return break_result
+
+        # A Quote-styled paragraph is a block quote, not a list -- detect it before list
+        # detection so its style (or leftover indent) is never mistaken for list nesting.
+        if self._is_quote_style(style_name):
+            return self._process_quote_paragraph(paragraph, style_name)
 
         # Handle lists
         list_type, level = _detect_list_level(paragraph, doc)
@@ -900,6 +961,15 @@ class DocxToAstConverter(BaseParser):
         url: str | None,
         source_style: str | None = None,
     ) -> Node:
+        # A run wearing the inline-code character style becomes a Code node -- the inverse
+        # of the renderer's inline-code style (#71). Code has no sub-formatting to preserve,
+        # but a code run can still be a hyperlink, so keep an enclosing Link.
+        if source_style and self._is_code_char_style(source_style):
+            code_node: Node = Code(content=text)
+            if url:
+                code_node = Link(url=url, content=[code_node])
+            return code_node
+
         inline_node: Node = Text(content=text)
 
         if format_key:

--- a/src/all2md/parsers/docx.py
+++ b/src/all2md/parsers/docx.py
@@ -486,6 +486,7 @@ class DocxToAstConverter(BaseParser):
                 del children[i + 1]
             else:
                 i += 1
+
     def _invert_title_promotion(self, children: list[Node]) -> None:
         """Undo :class:`TitlePromotionTransform`'s heading shift when a title leads.
 

--- a/src/all2md/renderers/docx.py
+++ b/src/all2md/renderers/docx.py
@@ -106,6 +106,13 @@ class DocxRenderer(NodeVisitor, BaseRenderer):
 
     """
 
+    # Character style written for inline Code, and paragraph style written for
+    # BlockQuote. Both are recovered by the DOCX parser so the round trip is lossless
+    # (#71). "Verbatim Char" matches pandoc's inline-code style; "Quote" is a Word
+    # built-in present in the default template.
+    _INLINE_CODE_CHAR_STYLE = "Verbatim Char"
+    _BLOCKQUOTE_STYLE = "Quote"
+
     def __init__(self, options: DocxRendererOptions | None = None):
         """Initialize the DOCX renderer with options."""
         BaseRenderer._validate_options_type(options, DocxRendererOptions, "docx")
@@ -524,6 +531,19 @@ class DocxRenderer(NodeVisitor, BaseRenderer):
             style.paragraph_format.space_before = self._Pt(6)
             style.paragraph_format.space_after = self._Pt(6)
 
+    def _ensure_inline_code_style(self) -> None:
+        """Create the inline-code character style if it doesn't already exist."""
+        if not self.document:
+            return
+
+        name = self._INLINE_CODE_CHAR_STYLE
+        if not self._has_style(name):
+            styles = self.document.styles
+            style = styles.add_style(name, self._WD_STYLE_TYPE.CHARACTER)
+            self._available_styles.add(name)
+            style.font.name = self.options.code_font
+            style.font.size = self._Pt(self.options.code_font_size)
+
     def _set_document_properties(self, metadata: dict) -> None:
         """Set document properties from metadata.
 
@@ -641,14 +661,26 @@ class DocxRenderer(NodeVisitor, BaseRenderer):
         # Don't create new paragraph if we're already in one (e.g., heading)
         if self._current_paragraph is None:
             source_style = node.metadata.get("source_style")
+            # Inside a blockquote, prefer Word's "Quote" paragraph style over a raw left
+            # indent: it looks right in Word and, unlike a bare indent, the parser can tell
+            # it apart from a list item (#71). An explicit source_style still wins.
+            use_quote_style = (
+                self._blockquote_depth > 0 and self.options.use_styles and self._has_style(self._BLOCKQUOTE_STYLE)
+            )
             if self.options.use_styles and source_style and self._has_style(source_style):
                 self._current_paragraph = self.document.add_paragraph(style=source_style)
+            elif use_quote_style:
+                self._current_paragraph = self.document.add_paragraph(style=self._BLOCKQUOTE_STYLE)
             else:
                 self._current_paragraph = self.document.add_paragraph()
 
-            # Apply blockquote indentation if inside a blockquote
+            # Indent for blockquote depth. With the Quote style the style supplies the
+            # first level's indent (and a bare direct indent would be misread as a list),
+            # so only add a direct indent for the fallback path or for deeper nesting.
             if self._blockquote_depth > 0:
-                self._current_paragraph.paragraph_format.left_indent = self._Inches(0.5 * self._blockquote_depth)
+                extra_depth = self._blockquote_depth - 1 if use_quote_style else self._blockquote_depth
+                if extra_depth > 0:
+                    self._current_paragraph.paragraph_format.left_indent = self._Inches(0.5 * extra_depth)
 
         # Render content
         for child in node.content:
@@ -1152,7 +1184,13 @@ class DocxRenderer(NodeVisitor, BaseRenderer):
                 )
 
             elif isinstance(node, Code):
-                # Render as code with code font
+                # Render as code with code font, and tag the run with a named character
+                # style so the DOCX parser can recover the inline code (#71). An inherited
+                # style (node_style) wins if present; otherwise apply our own, creating it
+                # on demand. Falls back to font-only when styles are disabled.
+                code_style = node_style or self._INLINE_CODE_CHAR_STYLE
+                if self.options.use_styles and code_style == self._INLINE_CODE_CHAR_STYLE:
+                    self._ensure_inline_code_style()
                 self._render_inlines(
                     paragraph,
                     [Text(content=node.content)],
@@ -1163,7 +1201,7 @@ class DocxRenderer(NodeVisitor, BaseRenderer):
                     superscript=superscript,
                     subscript=subscript,
                     code_font=True,
-                    character_style=node_style,
+                    character_style=code_style,
                 )
 
             elif isinstance(node, Link):
@@ -1270,9 +1308,10 @@ class DocxRenderer(NodeVisitor, BaseRenderer):
             if self.document:
                 self._current_paragraph = self.document.add_paragraph()
 
-        # Use efficient inline rendering with code font
+        # Render the Code node through the shared path so it also gets the inline-code
+        # character style that lets the DOCX parser recover it (#71).
         if self._current_paragraph:
-            self._render_inlines(self._current_paragraph, [Text(content=node.content)], code_font=True)
+            self._render_inlines(self._current_paragraph, [node])
 
     def visit_link(self, node: Link) -> None:
         """Render a Link node.

--- a/tests/unit/parsers/test_docx_parser.py
+++ b/tests/unit/parsers/test_docx_parser.py
@@ -22,6 +22,7 @@ from fixtures import FIXTURES_PATH
 
 from all2md.ast import (
     BlockQuote,
+    Code,
     CommentInline,
     Document,
     Emphasis,
@@ -881,3 +882,67 @@ class TestMathExtraction:
         assert "=-1" in content
         assert math_nodes[0].notation == "latex"
         assert math_nodes[0].representations["latex"].replace(" ", "") == content
+
+
+@pytest.mark.unit
+class TestCodeAndBlockquoteRoundTrip:
+    """Tests for inline code and blockquote DOCX round-trip fidelity (issue #71)."""
+
+    def test_quote_style_paragraph_becomes_blockquote(self) -> None:
+        """A Word 'Quote' paragraph parses to a BlockQuote, not a list item."""
+        doc = docx.Document()
+        doc.add_paragraph("a quoted line", style="Quote")
+
+        ast_doc = DocxToAstConverter().convert_to_ast(doc)
+
+        blockquotes = extract_nodes(ast_doc, BlockQuote)
+        assert len(blockquotes) == 1
+        assert not extract_nodes(ast_doc, List), "Quote paragraph must not be read as a list"
+        assert _inline_text(blockquotes[0].children[0].content) == "a quoted line"
+
+    def test_consecutive_quote_paragraphs_coalesce(self) -> None:
+        """Adjacent 'Quote' paragraphs merge into a single multi-paragraph BlockQuote."""
+        doc = docx.Document()
+        doc.add_paragraph("line one", style="Quote")
+        doc.add_paragraph("line two", style="Quote")
+
+        ast_doc = DocxToAstConverter().convert_to_ast(doc)
+
+        blockquotes = extract_nodes(ast_doc, BlockQuote)
+        assert len(blockquotes) == 1
+        assert len(blockquotes[0].children) == 2
+
+    def test_inline_code_char_style_becomes_code_node(self) -> None:
+        """A run wearing the inline-code character style parses to a Code node."""
+        from docx.enum.style import WD_STYLE_TYPE
+
+        doc = docx.Document()
+        doc.styles.add_style("Verbatim Char", WD_STYLE_TYPE.CHARACTER)
+        para = doc.add_paragraph("Use ")
+        code_run = para.add_run("f(x)")
+        code_run.style = "Verbatim Char"
+        para.add_run(" here")
+
+        ast_doc = DocxToAstConverter().convert_to_ast(doc)
+
+        code_nodes = extract_nodes(ast_doc, Code)
+        assert len(code_nodes) == 1
+        assert code_nodes[0].content == "f(x)"
+
+    def test_markdown_docx_markdown_preserves_inline_code_and_quote(self) -> None:
+        """Md -> docx -> md keeps inline code as code and a quote as a quote (#71)."""
+        from all2md import from_ast, to_ast
+
+        source = "Body with `inline code`.\n\n> a quoted line\n"
+        ast = to_ast(source.encode(), source_format="markdown")
+        docx_bytes = from_ast(ast, target_format="docx")
+        back = to_ast(docx_bytes, source_format="docx")
+
+        assert len(extract_nodes(back, Code)) == 1
+        assert len(extract_nodes(back, BlockQuote)) == 1
+        assert not extract_nodes(back, List), "Quote must not decay into a bullet list"
+
+        rendered = from_ast(back, target_format="markdown")
+        assert "`inline code`" in rendered
+        assert "> a quoted line" in rendered
+        assert "* a quoted line" not in rendered

--- a/tests/unit/parsers/test_docx_parser.py
+++ b/tests/unit/parsers/test_docx_parser.py
@@ -946,6 +946,8 @@ class TestCodeAndBlockquoteRoundTrip:
         assert "`inline code`" in rendered
         assert "> a quoted line" in rendered
         assert "* a quoted line" not in rendered
+
+
 class TestTitleRoundTrip:
     """Tests for the Word 'Title' style inverse (issue #70)."""
 

--- a/tests/unit/renderers/test_docx_renderer.py
+++ b/tests/unit/renderers/test_docx_renderer.py
@@ -545,7 +545,7 @@ class TestBlockElements:
         assert found
 
     def test_blockquote(self, tmp_path):
-        """Test blockquote rendering with indentation."""
+        """Test blockquote rendering uses Word's Quote style (#71)."""
         doc = Document(
             children=[
                 Paragraph(content=[Text(content="Normal text")]),
@@ -570,17 +570,16 @@ class TestBlockElements:
         assert quoted_para is not None, "Quoted text not found"
         assert normal_para is not None, "Normal text not found"
 
-        # Verify blockquote has indentation
-        quoted_indent = quoted_para.paragraph_format.left_indent
-        normal_indent = normal_para.paragraph_format.left_indent or 0
-
-        assert quoted_indent is not None, "Blockquote paragraph has no indentation"
-        assert (
-            quoted_indent > normal_indent
-        ), f"Blockquote indent ({quoted_indent}) should be greater than normal ({normal_indent})"
+        # The quote paragraph carries the Quote style (not a bare left indent, which the
+        # parser would misread as a list); the normal paragraph does not.
+        assert quoted_para.style.name == "Quote"
+        assert normal_para.style.name != "Quote"
+        # A single-level quote relies on the style for its indent, so it must not set a
+        # direct left indent -- that is exactly what got mistaken for list nesting.
+        assert quoted_para.paragraph_format.left_indent is None
 
     def test_nested_blockquote(self, tmp_path):
-        """Test nested blockquote rendering with increased indentation."""
+        """Test nested blockquote rendering with increased indentation (#71)."""
         doc = Document(
             children=[
                 BlockQuote(
@@ -609,15 +608,13 @@ class TestBlockElements:
         assert level1_para is not None, "Level 1 text not found"
         assert level2_para is not None, "Level 2 text not found"
 
-        # Verify nested blockquote has more indentation
-        level1_indent = level1_para.paragraph_format.left_indent
-        level2_indent = level2_para.paragraph_format.left_indent
-
-        assert level1_indent is not None, "Level 1 has no indentation"
-        assert level2_indent is not None, "Level 2 has no indentation"
-        assert (
-            level2_indent > level1_indent
-        ), f"Level 2 indent ({level2_indent}) should be greater than Level 1 ({level1_indent})"
+        # Both levels use the Quote style; the style supplies level 1's indent, and the
+        # deeper level adds a direct indent on top so nesting is still visible in Word.
+        assert level1_para.style.name == "Quote"
+        assert level2_para.style.name == "Quote"
+        assert level1_para.paragraph_format.left_indent is None
+        assert level2_para.paragraph_format.left_indent is not None
+        assert level2_para.paragraph_format.left_indent > 0
 
     def test_thematic_break(self, tmp_path):
         """Test horizontal rule rendering."""


### PR DESCRIPTION
Fixes #71.

Two independent renderer/parser asymmetries on the `md → docx → md` path, filed together because both are DOCX inline/block style-mapping gaps.

## 1. Inline code was dropped

The renderer emitted a `` `code` `` run with a monospace font but **no named character style**, so the parser — which recovers inline styling from run *styles*, not fonts — had nothing to key on. `` `inline code` `` round-tripped to plain `inline code`.

The renderer now tags inline-code runs with a `Verbatim Char` character style (pandoc's name for the same thing; created on demand, and only when `use_styles` is on), and the parser maps that style back to a `Code` node. Recognized names are configurable via the new `code_char_style_names` DOCX parser option.

## 2. A block quote came back as a bullet list

The renderer wrote the quoted paragraph as a `Normal` paragraph carrying a **left indent**, and the parser read that indent as list nesting — so `> a quoted line` silently became `* a quoted line`. A quote turning into a bullet looks intentional, which is arguably worse than dropping it.

The renderer now applies Word's built-in `Quote` paragraph style (which also makes the generated document look correct in Word) and no longer sets the bare single-level indent the parser would misread. The parser maps `Quote` / `Intense Quote` back to a `BlockQuote`, coalescing adjacent quote paragraphs into one quote. Recognized names are configurable via the new `quote_style_names` DOCX parser option.

## Result

`all2md roundtrip … --via docx` on a document with inline code and a quote goes from **`structure: 33 / inline: 0`** to **`100 / 100`** (no `inline_lost (code)`, no `block_changed (blockquote → bullet list)`). Both recoveries require styles (`use_styles=True`, the default); with styles disabled the render falls back to font-and-indent exactly as before — matching how `source_style` round-tripping already behaves.

## Verification

- New `TestCodeAndBlockquoteRoundTrip` (4 tests: quote→blockquote, adjacent-quote coalescing, inline-code char style→`Code`, full md→docx→md) — confirmed all **fail** against pre-fix code and pass with the fix.
- Updated the two existing blockquote render tests, which asserted the old bare-indent implementation, to assert the `Quote` style (the indent was exactly what got misread as a list).
- Full `test_docx_parser.py`, `test_docx_renderer.py`, options, and CLI suites green; converter manifest shows no drift; `mypy`/`ruff`/`black` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)