### PR TITLE
release: prepare v1.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.9.0] - 2026-07-15
+
 ### Added
 
 - **Conversion optimizer (`all2md optimize`).** Converts a document many times under
@@ -375,6 +377,64 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   it at a changed corpus, or a different `paths` set, could silently return stale
   hits. The index now records a fingerprint of the documents and index-relevant
   options at save time and is rebuilt when they no longer match.
+- **HTML: an ordered list keeps its `start` attribute instead of renumbering from 1.**
+  The HTML parser built the `List` node without ever reading `<ol start="N">`, so
+  `<ol start="3">` came back numbered from 1 on every HTML conversion — the Markdown
+  renderer already honored `List.start`, the parser just never populated it. Ordered
+  lists now carry their start value through (a non-numeric `start` falls back to 1), so
+  a list that does not begin at 1 survives conversion and the `markdown → html →
+  markdown` round trip.
+- **Markdown: multi-paragraph definition lists round-trip without collapsing.** Two
+  defects in the definition-list renderer flattened a list on a Markdown round trip: a
+  description's paragraphs were joined with a single newline (so a second paragraph
+  merged into the first as a lazy continuation on reparse), and consecutive
+  term/description groups were separated by a single newline (so the next term merged
+  into the previous description). Description blocks and term groups are now separated
+  by a blank line and continuation lines indented four spaces, so multi-paragraph
+  descriptions and multiple terms survive intact.
+- **Markdown: footnote definitions survive parsing under mistune 3.x.** The parser
+  recognized only the legacy `footnote_def` token and read identifiers from
+  `attrs['label']`; mistune 3.x instead groups definitions in a `footnotes` container of
+  `footnote_item` tokens (the label living in `attrs['key']` / the reference's `raw`
+  field, with `attrs` holding only a numeric index), so every footnote definition was
+  dropped from the AST and every reference lost its identifier. The parser now handles
+  the `footnotes` container and reads `key`/`raw` with a `label` fallback; a
+  multi-paragraph footnote is additionally rendered with a blank line between its blocks
+  and four-space continuation indent, so it no longer collapses into one paragraph on
+  reparse.
+- **Markdown: a table nested in a list item stays in the list.** A table inside a list
+  item was emitted at column zero instead of under the item's content margin, so on a
+  Markdown round trip it re-parsed as a top-level sibling and broke the list apart.
+  Idempotency did not catch it — the broken output was stable — but the round-trip
+  benchmark's HTML-equivalence oracle did. Table rendering now shifts every line to the
+  current indent, mirroring code-block handling, so the table stays inside its item; at
+  the top level the indent is empty and output is unchanged.
+- **A long single line is no longer mistaken for a file path and leaked as `OSError`.**
+  During source resolution `LocalPathRetriever.can_handle` called `Path(value).exists()`
+  on raw input before the parse-error wrapper, so a one-line string whose path component
+  exceeds the OS name limit raised `OSError(ENAMETOOLONG)` and escaped `convert()`
+  instead of surfacing as an `All2MdError`. The stat calls are now guarded (mirroring the
+  existing guard in the parser base), so oversized inline content is handled as content.
+
+### Performance
+
+- **Faster CLI cold start.** Building the dynamic CLI parser imported every format's
+  options module and introspected each field, adding ~1.7s to startup even when the
+  invocation never needed it. `--version`/`-V` and `--about`/`-A` are now short-circuited
+  before the parser is built (dropping `--version` from ~2.0s to ~0.8s, the bare import
+  cost), `AttachmentOptionsMixin` is imported from `all2md.options.common` rather than the
+  eager `all2md.options` package, and `get_type_hints()` is memoized per options class —
+  cutting `create_parser()` from ~1.7s to ~0.24s after a warm import, which also roughly
+  halves the small-file conversion path. A cold-start benchmark (`benchmarks/startup.py`)
+  guards these wins against regression.
+- **Cheaper repeated and batch conversions.** Four conversion-hot-path wins help
+  many-small-file and repeated-conversion workloads: the flattened, priority-sorted
+  converter list is memoized — and invalidated on register/unregister — instead of being
+  rebuilt on every `detect_format`; `check_version_requirement` is cached per
+  `(package, spec)` so the dependency-guard decorator stops re-reading installed versions
+  and re-parsing specifiers on every parse/render; resolved option type hints are shared
+  across option construction; and DOCX conversion with `attachment_mode="skip"`
+  short-circuits before reading the image blob (output is byte-identical).
 
 ## [1.8.2] - 2026-07-09
 
@@ -1015,7 +1075,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - NumPy-style docstrings
 - Modular architecture with clear separation of concerns
 
-[Unreleased]: https://github.com/thomas-villani/all2md/compare/v1.8.2...HEAD
+[Unreleased]: https://github.com/thomas-villani/all2md/compare/v1.9.0...HEAD
+[1.9.0]: https://github.com/thomas-villani/all2md/releases/tag/v1.9.0
 [1.8.2]: https://github.com/thomas-villani/all2md/releases/tag/v1.8.2
 [1.8.1]: https://github.com/thomas-villani/all2md/releases/tag/v1.8.1
 [1.8.0]: https://github.com/thomas-villani/all2md/releases/tag/v1.8.0

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -37,7 +37,7 @@ if str(SCRIPTS_PATH) not in sys.path:
 project = "all2md"
 copyright = "2025, Tom Villani, Ph.D."
 author = "Tom Villani, Ph.D."
