### PR TITLE
fix(csv): preserve line breaks in table cells

### DIFF
--- a/src/all2md/renderers/csv.py
+++ b/src/all2md/renderers/csv.py
@@ -23,7 +23,18 @@ import logging
 from pathlib import Path
 from typing import IO, Union
 
-from all2md.ast.nodes import Comment, CommentInline, Document, Heading, Node, Table, TableRow, Text
+from all2md.ast.nodes import (
+    Comment,
+    CommentInline,
+    Document,
+    Heading,
+    HTMLInline,
+    LineBreak,
+    Node,
+    Table,
+    TableRow,
+    Text,
+)
 from all2md.exceptions import RenderingError
 from all2md.options.csv import CsvRendererOptions
 from all2md.renderers.base import BaseRenderer
@@ -347,7 +358,13 @@ class CsvRenderer(BaseRenderer):
         for node in nodes:
             if isinstance(node, Text):
                 parts.append(node.content)
-            elif hasattr(node, "content"):
+            elif isinstance(node, LineBreak):
+                parts.append("\n")
+            elif isinstance(node, HTMLInline):
+                raw = node.content.strip().lower().replace(" ", "")
+                if raw in {"<br>", "<br/>"}:
+                    parts.append("\n")
+            elif hasattr(node, "content") and isinstance(node.content, list):
                 # Recurse into inline containers (Strong, Emphasis, Link, etc.)
                 parts.append(self._extract_text_content(node.content))
 

--- a/tests/unit/renderers/test_csv_renderer.py
+++ b/tests/unit/renderers/test_csv_renderer.py
@@ -15,7 +15,8 @@ Tests cover:
 
 import pytest
 
-from all2md.ast import Document, Heading, Paragraph, Table, TableCell, TableRow, Text
+from all2md import convert
+from all2md.ast import Document, Heading, HTMLInline, LineBreak, Paragraph, Table, TableCell, TableRow, Text
 from all2md.exceptions import RenderingError
 from all2md.options.csv import CsvRendererOptions
 from all2md.renderers.csv import CsvRenderer
@@ -368,3 +369,58 @@ class TestCsvDialect:
 
         # With single quote as quote char and quoting=all, should use single quotes
         assert "'" in result
+
+
+@pytest.mark.unit
+class TestCellLineBreaks:
+    """Multiline cell content must survive CSV export."""
+
+    def test_markdown_cell_br_preserves_newline(self) -> None:
+        """HTML <br> inside a markdown table cell becomes a quoted CSV newline."""
+        source = "| A | B |\n| --- | --- |\n| line1<br>line2 | x |\n"
+        result = convert(source, source_format="markdown", target_format="csv")
+        assert result == 'A,B\n"line1\nline2",x\n'
+
+    def test_linebreak_node_preserves_newline(self) -> None:
+        """AST LineBreak between Text nodes is emitted as a CSV cell newline."""
+        table = Table(
+            header=TableRow(cells=[TableCell(content=[Text(content="A")]), TableCell(content=[Text(content="B")])]),
+            rows=[
+                TableRow(
+                    cells=[
+                        TableCell(
+                            content=[
+                                Text(content="line1"),
+                                LineBreak(),
+                                Text(content="line2"),
+                            ]
+                        ),
+                        TableCell(content=[Text(content="x")]),
+                    ]
+                ),
+            ],
+        )
+        result = CsvRenderer().render_to_string(Document(children=[table]))
+        assert result == 'A,B\n"line1\nline2",x\n'
+
+    def test_html_inline_br_preserves_newline(self) -> None:
+        """HTMLInline <br> between Text nodes is emitted as a CSV cell newline."""
+        table = Table(
+            header=TableRow(cells=[TableCell(content=[Text(content="A")]), TableCell(content=[Text(content="B")])]),
+            rows=[
+                TableRow(
+                    cells=[
+                        TableCell(
+                            content=[
+                                Text(content="line1"),
+                                HTMLInline(content="<br>"),
+                                Text(content="line2"),
+                            ]
+                        ),
+                        TableCell(content=[Text(content="x")]),
+                    ]
+                ),
+            ],
+        )
+        result = CsvRenderer().render_to_string(Document(children=[table]))
+        assert result == 'A,B\n"line1\nline2",x\n'


### PR DESCRIPTION
CsvRenderer joined cell children with an empty string and ignored LineBreak / `<br>`, so a markdown table cell with an embedded break lost the newline when converting to CSV.

Handle LineBreak and br-style HTMLInline explicitly in the cell text extractor so multiline cells survive markdown→csv. Adds a regression test for the break-preserving path.