### PR TITLE
fix(markdown): indent list-item continuation lines and un-double-indent nested first child

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -104,6 +104,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Markdown: multi-paragraph and multi-line list items round-trip without collapsing.**
+  Three problems in the same surface conspired to flatten lists on a Markdown round trip:
+
+  *Loose lists were read as tight.* mistune 3.x carries the loose/tight flag on the list
+  token itself, not in `attrs`; reading it only from `attrs` marked every list tight, so the
+  renderer dropped the blank lines that separate a loose item's paragraphs and they merged
+  into one on reparse.
+
+  *Continuation lines were emitted at column zero.* A list item whose content wrapped across
+  several lines (soft-wrapped source, or a multi-paragraph item) indented only its first line;
+  every continuation went to the margin, where it reparses as a lazy continuation that
+  collapses the wrapped lines together — or, when a nested block landed there, breaks the item
+  apart. Code blocks and block quotes inside a list item had the same flaw and could escape to
+  column zero as siblings of the list. Continuation lines, and nested code/quote blocks, now
+  carry the item's indentation.
+
+  *A nested list as an item's first child double-indented.* The first-child render path
+  cleared the indent stacks but left the in-list flag set, so a nested list added its own
+  indent level on top of the marker — rendering `1. - x` as `1.     - x`. It now renders flush
+  and is shifted to the marker's content column like any other continuation.
+
+  A task checkbox (`[ ] `) is treated as first-line content rather than marker width, so
+  continuations align to the list marker and don't over-indent into an accidental code block.
+  Net effect: a document like a nested ordered/task list with wrapped prose now survives
+  `markdown → markdown` unchanged (idempotent), where before it flattened onto single lines.
 - **DOCX: inline code and block quotes survive the Markdown round trip.** Two independent
   renderer/parser asymmetries on the `md → docx → md` path, both filed as #71:
 

