### PR TITLE
fix(dokuwiki): keep empty list item bullets

### DIFF
--- a/src/all2md/renderers/dokuwiki.py
+++ b/src/all2md/renderers/dokuwiki.py
@@ -268,6 +268,8 @@ class DokuWikiRenderer(NodeVisitor, InlineContentMixin, BaseRenderer):
                 self._output.append(f"{indent}{marker} \n")
                 for child in node.children:
                     child.accept(self)
+        else:
+            self._output.append(f"{indent}{marker} \n")
 
     def visit_table(self, node: Table) -> None:
         """Render a Table node.

--- a/tests/unit/renderers/test_dokuwiki_renderer.py
+++ b/tests/unit/renderers/test_dokuwiki_renderer.py
@@ -435,6 +435,23 @@ class TestDokuWikiLists:
         assert "  * Nested item" in output
         assert "* Item 2" in output
 
+    def test_render_empty_list_item(self) -> None:
+        """Empty list items must still emit a bullet (sibling formats do)."""
+        doc = Document(
+            children=[
+                List(
+                    ordered=False,
+                    items=[
+                        ListItem(children=[Paragraph(content=[Text(content="a")])]),
+                        ListItem(children=[]),
+                        ListItem(children=[Paragraph(content=[Text(content="c")])]),
+                    ],
+                )
+            ]
+        )
+        output = DokuWikiRenderer().render_to_string(doc)
+        assert output == "* a\n* \n* c\n"
+
 
 @pytest.mark.unit
 class TestDokuWikiTables:


### PR DESCRIPTION
DokuWikiRenderer.visit_list_item skipped empty ListItem children, so a markdown list with a blank item (`- a` / `-` / `- c`) rendered as only two bullets. Markdown/MediaWiki/AsciiDoc/RST siblings keep the empty bullet for round-trip fidelity; the non-empty non-paragraph branch already emitted `{marker} \n`, but the empty path had no else.

Emit a blank bullet when the item has no children. Adds a regression test for the empty middle item.