### PR TITLE
fix(markdown): roundtrip footnotes as Markdown under default flavor (#94)

### DIFF
--- a/src/all2md/renderers/markdown.py
+++ b/src/all2md/renderers/markdown.py
@@ -474,6 +474,20 @@ class MarkdownRenderer(NodeVisitor, InlineContentMixin, BaseRenderer):
             return " " * sum(self._marker_width_stack)
         return " " * (self._indent_level * self.options.list_indent_width)
 
+    def _resolve_unsupported_inline_mode(self) -> str:
+        """Resolve ``unsupported_inline_mode`` with the shared smart fallback.
+
+        An *unset* ``"html"`` default becomes ``"force"`` so a construct the
+        flavor doesn't support (footnotes, marks, ...) emits readable Markdown
+        instead of raw HTML that the default ``html_passthrough_mode="escape"``
+        policy mangles on the next roundtrip. An explicit ``"html"`` is honored.
+        This mirrors the fallback ``visit_definition_list`` applies inline.
+        """
+        mode = str(self.options.unsupported_inline_mode)
+        if mode == "html" and not self.options._unsupported_inline_mode_was_explicit:
+            return "force"
+        return mode
+
     def _get_bullet_symbol(self, depth: int) -> str:
         """Get the bullet symbol for a given nesting depth.
 
@@ -1591,14 +1605,17 @@ class MarkdownRenderer(NodeVisitor, InlineContentMixin, BaseRenderer):
         """
         if self._flavor.supports_footnotes():
             self._output.append(f"[^{node.identifier}]")
-        else:
-            mode = self.options.unsupported_inline_mode
-            if mode == "plain":
-                pass
-            elif mode == "force":
-                self._output.append(f"[^{node.identifier}]")
-            else:
-                self._output.append(f"<sup>{node.identifier}</sup>")
+            return
+
+        mode = self._resolve_unsupported_inline_mode()
+        if mode == "plain":
+            pass
+        elif mode == "html":
+            # Only when the user explicitly asked for HTML: a raw <sup> is escaped
+            # by the default html_passthrough policy on the next roundtrip.
+            self._output.append(f"<sup>{node.identifier}</sup>")
+        else:  # "force" (also the resolved default): emit real Markdown syntax
+            self._output.append(f"[^{node.identifier}]")
 
     def visit_math_inline(self, node: "MathInline") -> None:
         """Render a MathInline node.
@@ -1638,41 +1655,55 @@ class MarkdownRenderer(NodeVisitor, InlineContentMixin, BaseRenderer):
 
         """
         if self._flavor.supports_footnotes():
-            self._output.append(f"[^{node.identifier}]: ")
-            for i, child in enumerate(node.content):
-                saved_output = self._output
-                self._output = []
+            self._render_footnote_definition_markdown(node)
+            return
+
+        mode = self._resolve_unsupported_inline_mode()
+        if mode == "drop":
+            return
+        if mode == "html":
+            # Explicit HTML only. Note the emitted <div> is escaped by the default
+            # html_passthrough policy on the next roundtrip.
+            self._output.append(f'<div id="fn-{node.identifier}">')
+            for child in node.content:
                 child.accept(self)
-                child_content = "".join(self._output)
-                self._output = saved_output
-                lines = child_content.split("\n")
-                if i == 0:
-                    # First block starts right after the "[^id]: " marker; any
-                    # continuation lines align four spaces under it.
-                    self._output.append(lines[0])
-                    for line in lines[1:]:
-                        self._output.append("\n" + ("    " + line if line else ""))
-                else:
-                    # Later blocks are separate paragraphs. They need a blank
-                    # line before them and four-space indentation on every line,
-                    # otherwise a bare newline makes them lazily merge into the
-                    # previous paragraph when the footnote is reparsed.
-                    self._output.append("\n")
-                    for line in lines:
-                        self._output.append("\n" + ("    " + line if line else ""))
+            self._output.append("</div>")
         else:
-            mode = self.options.unsupported_inline_mode
-            if mode == "drop":
-                return
-            elif mode == "html":
-                self._output.append(f'<div id="fn-{node.identifier}">')
-                for child in node.content:
-                    child.accept(self)
-                self._output.append("</div>")
+            # "force" (also the resolved default) and "plain": emit real Markdown
+            # footnote syntax, which roundtrips. Routing through the shared helper
+            # (not a bare child dump) keeps multi-paragraph definitions from
+            # collapsing into one paragraph on reparse.
+            self._render_footnote_definition_markdown(node)
+
+    def _render_footnote_definition_markdown(self, node: "FootnoteDefinition") -> None:
+        """Render a footnote definition as ``[^id]: ...`` Markdown.
+
+        Continuation lines and later block paragraphs are indented four spaces so
+        the definition re-parses with its structure (and multiple paragraphs)
+        intact instead of lazily merging.
+        """
+        self._output.append(f"[^{node.identifier}]: ")
+        for i, child in enumerate(node.content):
+            saved_output = self._output
+            self._output = []
+            child.accept(self)
+            child_content = "".join(self._output)
+            self._output = saved_output
+            lines = child_content.split("\n")
+            if i == 0:
+                # First block starts right after the "[^id]: " marker; any
+                # continuation lines align four spaces under it.
+                self._output.append(lines[0])
+                for line in lines[1:]:
+                    self._output.append("\n" + ("    " + line if line else ""))
             else:
-                self._output.append(f"[^{node.identifier}]: ")
-                for child in node.content:
-                    child.accept(self)
+                # Later blocks are separate paragraphs. They need a blank
+                # line before them and four-space indentation on every line,
+                # otherwise a bare newline makes them lazily merge into the
+                # previous paragraph when the footnote is reparsed.
+                self._output.append("\n")
+                for line in lines:
+                    self._output.append("\n" + ("    " + line if line else ""))
 
     def visit_definition_list(self, node: "DefinitionList") -> None:
         """Render a DefinitionList node.

--- a/tests/golden/__snapshots__/test_docx_golden.ambr
+++ b/tests/golden/__snapshots__/test_docx_golden.ambr
@@ -203,18 +203,18 @@
   
   Here we go!
   
-  The first footnote will come in this sentence<sup>1</sup>. And now this sentence can have an endnote<sup>end1</sup>. It’s just that easy. I’m telling you, it’s quite simple. Although, it’s strange to use *both* endnotes<sup>end2</sup> **and** footnotes<sup>2</sup>. Usually someone would choose one or the other, not usually both.
+  The first footnote will come in this sentence[^1]. And now this sentence can have an endnote[^end1]. It’s just that easy. I’m telling you, it’s quite simple. Although, it’s strange to use *both* endnotes[^end2] **and** footnotes[^2]. Usually someone would choose one or the other, not usually both.
   
   Now we can have another paragraph here. This one won’t have any endnotes or footnotes. However, it will have a comment. Something hilarious I’m sure.
   
   This should probably be all we need for the test document. So buh bye!
   
-  <div id="fn-1"> The first footnote</div>
+  [^1]:  The first footnote
   
-  <div id="fn-2"> Footnotes are this.</div>
+  [^2]:  Footnotes are this.
   
-  <div id="fn-end1"> Here’s an endnote.</div>
+  [^end1]:  Here’s an endnote.
   
-  <div id="fn-end2"> Endnotes are this.</div>
+  [^end2]:  Endnotes are this.
   '''
 # ---

--- a/tests/unit/renderers/test_markdown_renderer.py
+++ b/tests/unit/renderers/test_markdown_renderer.py
@@ -927,6 +927,54 @@ class TestEscaping:
 class TestFootnotes:
     """Tests for footnote rendering."""
 
+    def test_footnote_roundtrips_under_default_flavor(self):
+        """Footnotes must roundtrip as Markdown under the default (GFM) flavor.
+
+        The default ``unsupported_inline_mode='html'`` made GFM emit a raw
+        ``<sup>`` reference and ``<div id="fn-...">`` definition, which the
+        default html_passthrough policy then escaped to ``&lt;sup&gt;`` on the
+        next pass -- output the renderer's own parser corrupts.
+        """
+        from all2md import convert
+
+        source = "Text with a note.[^1]\n\n[^1]: The footnote body.\n"
+        once = convert(source, source_format="markdown", target_format="markdown")
+        twice = convert(once, source_format="markdown", target_format="markdown")
+
+        assert once == twice, "footnote roundtrip is not idempotent"
+        assert "[^1]" in once
+        assert "[^1]: The footnote body." in once
+        assert "<sup>" not in once
+        assert "fn-1" not in once
+
+    def test_multiparagraph_footnote_definition_does_not_collapse(self):
+        """A multi-paragraph footnote definition keeps both paragraphs on reparse."""
+        from all2md import convert, to_ast
+        from all2md.ast.nodes import FootnoteDefinition, Paragraph
+
+        source = "See note.[^1]\n\n[^1]: First paragraph.\n\n    Second paragraph.\n"
+        once = convert(source, source_format="markdown", target_format="markdown")
+        twice = convert(once, source_format="markdown", target_format="markdown")
+
+        assert once == twice
+        doc = to_ast(once, source_format="markdown")
+        defs = [n for n in doc.children if isinstance(n, FootnoteDefinition)]
+        assert len(defs) == 1
+        assert sum(1 for c in defs[0].content if isinstance(c, Paragraph)) == 2
+
+    def test_footnote_explicit_html_mode_still_emits_html(self):
+        """An explicit ``unsupported_inline_mode='html'`` is still honored."""
+        doc = Document(
+            children=[
+                Paragraph(content=[Text(content="Text"), FootnoteReference(identifier="1")]),
+                FootnoteDefinition(identifier="1", content=[Paragraph(content=[Text(content="Body")])]),
+            ]
+        )
+        options = MarkdownRendererOptions(flavor="gfm", unsupported_inline_mode="html")
+        result = MarkdownRenderer(options).render_to_string(doc)
+        assert "<sup>1</sup>" in result
+        assert '<div id="fn-1">' in result
+
     def test_footnote_reference_pandoc_flavor(self):
         """Test footnote reference with Pandoc flavor (supports footnotes)."""
         doc = Document(


### PR DESCRIPTION
## What

Fixes #94: under the default (GFM) flavor, footnotes were rendered as **raw HTML** — references as `<sup>1</sup>`, definitions as `<div id="fn-1">…</div>` — because GFM's `unsupported_inline_mode` defaults to `"html"`. The default `html_passthrough_mode="escape"` policy then escaped that HTML to `&lt;sup&gt;…` on the next roundtrip, so the renderer produced output its own parser corrupts. Multi-paragraph definitions also collapsed in the HTML form.

Before (default flavor, two passes):

```
x[^1]  →  x<sup>1</sup>                    →  x&lt;sup&gt;1&lt;/sup&gt;
[^1]: def   <div id="fn-1">def</div>          &lt;div id="fn-1"&gt;def&lt;/div&gt;
```

After: `x[^1]` / `[^1]: def` — stable and roundtrippable.

## Fix

`visit_definition_list` already had the right pattern: an **unset** `"html"` mode falls back to `"force"` so unsupported constructs emit readable Markdown. Footnotes lacked it. This PR:

- Extracts `_resolve_unsupported_inline_mode()` — the shared smart fallback (unset `"html"` → `"force"`; explicit `"html"` honored) — and applies it in both footnote visitors.
- Extracts `_render_footnote_definition_markdown()` and routes the `"force"`/default definition path through it (instead of a bare child dump), so **multi-paragraph definitions no longer collapse**.
- Preserves explicit `unsupported_inline_mode="html"` (still emits `<sup>`/`<div>`) and `"drop"` (still drops the definition).

## Tests

- `test_footnote_roundtrips_under_default_flavor` — idempotent, emits `[^1]`/`[^1]:`, no `<sup>`/`fn-1`.
- `test_multiparagraph_footnote_definition_does_not_collapse` — re-parses to 2 paragraphs.
- `test_footnote_explicit_html_mode_still_emits_html` — explicit html honored.
- Existing footnote tests (pandoc, explicit-html, drop-mode) still pass. Full `test_markdown_renderer.py` + roundtrip (unit + integration) green; ruff / black / mypy clean.

## Discovery

Surfaced by the roundtrip fidelity benchmark (#98). Once #98 merges, the `footnotes` / `kitchen-sink` corpus docs flip toward pass (the `<sup>`/`<div>` self-escape was the biggest failure).

Part of the roundtrip-fidelity fixes (#94, #95, #96, #97). Marks (#95) are the sibling — same root cause, different visitors — handled separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
