### PR TITLE
fix(markdown): keep list intact when admonition degrades to a labelled quote (#104)

### DIFF
--- a/benchmarks/roundtrip/corpus.py
+++ b/benchmarks/roundtrip/corpus.py
@@ -25,6 +25,12 @@ SYNTHETIC_DIR = HERE / "corpus" / "synthetic"
 # raw-HTML and let the HTML oracle skip it (all2md escapes raw HTML by policy).
 _RAW_HTML = re.compile(r"</?[a-zA-Z][a-zA-Z0-9]*(\s[^<>]*)?/?>")
 
+# A Material for MkDocs admonition marker: !!! type, ??? type, or ???+ type at
+# the start of a line. Admonitions use all2md's custom block token, which the
+# oracle's stock mistune renderer can't render, so the HTML oracle can't judge
+# them (idempotency still can).
+_ADMONITION = re.compile(r"^(?:!!!|\?\?\?\+?)\s", re.MULTILINE)
+
 
 @dataclass
 class Case:
@@ -40,6 +46,7 @@ class Case:
     source: str = "synthetic"
     path: Path | None = None
     has_raw_html: bool = False
+    has_admonitions: bool = False
     tags: list[str] = field(default_factory=list)
 
 
@@ -50,6 +57,10 @@ def _strip_fenced_code(md: str) -> str:
 
 def _looks_like_raw_html(md: str) -> bool:
     return bool(_RAW_HTML.search(_strip_fenced_code(md)))
+
+
+def _looks_like_admonition(md: str) -> bool:
+    return bool(_ADMONITION.search(_strip_fenced_code(md)))
 
 
 def load_synthetic_corpus(directory: Path | None = None) -> list[Case]:
@@ -65,6 +76,7 @@ def load_synthetic_corpus(directory: Path | None = None) -> list[Case]:
                 source="synthetic",
                 path=path,
                 has_raw_html=_looks_like_raw_html(md),
+                has_admonitions=_looks_like_admonition(md),
                 tags=[path.stem],
             )
         )

--- a/benchmarks/roundtrip/run.py
+++ b/benchmarks/roundtrip/run.py
@@ -26,7 +26,13 @@ from .oracles import CheckResult, html_equivalence_check, idempotency_check
 
 
 def evaluate_case(case: Case) -> list[CheckResult]:
-    """Run every oracle against one case, honoring policy skips."""
+    """Run every oracle against one case, honoring policy skips.
+
+    Idempotency always runs. The HTML-equivalence oracle is skipped for cases it
+    cannot fairly judge: raw HTML (lossy by all2md's escape policy) and
+    admonitions (the reference mistune renderer has no method for all2md's custom
+    admonition block token). Skips are neither a pass nor a failure.
+    """
     results = [idempotency_check(case.markdown)]
     if case.has_raw_html:
         results.append(
@@ -35,6 +41,15 @@ def evaluate_case(case: Case) -> list[CheckResult]:
                 passed=True,
                 skipped=True,
                 detail="raw HTML present; lossy by policy (html_passthrough_mode='escape')",
+            )
+        )
+    elif case.has_admonitions:
+        results.append(
+            CheckResult(
+                "html_equivalence",
+                passed=True,
+                skipped=True,
+                detail="admonitions present; reference renderer has no admonition token (idempotency still judges)",
             )
         )
     else:

--- a/src/all2md/renderers/markdown.py
+++ b/src/all2md/renderers/markdown.py
@@ -778,12 +778,22 @@ class MarkdownRenderer(NodeVisitor, InlineContentMixin, BaseRenderer):
             else:
                 # Capitalize and format the admonition type
                 label = admonition_type.capitalize()
+            label_md = f"**{label}:**"
 
-            # Prepend label to first non-empty line
-            for i, line in enumerate(lines):
-                if line.strip():  # Find first non-empty line
-                    lines[i] = f"**{label}:** {line}"
-                    break
+            first_child = node.children[0] if node.children else None
+            if isinstance(first_child, Paragraph):
+                # First block is a paragraph: inline the label into its first
+                # line, e.g. "> **Note:** body text".
+                for i, line in enumerate(lines):
+                    if line.strip():  # Find first non-empty line
+                        lines[i] = f"{label_md} {line}"
+                        break
+            else:
+                # First block is a list, code block, table, etc. Inlining the
+                # label would fold that block into the label's paragraph and
+                # break the roundtrip (e.g. "> **Tip:** * item"). Emit the
+                # label as its own paragraph so the block stays intact.
+                lines = [label_md, "", *lines]
 
         # Quote all lines, honoring the current indentation so a block quote
         # nested inside a list item stays under the item's margin instead of

--- a/tests/unit/parsers/test_markdown_mkdocs.py
+++ b/tests/unit/parsers/test_markdown_mkdocs.py
@@ -171,6 +171,22 @@ class TestAdmonitions:
         out = _render(_parse('!!! note "Heads up"\n    Body text.\n'), flavor="gfm")
         assert "> **Heads up:** Body text." in out
 
