### PR TITLE
fix(ini): render DEFAULT section without add_section

### DIFF
--- a/src/all2md/renderers/ini.py
+++ b/src/all2md/renderers/ini.py
@@ -146,9 +146,11 @@ class IniRenderer(BaseRenderer):
             else:
                 config = configparser.ConfigParser(allow_no_value=self.options.allow_no_value)
 
-            # Add sections and values
+            # Add sections and values.
+            # configparser reserves DEFAULT; set its keys directly (no add_section).
             for section, values in data.items():
-                config.add_section(section)
+                if section != configparser.DEFAULTSECT:
+                    config.add_section(section)
                 for key, value in values.items():
                     if value is None or value == "":
                         if self.options.allow_no_value:

--- a/tests/unit/renderers/test_ini_renderer.py
+++ b/tests/unit/renderers/test_ini_renderer.py
@@ -333,6 +333,40 @@ class TestDataExtractor:
         assert "DEFAULT" in data
         assert data["DEFAULT"]["key"] == "value"
 
+    def test_render_orphan_list_uses_default_section(self) -> None:
+        """Orphan key/value lists render under [DEFAULT], not ValueError."""
+        doc = Document(
+            children=[
+                List(
+                    items=[
+                        ListItem(
+                            children=[
+                                Paragraph(
+                                    content=[
+                                        Strong(content=[Text(content="host")]),
+                                        Text(content=": localhost"),
+                                    ]
+                                )
+                            ]
+                        )
+                    ],
+                    ordered=False,
+                )
+            ]
+        )
+        result = IniRenderer().render_to_string(doc)
+
+        assert "[DEFAULT]" in result
+        assert "host = localhost" in result
+
+    def test_render_heading_named_default(self) -> None:
+        """A heading literally named DEFAULT is a valid section."""
+        doc = create_ini_document({"DEFAULT": {"host": "localhost"}})
+        result = IniRenderer().render_to_string(doc)
+
+        assert "[DEFAULT]" in result
+        assert "host = localhost" in result
+
 
 @pytest.mark.unit
 class TestIniEdgeCases:


### PR DESCRIPTION
IniRenderer always called `add_section(section)` after DataExtractor built the section map. Orphan key/value lists (and a heading literally named DEFAULT) land under configparser's reserved DEFAULTSECT, so `add_section("DEFAULT")` raises ValueError and convert-to-ini fails with RenderingError.

```python
from all2md import convert
convert("* **host**: localhost\n", source_format="markdown", target_format="ini")
# RenderingError from ValueError: Invalid section name: 'DEFAULT'
```

Skip `add_section` when the section is DEFAULTSECT and set keys on the parser directly. Adds regression coverage for the DEFAULT path.