### PR TITLE
fix(markdown): indent tables nested in list items (#96)

### DIFF
--- a/src/all2md/renderers/markdown.py
+++ b/src/all2md/renderers/markdown.py
@@ -1074,6 +1074,34 @@ class MarkdownRenderer(NodeVisitor, InlineContentMixin, BaseRenderer):
             Table to render
 
         """
+        # Render the table into a temporary buffer, then shift every line to the
+        # current indent (mirrors visit_code_block). A table nested in a list
+        # item must stay under the item's margin; emitted at column zero it
+        # reparses as a sibling of the list instead of a child of the item. At
+        # the top level the indent is empty and the output is unchanged.
+        indent = self._current_indent()
+        saved_output = self._output
+        self._output = []
+        try:
+            self._render_table_grid(node)
+        finally:
+            table_text = "".join(self._output)
+            self._output = saved_output
+
+        if indent and table_text:
+            table_text = "\n".join(indent + line if line else line for line in table_text.split("\n"))
+        self._output.append(table_text)
+
+        # Emit block references if using after_block placement
+        if self.options.link_style == "reference" and self.options.reference_link_placement == "after_block":
+            self._emit_block_references()
+
+    def _render_table_grid(self, node: Table) -> None:
+        """Render a table's caption and rows to ``self._output`` (no indent).
+
+        Split out from ``visit_table`` so the caller can capture the table in a
+        buffer and shift it to the current indentation.
+        """
         # Render caption if present
         if node.caption:
             self._output.append(f"*{node.caption}*\n\n")
@@ -1103,10 +1131,6 @@ class MarkdownRenderer(NodeVisitor, InlineContentMixin, BaseRenderer):
             self._render_padded_table(node, rendered_rows, num_cols)
         else:
             self._render_minimal_table(node, rendered_rows, num_cols)
-
-        # Emit block references if using after_block placement
-        if self.options.link_style == "reference" and self.options.reference_link_placement == "after_block":
-            self._emit_block_references()
 
     def _render_table_as_html(self, node: Table) -> None:
         """Render a table as HTML when markdown tables are not supported.

--- a/tests/unit/renderers/test_markdown_renderer.py
+++ b/tests/unit/renderers/test_markdown_renderer.py
@@ -593,6 +593,38 @@ class TestLists:
         assert once.startswith("1. - [x] first line\n")
         assert "\nsecond line" not in once  # never at column zero
 
+    def test_table_in_list_item_stays_indented(self):
+        """A table nested in a list item must stay under the item's margin.
+
+        The table was emitted at column zero, so on reparse it broke out of the
+        list item to the document top level (splitting the surrounding list).
+        """
+        from all2md import convert, to_ast
+        from all2md.ast.nodes import List as ListNode
+        from all2md.ast.nodes import Table
+
+        source = "- lead:\n\n  | k | v |\n  |---|---|\n  | 1 | 2 |\n"
+        once = convert(source, source_format="markdown", target_format="markdown")
+        twice = convert(once, source_format="markdown", target_format="markdown")
+
+        assert once == twice, "table-in-list-item is not idempotent"
+        # Every table line sits at the item's content column (two spaces), not column zero.
+        assert "\n  | k | v |" in once
+        assert "\n| k | v |" not in once
+
+        # And it re-parses as a child of the list item, not a top-level sibling.
+        doc = to_ast(once, source_format="markdown")
+        assert not any(isinstance(child, Table) for child in doc.children), "table broke out of the list"
+        item_tables = [
+            node
+            for lst in doc.children
+            if isinstance(lst, ListNode)
+            for item in lst.items
+            for node in item.children
+            if isinstance(node, Table)
+        ]
+        assert len(item_tables) == 1
+
     def test_deeply_nested_list(self):
         """Test rendering deeply nested lists (3 levels)."""
         level3_list = List(ordered=False, items=[ListItem(children=[Paragraph(content=[Text(content="Level 3")])])])


### PR DESCRIPTION
## What

Fixes #96: a table nested in a list item was rendered at **column zero** instead of under the item's content margin. On a Markdown→Markdown roundtrip the table therefore re-parsed as a top-level sibling and broke out of the list (splitting it).

Before:

```
* lead:

| k | v |
|---|---|
| 1 | 2 |
```

After:

```
* lead:

  | k | v |
  |---|---|
  | 1 | 2 |
```

## Fix

`visit_table` now renders the table into a temporary buffer and shifts every line to `_current_indent()`, mirroring the existing `visit_code_block` / `visit_paragraph` handling. The grid rendering is split into `_render_table_grid` so the caller can capture and indent it. At the top level the indent is empty, so top-level tables are byte-for-byte unchanged.

This is the same failure family as #91 (list-item continuation lines / nested-first-child), extended to tables.

## Tests

- New `test_table_in_list_item_stays_indented` in `test_markdown_renderer.py`: asserts idempotency, that every table line sits at the content column, and — via re-parse — that the table stays a child of the list item (0 top-level tables, 1 nested).
- Full `test_markdown_renderer.py` suite passes; roundtrip (unit + integration) and markdown parser/conversion tests pass; ruff / black / mypy clean.

## Discovery

Surfaced by the roundtrip fidelity benchmark (#98) — its HTML-equivalence oracle caught it where idempotency alone couldn't (the broken output was stable). Once #98 merges, the `tables` / `kitchen-sink` corpus docs flip from FAIL to pass.

First of the roundtrip-fidelity fixes (#94, #95, #96, #97).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
