### PR TITLE
fix(org): put a newline after table header separators

### DIFF
--- a/src/all2md/renderers/org.py
+++ b/src/all2md/renderers/org.py
@@ -643,14 +643,14 @@ class OrgRenderer(NodeVisitor, InlineContentMixin, BaseRenderer):
                 row_parts.append(padded)
             self._output.append("| " + " | ".join(row_parts) + " |")
 
-            if i < len(rendered_grid) - 1:
-                self._output.append("\n")
-
-            # Add separator after header
+            # Header rule must end with a newline before the next body row
             if i == 0 and node.header:
                 self._output.append("\n|")
                 for width in col_widths:
                     self._output.append("-" * (width + 2) + "|")
+
+            if i < len(rendered_grid) - 1:
+                self._output.append("\n")
 
     def visit_table_row(self, node: TableRow) -> None:
         """Render a TableRow node.

--- a/tests/unit/renderers/test_org_renderer.py
+++ b/tests/unit/renderers/test_org_renderer.py
@@ -366,6 +366,32 @@ class TestTables:
         assert "| 1" in org
         assert "| 2" in org
 
+    def test_header_separator_ends_before_body_row(self) -> None:
+        """Body rows must start on a new line after the header rule."""
+        doc = Document(
+            children=[
+                Table(
+                    header=TableRow(
+                        cells=[TableCell(content=[Text(content="A")]), TableCell(content=[Text(content="B")])],
+                        is_header=True,
+                    ),
+                    rows=[
+                        TableRow(
+                            cells=[TableCell(content=[Text(content="1")]), TableCell(content=[Text(content="2")])]
+                        ),
+                    ],
+                )
+            ]
+        )
+        org = OrgRenderer().render_to_string(doc)
+        lines = [line for line in org.splitlines() if line.strip()]
+
+        assert "| A | B |" in org
+        assert "| 1 | 2 |" in org
+        assert any(line.startswith("|---") or line.startswith("|--") for line in lines)
+        # Separator and body must not be glued on one line (loses the body on parse).
+        assert not any("---|" in line and "| 1" in line for line in lines)
+
 
 @pytest.mark.unit
 class TestBlockQuotes:


### PR DESCRIPTION
OrgRenderer.visit_table emitted the header separator and the first body row with no newline between them, so a normal header+body table rendered as `|---|---|| 1 | 2 |`. Org tables are line-oriented (Markdown/RST siblings already put a newline after the rule), and the glued form loses body cells on re-parse.

Append a newline after the separator when more rows follow. Adds a regression test that the separator ends before the body row.