### PR TITLE
test(bench): markdown roundtrip fidelity benchmark (Phase 0/1)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -42,7 +42,9 @@ repos:
     rev: v6.0.0
     hooks:
       - id: trailing-whitespace
-        exclude: '.*\.ambr$'
+        # Roundtrip corpus files carry meaningful trailing whitespace (two-space
+        # Markdown hard breaks) as test data, like the .ambr snapshots.
+        exclude: '(\.ambr$|^benchmarks/roundtrip/corpus/)'
       - id: end-of-file-fixer
         exclude: '.*\.ambr$'
       - id: check-yaml

--- a/benchmarks/roundtrip/README.md
+++ b/benchmarks/roundtrip/README.md
@@ -1,0 +1,58 @@
+# Markdown roundtrip fidelity benchmark
+
+Measures whether `Markdown -> AST -> Markdown` preserves a document. Complements
+the other benchmarks: `benchmarks/corpus/` times *to-markdown* conversion and
+`benchmarks/startup.py` times cold start; this one checks **fidelity**.
+
+## Run it
+
+```bash
+python -m benchmarks.roundtrip              # per-document pass/fail table
+python -m benchmarks.roundtrip --show-diff   # + unified diffs for failures
+python -m benchmarks.roundtrip --json out.json
+```
+
+Exit code is non-zero if any oracle failed (policy skips don't count), so it can
+double as an ad-hoc check.
+
+## Two oracles
+
+Each document is judged by two independent oracles (`oracles.py`); a loss has to
+slip past both:
+
+- **idempotency** — render twice, assert the output is a fixed point
+  (`once == twice`). Cheap, deterministic, reference-free. This is the exact
+  criterion the recent list/footnote roundtrip fixes (#84/#85/#91) used.
+- **html_equivalence** — render the original and the roundtripped Markdown both
+  to HTML with a fixed reference renderer (mistune, configured with all2md's
+  default plugin set) and diff a normalized form. Independent of all2md's AST
+  model and Markdown renderer — where losses actually occur — so it catches
+  first-render loss that idempotency can't see.
+
+  *Caveat:* all2md also parses with mistune, so this oracle is independent of the
+  AST + render halves of the pipeline, not of the parse half. That matches our
+  failure surface but is not a fully third-party judge.
+
+Documents containing raw HTML are **skipped** by the HTML oracle: all2md escapes
+raw HTML by policy (`html_passthrough_mode="escape"`), so a difference there is
+expected, not a bug.
+
+## Corpus
+
+Phase 0/1 ships the **synthetic** corpus only: labeled Markdown under
+`corpus/synthetic/`, one construct family per file plus a `kitchen-sink`
+document that combines them. It deliberately covers the extensions the
+CommonMark / GFM spec suites don't (footnotes, definition lists, math,
+admonitions, mark/insert/super/subscript) and the specific shapes behind
+#84/#85/#91.
+
+The CommonMark / GFM spec suites are a planned follow-up (Phase 2); the `Case`
+shape in `corpus.py` is already source-agnostic to accommodate them.
+
+## Guarding the judge
+
+`tests/unit/test_roundtrip_benchmark.py` proves the oracles can both pass and
+fail: each is exercised on a faithful case and a deliberately broken one, and the
+HTML normalizer is checked to ignore incidental whitespace while still detecting
+a collapsed paragraph (the #85 loss shape). An oracle that cannot fail is
+worthless.

--- a/benchmarks/roundtrip/__init__.py
+++ b/benchmarks/roundtrip/__init__.py
@@ -1,0 +1,40 @@
+"""Markdown roundtrip fidelity benchmark for all2md.
+
+Where ``benchmarks/corpus/`` times *to-markdown* conversion and
+``benchmarks/startup.py`` times cold start, this package measures **Markdown-in
+roundtrip fidelity**: does ``Markdown -> AST -> Markdown`` preserve the document?
+
+Two independent oracles judge each case (see ``oracles.py``):
+
+- **idempotency** - render twice, assert the output is a fixed point. Cheap,
+  deterministic, and the exact criterion the recent list/footnote roundtrip
+  fixes (#84/#85/#91) were validated against.
+- **html_equivalence** - render the original and the roundtripped Markdown both
+  to HTML with a fixed reference renderer (mistune) and diff. Independent of
+  all2md's own AST model and Markdown renderer - the two surfaces where losses
+  actually occur - so it catches first-render loss idempotency can't see.
+
+The corpus (see ``corpus.py``) is synthetic Markdown authored to exercise the
+full construct matrix all2md supports, including the extensions the CommonMark /
+GFM spec suites don't cover (footnotes, definition lists, math, admonitions,
+mark/insert/super/subscript) and the specific shapes behind #84/#85/#91.
+
+Run it::
+
+    python -m benchmarks.roundtrip            # table to stdout
+    python -m benchmarks.roundtrip --json out.json
+    python -m benchmarks.roundtrip --show-diff   # print diffs for failures
+"""
+
+from __future__ import annotations
+
+from .corpus import Case, load_synthetic_corpus
+from .oracles import CheckResult, html_equivalence_check, idempotency_check
+
+__all__ = [
+    "Case",
+    "CheckResult",
+    "html_equivalence_check",
+    "idempotency_check",
+    "load_synthetic_corpus",
+]

--- a/benchmarks/roundtrip/__main__.py
+++ b/benchmarks/roundtrip/__main__.py
@@ -1,0 +1,10 @@
+"""Entry point for ``python -m benchmarks.roundtrip``."""
+
+from __future__ import annotations
+
+import sys
+
+from .run import main
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/benchmarks/roundtrip/corpus.py
+++ b/benchmarks/roundtrip/corpus.py
@@ -1,0 +1,71 @@
+"""Corpus loading for the roundtrip benchmark.
+
+Phase 0/1 ships the *synthetic* corpus only: labeled Markdown files under
+``corpus/synthetic/``, one construct family per file plus a ``kitchen-sink``
+document that combines them. Each file's stem is its construct family; tags are
+derived from content (e.g. ``has_raw_html`` marks a doc that is lossy by policy
+under all2md's ``html_passthrough_mode="escape"`` posture, so the HTML oracle
+skips it rather than flagging an expected loss).
+
+The CommonMark / GFM spec suites (Phase 2) will land as an additional loader
+here; the ``Case`` shape is already source-agnostic to accommodate them.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+SYNTHETIC_DIR = HERE / "corpus" / "synthetic"
+
+# A run of raw HTML: an open tag like <div ...>, </div>, or a self-closing tag.
+# Deliberately loose - if a doc contains anything HTML-ish we treat it as
+# raw-HTML and let the HTML oracle skip it (all2md escapes raw HTML by policy).
+_RAW_HTML = re.compile(r"</?[a-zA-Z][a-zA-Z0-9]*(\s[^<>]*)?/?>")
+
+
+@dataclass
+class Case:
+    """One corpus document.
+
+    ``source`` distinguishes the synthetic corpus from later spec suites.
+    ``has_raw_html`` flags documents the HTML-equivalence oracle should skip
+    because all2md intentionally escapes raw HTML (a policy loss, not a bug).
+    """
+
+    name: str
+    markdown: str
+    source: str = "synthetic"
+    path: Path | None = None
+    has_raw_html: bool = False
+    tags: list[str] = field(default_factory=list)
+
+
+def _strip_fenced_code(md: str) -> str:
+    """Drop fenced code so HTML shown as an example isn't read as raw HTML."""
+    return re.sub(r"```.*?```", "", md, flags=re.DOTALL)
+
+
+def _looks_like_raw_html(md: str) -> bool:
+    return bool(_RAW_HTML.search(_strip_fenced_code(md)))
+
+
+def load_synthetic_corpus(directory: Path | None = None) -> list[Case]:
+    """Load every ``*.md`` under the synthetic corpus dir, sorted by name."""
+    directory = directory or SYNTHETIC_DIR
+    cases: list[Case] = []
+    for path in sorted(directory.glob("*.md")):
+        md = path.read_text(encoding="utf-8")
+        cases.append(
+            Case(
+                name=path.stem,
+                markdown=md,
+                source="synthetic",
+                path=path,
+                has_raw_html=_looks_like_raw_html(md),
+                tags=[path.stem],
+            )
+        )
+    return cases

--- a/benchmarks/roundtrip/corpus/synthetic/admonitions.md
+++ b/benchmarks/roundtrip/corpus/synthetic/admonitions.md
@@ -1,0 +1,15 @@
+A note admonition:
+
+!!! note
+    This is the body of a note admonition. It should survive the roundtrip.
+
+A warning admonition with a custom title:
+
+!!! warning "Be careful"
+    The body of a warning admonition with *emphasis* inside.
+
+An admonition containing a list:
+
+!!! tip
+    - first tip item
+    - second tip item

--- a/benchmarks/roundtrip/corpus/synthetic/blockquotes.md
+++ b/benchmarks/roundtrip/corpus/synthetic/blockquotes.md
@@ -1,0 +1,35 @@
+A simple blockquote:
+
+> a single quoted line.
+
+A multi-line blockquote that is one paragraph:
+
+> first line of the quote
+> second line of the same paragraph
+
+A blockquote with two paragraphs:
+
+> first quoted paragraph.
+>
+> second quoted paragraph.
+
+A nested blockquote:
+
+> outer quote
+>
+> > inner quote
+> >
+> > still inner
+
+A blockquote containing other blocks:
+
+> a quoted paragraph, then a list:
+>
+> - quoted item one
+> - quoted item two
+>
+> and a quoted code block:
+>
+> ```text
+> quoted code
+> ```

--- a/benchmarks/roundtrip/corpus/synthetic/code-blocks.md
+++ b/benchmarks/roundtrip/corpus/synthetic/code-blocks.md
@@ -1,0 +1,38 @@
+A fenced code block with an info string:
+
+```python
+def hello(name):
+    return f"hi {name}"
+```
+
+A fenced code block with no language:
+
+```
+plain preformatted text
+  with indentation preserved
+```
+
+A fenced block that itself contains backticks, fenced with a longer run:
+
+````markdown
+```python
+nested fence
+```
+````
+
+A code block containing characters that look like markdown:
+
+```
+# not a heading
+- not a list
+*not emphasis*
+| not | a table |
+```
+
+A code block nested inside a list item:
+
+- here is some code:
+
+  ```json
+  {"key": "value"}
+  ```

--- a/benchmarks/roundtrip/corpus/synthetic/continuation-wraps.md
+++ b/benchmarks/roundtrip/corpus/synthetic/continuation-wraps.md
@@ -1,0 +1,20 @@
+Soft-wrapped continuation lines inside list items (the #91 continuation shape):
+
+- a list item whose text wraps
+  onto a second physical line and must stay in the same item
+- another item that also wraps
+  across a line without becoming a code block or a new item
+
+An ordered list with wrapped continuation lines:
+
+1. first item that wraps
+   onto a continuation line indented under the marker
+2. second item that likewise wraps
+   onto its own continuation line
+
+A wrapped item followed by a nested list:
+
+- an item whose lead text wraps
+  onto a continuation line
+  - and then has a nested bullet
+  - and a second nested bullet

--- a/benchmarks/roundtrip/corpus/synthetic/definition-lists.md
+++ b/benchmarks/roundtrip/corpus/synthetic/definition-lists.md
@@ -1,0 +1,18 @@
+A simple definition list:
+
+Term one
+:   The definition of the first term.
+
+Term two
+:   The definition of the second term.
+
+A term with multiple definitions:
+
+Fruit
+:   An apple.
+:   A banana.
+
+A definition with inline formatting:
+
+all2md
+:   A library for *bidirectional* conversion between formats and [Markdown](https://example.com).

--- a/benchmarks/roundtrip/corpus/synthetic/extended-inline.md
+++ b/benchmarks/roundtrip/corpus/synthetic/extended-inline.md
@@ -1,0 +1,9 @@
+Strikethrough with ~~deleted text~~ in a sentence.
+
+Highlighted ==marked text== using the pymdownx mark syntax.
+
+Inserted ^^inserted text^^ using the insert syntax.
+
+Superscript like 2^10^ and subscript like H~2~O in a formula.
+
+A line combining ~~strike~~, ==mark==, ^^insert^^, super^script^, and sub~script~.

--- a/benchmarks/roundtrip/corpus/synthetic/footnotes.md
+++ b/benchmarks/roundtrip/corpus/synthetic/footnotes.md
@@ -1,0 +1,12 @@
+A paragraph with a footnote reference.[^1] And another one here.[^second]
+
+Text that reuses no footnotes but references a multi-paragraph one.[^long]
+
+[^1]: A short footnote definition.
+
+[^second]: A footnote with *emphasis* and a [link](https://example.com).
+
+[^long]: A footnote whose definition spans multiple paragraphs.
+
+    The second paragraph of the footnote must survive the roundtrip and not
+    collapse into the first.

--- a/benchmarks/roundtrip/corpus/synthetic/headings.md
+++ b/benchmarks/roundtrip/corpus/synthetic/headings.md
@@ -1,0 +1,21 @@
+# Heading level one
+
+Some text under the top heading.
+
+## Heading level two
+
+### Heading level three
+
+#### Heading level four
+
+##### Heading level five
+
+###### Heading level six
+
+## Heading with `code` and *emphasis*
+
+Text between two headings.
+
+## Another level two
+
+Trailing paragraph.

--- a/benchmarks/roundtrip/corpus/synthetic/inline-formatting.md
+++ b/benchmarks/roundtrip/corpus/synthetic/inline-formatting.md
@@ -1,0 +1,15 @@
+Plain text with *emphasis*, **strong emphasis**, and ***both at once***.
+
+Inline `code spans` and `code with *stars* inside` that must stay literal.
+
+A [regular link](https://example.com) and a [link with title](https://example.com "the title").
+
+An ![inline image](https://example.com/img.png "alt title") in a sentence.
+
+Nested emphasis: **bold with *italic* inside** and *italic with **bold** inside*.
+
+Emphasis touching punctuation, like *this*, and mid-word intra*word*emphasis.
+
+An escaped \*asterisk\* and an escaped \_underscore\_ that are not emphasis.
+
+An autolink <https://example.com> and a bare URL https://example.org in text.

--- a/benchmarks/roundtrip/corpus/synthetic/kitchen-sink.md
+++ b/benchmarks/roundtrip/corpus/synthetic/kitchen-sink.md
@@ -1,0 +1,55 @@
+# Kitchen Sink
+
+A document that combines many constructs so we can catch bad *interactions*
+between them, not just each one in isolation.
+
+## Prose and inline
+
+A paragraph with *emphasis*, **strong**, `code`, ~~strikethrough~~, a
+[link](https://example.com), and a footnote reference.[^note] It also soft-wraps
+across
+two lines.
+
+## A loose list with mixed content
+
+1. First item with a paragraph.
+
+   And a second paragraph, plus a nested list:
+
+   - nested bullet with a `code` span
+   - nested bullet with **strong** text
+2. Second item containing a table:
+
+   | Key | Value |
+   |:----|------:|
+   | a   | 1     |
+   | b   | 2     |
+3. [ ] Third item is an unchecked task that wraps
+   onto a continuation line
+
+## A blockquote with structure
+
+> A quoted paragraph introducing math: $a^2 + b^2 = c^2$.
+>
+> > A nested quote with a fenced block:
+> >
+> > ```python
+> > print("nested")
+> > ```
+
+## Definitions and math
+
+Term
+:   A definition with a [link](https://example.org) and *emphasis*.
+
+$$
+\int_0^1 x^2 \, dx = \frac{1}{3}
+$$
+
+---
+
+The closing paragraph after a thematic break.
+
+[^note]: The footnote definition, with a second paragraph.
+
+    This paragraph must not collapse into the first.

--- a/benchmarks/roundtrip/corpus/synthetic/lists-loose.md
+++ b/benchmarks/roundtrip/corpus/synthetic/lists-loose.md
@@ -1,0 +1,26 @@
+A loose list where each item has multiple paragraphs (the #85 shape):
+
+1. First item, first paragraph.
+
+   First item, second paragraph — this must not collapse into the first.
+2. Second item, first paragraph.
+
+   Second item, second paragraph.
+
+A loose unordered list:
+
+- Alpha, paragraph one.
+
+  Alpha, paragraph two.
+- Bravo, a single paragraph.
+
+A loose list whose items hold more than prose:
+
+- An item with a following code block:
+
+  ```python
+  print("still inside the item")
+  ```
+- An item with a nested quote:
+
+  > quoted line inside the item

--- a/benchmarks/roundtrip/corpus/synthetic/lists-nested.md
+++ b/benchmarks/roundtrip/corpus/synthetic/lists-nested.md
@@ -1,0 +1,29 @@
+A nested unordered list:
+
+- top level one
+  - second level a
+  - second level b
+    - third level i
+    - third level ii
+- top level two
+
+A nested list used as an item's first child (the #91 double-indent shape):
+
+1. - nested bullet as first child
+   - another nested bullet
+2. a normal second item
+
+Ordered inside unordered:
+
+- a bullet
+  1. numbered child one
+  2. numbered child two
+- another bullet
+
+A nested list whose parent item also has trailing prose:
+
+- parent item text
+  - child one
+  - child two
+
+  more parent text after the nested list

--- a/benchmarks/roundtrip/corpus/synthetic/lists-tight.md
+++ b/benchmarks/roundtrip/corpus/synthetic/lists-tight.md
@@ -1,0 +1,23 @@
+A tight unordered list:
+
+- first item
+- second item
+- third item with `code`
+
+A tight ordered list:
+
+1. first item
+2. second item
+3. third item
+
+An ordered list starting at a non-one number:
+
+3. three
+4. four
+5. five
+
+A list with mixed inline formatting:
+
+- an item with *emphasis*
+- an item with a [link](https://example.com)
+- an item with **strong** text

--- a/benchmarks/roundtrip/corpus/synthetic/math.md
+++ b/benchmarks/roundtrip/corpus/synthetic/math.md
@@ -1,0 +1,11 @@
+Inline math like $E = mc^2$ appears within a sentence.
+
+A display math block on its own:
+
+$$
+\int_0^\infty e^{-x} \, dx = 1
+$$
+
+A paragraph mixing inline math $a^2 + b^2 = c^2$ with ordinary text.
+
+A single-line display block: $$\sum_{i=1}^{n} i = \frac{n(n+1)}{2}$$

--- a/benchmarks/roundtrip/corpus/synthetic/paragraphs-and-breaks.md
+++ b/benchmarks/roundtrip/corpus/synthetic/paragraphs-and-breaks.md
@@ -1,0 +1,13 @@
+A first paragraph that is reasonably long and spills across a couple of
+sentences so we can see how soft wrapping is handled on the way back out.
+
+A second paragraph separated by a blank line from the first.
+
+A line ending in a hard break  
+continues on the next line as the same paragraph.
+
+Another hard break using a backslash\
+also stays in one paragraph.
+
+A soft-wrapped
+paragraph without any break markers should collapse to a single logical line.

--- a/benchmarks/roundtrip/corpus/synthetic/raw-html.md
+++ b/benchmarks/roundtrip/corpus/synthetic/raw-html.md
@@ -1,0 +1,13 @@
+A paragraph with an inline <span class="hl">raw HTML span</span> element.
+
+Text with an <u>underlined</u> word and a <br> hard break tag.
+
+A raw HTML block:
+
+<div class="callout">
+  <p>A paragraph inside a raw HTML block.</p>
+</div>
+
+A paragraph after the block. Raw HTML is escaped by policy under all2md's
+default `html_passthrough_mode="escape"`, so the HTML-equivalence oracle skips
+this document; idempotency should still hold.

--- a/benchmarks/roundtrip/corpus/synthetic/reference-links.md
+++ b/benchmarks/roundtrip/corpus/synthetic/reference-links.md
@@ -1,0 +1,11 @@
+A paragraph with a [reference-style link][ref] and a [second one][other].
+
+A [collapsed reference][] link and a [shortcut] link.
+
+A reference-style image ![alt text][img] in a paragraph.
+
+[ref]: https://example.com "A titled reference"
+[other]: https://example.org
+[collapsed reference]: https://example.net
+[shortcut]: https://example.com/shortcut
+[img]: https://example.com/image.png "image title"

--- a/benchmarks/roundtrip/corpus/synthetic/tables.md
+++ b/benchmarks/roundtrip/corpus/synthetic/tables.md
@@ -1,0 +1,29 @@
+A basic GFM table:
+
+| Name  | Role      | Active |
+|-------|-----------|--------|
+| Alice | Engineer  | yes    |
+| Bob   | Designer  | no     |
+
+A table with column alignment:
+
+| Left | Center | Right |
+|:-----|:------:|------:|
+| a    | b      | c     |
+| dd   | ee     | ff    |
+
+A table whose cells contain inline formatting:
+
+| Feature | Notes                          |
+|---------|--------------------------------|
+| links   | see [docs](https://example.com) |
+| code    | use `all2md`                   |
+| style   | *emphasis* and **strong**      |
+
+A table nested inside a list item:
+
+- a bullet introducing a table:
+
+  | k | v |
+  |---|---|
+  | 1 | 2 |

--- a/benchmarks/roundtrip/corpus/synthetic/task-lists.md
+++ b/benchmarks/roundtrip/corpus/synthetic/task-lists.md
@@ -1,0 +1,19 @@
+A GitHub-style task list:
+
+- [ ] an unchecked task
+- [x] a checked task
+- [ ] a task with *emphasis* and a [link](https://example.com)
+
+A nested task list:
+
+- [ ] parent task
+  - [x] finished subtask
+  - [ ] pending subtask
+
+An ordered task list with multi-line items (the #91 Part-6 shape):
+
+1. [ ] first task that wraps
+   onto a continuation line
+2. [x] second task, done
+
+   with a follow-up paragraph inside the item

--- a/benchmarks/roundtrip/corpus/synthetic/thematic-breaks.md
+++ b/benchmarks/roundtrip/corpus/synthetic/thematic-breaks.md
@@ -1,0 +1,13 @@
+A paragraph before a thematic break.
+
+---
+
+A paragraph between two breaks.
+
+***
+
+A paragraph after an asterisk break.
+
+___
+
+The final paragraph after an underscore break.

--- a/benchmarks/roundtrip/oracles.py
+++ b/benchmarks/roundtrip/oracles.py
@@ -1,0 +1,230 @@
+"""Roundtrip fidelity oracles.
+
+Each oracle takes a Markdown string and returns a :class:`CheckResult`. The two
+oracles are deliberately independent so a loss has to slip past *both*:
+
+``idempotency_check``
+    ``once = md -> AST -> md``; ``twice = once -> AST -> md``. Passes iff
+    ``once == twice`` (a fixed point). Purely syntactic and reference-free.
+
+``html_equivalence_check``
+    Renders both ``md`` and ``once`` to HTML with a *fixed reference renderer*
+    (mistune's own HTML renderer, configured with the same plugin set all2md's
+    parser enables) and compares a normalized form. Because the reference
+    renderer is independent of all2md's AST model and Markdown renderer - the
+    surfaces where roundtrip losses actually happen - it catches loss that
+    already occurred on the first render and is therefore stable under
+    idempotency.
+
+Caveat worth stating plainly: all2md *parses* with mistune too, so the HTML
+oracle is independent of the AST + render halves of the pipeline, not of the
+parse half. That is the right scope for our failure surface (the recent
+regressions all lived in the AST builder and the list renderer), but it is not a
+fully third-party judge.
+"""
+
+from __future__ import annotations
+
+import difflib
+import re
+from dataclasses import dataclass
+from functools import lru_cache
+from typing import TYPE_CHECKING, Optional
+
+import all2md
+
+if TYPE_CHECKING:
+    from all2md.options.markdown import MarkdownRendererOptions
+
+
+@dataclass
+class CheckResult:
+    """Outcome of one oracle on one document.
+
+    ``passed`` is the pass/fail verdict. ``skipped`` marks a case the oracle
+    cannot fairly judge (e.g. HTML-equivalence on a raw-HTML doc, which is lossy
+    by policy); a skipped result is neither a pass nor a failure. ``diff`` holds
+    a human-readable unified diff when the check fails.
+    """
+
+    oracle: str
+    passed: bool
+    detail: str = ""
+    diff: Optional[str] = None
+    skipped: bool = False
+
+
+def _roundtrip_once(md: str, renderer_options: Optional["MarkdownRendererOptions"]) -> str:
+    """Run one ``Markdown -> AST -> Markdown`` pass."""
+    result = all2md.convert(
+        md,
+        source_format="markdown",
+        target_format="markdown",
+        renderer_options=renderer_options,
+    )
+    assert isinstance(result, str)  # markdown target is always text
+    return result
+
+
+def idempotency_check(
+    md: str,
+    *,
+    renderer_options: Optional["MarkdownRendererOptions"] = None,
+) -> CheckResult:
+    """Assert the roundtrip reaches a fixed point (``once == twice``).
+
+    The first render may legitimately normalize the source (list markers, wrap
+    width, blank-line policy); that is not a loss. A *second* render that
+    differs from the first means the rendered Markdown re-parsed to a different
+    AST - the signature of the list/footnote roundtrip bugs (#84/#85/#91).
+    """
+    try:
+        once = _roundtrip_once(md, renderer_options)
+    except Exception as exc:  # a construct that errors on roundtrip is itself a finding
+        return CheckResult("idempotency", passed=False, detail=f"first render raised {type(exc).__name__}: {exc}")
+    try:
+        twice = _roundtrip_once(once, renderer_options)
+    except Exception as exc:
+        return CheckResult("idempotency", passed=False, detail=f"second render raised {type(exc).__name__}: {exc}")
+
+    if once == twice:
+        return CheckResult("idempotency", passed=True)
+    return CheckResult(
+        "idempotency",
+        passed=False,
+        detail="roundtrip is not a fixed point: rendering the output again changed it",
+        diff=_unified_diff(once, twice, "once", "twice"),
+    )
+
+
+def html_equivalence_check(
+    md: str,
+    *,
+    renderer_options: Optional["MarkdownRendererOptions"] = None,
+) -> CheckResult:
+    """Assert the roundtrip preserves meaning, measured as reference HTML.
+
+    ``normalize(ref_html(md)) == normalize(ref_html(md -> AST -> md))``. Catches
+    semantic loss (a dropped paragraph, a mangled table cell) that idempotency
+    misses when the loss happens on the first render and is then stable.
+    """
+    try:
+        once = _roundtrip_once(md, renderer_options)
+    except Exception as exc:
+        return CheckResult("html_equivalence", passed=False, detail=f"render raised {type(exc).__name__}: {exc}")
+
+    original_html = _normalize_html(_reference_html(md))
+    roundtrip_html = _normalize_html(_reference_html(once))
+
+    if original_html == roundtrip_html:
+        return CheckResult("html_equivalence", passed=True)
+    return CheckResult(
+        "html_equivalence",
+        passed=False,
+        detail="reference HTML differs between the original and the roundtripped Markdown",
+        diff=_unified_diff(original_html, roundtrip_html, "original.html", "roundtrip.html"),
+    )
+
+
+# --- reference HTML rendering -------------------------------------------------
+
+
+@lru_cache(maxsize=1)
+def _reference_markdown():  # type: ignore[no-untyped-def]
+    """Build a mistune Markdown->HTML renderer matching all2md's default plugins.
+
+    Mirrors the plugin set enabled in ``all2md.parsers.markdown`` so the oracle
+    understands the same constructs (tables, footnotes, task lists, math, def
+    lists, the pymdownx inline marks) rather than passing them through as literal
+    text - which would blind it to corruption of those constructs. Admonitions
+    are intentionally omitted: they use all2md's custom block token, which
+    mistune's stock HTML renderer has no method for, so the HTML oracle is not
+    authoritative for them (idempotency still is).
+    """
+    import mistune
+    from mistune.plugins.table import table_in_list, table_in_quote
+
+    plugins = [
+        "strikethrough",
+        "table",
+        table_in_list,
+        table_in_quote,
+        "footnotes",
+        "task_lists",
+        "math",
+        "def_list",
+        "mark",
+        "insert",
+        "superscript",
+        "subscript",
+        "url",
+    ]
+    return mistune.create_markdown(escape=False, plugins=plugins)
+
+
+def _reference_html(md: str) -> str:
+    rendered = _reference_markdown()(md)
+    return rendered if isinstance(rendered, str) else ""
+
+
+# --- HTML normalization -------------------------------------------------------
+
+_VOID_TAGS = frozenset(
+    {"area", "base", "br", "col", "embed", "hr", "img", "input", "link", "meta", "param", "source", "track", "wbr"}
+)
+_WS = re.compile(r"\s+")
+
+
+def _normalize_html(html: str) -> str:
+    """Serialize HTML to a canonical, diff-friendly form.
+
+    Insignificant inter-tag whitespace is dropped and text runs are collapsed to
+    single spaces, so two HTML fragments that differ only in incidental
+    whitespace compare equal while genuine structural differences (a missing
+    element, a changed cell) stand out line by line.
+    """
+    from bs4 import BeautifulSoup
+    from bs4.element import NavigableString, Tag
+
+    soup = BeautifulSoup(html, "html.parser")
+    lines: list[str] = []
+
+    def walk(node: object, depth: int) -> None:
+        indent = "  " * depth
+        if isinstance(node, NavigableString):
+            text = _WS.sub(" ", str(node)).strip()
+            if text:
+                lines.append(f"{indent}#text {text!r}")
+            return
+        if isinstance(node, Tag):
+            attrs = " ".join(f'{k}="{_attr_value(node.get(k))}"' for k in sorted(node.attrs))
+            head = f"{node.name} {attrs}".rstrip()
+            if node.name in _VOID_TAGS:
+                lines.append(f"{indent}<{head}/>")
+                return
+            lines.append(f"{indent}<{head}>")
+            for child in node.children:
+                walk(child, depth + 1)
+            lines.append(f"{indent}</{node.name}>")
+
+    for child in soup.children:
+        walk(child, 0)
+    return "\n".join(lines)
+
+
+def _attr_value(value: object) -> str:
+    """Render an attribute value, joining bs4's list-valued attrs (e.g. ``class``)."""
+    if isinstance(value, (list, tuple)):
+        return " ".join(str(v) for v in value)
+    return str(value)
+
+
+def _unified_diff(a: str, b: str, a_name: str, b_name: str) -> str:
+    diff = difflib.unified_diff(
+        a.splitlines(),
+        b.splitlines(),
+        fromfile=a_name,
+        tofile=b_name,
+        lineterm="",
+    )
+    return "\n".join(diff)

--- a/benchmarks/roundtrip/run.py
+++ b/benchmarks/roundtrip/run.py
@@ -1,0 +1,135 @@
+"""CLI for the Markdown roundtrip fidelity benchmark.
+
+Runs both oracles (idempotency + HTML-equivalence) over the synthetic corpus and
+prints a per-document table. This is a diagnostic / triage tool - it surfaces
+which constructs currently fail to roundtrip, which is the point of Phase 0/1.
+A blocking CI gate (Phase 3) will consume the same oracles + corpus later.
+
+    python -m benchmarks.roundtrip                 # table to stdout
+    python -m benchmarks.roundtrip --show-diff      # + unified diffs for failures
+    python -m benchmarks.roundtrip --json out.json  # machine-readable results
+
+Exit code is non-zero iff any oracle failed (skips don't count), so the tool can
+double as an ad-hoc check while we burn issues down.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from dataclasses import asdict
+from pathlib import Path
+
+from .corpus import Case, load_synthetic_corpus
+from .oracles import CheckResult, html_equivalence_check, idempotency_check
+
+
+def evaluate_case(case: Case) -> list[CheckResult]:
+    """Run every oracle against one case, honoring policy skips."""
+    results = [idempotency_check(case.markdown)]
+    if case.has_raw_html:
+        results.append(
+            CheckResult(
+                "html_equivalence",
+                passed=True,
+                skipped=True,
+                detail="raw HTML present; lossy by policy (html_passthrough_mode='escape')",
+            )
+        )
+    else:
+        results.append(html_equivalence_check(case.markdown))
+    return results
+
+
+def _status(result: CheckResult) -> str:
+    if result.skipped:
+        return "SKIP"
+    return "pass" if result.passed else "FAIL"
+
+
+def _format_table(rows: list[tuple[Case, list[CheckResult]]]) -> str:
+    name_w = max((len(c.name) for c, _ in rows), default=8)
+    name_w = max(name_w, len("document"))
+    header = f"{'document':<{name_w}}  {'idempotency':>12}  {'html_equiv':>12}"
+    lines = [header, "-" * len(header)]
+    for case, results in rows:
+        by_oracle = {r.oracle: r for r in results}
+        idem = _status(by_oracle["idempotency"])
+        html = _status(by_oracle["html_equivalence"])
+        lines.append(f"{case.name:<{name_w}}  {idem:>12}  {html:>12}")
+    return "\n".join(lines)
+
+
+def _summary(rows: list[tuple[Case, list[CheckResult]]]) -> tuple[int, int, int]:
+    passed = failed = skipped = 0
+    for _, results in rows:
+        for r in results:
+            if r.skipped:
+                skipped += 1
+            elif r.passed:
+                passed += 1
+            else:
+                failed += 1
+    return passed, failed, skipped
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(prog="benchmarks.roundtrip", description=__doc__)
+    p.add_argument("--json", type=Path, default=None, help="Write machine-readable results to this path")
+    p.add_argument("--show-diff", action="store_true", help="Print unified diffs for every failing oracle")
+    p.add_argument(
+        "--corpus-dir",
+        type=Path,
+        default=None,
+        help="Override the synthetic corpus directory (default: benchmarks/roundtrip/corpus/synthetic)",
+    )
+    return p
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _build_parser().parse_args(argv)
+
+    cases = load_synthetic_corpus(args.corpus_dir)
+    if not cases:
+        print("No corpus documents found.", file=sys.stderr)
+        return 2
+
+    rows = [(case, evaluate_case(case)) for case in cases]
+
+    print(_format_table(rows))
+    passed, failed, skipped = _summary(rows)
+    print()
+    print(f"{passed} passed, {failed} failed, {skipped} skipped  ({len(cases)} documents x 2 oracles)")
+
+    if args.show_diff:
+        for case, results in rows:
+            for r in results:
+                if not r.passed and not r.skipped:
+                    print(f"\n=== {case.name} :: {r.oracle} ===")
+                    print(r.detail)
+                    if r.diff:
+                        print(r.diff)
+
+    if args.json is not None:
+        payload = {
+            "documents": [
+                {
+                    "name": case.name,
+                    "source": case.source,
+                    "has_raw_html": case.has_raw_html,
+                    "results": [asdict(r) for r in results],
+                }
+                for case, results in rows
+            ],
+            "summary": {"passed": passed, "failed": failed, "skipped": skipped},
+        }
+        args.json.parent.mkdir(parents=True, exist_ok=True)
+        args.json.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+        print(f"\nWrote results to {args.json}", flush=True)
+
+    return 1 if failed else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,7 +1,11 @@
 [pytest]
-minversion = 6.0
+minversion = 7.0
 addopts = -ra -q --tb=short
 testpaths = tests
+# Put the repo root on sys.path so tests can import the (non-packaged) top-level
+# `benchmarks` package. Without this, collection works under `python -m pytest`
+# (which adds the cwd) but fails under the bare `pytest` console script used in CI.
+pythonpath = .
 norecursedirs = .git .hypothesis __pycache__ examples
 markers =
     unit: Unit tests - fast, isolated component tests

--- a/tests/unit/test_roundtrip_benchmark.py
+++ b/tests/unit/test_roundtrip_benchmark.py
@@ -1,0 +1,137 @@
+"""Self-tests for the Markdown roundtrip benchmark oracles.
+
+These guard the *judge*, not all2md. An oracle that cannot fail is worthless, so
+each oracle is exercised on both a faithful case (must pass) and a deliberately
+broken one (must fail). The broken cases are constructed by controlling the
+roundtrip function directly (monkeypatching ``_roundtrip_once``) rather than by
+relying on a current all2md bug, so the tests stay valid as all2md is fixed.
+
+The HTML semantic normalizer is additionally checked to (a) ignore incidental
+whitespace and (b) still distinguish the exact loss shape - a collapsed
+paragraph - that motivated this benchmark (#85).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from benchmarks.roundtrip import corpus, oracles
+from benchmarks.roundtrip.oracles import (
+    html_equivalence_check,
+    idempotency_check,
+)
+from benchmarks.roundtrip.run import evaluate_case
+
+pytestmark = pytest.mark.unit
+
+
+# --- the semantic (HTML) normalizer can tell real loss from noise -------------
+
+
+def _norm(md: str) -> str:
+    return oracles._normalize_html(oracles._reference_html(md))
+
+
+def test_normalizer_ignores_incidental_whitespace() -> None:
+    # Collapsible whitespace inside a paragraph is not a semantic difference.
+    assert _norm("a  b") == _norm("a b")
+    assert _norm("a\nb") == _norm("a b")
+
+
+def test_normalizer_detects_paragraph_collapse() -> None:
+    # The #85 loss: two paragraphs merged into one must be visible to the judge.
+    two_paragraphs = _norm("first\n\nsecond")
+    one_paragraph = _norm("first second")
+    assert two_paragraphs != one_paragraph
+
+
+def test_normalizer_detects_changed_table_cell() -> None:
+    good = _norm("| a | b |\n|---|---|\n| 1 | 2 |")
+    bad = _norm("| a | b |\n|---|---|\n| 1 | 9 |")
+    assert good != bad
+
+
+# --- idempotency oracle -------------------------------------------------------
+
+
+def test_idempotency_passes_on_stable_document() -> None:
+    result = idempotency_check("# Title\n\n- alpha\n- bravo\n")
+    assert result.passed
+    assert not result.skipped
+
+
+def test_idempotency_flags_non_fixed_point(monkeypatch: pytest.MonkeyPatch) -> None:
+    # Force once != twice: first render appends a marker, second does not.
+    calls = {"n": 0}
+
+    def fake_roundtrip(md: str, _opts: object) -> str:
+        calls["n"] += 1
+        return md if calls["n"] == 1 else md + "\nMUTATED\n"
+
+    monkeypatch.setattr(oracles, "_roundtrip_once", fake_roundtrip)
+    result = idempotency_check("anything")
+    assert not result.passed
+    assert result.diff  # a unified diff is attached for triage
+
+
+def test_idempotency_reports_render_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    def boom(md: str, _opts: object) -> str:
+        raise ValueError("kaboom")
+
+    monkeypatch.setattr(oracles, "_roundtrip_once", boom)
+    result = idempotency_check("anything")
+    assert not result.passed
+    assert "kaboom" in result.detail
+
+
+# --- HTML-equivalence oracle --------------------------------------------------
+
+
+def test_html_equivalence_passes_on_faithful_reformatting(monkeypatch: pytest.MonkeyPatch) -> None:
+    # A roundtrip that only reformats (bullet marker, blank lines) but preserves
+    # meaning must PASS - otherwise the oracle would flag benign normalization.
+    def reformat(md: str, _opts: object) -> str:
+        return "- a\n- b\n"
+
+    monkeypatch.setattr(oracles, "_roundtrip_once", reformat)
+    result = html_equivalence_check("* a\n* b\n")
+    assert result.passed
+
+
+def test_html_equivalence_flags_semantic_loss(monkeypatch: pytest.MonkeyPatch) -> None:
+    # A roundtrip that drops a paragraph must FAIL.
+    def drop_paragraph(md: str, _opts: object) -> str:
+        return "first\n"
+
+    monkeypatch.setattr(oracles, "_roundtrip_once", drop_paragraph)
+    result = html_equivalence_check("first\n\nsecond\n")
+    assert not result.passed
+    assert result.diff
+
+
+# --- corpus loading + policy skips --------------------------------------------
+
+
+def test_raw_html_detection() -> None:
+    assert corpus._looks_like_raw_html("a <div>block</div> b")
+    assert corpus._looks_like_raw_html("text with <br> tag")
+    assert not corpus._looks_like_raw_html("plain *emphasis* and `code`")
+    # HTML shown *inside* a fenced code block is an example, not raw passthrough.
+    assert not corpus._looks_like_raw_html("```html\n<div>example</div>\n```")
+
+
+def test_synthetic_corpus_loads() -> None:
+    cases = corpus.load_synthetic_corpus()
+    assert cases, "synthetic corpus should not be empty"
+    names = {c.name for c in cases}
+    assert "kitchen-sink" in names
+    # The raw-html document must be flagged so the HTML oracle skips it.
+    raw = next(c for c in cases if c.name == "raw-html")
+    assert raw.has_raw_html
+
+
+def test_evaluate_case_skips_html_oracle_for_raw_html() -> None:
+    case = corpus.Case(name="x", markdown="<div>raw</div>\n", has_raw_html=True)
+    results = {r.oracle: r for r in evaluate_case(case)}
+    assert results["html_equivalence"].skipped
+    assert "idempotency" in results


### PR DESCRIPTION
## What

Adds `benchmarks/roundtrip/`, a tiered **Markdown-in roundtrip fidelity** benchmark, plus judge-can-fail self-tests. Complements the existing benchmarks (`benchmarks/corpus/` times *to-markdown*; `benchmarks/startup.py` times cold start) — this one measures whether `Markdown → AST → Markdown` preserves a document.

This is **Phase 0/1** of the plan: shared oracles + a synthetic corpus, runnable manually to surface issues. The CommonMark/GFM spec suites (Phase 2) and a blocking CI gate (Phase 3) are planned follow-ups; the `Case` shape is already source-agnostic for the spec suites.

## Two independent oracles

A loss has to slip past both (`oracles.py`):

- **idempotency** — render twice, assert a fixed point (`once == twice`). Cheap, deterministic, reference-free; the exact criterion the recent list/footnote fixes (#84/#85/#91) used.
- **html_equivalence** — render the original and roundtripped Markdown to HTML with a fixed reference renderer (mistune, all2md's default plugin set) and diff a normalized form. Independent of all2md's AST model and Markdown renderer — where losses occur — so it catches first-render loss idempotency can't see. Raw-HTML docs are skipped (lossy by policy under `html_passthrough_mode="escape"`). Caveat: all2md also parses with mistune, so the oracle is independent of the AST + render halves, not the parse half.

## Corpus

20 labeled synthetic docs under `corpus/synthetic/` (one construct family each + a `kitchen-sink`), deliberately covering the extensions the spec suites don't (footnotes, definition lists, math, admonitions, mark/insert/super/subscript) and the shapes behind #84/#85/#91.

## Guarding the judge

`tests/unit/test_roundtrip_benchmark.py` proves each oracle can both pass (faithful input) and fail (deliberately broken input, via controlled roundtrips so the tests stay valid as all2md is fixed), and that the HTML normalizer ignores incidental whitespace while still detecting a collapsed paragraph.

## Findings already surfaced

Running the benchmark over the synthetic corpus (28 pass / 11 fail / 1 skip) uncovered real roundtrip defects, now filed:

- **#94** — footnotes render as raw HTML (`<sup>`/`<div>`) in default/gfm flavors and self-escape on a second roundtrip; multi-paragraph defs collapse.
- **#95** — inline marks (`==`/`^^`/`^`/`~`) render as raw HTML in all flavors and self-escape; insert uses `<u>` instead of `<ins>`.
- **#96** — a table nested in a list item is de-indented and breaks out of the list on roundtrip.
- **#97** — inline `$$…$$` display math after same-line text is dropped (lower priority).

## Run it

```bash
python -m benchmarks.roundtrip              # per-document pass/fail table
python -m benchmarks.roundtrip --show-diff  # + unified diffs for failures
```

## Notes

- Corpus files carry meaningful trailing whitespace (two-space hard breaks), so they're excluded from the `trailing-whitespace` pre-commit hook like the `.ambr` snapshots.
- No production code touched — benchmark + tests only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
