### PR TITLE
fix(rtf): do not rewrap pyth List when prefixing paragraphs

### DIFF
--- a/src/all2md/renderers/rtf.py
+++ b/src/all2md/renderers/rtf.py
@@ -155,6 +155,10 @@ class RtfRenderer(NodeVisitor, BaseRenderer):
 
     def _prefix_paragraph(self, paragraph: Any, prefix: str) -> Any:
         """Return a copy of a paragraph with prefix text prepended."""
+        # pyth List subclasses Paragraph; do not rewrap ListEntry children.
+        List_cls = cast(Any, self._List)
+        if List_cls is not None and isinstance(paragraph, List_cls):
+            return paragraph
         runs = [self._create_text_run(prefix)]
         runs.extend(paragraph.content)
         return cast(Any, self._Paragraph)(content=runs)

--- a/tests/unit/renderers/test_rtf_renderer.py
+++ b/tests/unit/renderers/test_rtf_renderer.py
@@ -424,6 +424,58 @@ class TestRtfRendererDefinitionLists:
         assert "Term" in rtf_output
         assert "Definition" in rtf_output
 
+    def test_render_definition_list_with_nested_list(self) -> None:
+        """Nested lists in definitions must not crash (pyth List subclasses Paragraph)."""
+        doc = Document(
+            children=[
+                DefinitionList(
+                    items=[
+                        (
+                            DefinitionTerm(content=[Text(content="Term")]),
+                            [
+                                DefinitionDescription(
+                                    content=[
+                                        Paragraph(content=[Text(content="Definition")]),
+                                        List(
+                                            ordered=False,
+                                            items=[
+                                                ListItem(children=[Paragraph(content=[Text(content="nested-item")])])
+                                            ],
+                                        ),
+                                    ]
+                                )
+                            ],
+                        )
+                    ]
+                )
+            ]
+        )
+        renderer = RtfRenderer()
+        rtf_output = renderer.render_to_string(doc)
+        assert "Term" in rtf_output
+        assert "Definition" in rtf_output
+        assert "nested-item" in rtf_output
+
+    def test_render_blockquote_with_nested_list(self) -> None:
+        """Block quotes that contain lists must render without TypeError."""
+        doc = Document(
+            children=[
+                BlockQuote(
+                    children=[
+                        Paragraph(content=[Text(content="quoted")]),
+                        List(
+                            ordered=False,
+                            items=[ListItem(children=[Paragraph(content=[Text(content="quoted-item")])])],
+                        ),
+                    ]
+                )
+            ]
+        )
+        renderer = RtfRenderer()
+        rtf_output = renderer.render_to_string(doc)
+        assert "quoted" in rtf_output
+        assert "quoted-item" in rtf_output
+
 
 @pytest.mark.unit
 class TestRtfRendererInlineFormatting:


### PR DESCRIPTION
RtfRenderer._prefix_paragraph always rebuilt a Paragraph around the existing content. pyth's List subclasses Paragraph, so a list nested under a block quote or definition description was rewrapped as `Paragraph(content=[ListEntry…])` and raised TypeError.

```python
from all2md import convert
convert("> quoted\n> - item\n", source_format="markdown", target_format="rtf")
# TypeError: Wrong content type for Paragraph: ListEntry
```

Return List nodes unchanged when prefixing. Adds regressions for a nested list in a definition description and a list inside a block quote.