+    def test_gfm_degradation_puts_label_on_own_line_before_list(self) -> None:
+        # When the admonition body opens with a non-paragraph block (a list),
+        # inlining the label would fold the list into the label's paragraph
+        # ("> **Tip:** * item") and break the roundtrip. The label must land on
+        # its own line so the list stays a list. See #104.
+        out = _render(_parse("!!! tip\n    - one\n    - two\n"), flavor="gfm")
+        assert "> **Tip:** *" not in out
+        assert "> **Tip:**\n" in out
+        assert "> * one" in out
+
+    def test_gfm_degradation_with_list_is_idempotent(self) -> None:
+        src = "!!! tip\n    - one\n    - two\n"
+        first = _render(_parse(src), flavor="gfm")
+        second = _render(_parse(first), flavor="gfm")
+        assert first == second
+
     def test_round_trip_is_idempotent(self) -> None:
         src = '!!! note "Heads up"\n    Para one.\n\n    Para two.\n\nOutside.\n'
         doc = _parse(src)

--- a/tests/unit/test_roundtrip_benchmark.py
+++ b/tests/unit/test_roundtrip_benchmark.py
@@ -120,6 +120,15 @@ def test_raw_html_detection() -> None:
     assert not corpus._looks_like_raw_html("```html\n<div>example</div>\n```")
 
 
+def test_admonition_detection() -> None:
+    assert corpus._looks_like_admonition("!!! note\n    body\n")
+    assert corpus._looks_like_admonition('??? warning "T"\n    body\n')
+    assert corpus._looks_like_admonition("???+ tip\n    body\n")
+    assert not corpus._looks_like_admonition("plain text with !!! bang in the middle")
+    # An admonition marker shown inside a fenced code block is an example.
+    assert not corpus._looks_like_admonition("```\n!!! note\n    body\n```")
+
+
 def test_synthetic_corpus_loads() -> None:
     cases = corpus.load_synthetic_corpus()
     assert cases, "synthetic corpus should not be empty"
@@ -128,6 +137,9 @@ def test_synthetic_corpus_loads() -> None:
     # The raw-html document must be flagged so the HTML oracle skips it.
     raw = next(c for c in cases if c.name == "raw-html")
     assert raw.has_raw_html
+    # The admonitions document must be flagged so the HTML oracle skips it.
+    adm = next(c for c in cases if c.name == "admonitions")
+    assert adm.has_admonitions
 
 
 def test_evaluate_case_skips_html_oracle_for_raw_html() -> None:
@@ -135,3 +147,11 @@ def test_evaluate_case_skips_html_oracle_for_raw_html() -> None:
     results = {r.oracle: r for r in evaluate_case(case)}
     assert results["html_equivalence"].skipped
     assert "idempotency" in results
+
+
+def test_evaluate_case_skips_html_oracle_for_admonitions() -> None:
+    case = corpus.Case(name="x", markdown="!!! note\n    body\n", has_admonitions=True)
+    results = {r.oracle: r for r in evaluate_case(case)}
+    assert results["html_equivalence"].skipped
+    # Idempotency still runs and should pass for a well-formed admonition.
+    assert results["idempotency"].passed


### PR DESCRIPTION
Fixes #104.

## Problem

When a Material for MkDocs admonition (`!!! type`) renders to a flavor without admonition support (e.g. GFM, the default), it degrades to a labelled blockquote (`> **Type:** …`). The label was unconditionally prepended to the first content line — fine for a paragraph body, but when the body opens with a **list**, the label got jammed onto the first item (`> **Tip:** * one`), folding the list into the label's paragraph and breaking the roundtrip.

Caught by the `benchmarks/roundtrip` idempotency oracle (`admonitions` doc), the last real bug from the benchmark's initial triage that hadn't been tracked.

**Before (GFM):**
```
> **Tip:** * one
> * two
```
Not idempotent — the second pass escapes the marker (`\* one`) and re-lists `two`.

**After (GFM):**
```
> **Tip:**
> 
> * one
> * two
```

## Fix

- `visit_block_quote`: inline the `**Type:**` label into the first content line only when the first block child is a `Paragraph`; otherwise emit the label as its own paragraph so the following block (list, code, table, …) stays intact. Paragraph-first admonitions render exactly as before.
- Benchmark honesty: the reference mistune renderer has no method for all2md's custom admonition block token, so the HTML-equivalence oracle can't fairly judge admonitions. Flag admonition docs (`has_admonitions`) and skip the HTML oracle for them — same posture as `raw-html` — leaving idempotency as the judge. The `admonitions` doc now shows `pass / SKIP` instead of `FAIL / FAIL`.

## Tests

- New renderer regression tests: label lands on its own line before a list, and the GFM-degradation-with-list roundtrip is idempotent (`tests/unit/parsers/test_markdown_mkdocs.py`).
- New benchmark self-tests: admonition detection (incl. fenced-code exclusion) and the HTML-oracle skip (`tests/unit/test_roundtrip_benchmark.py`).
- Full golden suite unchanged (121 snapshots pass — paragraph-first admonitions are byte-identical).

Benchmark after this PR: `admonitions` → `pass / SKIP`. Remaining non-passing docs are `extended-inline` (#101, insert/underline) and `raw-html` (lossy by policy).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
