### PR TITLE
docs: post-1.8.0 refresh (D1-D6)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -104,6 +104,53 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Markdown: footnotes round-trip as Markdown under the default flavor.** A footnote
+  reference and its definition rendered to raw HTML on the default flavor, which the
+  default `html_passthrough` policy then escaped on the next pass — so a footnote did
+  not survive a `markdown → markdown` round trip. Footnotes now render in Markdown
+  syntax by default and round-trip intact.
+- **Markdown: inline marks, superscript and subscript are flavor-aware and round-trip
+  by default.** Highlight (`==text==`), superscript (`^text^`) and subscript (`~text~`)
+  defaulted to HTML tags that the default passthrough policy escaped on reparse. They
+  now default to the roundtrip-safe Markdown spelling (flavors that support the syntax
+  natively emit it directly); set the corresponding `*_mode` option to `html` for
+  wider display support.
+- **Markdown: underline (`^^text^^`) and non-GFM strikethrough round-trip instead of
+  self-escaping.** Underline rendered `<u>…</u>` by default and the `<del>` fallback
+  for flavors without `~~` did the same, both of which the default passthrough policy
+  escaped to `&lt;u&gt;…` on the next pass. Underline now defaults to the pymdownx
+  `^^text^^` insert spelling (the old `"markdown"` mode emitted `__…__`, which every
+  flavor parses as **bold**, silently losing the underline); strikethrough on a flavor
+  without `~~` now emits `~~` by default. Explicit `html` still opts into the tags.
+- **Markdown: inline `$$…$$` display math is kept, not dropped.** An inline `$$…$$`
+  span was silently discarded instead of being preserved as display math.
+- **Markdown: a list survives an admonition that degrades to a labelled quote.** When
+  an admonition inside a list item degraded to a labelled block quote, the surrounding
+  list was broken apart; it now stays intact.
+- **PDF: prose from *every* rejected table is preserved, not just degenerate grids.**
+  Text inside a detected table's bbox is stripped from the ordinary text stream before
+  the table is validated, so a rejection path that returned `None` deleted that text.
+  A prior fix covered only degenerate (1×N / N×1) grids; the oversized-grid,
+  mostly-empty, uniform-cell and dot-leader-TOC rejections still dropped a
+  sparse-but-real table (a financial statement, a form) or a table of contents. All
+  four now demote the region to a paragraph.
+- **Round-trip scoring counts code, math and raw-HTML block content.** `CodeBlock`,
+  `MathBlock`, `HTMLBlock` and their inline siblings keep their payload in a plain
+  string with no `Text` children, so the text dimension never compared it — a round
+  trip that dropped or mangled an entire code block scored a false `100`. Their content
+  (and image alt text) is now part of the comparison.
+- **Confidence: conversions with no quality instrumentation report `not_assessed`,
+  not a false `high`.** Formats that emit no scored signals and no degraded events
+  (docx, pptx, html) scored a vacuous `100/HIGH`, so a mangled `.docx` read as verified
+  clean. Such a report is now banded `not_assessed`; the numeric score is unchanged.
+- **DOCX: title-promotion inversion clamps heading levels at 6.** Demoting the headings
+  after a leading title used an unbounded `level += 1`, pushing an H6 to an out-of-spec
+  level 7 that serialization and the round-trip scorer saw. It is now clamped, mirroring
+  the forward transform's bottom clamp.
+- **`all2md optimize` searches only valid `figures_parsing` / `details_parsing` values.**
+  The HTML search space listed values (`figure`, `image`, `details`, `content`) that no
+  parser accepts; they were silently no-ops and could be written into a recommended
+  `.all2md.toml`. Replaced with valid choices, guarded by a test.
 - **Markdown: multi-paragraph and multi-line list items round-trip without collapsing.**
   Three problems in the same surface conspired to flatten lists on a Markdown round trip:
 

--- a/README.md
+++ b/README.md
@@ -82,6 +82,19 @@ all2md search "project timeline" --semantic ./docs/
 # Chunk documents for RAG/LLM pipelines (JSONL with section + page provenance)
 all2md chunk report.pdf --strategy semantic --max-tokens 512 --overlap 64
 
