### PR TITLE
fix(asciidoc): restore escapes in cross-reference targets

### DIFF
--- a/src/all2md/parsers/asciidoc.py
+++ b/src/all2md/parsers/asciidoc.py
@@ -1137,8 +1137,9 @@ class AsciiDocParser(BaseParser):
 
         match = self.xref_pattern.match(text)
         if match:
-            ref_id = match.group(1)
-            ref_text = match.group(2) if len(match.groups()) >= 2 and match.group(2) else ref_id
+            ref_id = self._postprocess_escapes(match.group(1), escape_map)
+            ref_text_raw = match.group(2) if len(match.groups()) >= 2 and match.group(2) else None
+            ref_text = self._postprocess_escapes(ref_text_raw, escape_map) if ref_text_raw is not None else ref_id
             url = sanitize_url(f"#{ref_id}")
             return [Link(url=url, content=[Text(content=ref_text)])], match.end()
 

--- a/tests/unit/parsers/test_asciidoc_parser.py
+++ b/tests/unit/parsers/test_asciidoc_parser.py
@@ -933,6 +933,23 @@ class TestAsciiDocAnchorsAndXrefs:
                 # Check that custom text is used
                 assert node.content[0].content == "the introduction"
 
+    def test_xref_with_escaped_brace_restores_literal(self) -> None:
+        """Escaped braces inside <<xref>> must not leak escape placeholders."""
+        parser = AsciiDocParser()
+        doc = parser.parse(r"See <<\{}>> and <<\{foo},label \{x}>>")
+
+        para = doc.children[0]
+        assert isinstance(para, Paragraph)
+        links = [n for n in para.content if isinstance(n, Link)]
+        assert len(links) == 2
+        assert links[0].url == "#{}"
+        assert links[0].content[0].content == "{}"
+        assert links[1].url == "#{foo}"
+        assert links[1].content[0].content == "label {x}"
+        for link in links:
+            assert "\x00ESC\x00" not in link.url
+            assert "\x00ESC\x00" not in link.content[0].content
+
 
 class TestAsciiDocRoundTrip:
     """Tests for round-trip conversion (parse -> render)."""


### PR DESCRIPTION
AsciiDocParser._try_parse_links built `Link(url, content)` from `<<id>>` / `<<id,text>>` without `_postprocess_escapes`, while the `link:` branch in the same function already restores escapes. Escaped braces (`\{`) leaked internal `\x00ESC\x00` placeholders into the URL and link text.

```python
from all2md.parsers.asciidoc import AsciiDocParser
link = AsciiDocParser().parse(r"<<\{}>>").children[0].content[0]
# link.url == "#\x00ESC\x000\x00ESC\x00}"
```

Postprocess `ref_id` and `ref_text` before building the Link. Adds a regression that escaped braces in xref targets restore to literal `{…}`.
