### PR TITLE
fix(markdown): roundtrip underline and non-GFM strikethrough by default

### DIFF
--- a/src/all2md/options/markdown.py
+++ b/src/all2md/options/markdown.py
@@ -297,9 +297,13 @@ class MarkdownRendererOptions(BaseRendererOptions):
         },
     )
     underline_mode: UnderlineMode = field(
-        default="html",
+        # Default to Markdown (``^^text^^``, the pymdownx "insert" spelling) so
+        # underline roundtrips: the HTML ``<u>`` alternative is escaped by the
+        # default html_passthrough policy on the next Markdown roundtrip. Mirrors
+        # superscript_mode/subscript_mode. Set to "html" for wider display support.
+        default="markdown",
         metadata={
-            "help": "How to handle underlined text",
+            "help": "How to handle underlined text: markdown (^^text^^), html (<u>), or ignore",
             "choices": ["html", "markdown", "ignore"],
             "importance": "advanced",
         },

--- a/src/all2md/options/markdown.py
+++ b/src/all2md/options/markdown.py
@@ -193,8 +193,7 @@ class MarkdownRendererOptions(BaseRendererOptions):
     underline_mode : {"html", "markdown", "ignore"}, default "markdown"
         Fallback for flavors that don't natively support underline. Flavors that
         do (markdown_plus) always emit ``^^text^^``; for the rest:
-        - "markdown": Use ^^text^^ (the pymdownx "insert" spelling; roundtrips, but
-          needs an extension to render)
+        - "markdown": Use ^^text^^ (the pymdownx insert spelling; roundtrips, needs an extension to render)
         - "html": Use <u>text</u> tags (wider display support, but escaped on roundtrip)
         - "ignore": Strip underline formatting
     superscript_mode : {"html", "markdown", "ignore"}, default "markdown"

--- a/src/all2md/options/markdown.py
+++ b/src/all2md/options/markdown.py
@@ -190,10 +190,12 @@ class MarkdownRendererOptions(BaseRendererOptions):
         Characters to cycle through for nested bullet lists.
     list_indent_width : int, default 4
         Number of spaces to use for each level of list indentation.
-    underline_mode : {"html", "markdown", "ignore"}, default "html"
-        How to handle underlined text:
-        - "html": Use <u>text</u> tags
-        - "markdown": Use __text__ (non-standard)
+    underline_mode : {"html", "markdown", "ignore"}, default "markdown"
+        Fallback for flavors that don't natively support underline. Flavors that
+        do (markdown_plus) always emit ``^^text^^``; for the rest:
+        - "markdown": Use ^^text^^ (the pymdownx "insert" spelling; roundtrips, but
+          needs an extension to render)
+        - "html": Use <u>text</u> tags (wider display support, but escaped on roundtrip)
         - "ignore": Strip underline formatting
     superscript_mode : {"html", "markdown", "ignore"}, default "markdown"
         Fallback for flavors that don't natively support superscript. Flavors

--- a/src/all2md/renderers/markdown.py
+++ b/src/all2md/renderers/markdown.py
@@ -1478,17 +1478,21 @@ class MarkdownRenderer(NodeVisitor, InlineContentMixin, BaseRenderer):
         content = self._render_inline_content(node.content)
         if self._flavor.supports_strikethrough():
             self._output.append(f"~~{content}~~")
-        else:
-            mode = self.options.unsupported_inline_mode
-            if mode == "plain":
-                # Strip formatting, render content only
-                self._output.append(content)
-            elif mode == "force":
-                # Use markdown syntax anyway
-                self._output.append(f"~~{content}~~")
-            else:  # mode == "html"
-                # Use HTML tags
-                self._output.append(f"<del>{content}</del>")
+            return
+
+        # Smart fallback: an unset "html" default becomes "force" so a flavor
+        # without ~~ still emits ~~text~~ (which the parser reads back) instead of
+        # a raw <del> that the default html_passthrough policy escapes on the next
+        # pass. Mirrors visit_mark.
+        mode = self.options.unsupported_inline_mode
+        if mode == "html" and not self.options._unsupported_inline_mode_was_explicit:
+            mode = "force"
+        if mode == "plain":
+            self._output.append(content)
+        elif mode == "html":
+            self._output.append(f"<del>{content}</del>")
+        else:  # "force" (also the resolved default)
+            self._output.append(f"~~{content}~~")
 
     def visit_mark(self, node: Mark) -> None:
         """Render a Mark (highlight) node.
@@ -1532,12 +1536,22 @@ class MarkdownRenderer(NodeVisitor, InlineContentMixin, BaseRenderer):
 
         """
         content = self._render_inline_content(node.content)
-        mode = self.options.underline_mode
 
+        # A flavor that natively supports ^^text^^ (MarkdownPlus) emits it directly,
+        # like visit_superscript does for ^. Other flavors fall back per
+        # underline_mode (default "markdown", which roundtrips through the insert
+        # plugin; set "html" for wider display). Note "markdown" emits ^^ -- the
+        # pymdownx "insert" spelling the parser reads back as Underline -- not __,
+        # which every flavor parses as strong emphasis, silently losing the underline.
+        if self._flavor.supports_underline():
+            self._output.append(f"^^{content}^^")
+            return
+
+        mode = self.options.underline_mode
         if mode == "html":
             self._output.append(f"<u>{content}</u>")
         elif mode == "markdown":
-            self._output.append(f"__{content}__")
+            self._output.append(f"^^{content}^^")
         else:
             self._output.append(content)
 

--- a/src/all2md/utils/flavors.py
+++ b/src/all2md/utils/flavors.py
@@ -170,6 +170,21 @@ class MarkdownFlavor(ABC):
         """
         return False
 
+    def supports_underline(self) -> bool:
+        """Check if this flavor natively supports ``^^text^^`` underline syntax.
+
+        Concrete (default ``False``) rather than abstract: underline is the
+        pymdownx / Material "insert" extension, natively supported only by the
+        MarkdownPlus flavor. Other flavors fall back per ``underline_mode``.
+
+        Returns
+        -------
+        bool
+            True if ``^^text^^`` underline syntax is supported
+
+        """
+        return False
+
     @abstractmethod
     def supports_admonitions(self) -> bool:
         """Check if this flavor supports Material for MkDocs admonitions.
@@ -964,6 +979,17 @@ class MarkdownPlusFlavor(MarkdownFlavor):
 
     def supports_subscript(self) -> bool:
         """MarkdownPlus supports ``~text~`` subscript syntax.
+
+        Returns
+        -------
+        bool
+            True
+
+        """
+        return True
+
+    def supports_underline(self) -> bool:
+        """MarkdownPlus supports ``^^text^^`` underline syntax.
 
         Returns
         -------

--- a/tests/golden/__snapshots__/test_docx_golden.ambr
+++ b/tests/golden/__snapshots__/test_docx_golden.ambr
@@ -3,7 +3,7 @@
   '''
   # Formatting Test Document
   
-  This paragraph contains **bold text**, *italic text*, and <u>underlined text</u>.
+  This paragraph contains **bold text**, *italic text*, and ^^underlined text^^.
   
   This paragraph has ***bold and italic text*** together.
   
@@ -24,7 +24,7 @@
   '''
   # Formatting Test Document
   
-  This paragraph contains **bold text**, *italic text*, and <u>underlined text</u>.
+  This paragraph contains **bold text**, *italic text*, and ^^underlined text^^.
   
   This paragraph has ***bold and italic text*** together.
   
@@ -45,7 +45,7 @@
   '''
   # Formatting Test Document
   
-  This paragraph contains **bold text**, *italic text*, and <u>underlined text</u>.
+  This paragraph contains **bold text**, *italic text*, and ^^underlined text^^.
   
   This paragraph has ***bold and italic text*** together.
   
@@ -66,7 +66,7 @@
   '''
   # Formatting Test Document
   
-  This paragraph contains **bold text**, *italic text*, and <u>underlined text</u>.
+  This paragraph contains **bold text**, *italic text*, and ^^underlined text^^.
   
   This paragraph has ***bold and italic text*** together.
   
@@ -145,7 +145,7 @@
   
   Second paragraph with **bold** text and *italic* text and ***both***
   
-  Here’s some <u>underlined text</u>.
+  Here’s some ^^underlined text^^.
   
   Here we want a longer paragraph that can span a few lines in a document. It should be like 3 or 4 sentences, which is the normal length of a paragraph. We can even include some **formatting** for emphasis. It’s getting pretty long now, I think we’re almost done.
   

--- a/tests/golden/__snapshots__/test_other_formats_golden.ambr
+++ b/tests/golden/__snapshots__/test_other_formats_golden.ambr
@@ -130,7 +130,7 @@
   
   ## Second content slide
   
-  This one has**formatting**that is<u>fancier</u>*sometimes*even***too fancy***
+  This one has**formatting**that is^^fancier^^*sometimes*even***too fancy***
   
   * And we’ll do a nested list
   * Here’s the first nested item

--- a/tests/unit/renderers/test_markdown_renderer.py
+++ b/tests/unit/renderers/test_markdown_renderer.py
@@ -275,21 +275,54 @@ class TestExtendedInlineFormatting:
         result = renderer.render_to_string(doc)
         assert result == "~~deleted~~"
 
-    def test_strikethrough_commonmark(self):
-        """Test strikethrough fallback with CommonMark."""
+    def test_strikethrough_commonmark_default_roundtrips(self):
+        """On a flavor without ~~, the unset default emits ~~ (not <del>).
+
+        A raw <del> is escaped by the default html_passthrough policy on the next
+        Markdown pass, so the roundtrip-safe force spelling is the default. Mirrors
+        the mark fallback.
+        """
         doc = Document(children=[Paragraph(content=[Strikethrough(content=[Text(content="deleted")])])])
         options = MarkdownRendererOptions(flavor="commonmark")
         renderer = MarkdownRenderer(options)
         result = renderer.render_to_string(doc)
+        assert result == "~~deleted~~"
+
+    def test_strikethrough_commonmark_explicit_html(self):
+        """An explicit unsupported_inline_mode='html' still opts into <del>."""
+        doc = Document(children=[Paragraph(content=[Strikethrough(content=[Text(content="deleted")])])])
+        options = MarkdownRendererOptions(flavor="commonmark", unsupported_inline_mode="html")
+        renderer = MarkdownRenderer(options)
+        result = renderer.render_to_string(doc)
         assert result == "<del>deleted</del>"
 
+    def test_underline_default_roundtrips(self):
+        """The default underline_mode emits ^^ (roundtrips via the insert plugin).
+
+        A raw <u> is escaped by the default html_passthrough policy on the next
+        Markdown pass; ^^text^^ is read back as an Underline. __text__ is *not* a
+        safe alternative -- every flavor parses it as strong emphasis.
+        """
+        doc = Document(children=[Paragraph(content=[Underline(content=[Text(content="underlined")])])])
+        renderer = MarkdownRenderer()
+        result = renderer.render_to_string(doc)
+        assert result == "^^underlined^^"
+
     def test_underline_html_mode(self):
-        """Test underline with HTML mode."""
+        """An explicit underline_mode='html' opts into <u>."""
         doc = Document(children=[Paragraph(content=[Underline(content=[Text(content="underlined")])])])
         options = MarkdownRendererOptions(underline_mode="html")
         renderer = MarkdownRenderer(options)
         result = renderer.render_to_string(doc)
         assert result == "<u>underlined</u>"
+
+    def test_underline_markdown_plus_flavor_is_native(self):
+        """MarkdownPlus supports ^^ natively, so it wins even over underline_mode='html'."""
+        doc = Document(children=[Paragraph(content=[Underline(content=[Text(content="underlined")])])])
+        options = MarkdownRendererOptions(flavor="markdown_plus", underline_mode="html")
+        renderer = MarkdownRenderer(options)
+        result = renderer.render_to_string(doc)
+        assert result == "^^underlined^^"
 
     def test_superscript_html_mode(self):
         """Test superscript with HTML mode."""


### PR DESCRIPTION
## Problem

`underline_mode` defaulted to `"html"`, so an Underline rendered `<u>text</u>`. The default `html_passthrough` policy escapes that to `&lt;u&gt;text&lt;/u&gt;` on the next Markdown pass, so `^^text^^` did not survive a roundtrip — the same self-escape data-corruption bug fixed for footnotes/marks/superscript/subscript in #94/#95/#97. Underline was the sibling left behind. The `insert` (`^^`) plugin is on by default, so this hits default parses.

Separately, the `"markdown"` underline branch emitted `__text__`, which **every** flavor parses as strong emphasis — silently turning underline into bold on roundtrip.

`visit_strikethrough` had the same asymmetry on a narrower trigger: on a flavor without `~~` (e.g. CommonMark) it emitted a `<del>` that gets escaped the same way.

## Fix

- Default `underline_mode` to `"markdown"`, emitting `^^text^^` (the pymdownx "insert" spelling the parser reads back as Underline). Fix the `"markdown"` branch to emit `^^`, not `__`.
- New `supports_underline()` flavor capability (MarkdownPlus native, others fall back per mode), making `visit_underline` flavor-aware exactly like `visit_superscript`.
- Apply the mark smart-fallback to `visit_strikethrough`: an unset `unsupported_inline_mode` default now forces `~~` instead of `<del>`.
- Explicit `underline_mode="html"` / `unsupported_inline_mode="html"` still opt into `<u>` / `<del>`.

Verified idempotent under default GFM (underline) and CommonMark (strikethrough); explicit-html opt-in preserved. New tests lock in the default, the flavor-native path, and the html opt-in.

Part of the post-1.8.0 review cleanup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)