### PR TITLE
fix(pdf): preserve prose from every rejected table, not just degenerate grids

### DIFF
--- a/src/all2md/parsers/pdf.py
+++ b/src/all2md/parsers/pdf.py
@@ -2605,7 +2605,7 @@ class PdfToAstConverter(BaseParser):
                     f"Rejecting pymupdf table on page {page_num + 1}: {n_rows}x{n_cols} grid exceeds size caps"
                 )
                 self._record_table_rejection("oversized_grid")
-                return None
+                return self._region_text_as_paragraph(page, fitz.Rect(table.bbox), page_num)
             n_empty = sum(1 for r in table_data for c in r if c is None or not str(c).strip())
             if n_empty / n_cells > MAX_TABLE_EMPTY_RATIO:
                 logger.debug(
@@ -2613,7 +2613,7 @@ class PdfToAstConverter(BaseParser):
                     f"{n_empty}/{n_cells} ({n_empty / n_cells:.0%}) cells empty"
                 )
                 self._record_table_rejection("mostly_empty")
-                return None
+                return self._region_text_as_paragraph(page, fitz.Rect(table.bbox), page_num)
             unique_texts = {str(c).strip() for r in table_data for c in r if c is not None and str(c).strip()}
             n_filled = n_cells - n_empty
             if len(unique_texts) == 1 and n_filled >= MIN_FILLED_FOR_UNIFORMITY_CHECK:
@@ -2622,7 +2622,7 @@ class PdfToAstConverter(BaseParser):
                     f"all {n_filled} non-empty cells have identical content"
                 )
                 self._record_table_rejection("uniform_cells")
-                return None
+                return self._region_text_as_paragraph(page, fitz.Rect(table.bbox), page_num)
             n_dot_leader = sum(1 for r in table_data for c in r if c is not None and is_dot_leader_cell(str(c)))
             if n_filled and n_dot_leader / n_filled > MAX_DOT_LEADER_CELL_RATIO:
                 logger.debug(
@@ -2631,7 +2631,7 @@ class PdfToAstConverter(BaseParser):
                     f"dot-leader noise (looks like TOC region)"
                 )
                 self._record_table_rejection("dot_leader_toc")
-                return None
+                return self._region_text_as_paragraph(page, fitz.Rect(table.bbox), page_num)
 
             # Separate header row (first row) from data rows
             header_row_data = table_data[0] if table_data else []

--- a/tests/unit/formats/pdf/test_pdf_table_guards.py
+++ b/tests/unit/formats/pdf/test_pdf_table_guards.py
@@ -151,3 +151,43 @@ def test_empty_region_yields_nothing(converter):
     node = converter._process_table_to_ast(_FakeTable(SINGLE_ROW, (0, 0, 100, 50)), page, page_num=0)
 
     assert node is None
+
+
+# Grids that each trip a *different* rejection branch. #77 demoted only the
+# degenerate-grid branch to prose; these four still returned None, silently
+# deleting a sparse-but-real table (a financial statement or form crosses the
+# 70%-empty bar), a TOC region, or an oversized grid. Each grid is built to fire
+# exactly one branch given the _pdf_tables thresholds (MIN 2x2, MAX 25 cols /
+# 200 rows, empty > 0.70, uniform >= 5 filled, dot-leader > 0.30).
+OVERSIZED_GRID = [[f"h{i}" for i in range(26)], [f"v{i}" for i in range(26)]]
+MOSTLY_EMPTY_GRID = [["a", "b", ""], ["", "", ""], ["", "", ""]]
+UNIFORM_GRID = [["X", "X"], ["X", "X"], ["X", "X"]]
+DOT_LEADER_GRID = [["Introduction", ".........."], ["Methods", ".........."]]
+
+
+@pytest.mark.parametrize(
+    ("grid", "rejection"),
+    [
+        pytest.param(OVERSIZED_GRID, "oversized_grid", id="oversized"),
+        pytest.param(MOSTLY_EMPTY_GRID, "mostly_empty", id="mostly-empty"),
+        pytest.param(UNIFORM_GRID, "uniform_cells", id="uniform"),
+        pytest.param(DOT_LEADER_GRID, "dot_leader_toc", id="dot-leader-toc"),
+    ],
+)
+def test_every_rejection_branch_demotes_to_prose(converter, grid, rejection):
+    """Every table-rejection branch must preserve the region's text, never delete it.
+
+    The text inside a rejected table's bbox is already gone from the ordinary text
+    blocks, so a ``return None`` drops it on the floor. Only the degenerate-grid
+    branch was fixed for that; the rest are pinned here.
+    """
+    region_text = "alpha beta gamma delta"
+    page = _FakePage(region_text)
+    node = converter._process_table_to_ast(_FakeTable(grid, (0, 0, 100, 50)), page, page_num=0)
+
+    assert not isinstance(node, AstTable), f"a {rejection} detection is not a real table"
+    assert isinstance(node, AstParagraph), f"{rejection} must demote to prose, not delete (returned {node!r})"
+    recovered = _text_of(node).split()
+    for word in region_text.split():
+        assert word in recovered, f"rejecting the {rejection} region lost the word {word!r}"
+    assert converter._tables_rejected == 1, f"{rejection} demotion must be recorded for the quality card"


### PR DESCRIPTION
## Problem

Text inside a detected table's bbox is stripped from the ordinary text blocks **before** the table is validated, so a rejection path that `return None` deletes that text instead of demoting it to prose. #77 fixed this for the `degenerate_grid` branch but left four siblings returning `None`:

- `oversized_grid` (grid exceeds size caps)
- `mostly_empty` (>70% empty cells)
- `uniform_cells` (all non-empty cells identical)
- `dot_leader_toc` (TOC dot-leader region)

A sparse-but-real table — a financial statement or form that crosses the 70%-empty bar — or a TOC region was therefore silently dropped from the output.

## Fix

Route all four branches through `_region_text_as_paragraph(page, fitz.Rect(table.bbox), page_num)`, exactly like `degenerate_grid`. The rejection is still recorded for the quality card.

Adds a parametrized guard test that trips each of the four branches (built against the `_pdf_tables` thresholds) and asserts the region's words survive. Confirmed to fail against the old `return None`.

Part of the post-1.8.0 review cleanup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)