--- a/src/all2md/renderers/markdown.py
+++ b/src/all2md/renderers/markdown.py
@@ -605,6 +605,12 @@ class MarkdownRenderer(NodeVisitor, InlineContentMixin, BaseRenderer):
         """
         content = self._render_inline_content(node.content)
         indent = self._current_indent()
+        # A paragraph inside a list item may span several lines (soft-wrapped source
+        # becomes embedded newlines). Every continuation line must carry the same indent
+        # as the first, or it lands at column zero and reparses as a lazy continuation --
+        # collapsing the wrapped lines into one and, in a nested list, breaking the item.
+        if indent and "\n" in content:
+            content = content.replace("\n", "\n" + indent)
         self._output.append(f"{indent}{content}")
 
         # Emit block references if using after_block placement
@@ -855,21 +861,36 @@ class MarkdownRenderer(NodeVisitor, InlineContentMixin, BaseRenderer):
                 saved_output = self._output
                 self._output = []
 
-                # Save and clear both marker width stack and indent level
-                # so first child doesn't add any indentation
+                # Save and clear the marker width stack, indent level, and in-list flag
+                # so the first child renders flush (its indentation is supplied below by
+                # content_indent). Leaving _in_list set made a nested list as the first
+                # child add its own indent level on top of the marker, double-indenting it.
                 saved_stack = self._marker_width_stack.copy()
                 saved_indent_level = self._indent_level
+                saved_in_list = self._in_list
                 self._marker_width_stack.clear()
                 self._indent_level = 0
+                self._in_list = False
 
                 child.accept(self)
 
                 # Restore state
                 self._marker_width_stack = saved_stack
                 self._indent_level = saved_indent_level
+                self._in_list = saved_in_list
 
                 child_content = "".join(self._output)
                 self._output = saved_output
+                # The first child rendered with indentation cleared, so its own
+                # continuation lines (and any nested block/list lines) sit at column
+                # zero. Shift every line after the first to the marker's content column
+                # so they stay part of this item instead of reparsing at the margin.
+                # Nested levels each add their own shift, so the totals compound correctly.
+                content_indent = indent + " " * marker_width
+                if content_indent and "\n" in child_content:
+                    first, _, rest = child_content.partition("\n")
+                    rest = "\n".join(content_indent + line if line else line for line in rest.split("\n"))
+                    child_content = f"{first}\n{rest}"
                 self._output.append(child_content)
             else:
                 # For subsequent children, push marker width to stack first

--- a/tests/unit/renderers/test_markdown_renderer.py
+++ b/tests/unit/renderers/test_markdown_renderer.py
@@ -532,6 +532,67 @@ class TestLists:
         assert lines[1] == "  Second paragraph"
         assert lines[2] == "* Next item"
 
+    def test_soft_wrapped_paragraph_indented_in_item(self):
+        """A multi-line (soft-wrapped) paragraph in a list item keeps its indent.
+
+        The continuation line was emitted at column zero, so on reparse it became a
+        lazy continuation that collapsed the wrapped lines into one; a nested item
+        broke apart entirely.
+        """
+        from all2md import convert
+
+        opts = MarkdownRendererOptions(flavor="gfm")
+        source = "* a line that\n  wraps here\n"
+        once = convert(source, source_format="markdown", target_format="markdown", renderer_options=opts)
+        twice = convert(once, source_format="markdown", target_format="markdown", renderer_options=opts)
+
+        assert once == twice, "soft-wrapped list item is not idempotent"
+        # Continuation aligned under the marker's content column, not at column zero.
+        assert "* a line that\n  wraps here" in once
+        assert "\nwraps here" not in once
+
+    def test_nested_list_as_first_child_not_double_indented(self):
+        """A nested list that is a list item's first child must not double-indent.
+
+        The first-child branch cleared the indent stack but left ``_in_list`` set, so a
+        nested list added its own indent level on top of the marker -- rendering the item
+        as ``1.     - x`` (five stray spaces) instead of ``1. - x``.
+        """
+        doc = Document(
+            children=[
+                List(
+                    ordered=True,
+                    start=1,
+                    items=[
+                        ListItem(
+                            children=[
+                                List(
+                                    ordered=False,
+                                    items=[ListItem(children=[Paragraph(content=[Text(content="alpha")])])],
+                                )
+                            ]
+                        )
+                    ],
+                )
+            ]
+        )
+        result = MarkdownRenderer().render_to_string(doc)
+        assert result.splitlines()[0] == "1. - alpha"
+
+    def test_ordered_task_multiline_roundtrips(self):
+        """The Part 6 shape: an ordered item wrapping a multi-line task item."""
+        from all2md import convert
+
+        opts = MarkdownRendererOptions(flavor="gfm")
+        source = "1. - [x] first line\n     second line\n"
+        once = convert(source, source_format="markdown", target_format="markdown", renderer_options=opts)
+        twice = convert(once, source_format="markdown", target_format="markdown", renderer_options=opts)
+
+        assert once == twice, "ordered>task>multiline is not idempotent"
+        # Clean marker (no stray padding) and the continuation aligned under the content.
+        assert once.startswith("1. - [x] first line\n")
+        assert "\nsecond line" not in once  # never at column zero
+
     def test_deeply_nested_list(self):
         """Test rendering deeply nested lists (3 levels)."""
         level3_list = List(ordered=False, items=[ListItem(children=[Paragraph(content=[Text(content="Level 3")])])])


### PR DESCRIPTION
Follow-up to #85 (loose-list roundtrip), landing the other half of the same list-rendering surface. Together with #85, a nested ordered/task list of wrapped prose now survives `markdown → markdown` unchanged.

## Two renderer bugs

The markdown **parser** produces a correct AST (properly nested lists) — which is why `all2md view` (AST → HTML) always looked fine — but the markdown **renderer** flattened it:

1. **Continuation lines at column zero.** A multi-line paragraph inside a list item (soft-wrapped source, or a multi-paragraph item) indented only its *first* line; every continuation went to the margin, where it reparses as a lazy continuation that collapses the wrapped lines into one — or, when over-indented, flips to a code block.
2. **Nested list as an item's first child double-indented.** The first-child render path cleared the indent stacks but left `_in_list` set, so a nested list added its own indent level *on top of* the marker — rendering `1. - x` as `1.     - x`.

Both are visible in a real document whose "Part 6" is a loose ordered list of multi-line `- [x]` task items: items joined onto single lines and markers were mis-spaced.

## Fix

- `visit_paragraph` indents continuation lines to the current indent.
- `visit_list_item`'s first-child branch clears `_in_list` and shifts the child's continuation lines to the marker's content column; nesting levels compound correctly. It reuses #85's `base_marker` width (excludes the task checkbox), so continuations align to the list marker rather than over-indenting into an accidental code block.

## Verification

- On the real document, "Part 6" now renders with clean `1. - [x]` markers and correctly indented continuations, and the **whole file is idempotent** under `markdown → markdown`.
- Three new regression tests (soft-wrapped item, nested-list-first-child, the ordered→task→multiline "Part 6" shape) — confirmed they **fail** on pre-fix code (one shows the code-block flip) and pass with the fix.
- Full markdown renderer/parser + golden suites green (234 passed); `mypy`/`ruff`/`black` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)