### PR TITLE
fix(confidence): band uninstrumented conversions "not_assessed", not "high"

### DIFF
--- a/src/all2md/api.py
+++ b/src/all2md/api.py
@@ -959,8 +959,10 @@ def confidence_report(
     Returns
     -------
     ConfidenceReport
-        The scored quality card. Formats that produce no signals and record no
-        degraded events yield a perfect ``score`` of 100 (band ``"high"``).
+        The scored quality card. Formats that produce no scored signals and record
+        no degraded events yield a ``score`` of 100 banded ``"not_assessed"`` --
+        the converter ran no quality checks, so the 100 is not a clean bill of
+        health.
 
     Examples
     --------
@@ -986,8 +988,10 @@ def confidence_report(
     raw = ast_doc.metadata.get("confidence") if ast_doc.metadata else None
     if isinstance(raw, dict):
         return ConfidenceReport.from_dict(raw)
-    # No report attached (e.g. a hand-built Document): report a clean card.
-    return ConfidenceReport(score=100, band="high", producer="", signals={}, degraded_events=[])
+    # No report attached (e.g. a hand-built Document, or a format with no quality
+    # instrumentation): the conversion was never assessed, so band it as such
+    # rather than implying a verified-clean 100.
+    return ConfidenceReport(score=100, band="not_assessed", producer="", signals={}, degraded_events=[])
 
 
 def roundtrippable_formats() -> list[str]:

--- a/src/all2md/confidence.py
+++ b/src/all2md/confidence.py
@@ -35,7 +35,10 @@ from dataclasses import dataclass, field
 from typing import Any, Literal
 
 Severity = Literal["info", "warn", "error"]
-Band = Literal["high", "medium", "low"]
+#: ``"not_assessed"`` is distinct from ``"high"``: it means the converter ran no
+#: quality instrumentation at all (no scored signals, no degraded events), so the
+#: vacuous 100 must not be read as "verified clean". See :func:`score_conversion`.
+Band = Literal["high", "medium", "low", "not_assessed"]
 
 # --- Scoring model -----------------------------------------------------------
 #
@@ -44,6 +47,11 @@ Band = Literal["high", "medium", "low"]
 # module constants so the ``optimize`` capstone (and tests) can reason about —
 # and tune — them. The score is reference-free: it only inspects what the
 # converter itself observed, never a ground-truth original.
+#
+# A subtlety this creates: a converter that observed *nothing* (no scored signals,
+# no degraded events) also starts and stays at 100. That is not a clean bill of
+# health, it is the absence of a detector, so such a report is banded
+# ``"not_assessed"`` rather than ``"high"`` — see ``score_conversion``.
 
 #: Points a fully text-empty page-image document can lose to the text-density
 #: penalty. Recovering that text (e.g. by enabling OCR) claws these points back,
@@ -72,6 +80,13 @@ DEGRADED_EVENT_PENALTY_CAP = 45.0
 BAND_HIGH_THRESHOLD = 80
 #: Score at or above which confidence is reported as ``"medium"`` (below is ``"low"``).
 BAND_MEDIUM_THRESHOLD = 50
+
+#: Signal keys that actually feed the score: the text-density and OCR-reliance
+#: penalties read exactly these. A report carrying none of them *and* no degraded
+#: events was never quality-assessed -- its 100 is the absence of a detector, not
+#: a clean bill of health -- so it is banded ``"not_assessed"``. Keep this in sync
+#: with the signals :func:`_text_density_penalty` / :func:`_ocr_reliance_penalty` read.
+SCORED_SIGNAL_KEYS: tuple[str, ...] = ("chars_per_page", "ocr_page_fraction")
 
 
 @dataclass
@@ -238,12 +253,29 @@ def _degraded_event_penalty(events: list[DegradedEvent]) -> float:
 
 
 def band_for_score(score: int) -> Band:
-    """Bucket a ``0-100`` score into ``"high"`` / ``"medium"`` / ``"low"``."""
+    """Bucket a ``0-100`` score into ``"high"`` / ``"medium"`` / ``"low"``.
+
+    Never returns ``"not_assessed"``: that band depends on *what evidence exists*,
+    not on the score, so it is decided in :func:`score_conversion`.
+    """
     if score >= BAND_HIGH_THRESHOLD:
         return "high"
     if score >= BAND_MEDIUM_THRESHOLD:
         return "medium"
     return "low"
+
+
+def _has_quality_evidence(signals: dict[str, Any], events: list[DegradedEvent]) -> bool:
+    """Whether a report carries any input the score can actually assess.
+
+    True when there is at least one degraded event or one scored signal
+    (:data:`SCORED_SIGNAL_KEYS`). Non-scored signals (bare counts) do not count:
+    they do not move the score, so a report carrying only those is still a
+    vacuous 100.
+    """
+    if events:
+        return True
+    return any(signals.get(key) is not None for key in SCORED_SIGNAL_KEYS)
 
 
 def score_conversion(signals: dict[str, Any], events: list[DegradedEvent]) -> tuple[int, Band]:
@@ -252,6 +284,12 @@ def score_conversion(signals: dict[str, Any], events: list[DegradedEvent]) -> tu
     Reference-free: the score starts at ``100`` and subtracts a text-density
     penalty, an OCR-reliance penalty, and a (capped) degraded-event penalty. The
     result is clamped to ``[0, 100]``.
+
+    A conversion that produced no scored signals and no degraded events is banded
+    ``"not_assessed"`` rather than ``"high"``. Formats without quality
+    instrumentation (docx, pptx, html) hit this path: their score is a vacuous
+    100 that means "no detector ran", not "verified clean", and conflating the two
+    would let a mangled ``.docx`` report ``100/HIGH``.
 
     Parameters
     ----------
@@ -268,6 +306,8 @@ def score_conversion(signals: dict[str, Any], events: list[DegradedEvent]) -> tu
     """
     penalty = _text_density_penalty(signals) + _ocr_reliance_penalty(signals) + _degraded_event_penalty(events)
     score = int(round(max(0.0, min(100.0, 100.0 - penalty))))
+    if not _has_quality_evidence(signals, events):
+        return score, "not_assessed"
     return score, band_for_score(score)
 
 

--- a/tests/integration/test_confidence_report.py
+++ b/tests/integration/test_confidence_report.py
@@ -62,11 +62,17 @@ class TestPdfProducer:
 @pytest.mark.integration
 @pytest.mark.docx
 class TestDocxProducer:
-    def test_clean_docx_scores_high(self):
+    def test_clean_docx_is_not_assessed(self):
+        """Docx emits no scored signals, so a clean file is 100/not_assessed.
+
+        The 100 means "no quality detector ran", not "verified clean" -- banding
+        it ``"not_assessed"`` keeps a mangled .docx from reading as 100/HIGH.
+        """
         report = confidence_report(str(BASIC_DOCX))
         assert report.producer == "docx"
         assert report.score == 100
         assert not report.degraded_events
+        assert report.band == "not_assessed"
 
     def test_dropped_chart_is_surfaced_and_penalized(self):
         # complex.docx embeds a chart, which all2md has no Markdown form for.
@@ -99,10 +105,12 @@ class TestConfidenceApi:
         payload = json.loads(ast_to_json(doc))
         assert "confidence" in payload["metadata"]
 
-    def test_handbuilt_document_reports_clean(self):
+    def test_handbuilt_document_is_not_assessed(self):
+        # A Document with no attached confidence metadata was never assessed;
+        # the card must say so rather than implying a verified-clean 100.
         report = confidence_report(Document(children=[]))
         assert report.score == 100
-        assert report.band == "high"
+        assert report.band == "not_assessed"
         assert report.degraded_events == []
 
 

--- a/tests/unit/test_confidence.py
+++ b/tests/unit/test_confidence.py
@@ -31,8 +31,29 @@ class TestBands:
 
 
 class TestScoreConversion:
-    def test_no_signals_no_events_is_perfect(self):
-        assert score_conversion({}, []) == (100, "high")
+    def test_no_signals_no_events_is_not_assessed(self):
+        """A conversion with no scored signals and no events was never assessed.
+
+        The score is a vacuous 100 (nothing to subtract), which must band as
+        ``"not_assessed"`` -- "no detector ran" -- not ``"high"`` / verified clean.
+        This is the docx/pptx/html case.
+        """
+        assert score_conversion({}, []) == (100, "not_assessed")
+
+    def test_non_scored_signals_alone_are_not_assessed(self):
+        """Bare counts alone are not quality assessment.
+
+        They do not move the score, so a report carrying only them is still a
+        vacuous 100 and must band ``"not_assessed"``.
+        """
+        score, band = score_conversion({"tables": 4, "images": 2}, [])
+        assert (score, band) == (100, "not_assessed")
+
+    def test_a_single_event_makes_it_assessed(self):
+        """One degraded event is enough instrumentation to earn a real band."""
+        score, band = score_conversion({}, [DegradedEvent(parser="docx", kind="x", severity="warn")])
+        assert band == "high"
+        assert score < 100
 
     def test_healthy_pdf_signals_stay_perfect(self):
         signals = {"chars_per_page": 800.0, "ocr_page_fraction": 0.0, "tables_rejected": 0}


### PR DESCRIPTION
## Problem

The confidence score starts at 100 and only subtracts on observed evidence. A format with no quality instrumentation — docx, pptx, html — emits no scored signals and no degraded events, so it scores a **vacuous 100/HIGH**. A completely mangled `.docx` reports `100/100 (HIGH)`, conflating "no detector ran" with "verified clean". `confidence_report`'s no-report fallback hard-coded `band="high"` for the same non-reason.

## Fix

Add a fourth band, **`not_assessed`**. A report with no scored signal (`SCORED_SIGNAL_KEYS = chars_per_page, ocr_page_fraction`) and no degraded event is banded `not_assessed` instead of `high`.

- The decision lives in `score_conversion` (it depends on *what evidence exists*, not the score); `band_for_score` still only returns high/medium/low.
- The numeric **score is unchanged** (still 100), so `optimize`'s `100 − confidence.score` breakage penalty is unaffected.
- A clean PDF (emits `chars_per_page`) still bands `high`; a single degraded event is enough instrumentation to earn a real band.
- The CLI card renders `NOT_ASSESSED`; JSON carries `"not_assessed"`.

Tests updated: clean docx and hand-built doc now assert `not_assessed`; added coverage for count-only signals and the single-event case.

Implements the chosen approach for I5 from the post-1.8.0 review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)