### PR TITLE
fix(markdown): roundtrip inline marks as Markdown by default (#95)

### DIFF
--- a/src/all2md/options/markdown.py
+++ b/src/all2md/options/markdown.py
@@ -196,12 +196,14 @@ class MarkdownRendererOptions(BaseRendererOptions):
         - "markdown": Use __text__ (non-standard)
         - "ignore": Strip underline formatting
     superscript_mode : {"html", "markdown", "ignore"}, default "markdown"
-        How to handle superscript text:
+        Fallback for flavors that don't natively support superscript. Flavors
+        that do (markdown_plus) always emit ``^text^``; for the rest:
         - "markdown": Use ^text^ (roundtrips; non-standard, needs an extension to render)
         - "html": Use <sup>text</sup> tags (wider display support, but escaped on roundtrip)
         - "ignore": Strip superscript formatting
     subscript_mode : {"html", "markdown", "ignore"}, default "markdown"
-        How to handle subscript text:
+        Fallback for flavors that don't natively support subscript. Flavors that
+        do (markdown_plus) always emit ``~text~``; for the rest:
         - "markdown": Use ~text~ (roundtrips; non-standard, needs an extension to render)
         - "html": Use <sub>text</sub> tags (wider display support, but escaped on roundtrip)
         - "ignore": Strip subscript formatting

--- a/src/all2md/options/markdown.py
+++ b/src/all2md/options/markdown.py
@@ -195,15 +195,15 @@ class MarkdownRendererOptions(BaseRendererOptions):
         - "html": Use <u>text</u> tags
         - "markdown": Use __text__ (non-standard)
         - "ignore": Strip underline formatting
-    superscript_mode : {"html", "markdown", "ignore"}, default "html"
+    superscript_mode : {"html", "markdown", "ignore"}, default "markdown"
         How to handle superscript text:
-        - "html": Use <sup>text</sup> tags
-        - "markdown": Use ^text^ (non-standard)
+        - "markdown": Use ^text^ (roundtrips; non-standard, needs an extension to render)
+        - "html": Use <sup>text</sup> tags (wider display support, but escaped on roundtrip)
         - "ignore": Strip superscript formatting
-    subscript_mode : {"html", "markdown", "ignore"}, default "html"
+    subscript_mode : {"html", "markdown", "ignore"}, default "markdown"
         How to handle subscript text:
-        - "html": Use <sub>text</sub> tags
-        - "markdown": Use ~text~ (non-standard)
+        - "markdown": Use ~text~ (roundtrips; non-standard, needs an extension to render)
+        - "html": Use <sub>text</sub> tags (wider display support, but escaped on roundtrip)
         - "ignore": Strip subscript formatting
     use_hash_headings : bool, default True
         Whether to use # syntax for headings instead of underline style.
@@ -303,7 +303,10 @@ class MarkdownRendererOptions(BaseRendererOptions):
         },
     )
     superscript_mode: SuperscriptMode = field(
-        default="html",
+        # Default to Markdown (``^text^``) so superscript roundtrips: the HTML
+        # ``<sup>`` alternative is escaped by the default html_passthrough policy
+        # on the next Markdown roundtrip. Set to "html" for wider display support.
+        default="markdown",
         metadata={
             "help": "How to handle superscript text",
             "choices": ["html", "markdown", "ignore"],
@@ -311,7 +314,9 @@ class MarkdownRendererOptions(BaseRendererOptions):
         },
     )
     subscript_mode: SubscriptMode = field(
-        default="html",
+        # Default to Markdown (``~text~``) so subscript roundtrips; see
+        # superscript_mode. Set to "html" for wider display support.
+        default="markdown",
         metadata={
             "help": "How to handle subscript text",
             "choices": ["html", "markdown", "ignore"],

--- a/src/all2md/renderers/markdown.py
+++ b/src/all2md/renderers/markdown.py
@@ -1458,14 +1458,21 @@ class MarkdownRenderer(NodeVisitor, InlineContentMixin, BaseRenderer):
         content = self._render_inline_content(node.content)
         if self._flavor.supports_mark():
             self._output.append(f"=={content}==")
-        else:
-            mode = self.options.unsupported_inline_mode
-            if mode == "plain":
-                self._output.append(content)
-            elif mode == "force":
-                self._output.append(f"=={content}==")
-            else:  # mode == "html"
-                self._output.append(f"<mark>{content}</mark>")
+            return
+
+        # Smart fallback: an unset "html" default becomes "force" so the mark
+        # emits ==text== (which roundtrips) instead of a raw <mark> that the
+        # default html_passthrough policy escapes on the next pass. Mirrors the
+        # fallback visit_footnote_reference/visit_definition_list apply.
+        mode = self.options.unsupported_inline_mode
+        if mode == "html" and not self.options._unsupported_inline_mode_was_explicit:
+            mode = "force"
+        if mode == "plain":
+            self._output.append(content)
+        elif mode == "html":
+            self._output.append(f"<mark>{content}</mark>")
+        else:  # "force" (also the resolved default)
+            self._output.append(f"=={content}==")
 
     def visit_underline(self, node: Underline) -> None:
         """Render an Underline node.

--- a/src/all2md/renderers/markdown.py
+++ b/src/all2md/renderers/markdown.py
@@ -1503,8 +1503,15 @@ class MarkdownRenderer(NodeVisitor, InlineContentMixin, BaseRenderer):
 
         """
         content = self._render_inline_content(node.content)
-        mode = self.options.superscript_mode
 
+        # A flavor that natively supports ^text^ (MarkdownPlus) emits it directly,
+        # like visit_mark does for ==. Other flavors fall back per superscript_mode
+        # (default "markdown", which roundtrips; set "html" for wider display).
+        if self._flavor.supports_superscript():
+            self._output.append(f"^{content}^")
+            return
+
+        mode = self.options.superscript_mode
         if mode == "html":
             self._output.append(f"<sup>{content}</sup>")
         elif mode == "markdown":
@@ -1522,8 +1529,14 @@ class MarkdownRenderer(NodeVisitor, InlineContentMixin, BaseRenderer):
 
         """
         content = self._render_inline_content(node.content)
-        mode = self.options.subscript_mode
 
+        # See visit_superscript: a flavor that natively supports ~text~
+        # (MarkdownPlus) emits it directly; others fall back per subscript_mode.
+        if self._flavor.supports_subscript():
+            self._output.append(f"~{content}~")
+            return
+
+        mode = self.options.subscript_mode
         if mode == "html":
             self._output.append(f"<sub>{content}</sub>")
         elif mode == "markdown":

--- a/src/all2md/utils/flavors.py
+++ b/src/all2md/utils/flavors.py
@@ -141,6 +141,35 @@ class MarkdownFlavor(ABC):
         """
         pass
 
+    def supports_superscript(self) -> bool:
+        """Check if this flavor natively supports ``^text^`` superscript syntax.
+
+        Concrete (default ``False``) rather than abstract: superscript is part of
+        the pymdownx / Material mark family, natively supported only by the
+        MarkdownPlus flavor. Other flavors fall back per ``superscript_mode``.
+
+        Returns
+        -------
+        bool
+            True if ``^text^`` superscript syntax is supported
+
+        """
+        return False
+
+    def supports_subscript(self) -> bool:
+        """Check if this flavor natively supports ``~text~`` subscript syntax.
+
+        See :meth:`supports_superscript`; defaults to ``False`` and is overridden
+        by the MarkdownPlus flavor.
+
+        Returns
+        -------
+        bool
+            True if ``~text~`` subscript syntax is supported
+
+        """
+        return False
+
     @abstractmethod
     def supports_admonitions(self) -> bool:
         """Check if this flavor supports Material for MkDocs admonitions.
@@ -913,6 +942,28 @@ class MarkdownPlusFlavor(MarkdownFlavor):
 
     def supports_mark(self) -> bool:
         """MarkdownPlus supports ``==`` highlight syntax.
+
+        Returns
+        -------
+        bool
+            True
+
+        """
+        return True
+
+    def supports_superscript(self) -> bool:
+        """MarkdownPlus supports ``^text^`` superscript syntax.
+
+        Returns
+        -------
+        bool
+            True
+
+        """
+        return True
+
+    def supports_subscript(self) -> bool:
+        """MarkdownPlus supports ``~text~`` subscript syntax.
 
         Returns
         -------

--- a/tests/golden/__snapshots__/test_html_golden.ambr
+++ b/tests/golden/__snapshots__/test_html_golden.ambr
@@ -30,7 +30,7 @@
   
   Text with **bold**, *italic*, `code`, ~~strikethrough~~, and highlighted text.
   
-  Text with <sub>subscript</sub> and <sup>superscript</sup>.
+  Text with ~subscript~ and ^superscript^.
   
   A paragraph with  
   line  

--- a/tests/golden/__snapshots__/test_textual_formats_golden.ambr
+++ b/tests/golden/__snapshots__/test_textual_formats_golden.ambr
@@ -29,7 +29,7 @@
   
   ## Advanced Formatting
   
-  Text with <sup>superscript</sup> and <sub>subscript</sub>.
+  Text with ^superscript^ and ~subscript~.
   
   Text with ~~strikethrough~~ content.
   
@@ -304,7 +304,7 @@
   ## Introduction
   
   This document demonstrates **all** the *major* features of `Textile` formatting.  
-   It includes <sup>superscript</sup> and <sub>subscript</sub> text.
+   It includes ^superscript^ and ~subscript~ text.
   
   Visit [our website](https://example.com) for more information.
   
@@ -418,7 +418,7 @@
   
   ## Advanced Formatting
   
-  Text with <sup>superscript</sup> and <sub>subscript</sub>.
+  Text with ^superscript^ and ~subscript~.
   
   Text with ~~strikethrough~~ content and underline text.
   

--- a/tests/unit/parsers/test_markdown_mkdocs.py
+++ b/tests/unit/parsers/test_markdown_mkdocs.py
@@ -96,6 +96,18 @@ class TestInlineMarks:
         out = _render(_parse("a ==hi== b"), flavor="gfm", unsupported_inline_mode="html")
         assert "<mark>hi</mark>" in out
 
+    def test_superscript_subscript_native_on_markdown_plus(self) -> None:
+        # markdown_plus natively supports ^sup^ / ~sub~; the flavor drives it,
+        # like ==highlight==, so it emits Markdown regardless of the *_mode option.
+        assert "2^10^" in _render(_parse("2^10^"), flavor="markdown_plus", superscript_mode="html")
+        assert "H~2~O" in _render(_parse("H~2~O"), flavor="markdown_plus", subscript_mode="html")
+
+    def test_superscript_falls_back_to_mode_on_gfm(self) -> None:
+        # GFM has no ^sup^ syntax, so the superscript_mode fallback applies:
+        # default "markdown" (roundtrips), explicit "html" for display.
+        assert "2^10^" in _render(_parse("2^10^"), flavor="gfm")
+        assert "2<sup>10</sup>" in _render(_parse("2^10^"), flavor="gfm", superscript_mode="html")
+
 
 class TestAdmonitions:
     """Material for MkDocs admonitions and collapsible variants."""

--- a/tests/unit/parsers/test_markdown_mkdocs.py
+++ b/tests/unit/parsers/test_markdown_mkdocs.py
@@ -85,8 +85,15 @@ class TestInlineMarks:
         out = _render(_parse("a ==hi== b"), flavor="markdown_plus")
         assert "==hi==" in out
 
-    def test_highlight_degrades_to_html_on_gfm(self) -> None:
+    def test_highlight_roundtrips_on_gfm_by_default(self) -> None:
+        # GFM doesn't support ==highlight==, but the default emits Markdown (not a
+        # raw <mark> that self-escapes on the next roundtrip). See #95.
         out = _render(_parse("a ==hi== b"), flavor="gfm")
+        assert "==hi==" in out
+        assert "<mark>" not in out
+
+    def test_highlight_degrades_to_html_on_gfm_when_explicit(self) -> None:
+        out = _render(_parse("a ==hi== b"), flavor="gfm", unsupported_inline_mode="html")
         assert "<mark>hi</mark>" in out
 
 

--- a/tests/unit/renderers/test_markdown_renderer.py
+++ b/tests/unit/renderers/test_markdown_renderer.py
@@ -32,6 +32,7 @@ from all2md.ast import (
     Link,
     List,
     ListItem,
+    Mark,
     MathBlock,
     MathInline,
     Paragraph,
@@ -278,6 +279,40 @@ class TestExtendedInlineFormatting:
         renderer = MarkdownRenderer(options)
         result = renderer.render_to_string(doc)
         assert result == "<sub>0</sub>"
+
+    def test_superscript_defaults_to_markdown(self):
+        """Superscript defaults to ``^text^`` so it roundtrips (was raw <sup>)."""
+        doc = Document(children=[Paragraph(content=[Superscript(content=[Text(content="2")])])])
+        assert MarkdownRenderer().render_to_string(doc) == "^2^"
+
+    def test_subscript_defaults_to_markdown(self):
+        """Subscript defaults to ``~text~`` so it roundtrips (was raw <sub>)."""
+        doc = Document(children=[Paragraph(content=[Subscript(content=[Text(content="0")])])])
+        assert MarkdownRenderer().render_to_string(doc) == "~0~"
+
+    def test_marks_roundtrip_under_default_flavor(self):
+        """Mark/superscript/subscript emit Markdown (not self-escaping HTML) by default.
+
+        The default GFM flavor rendered ==x== as <mark>, ^x^ as <sup>, ~x~ as
+        <sub>; the default html_passthrough policy then escaped that HTML to
+        &lt;mark&gt; on the next roundtrip. They must roundtrip as Markdown.
+        """
+        from all2md import convert
+
+        source = "==hi== and 2^10^ and H~2~O and ~~gone~~\n"
+        once = convert(source, source_format="markdown", target_format="markdown")
+        twice = convert(once, source_format="markdown", target_format="markdown")
+
+        assert once == twice
+        for token in ("==hi==", "2^10^", "H~2~O", "~~gone~~"):
+            assert token in once
+        assert "<mark>" not in once and "<sup>" not in once and "<sub>" not in once
+
+    def test_mark_explicit_html_mode_still_emits_html(self):
+        """An explicit ``unsupported_inline_mode='html'`` still emits <mark>."""
+        doc = Document(children=[Paragraph(content=[Mark(content=[Text(content="hi")])])])
+        options = MarkdownRendererOptions(flavor="gfm", unsupported_inline_mode="html")
+        assert MarkdownRenderer(options).render_to_string(doc) == "<mark>hi</mark>"
 
 
 @pytest.mark.unit


### PR DESCRIPTION
## What

Fixes #95: under the default (GFM) flavor, `==highlight==`, `^superscript^`, and `~subscript~` rendered as raw `<mark>`/`<sup>`/`<sub>`, which the default `html_passthrough_mode="escape"` policy then escaped to `&lt;mark&gt;…` on the next roundtrip — output the renderer's own parser corrupts.

Before (default) → after:

```
==hi== 2^10^ H~2~O   →  <mark>hi</mark> 2<sup>10</sup> H<sub>2</sub>O   (self-escapes on next pass)
                     →  ==hi== 2^10^ H~2~O   (roundtrips)
```

## Fix

Per the discussion on the roundtrip-vs-display tradeoff, these now default to **Markdown syntax** (roundtrip-faithful); explicit HTML is still available:

- **Mark (`==`)**: applies the smart fallback (unset `"html"` → `"force"`), mirroring #94. Explicit `unsupported_inline_mode="html"` still emits `<mark>`.
- **`superscript_mode` / `subscript_mode`**: default changed `"html"` → `"markdown"` (emit `^text^` / `~text~`). Set `"html"` for wider display support at the cost of roundtrip fidelity.

Strikethrough already roundtripped (GFM supports `~~`).

## Deliberately out of scope

Underline/insert are left as-is. `^^insert^^` parses to the same `Underline` node as underline, so round-tripping it (and emitting `<ins>` instead of `<u>`) needs AST disambiguation — tracked in **#101**.

## Tests

- New: `test_superscript_defaults_to_markdown`, `test_subscript_defaults_to_markdown`, `test_marks_roundtrip_under_default_flavor` (idempotent, emits `==`/`^`/`~`, no `<mark>`/`<sup>`/`<sub>`), `test_mark_explicit_html_mode_still_emits_html`.
- Updated the mkdocs highlight test to assert the new default + the explicit-html path.
- Refreshed 2 golden snapshots where Textile / AsciiDoc / HTML → Markdown now emit `^`/`~` superscript/subscript (verified the diffs are *only* that change).
- Existing explicit-mode super/subscript tests still pass. ruff / black / mypy clean.

## Discovery

Surfaced by the roundtrip fidelity benchmark (#98), corpus doc `extended-inline`. Completes the "self-escaping HTML for extensions" theme alongside #94.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