+# Score how much to trust a conversion (reference-free "quality card")
+all2md report scan.pdf
+all2md report inbox/*.docx --fail-under 80   # CI gate
+
+# Measure round-trip fidelity: convert -> parse back -> score what survived
+all2md roundtrip notes.md --via docx
+
+# Auto-tune converter settings for a difficult document (headline: gnarly PDFs)
+all2md optimize scanned.pdf --sample-pages 5
+
+# Speed up repeat runs on unchanged files with the opt-in on-disk cache
+all2md optimize scanned.pdf --cache        # also: export ALL2MD_CACHE=1
+
 # Pipe and chain commands with stdin/stdout support (use '-' for stdin)
 curl https://example.com/doc.pdf | all2md - | grep "important"
 cat report.html | all2md - --format html --rich
@@ -185,8 +198,17 @@ Beyond basic conversion, the CLI includes advanced features for production workf
 - **Config Management** - Generate, validate, and manage conversion configs
 - **Format Discovery** - `all2md list-formats` shows all supported formats and dependencies
 - **Agent-Friendly** - Clean, intuitive interface that AI agents can use directly, plus pre-built agent skills installable via `all2md install-skills`
+- **Conversion Cache** - Opt-in on-disk cache (`--cache`, or `ALL2MD_CACHE=1`) reuses parsed documents across runs of `grep`, `search`, `chunk`, `view`, `report`, `roundtrip`, and `optimize`
 
-### 4. AI-Native Integration
+### 4. Conversion Quality & Tuning
+
+Know how good a conversion is — and make it better — without a ground-truth reference:
+
+- **`all2md report`** — a reference-free confidence "quality card" for any document, built from the sanity signals the parsers already compute (text density, table cell-fill/dot-leader ratios, OCR reliance, dropped-content events). Also rides on `Document.metadata['confidence']`. Use `--fail-under` as a CI gate.
+- **`all2md roundtrip`** — round-trip fidelity scoring: convert a document to another format, parse it straight back, and score the structure that survived (`0-100` plus per-dimension metrics and itemized differences). A lossless round trip scores exactly `100`.
+- **`all2md optimize`** — auto-tune converter settings for a difficult document (headline case: gnarly PDFs) against a reference-free objective, emitted as a runnable command and a `.all2md.toml` snippet.
+
+### 5. AI-Native Integration
 
 **RAG-Native Chunking** — Split any document into chunks ready for retrieval-augmented generation, with provenance most chunkers throw away.
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -11,8 +11,8 @@ Legend: 🌱 natural next step · 🚀 ambitious · 🌙 moonshot · ✅ foundat
 > strategies, `all2md.chunk()` Python API, `[chunk]` extra) — plus mermaid/syntax-
 > highlighting in `view`/`serve` and one-click `uv` install scripts. The **Fidelity &
 > Trust** batch has since landed the conversion cache, the confidence report
-> (`all2md report`), DOCX character-style round-tripping, and round-trip fidelity scoring
-> (`all2md roundtrip`), leaving the conversion optimizer unblocked as its capstone.
+> (`all2md report`), DOCX character-style round-tripping, round-trip fidelity scoring
+> (`all2md roundtrip`), and its capstone the conversion optimizer (`all2md optimize`).
 > Shipped items are marked 🚢 inline below; the license question that gated chunking is
 > resolved (chunkers vendored, optional extra). Tactical near-term work lives in `todo.md`,
 > which is developer-local (git-ignored) — anything that needs to outlive a working tree is
@@ -98,20 +98,24 @@ People star us because "it just converted my gnarly PDF perfectly." Protect and 
   character styles ("Quote Char", "Intense Reference") now ride on the inline node's
   `metadata['source_style']` and are re-applied when rendering to DOCX with a template,
   matching the paragraph-level behaviour (🚢 v1.1.1).
-- 🌱 **DOCX/HTML round-trip asymmetries** — *found by `all2md roundtrip`, unfixed.* Each is a
-  renderer/parser pair that does not invert:
+- 🚢 **DOCX/HTML round-trip asymmetries** — *found by `all2md roundtrip`, now fixed
+  (unreleased).* Each was a renderer/parser pair that did not invert:
   - [#70](https://github.com/thomas-villani/all2md/issues/70) — rendering to DOCX applies
     `TitlePromotionTransform` (leading H1 → Word "Title", every later heading shifted up
-    one), but the DOCX parser maps "Title" → `Paragraph`. So `md → docx → md` demotes the
-    title *and* shifts H2→H1.
-  - [#71](https://github.com/thomas-villani/all2md/issues/71) — the DOCX round trip drops
-    inline `Code`, and writes a `BlockQuote` as an indented `Normal` paragraph that the
-    parser reads back as a bullet list.
-  - [#72](https://github.com/thomas-villani/all2md/issues/72) — the HTML parser wraps `<li>`
-    content in a `Paragraph` unconditionally, so `<li><p>x</p></li>` parses to
-    `ListItem > Paragraph > Paragraph > Text`.
+    one), but the DOCX parser mapped "Title" → `Paragraph`, so `md → docx → md` demoted the
+    title *and* shifted H2→H1. The parser now maps "Title" back to a title heading and
+    inverts the promotion (clamped at level 6).
+  - [#71](https://github.com/thomas-villani/all2md/issues/71) — the DOCX round trip dropped
+    inline `Code`, and wrote a `BlockQuote` as an indented `Normal` paragraph that the
+    parser read back as a bullet list. Inline code now rides on a `Verbatim Char` style and
+    quotes on named quote styles.
+  - [#72](https://github.com/thomas-villani/all2md/issues/72) — the HTML parser wrapped `<li>`
+    content in a `Paragraph` unconditionally, so `<li><p>x</p></li>` parsed to
+    `ListItem > Paragraph > Paragraph > Text`; loose items no longer double-wrap.
 
-  Reproduce any of them with `all2md roundtrip <file> --via docx` (or `--via html`).
+  The round-trip scorer that surfaced these now also scores code/math/HTML block content,
+  so a regression in any of them shows up in `all2md roundtrip <file> --via docx` (or
+  `--via html`).
 - 🚀 **Layout-aware PDF reconstruction** — correct reading order across columns,
   footnote/endnote linking, running header/footer stripping, caption↔figure association.
   The eternal PDF pain points; we already have `_pdf_layout.py` to build on.
@@ -145,7 +149,8 @@ People star us because "it just converted my gnarly PDF perfectly." Protect and 
   computed as guards (table cell-fill density, dot-leader ratio, ghost-image counts,
   near-empty-page ratio) as a structured "quality card" instead of log noise. Reference-free,
   so it works on documents with no ground truth.
-- 🚀 **Conversion optimizer (`all2md optimize`)** — auto-tune converter settings for a
+- 🚢 **Conversion optimizer (`all2md optimize`)** — *shipped (unreleased; lands in v1.9.0).*
+  Auto-tune converter settings for a
   difficult document (headline case: gnarly PDFs). Searches the parameter space
   (`table_detection_mode`, `detect_columns`, OCR mode/engine, `min_image_dimension`,
   header/footer filtering, dehyphenation, layout model, heading size-ratio, …) and returns
@@ -155,8 +160,8 @@ People star us because "it just converted my gnarly PDF perfectly." Protect and 
     optimizer needs a **reference-free** quality score — exactly the vector the *confidence
     report* produces (real-word ratio, table sanity, ghost-image count, reading-order
     coherence, near-empty-page ratio, hyphenation-merge success). **Both halves of that
-    substrate now exist** (confidence 🚢, round-trip 🚢), so this is *unblocked* and is the
-    next item up. Use `confidence_report(...).score` where no reference can be manufactured
+    substrate exist** (confidence 🚢, round-trip 🚢), and the optimizer shipped on top of
+    them. Use `confidence_report(...).score` where no reference can be manufactured
     and `roundtrip_report(...).score` where one can; both respond to converter options — e.g.
     `html_passthrough_mode="pass-through"` moves `basic.md` from 98 to 100 — which is exactly
     what makes them hill-climbable.
@@ -324,24 +329,20 @@ shipped, along with mermaid rendering and `uv` install scripts.
 
 **Done in the Fidelity & Trust batch** (unreleased, lands in v1.9.0): ~~round-trip fidelity
 scoring~~ 🚢, ~~conversion confidence report~~ 🚢, ~~DOCX character-style round-trip~~ 🚢,
-~~search-index / conversion-cache correctness~~ 🚢. That closes the previous arc's top two
-entries and unblocks the batch capstone, which leads the revised arc below.
+~~search-index / conversion-cache correctness~~ 🚢, ~~conversion optimizer~~ 🚢 (the batch
+capstone), and ~~the DOCX/HTML round-trip asymmetries #70/#71/#72~~ 🚢 that the round-trip
+scorer surfaced. That closes the previous arc's top entries and the capstone both.
 
 Revised arc for the **next batch**, ordered by leverage-per-effort:
 
-1. **Conversion optimizer (`all2md optimize`)** — the capstone, now unblocked: both quality
-   scores it hill-climbs on exist and are exercised by tests. Start here.
-2. **Public fidelity benchmark** — round-trip scoring exists, so productize it: wire it into
+1. **Public fidelity benchmark** — round-trip scoring exists, so productize it: wire it into
    the `benchmarks/corpus/` harness for a corpus-wide report, then a head-to-head vs.
    markitdown / pandoc / docling.
-3. **DOCX/HTML round-trip asymmetries** — the concrete defects `all2md roundtrip` surfaced
-   on its first run (Theme 2). Small, well-specified, and each one raises the benchmark
-   number above.
-4. **Async facade + async I/O edge** — unblocks the server/MCP story (see the Async
+2. **Async facade + async I/O edge** — unblocks the server/MCP story (see the Async
    Architecture Decision); the deferred-asset-resolution phase is the user-visible win.
-5. **GitHub Action + Docker image** — adoption channels for a project gaining stars; Docker
+3. **GitHub Action + Docker image** — adoption channels for a project gaining stars; Docker
    is the shared building block for the Action and a future hosted API.
-6. **Math support** + **layout-aware PDF** — deepen the fidelity moat (larger efforts).
+4. **Math support** + **layout-aware PDF** — deepen the fidelity moat (larger efforts).
 
 Everything below 🚀/🌙 is opportunistic — pull forward whatever a real user asks for. The
 small `todo.md` bug-fixes (filename-hint detection, leading blank line in DOCX, smarter

--- a/docs/source/cli.rst
+++ b/docs/source/cli.rst
@@ -762,6 +762,74 @@ extra keyword arguments to the converter (e.g. ``attachment_mode="skip"``).
 For lower-level control over an AST you already hold, call
 ``all2md.chunking.chunk_ast(doc, strategy=..., max_tokens=...)`` directly.
 
+Report Command
+--------------
+
+``all2md report`` prints a conversion **confidence report** — a reference-free
+"quality card" for each document. Unlike ``roundtrip`` it needs no ground truth:
+it surfaces the sanity signals the parsers already compute (text density, table
+cell-fill and dot-leader ratios, OCR reliance, dropped-content events) as a
+structured score instead of log noise.
+
+.. code-block:: bash
+
+   # How much should I trust this conversion?
+   all2md report scan.pdf
+
+   # Gate a batch in CI: fail if any document scores below 80
+   all2md report inbox/*.docx --fail-under 80
+
+   # Machine-readable (an array when multiple inputs are given)
+   all2md report scan.pdf --json
+
+.. code-block:: text
+
+   $ all2md report scan.pdf
+   scan.pdf
+     confidence: 72/100  (MEDIUM)
+     producer:   pdf
+
+     signals
+       chars per page      41   warn
+       ocr page fraction   1
+       tables detected     3
+
+     degraded events
+       warn  table_rejected  (mostly_empty)
+
+The score starts at 100 and subtracts for observed evidence of lost or
+low-fidelity content, so it inspects only what the converter itself saw. A
+conversion that produced **no** quality instrumentation — no scored signals and
+no degraded events, as docx, pptx and html do today — is banded ``NOT_ASSESSED``
+rather than ``HIGH``: its 100 means "no detector ran", not "verified clean".
+
+Key Options
+~~~~~~~~~~~
+
+* ``--fail-under SCORE`` — exit non-zero if any document scores below ``SCORE``
+  (0-100). Useful as a CI gate.
+* ``--json`` — emit the report(s) as JSON (an array for multiple inputs).
+* ``--out, -o FILE`` — write to a file instead of stdout.
+* ``--attachment-mode {skip,alt_text,save,base64}`` — the report is unaffected by
+  the choice; use ``skip``/``alt_text`` to avoid decoding large embedded images.
+* ``--cache`` / ``--cache-dir DIR`` — reuse parsed documents from an on-disk cache
+  (see :ref:`conversion-cache`).
+
+Python API
+~~~~~~~~~~
+
+.. code-block:: python
+
+   from all2md import confidence_report
+
+   report = confidence_report("scan.pdf")
+   print(report.score, report.band)          # e.g. 72 medium
+   for event in report.degraded_events:
+       print(event.severity, event.kind, event.detail)
+
+The same card rides on ``Document.metadata['confidence']`` for every conversion,
+so you can read it off any ``to_ast`` result without a second pass.
+
 Roundtrip Command
 -----------------
 
@@ -943,6 +1011,37 @@ Python API
        print(candidate.fitness, candidate.origin, candidate.options)
 
    print(optimizable_formats())    # ['docx', 'html', 'pdf']
+
+.. _conversion-cache:
+
+Conversion Cache
+----------------
+
+Parsing is the expensive step, and several commands re-read the same files
+repeatedly — ``optimize`` reconverts a document dozens of times, and ``grep`` /
+``search`` / ``chunk`` re-parse an unchanged corpus on every run. An **opt-in**
+on-disk cache stores the parsed result keyed by the input's fingerprint and the
+conversion options, so a repeat run skips the re-parse entirely (a warm cache cut
+a 31-candidate ``optimize`` run from 18.5s to 0.3s).
+
+The cache is available on ``grep``, ``search``, ``chunk``, ``view``, ``report``,
+``roundtrip`` and ``optimize``:
+
+.. code-block:: bash
+
+   all2md optimize scanned.pdf --cache
+   all2md report inbox/*.docx --cache
+   all2md grep "revenue" reports/ --cache
+
+* ``--cache`` — enable the cache for the command. Off by default. Also enabled by
+  setting ``ALL2MD_CACHE=1`` in the environment.
+* ``--cache-dir DIR`` — where to store it. Defaults to a per-OS user cache
+  directory, or ``$ALL2MD_CACHE_DIR`` if set.
+
+An entry is reused only when both the input fingerprint and the conversion options
+match, so editing a file or changing a parser option transparently produces a
+fresh conversion. The environment variables are listed in
+:doc:`environment_variables`.
 
 Lint Command
 ------------

--- a/docs/source/environment_variables.rst
+++ b/docs/source/environment_variables.rst
@@ -479,6 +479,47 @@ Supports both JSON and TOML formats. TOML is preferred for human editing as it s
        environment:
          ALL2MD_CONFIG: /etc/all2md/config.toml
 
+Conversion Cache
+----------------
+
+The opt-in on-disk conversion cache (``--cache`` on ``grep``, ``search``,
+``chunk``, ``view``, ``report``, ``roundtrip`` and ``optimize``) is also
+controllable from the environment. See :ref:`conversion-cache` for what it does.
+
+ALL2MD_CACHE
+~~~~~~~~~~~~
+
+**Purpose:** Enable the conversion cache without passing ``--cache`` on every command.
+
+**Type:** Boolean
+
+**Default:** ``false`` (cache disabled)
+
+**Valid Values:** ``1``, ``true``, ``yes``, ``on`` (case-insensitive) enable it.
+
+**Example:**
+
+.. code-block:: bash
+
+   export ALL2MD_CACHE=1
+   all2md optimize scanned.pdf        # cache used without --cache
+
+ALL2MD_CACHE_DIR
+~~~~~~~~~~~~~~~~
+
+**Purpose:** Directory for the on-disk conversion cache.
+
+**Type:** String (directory path)
+
+**Default:** A per-OS user cache directory. Overridden by ``--cache-dir`` when both are set.
+
+**Example:**
+
+.. code-block:: bash
+
+   export ALL2MD_CACHE_DIR=/var/cache/all2md
+   all2md report inbox/*.docx --cache
+
 CLI Option Environment Variables
 ---------------------------------
 

--- a/docs/source/options.rst
+++ b/docs/source/options.rst
@@ -1737,6 +1737,24 @@ handling from AttachmentOptionsMixin for embedded images and media.
    :Default factory: ``DocxOptions.<lambda>``
    :Importance: advanced
 
+**code_char_style_names**
+
+   List of run character style names to treat as inline code (case-insensitive exact match). The DOCX renderer writes inline code with the 'Verbatim Char' style; pandoc uses the same name.
+
+   :Type: ``list[str]``
+   :CLI flag: ``--docx-code-char-style-names``
+   :Default factory: ``DocxOptions.<lambda>``
+   :Importance: advanced
+
+**quote_style_names**
+
+   List of paragraph style names to treat as block quotes (case-insensitive exact match)
+
+   :Type: ``list[str]``
+   :CLI flag: ``--docx-quote-style-names``
+   :Default factory: ``DocxOptions.<lambda>``
+   :Importance: advanced
+
 DOCX Renderer Options
 ^^^^^^^^^^^^^^^^^^^^^
 
@@ -5211,10 +5229,10 @@ The Markdown format has no dedicated CLI flags. The common Markdown formatting f
 
 **underline_mode**
 
-   How to handle underlined text
+   How to handle underlined text: markdown (^^text^^), html (<u>), or ignore
 
    :Type: ``Literal['html', 'markdown', 'ignore']``
-   :Default: ``'html'``
+   :Default: ``'markdown'``
    :Choices: ``html``, ``markdown``, ``ignore``
    :Importance: advanced
 
@@ -5223,7 +5241,7 @@ The Markdown format has no dedicated CLI flags. The common Markdown formatting f
    How to handle superscript text
 
    :Type: ``Literal['html', 'markdown', 'ignore']``
-   :Default: ``'html'``
+   :Default: ``'markdown'``
    :Choices: ``html``, ``markdown``, ``ignore``
    :Importance: advanced
 
@@ -5232,7 +5250,7 @@ The Markdown format has no dedicated CLI flags. The common Markdown formatting f
    How to handle subscript text
 
    :Type: ``Literal['html', 'markdown', 'ignore']``
-   :Default: ``'html'``
+   :Default: ``'markdown'``
    :Choices: ``html``, ``markdown``, ``ignore``
    :Importance: advanced
 
@@ -11190,11 +11208,11 @@ modules to ensure consistent Markdown generation.
 
 **underline_mode**
 
-   How to handle underlined text
+   How to handle underlined text: markdown (^^text^^), html (<u>), or ignore
 
    :Type: ``Literal['html', 'markdown', 'ignore']``
    :CLI flag: ``--markdown-underline-mode``
-   :Default: ``'html'``
+   :Default: ``'markdown'``
    :Choices: ``html``, ``markdown``, ``ignore``
    :Importance: advanced
 
@@ -11204,7 +11222,7 @@ modules to ensure consistent Markdown generation.
 
    :Type: ``Literal['html', 'markdown', 'ignore']``
    :CLI flag: ``--markdown-superscript-mode``
-   :Default: ``'html'``
+   :Default: ``'markdown'``
    :Choices: ``html``, ``markdown``, ``ignore``
    :Importance: advanced
 
@@ -11214,7 +11232,7 @@ modules to ensure consistent Markdown generation.
 
    :Type: ``Literal['html', 'markdown', 'ignore']``
    :CLI flag: ``--markdown-subscript-mode``
-   :Default: ``'html'``
+   :Default: ``'markdown'``
    :Choices: ``html``, ``markdown``, ``ignore``
    :Importance: advanced
 


### PR DESCRIPTION
Documentation refresh closing the drift found in the post-1.8.0 review, on top of the six code fixes (#106–#111) now on main.

## Changes

- **D1 — `options.rst` regenerated** (`scripts/generate_options_doc.py`). Picks up the two docx fields missing from the committed copy (`code_char_style_names`, `quote_style_names`) and the `underline_mode` default/help changed by #107. Auto-generated, committed as-is.
- **D2 — `Report Command` section added to `cli.rst`.** `all2md report` was undocumented though `roundtrip` and `optimize` had sections. Notes the new `not_assessed` band.
- **D3 — ROADMAP status refresh.** The conversion optimizer was still marked "unblocked / next item up" and #70/#71/#72 as "unfixed"; all have shipped. Flipped to 🚢, updated the "next batch" arc, renumbered.
- **D4 — CHANGELOG `[Unreleased]`.** Added the missing Markdown roundtrip-fidelity fixes (#94/#95/#97/#104) and this session's fixes (#106–#111).
- **D5 — Conversion cache docs.** A shared "Conversion Cache" section in `cli.rst` (with a `:ref:` anchor) and `ALL2MD_CACHE` / `ALL2MD_CACHE_DIR` in `environment_variables.rst`; `--cache` is on seven commands but the env vars were undocumented.
- **D6 — README.** Added report/roundtrip/optimize/`--cache` to the CLI cheatsheet and a "Conversion Quality & Tuning" feature block.

Sphinx docs build passes clean under `-W`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)