### PR TITLE
fix(docx): clamp title-promotion inversion at heading level 6

### DIFF
--- a/src/all2md/parsers/docx.py
+++ b/src/all2md/parsers/docx.py
@@ -510,7 +510,12 @@ class DocxToAstConverter(BaseParser):
 
         for child in children[title_index + 1 :]:
             if isinstance(child, Heading):
-                child.level += 1
+                # Clamp at 6: Heading enforces a 1-6 level, so an H6 here would
+                # otherwise be mutated to an out-of-spec level 7 (the Markdown
+                # renderer hides it, but serialization and the round-trip scorer
+                # see the invalid node). Mirrors the forward transform's max(1, ..)
+                # bottom clamp. An H6 simply stays an H6 -- there is no level above it.
+                child.level = min(6, child.level + 1)
 
     # DrawingML ``graphicData/@uri`` values for content types all2md does not
     # render (and therefore drops): embedded charts and SmartArt diagrams.

--- a/tests/unit/parsers/test_docx_parser.py
+++ b/tests/unit/parsers/test_docx_parser.py
@@ -978,6 +978,23 @@ class TestTitleRoundTrip:
         assert [h.level for h in headings] == [1, 2, 3]
         assert headings[0].metadata.get("is_title") is True
 
+    def test_demotion_after_title_is_clamped_at_level_6(self) -> None:
+        """An H6 after a title must stay an H6, not become an out-of-spec level 7.
+
+        ``Heading`` enforces a 1-6 level; the demotion mutates ``.level`` directly,
+        which would otherwise leave an invalid node that serialization and the
+        round-trip scorer see even though the Markdown renderer hides it.
+        """
+        doc = docx.Document()
+        doc.add_paragraph("My Title", style="Title")
+        doc.add_heading("Deep", level=6)
+
+        ast_doc = DocxToAstConverter().convert_to_ast(doc)
+        headings = [c for c in ast_doc.children if isinstance(c, Heading)]
+
+        assert [h.level for h in headings] == [1, 6]
+        assert all(1 <= h.level <= 6 for h in headings), "demotion produced an out-of-range heading level"
+
     def test_non_leading_title_does_not_shift_headings(self) -> None:
         """A title that is not the first content leaves following headings untouched."""
         doc = docx.Document()


### PR DESCRIPTION
## Problem

`_invert_title_promotion` demotes every heading after a leading title with `child.level += 1` and no upper bound. `Heading` enforces a 1–6 level in `__post_init__`, but the demotion mutates `.level` directly, so an H6 is pushed to an out-of-spec **level 7**. The Markdown renderer clamps it on output, but serialization (AST-JSON) and the round-trip scorer see the invalid node.

## Fix

Clamp with `min(6, level + 1)`, mirroring the forward `TitlePromotionTransform`'s `max(1, level - 1)` bottom clamp. Since `Heading` guarantees levels ≤ 6, there is no legitimate level above 6 to preserve — an H6 simply stays an H6.

Adds a regression test (Title + Heading 6 → levels `[1, 6]`, all in range), confirmed to fail (`[1, 7]`) against the old code.

Note: this PR intentionally does **not** change the inversion's firing rule (it still fires whenever a Title-styled paragraph leads, which can shift a hand-authored Word doc's outline). Distinguishing all2md-authored docs from human ones would need a persisted marker in the rendered docx — a larger, output-format-changing change left for separate consideration.

Addresses I6 from the post-1.8.0 review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)