-release = "1.8.1"
+release = "1.9.0"
 
 # -- General configuration ---------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration

--- a/mcpb/manifest.json
+++ b/mcpb/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": "0.4",
   "name": "all2md",
   "display_name": "all2md",
-  "version": "1.8.1",
+  "version": "1.9.0",
   "description": "Convert PDFs, Office files, HTML, email, and 40+ formats to Markdown and back, directly inside Claude.",
   "long_description": "all2md's built-in MCP server, packaged for one-click install. Lets AI assistants read and convert documents across 40+ formats via an AST-based conversion pipeline, render Markdown back out to PDF/DOCX/PPTX/EPUB/HTML/RST, and edit documents section-by-section. Read-only query tools let assistants search across a corpus (grep + keyword/BM25), diff two documents, and outline a document's headings. Includes smart source auto-detection (file path, data URI, base64, plain text), section extraction, and security controls (a user-chosen workspace folder, network off by default, and path validation).",
   "author": {

--- a/mcpb/pyproject.toml
+++ b/mcpb/pyproject.toml
@@ -7,10 +7,10 @@
 # [tool.bumpversion] config — do NOT hand-edit the version strings below.
 [project]
 name = "all2md-mcpb"
-version = "1.8.1"
+version = "1.9.0"
 requires-python = ">=3.10"
 dependencies = [
-    "all2md[mcp,pdf,pdf_render,docx,html,xlsx,pptx,epub,rst,markdown,odf]>=1.8.1",
+    "all2md[mcp,pdf,pdf_render,docx,html,xlsx,pptx,epub,rst,markdown,odf]>=1.9.0",
     # The search_documents MCP tool defaults to keyword (BM25) mode, which needs
     # rank-bm25. Depend on it directly rather than via the `search` extra: that
     # extra also pulls faiss-cpu and sentence-transformers for vector/hybrid

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "all2md"
-version = "1.8.1"
+version = "1.9.0"
 description = "Rapid, lightweight conversion of various document formats to markdown for LLMs"
 readme = "README.md"
 authors = [
@@ -465,7 +465,7 @@ skips = [
 ]
 
 [tool.bumpversion]
-current_version = "1.8.1"
+current_version = "1.9.0"
 parse = "(?P<major>\\d+)\\.(?P<minor>\\d+)\\.(?P<patch>\\d+)"
 serialize = ["{major}.{minor}.{patch}"]
 commit = true

--- a/src/all2md/__init__.py
+++ b/src/all2md/__init__.py
@@ -85,7 +85,7 @@ if sys.version_info < (3, 10):
         f"all2md requires Python 3.10 or later. You are using Python {sys.version_info.major}.{sys.version_info.minor}."
     )
 
-__version__ = "1.8.1"
+__version__ = "1.9.0"
 
 from typing import TYPE_CHECKING, Any
 

--- a/uv.lock
+++ b/uv.lock
@@ -61,7 +61,7 @@ wheels = [
 
 [[package]]
 name = "all2md"
-version = "1.8.1"
+version = "1.9.0"
 source = { editable = "." }
 dependencies = [
     { name = "platformdirs" },


### PR DESCRIPTION
## Release prep for v1.9.0

Cuts the `1.9.0` release off `main`. No functional code changes — CHANGELOG finalization + version bump only.

### What's here
1. **`docs(changelog): cut 1.9.0 release section`** — adds the pending changelog entries for fixes/perf that merged without their lines (#83, #84, #86, #87, #96/#99, #92, #93), then renames the accumulated `[Unreleased]` section to `[1.9.0] - 2026-07-15` and refreshes the compare/tag links.
2. **`Bump version: 1.8.1 → 1.9.0`** — `bump-my-version bump minor` across all managed files: `pyproject.toml` (×2), `src/all2md/__init__.py`, `docs/source/conf.py`, `mcpb/manifest.json`, `mcpb/pyproject.toml` (version + `>=` pin), and `uv.lock`.

### Release-readiness checks (all green)
- ✅ CI + CodeQL green on `main` at the base commit (#112).
- ✅ The `v1.8.2` patch fixes are all forward-ported to `main` (docx bullets, `ci: release/**`, mypy mbox stubs); only the version bump was — correctly — not ported.
- ✅ Every user-facing commit since `v1.8.1` maps to a CHANGELOG entry. The lone unlisted fix (`5d6444e`, guard `report --json` stdout) patches the confidence/report feature that is itself new this cycle, so it ships correct with no separate line.
- ✅ All version strings consistent at `1.9.0`; CI's `version == tag` and `mcpb == tag` gates will pass.

### Tagging (deliberately not done here)
No tag was created on this branch — a branch tag would be orphaned by the merge. **After merging, tag `main` as `v1.9.0` and push** to fire the PyPI publish:

```
git checkout main && git pull
git tag v1.9.0 && git push origin v1.9.0
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
