### PR TITLE
fix(markdown): keep inline $$…$$ display math instead of dropping it (#97)

### DIFF
--- a/src/all2md/parsers/markdown.py
+++ b/src/all2md/parsers/markdown.py
@@ -1127,6 +1127,17 @@ class MarkdownToAstConverter(BaseParser):
         content = token.get("raw", "")
         return MathInline(content=content)
 
+    def _handle_inline_block_math_token(self, token: dict[str, Any]) -> MathInline:
+        """Handle a ``block_math`` token that mistune emitted inline.
+
+        ``$$...$$`` after text on the same line is tokenized as a ``block_math``
+        token nested in the paragraph's inline children. Without a handler it was
+        dropped; keep it as inline display math (the ``display`` metadata flag
+        makes the renderer emit ``$$...$$`` again so it roundtrips).
+        """
+        content = token.get("raw", "")
+        return MathInline(content=content, metadata={"display": True})
+
     def _handle_footnote_ref_token(self, token: dict[str, Any]) -> FootnoteReference:
         """Handle footnote_ref token."""
         attrs = token.get("attrs", {})
@@ -1171,6 +1182,7 @@ class MarkdownToAstConverter(BaseParser):
             "subscript": self._handle_subscript_token,
             "inline_html": self._handle_inline_html_token,
             "inline_math": self._handle_inline_math_token,
+            "block_math": self._handle_inline_block_math_token,
             "footnote_ref": self._handle_footnote_ref_token,
         }
 

--- a/src/all2md/renderers/markdown.py
+++ b/src/all2md/renderers/markdown.py
@@ -1673,8 +1673,13 @@ class MarkdownRenderer(NodeVisitor, InlineContentMixin, BaseRenderer):
         preferred = self.options.math_mode
         content, notation = node.get_preferred_representation(preferred)
 
+        # Inline display math ($$...$$ that appeared after text on the same line)
+        # is kept as a MathInline flagged "display"; emit the $$ delimiter so it
+        # roundtrips instead of collapsing to inline $...$.
+        delim = "$$" if node.metadata.get("display") else "$"
+
         if self._flavor.supports_math() and notation == "latex":
-            self._output.append(f"${content}$")
+            self._output.append(f"{delim}{content}{delim}")
             return
 
         if self._flavor.supports_math():
@@ -1685,7 +1690,7 @@ class MarkdownRenderer(NodeVisitor, InlineContentMixin, BaseRenderer):
         if mode == "plain":
             self._output.append(content)
         elif mode == "force" and notation == "latex":
-            self._output.append(f"${content}$")
+            self._output.append(f"{delim}{content}{delim}")
         else:
             self._output.append(render_math_html(content, notation, inline=True))
 

--- a/tests/unit/renderers/test_markdown_renderer.py
+++ b/tests/unit/renderers/test_markdown_renderer.py
@@ -131,6 +131,33 @@ class TestMathRendering:
         result = renderer.render_to_string(doc)
         assert '<div class="math math-block" data-notation="mathml">' in result
 
+    def test_inline_display_math_roundtrips(self) -> None:
+        """`$$...$$` after text on the same line survives and roundtrips (#97).
+
+        mistune tokenizes it as an inline block_math child; without a handler it
+        was dropped entirely, leaving just the surrounding text.
+        """
+        from all2md import convert
+
+        source = "Lead text $$\\sum x$$ trailing\n"
+        once = convert(source, source_format="markdown", target_format="markdown")
+        twice = convert(once, source_format="markdown", target_format="markdown")
+
+        assert once == twice, "inline display math is not idempotent"
+        assert "$$\\sum x$$" in once  # kept as inline display math, not dropped or collapsed to $...$
+
+    def test_inline_display_math_parsed_as_display_flagged_inline(self) -> None:
+        from all2md import to_ast
+        from all2md.ast.nodes import MathInline, Paragraph
+
+        doc = to_ast("Lead text $$\\sum x$$", source_format="markdown")
+        para = doc.children[0]
+        assert isinstance(para, Paragraph)
+        maths = [n for n in para.content if isinstance(n, MathInline)]
+        assert len(maths) == 1
+        assert maths[0].content == "\\sum x"
+        assert maths[0].metadata.get("display") is True
+
 
 @pytest.mark.unit
 class TestHeadingRendering:


### PR DESCRIPTION
## What

Fixes #97: a `$$…$$` display-math span that follows text on the **same line** was dropped entirely on a roundtrip.

```
"Lead text $$\sum x$$"          →  "Lead text"                (math gone)
"Lead text $$\sum x$$ trailing" →  "Lead text  trailing"      (math gone, double space)
```

## Root cause

mistune tokenizes inline `$$…$$` as a `block_math` token nested in the paragraph's **inline** children. The inline token dispatcher (`_process_inline_token`) had no `block_math` handler, so it returned `None` and the token was silently dropped. (Standalone `$$…$$` on its own line is a top-level `block_math` and was fine — it becomes a `MathBlock`.)

## Fix

- **Parser:** map an inline `block_math` token to a `MathInline` flagged `display=True` (via the existing `metadata` dict — no AST schema change).
- **Renderer:** `visit_math_inline` emits the `$$` delimiter for a display-flagged node, so it roundtrips as `$$…$$` instead of collapsing to inline `$…$`.

Standalone `$$…$$` still parses to a `MathBlock` and is unaffected; single-`$` inline math is unchanged.

After:

```
"Lead text $$\sum x$$"          →  "Lead text $$\sum x$$"     (idempotent)
"Lead text $$\sum x$$ trailing" →  "Lead text $$\sum x$$ trailing"
```

## Tests

- `test_inline_display_math_roundtrips` — idempotent, `$$\sum x$$` preserved.
- `test_inline_display_math_parsed_as_display_flagged_inline` — parses to a `display=True` `MathInline`.
- Full markdown renderer + parser + golden suites pass; ruff / black / mypy clean.

## Discovery

Surfaced by the roundtrip fidelity benchmark's `math` corpus doc, which now passes both oracles (idempotency + HTML-equivalence). Last of the #94–#97 benchmark findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
