### PR TITLE
fix(asciidoc): do not hang on escaped braces in attr shape

### DIFF
--- a/src/all2md/parsers/asciidoc.py
+++ b/src/all2md/parsers/asciidoc.py
@@ -1374,6 +1374,10 @@ class AsciiDocParser(BaseParser):
                 next_match = self.combined_inline_pattern.search(remaining)
                 next_special = next_match.start() if next_match else len(remaining)
 
+                # Rejected combined match at cursor must advance or the loop hangs.
+                if next_special == 0 and next_match is not None:
+                    next_special = next_match.end()
+
                 text_content = remaining[:next_special]
                 if text_content:
                     text_content = self._postprocess_escapes(text_content, escape_map)

--- a/tests/unit/parsers/test_asciidoc_parser.py
+++ b/tests/unit/parsers/test_asciidoc_parser.py
@@ -1,7 +1,7 @@
 #  Copyright (c) 2025 Tom Villani, Ph.D.
 """Unit tests for AsciiDoc parser and renderer."""
 
-import signal
+import threading
 
 from all2md.ast import (
     BlockQuote,
@@ -422,22 +422,17 @@ class TestAsciiDocEscaping:
 
     def test_escaped_brace_forming_attr_shape_does_not_hang(self) -> None:
         """Escaped `{` inside `{...}` must parse as literal text, not hang."""
-
-        class _Timeout(Exception):
-            pass
-
-        def _on_alarm(signum: int, frame: object) -> None:
-            raise _Timeout()
-
         parser = AsciiDocParser()
-        previous = signal.signal(signal.SIGALRM, _on_alarm)
-        try:
-            signal.alarm(2)
-            doc = parser.parse(r"{\{}")
-            signal.alarm(0)
-        finally:
-            signal.signal(signal.SIGALRM, previous)
+        parsed: list[Document] = []
 
+        # Parse off-thread so a regression fails the test instead of hanging the
+        # suite. The thread is a daemon, so a spinning parser cannot block exit.
+        worker = threading.Thread(target=lambda: parsed.append(parser.parse(r"{\{}")), daemon=True)
+        worker.start()
+        worker.join(timeout=30)
+        assert not worker.is_alive(), "parser hung on an escaped brace in attribute-ref shape"
+
+        doc = parsed[0]
         para = doc.children[0]
         assert isinstance(para, Paragraph)
         text_content = "".join(n.content if isinstance(n, Text) else "" for n in para.content)

--- a/tests/unit/parsers/test_asciidoc_parser.py
+++ b/tests/unit/parsers/test_asciidoc_parser.py
@@ -1,6 +1,8 @@
 #  Copyright (c) 2025 Tom Villani, Ph.D.
 """Unit tests for AsciiDoc parser and renderer."""
 
+import signal
+
 from all2md.ast import (
     BlockQuote,
     Code,
@@ -417,6 +419,29 @@ class TestAsciiDocEscaping:
         para = doc.children[0]
         text_content = "".join(n.content if isinstance(n, Text) else "" for n in para.content)
         assert "{is not}" in text_content
+
+    def test_escaped_brace_forming_attr_shape_does_not_hang(self) -> None:
+        """Escaped `{` inside `{...}` must parse as literal text, not hang."""
+
+        class _Timeout(Exception):
+            pass
+
+        def _on_alarm(signum: int, frame: object) -> None:
+            raise _Timeout()
+
+        parser = AsciiDocParser()
+        previous = signal.signal(signal.SIGALRM, _on_alarm)
+        try:
+            signal.alarm(2)
+            doc = parser.parse(r"{\{}")
+            signal.alarm(0)
+        finally:
+            signal.signal(signal.SIGALRM, previous)
+
+        para = doc.children[0]
+        assert isinstance(para, Paragraph)
+        text_content = "".join(n.content if isinstance(n, Text) else "" for n in para.content)
+        assert text_content == "{{}"
 
 
 class TestAsciiDocUnconstrainedFormatting:


### PR DESCRIPTION
AsciiDocParser._parse_inline_recursive could infinite-loop on valid AsciiDoc where an escaped brace still forms a `{…}` shape (minimal: `{\{}`).

Escape preprocessing turns `\{` into a placeholder, the combined inline pattern matches an attribute-ref at the cursor, `_try_parse_attribute_ref` declines, and the fallback set `next_special = 0` without advancing.

When a combined match sits at the cursor but no handler accepts it, advance past `match.end()` and emit the span as literal text. Adds an alarm-bounded regression for the hang.
