### PR TITLE
fix(mediawiki): keep literal pipes in table cell text

### DIFF
--- a/src/all2md/parsers/mediawiki.py
+++ b/src/all2md/parsers/mediawiki.py
@@ -778,6 +778,16 @@ class MediaWikiParser(BaseParser):
         consumed = i - start_idx
         return BlockQuote(children=[Paragraph(content=cast(list[Node], content))]), consumed
 
+    @staticmethod
+    def _strip_cell_attributes(cell_text: str) -> str:
+        """Drop leading MediaWiki cell attrs (key=value|...), keep literal pipes."""
+        if "|" not in cell_text:
+            return cell_text.strip()
+        before, after = cell_text.split("|", 1)
+        if "=" in before:
+            return after.strip()
+        return cell_text.strip()
+
     def _process_table(self, table_tag: Any) -> Table | None:
         """Parse a MediaWiki table.
 
@@ -826,8 +836,7 @@ class MediaWikiParser(BaseParser):
                 # Handle multiple cells on one line (!! separator)
                 cell_texts = cell_text.split("!!")
                 for ct in cell_texts:
-                    # Remove cell attributes (e.g., style="...")
-                    ct = re.sub(r"^\s*[^|]*\|\s*", "", ct).strip()
+                    ct = self._strip_cell_attributes(ct)
                     content = [Text(content=ct)]
                     current_row_cells.append(TableCell(content=cast(list[Node], content)))
 
@@ -837,8 +846,7 @@ class MediaWikiParser(BaseParser):
                 # Handle multiple cells on one line (|| separator)
                 cell_texts = cell_text.split("||")
                 for ct in cell_texts:
-                    # Remove cell attributes
-                    ct = re.sub(r"^\s*[^|]*\|\s*", "", ct).strip()
+                    ct = self._strip_cell_attributes(ct)
                     content = [Text(content=ct)]
                     current_row_cells.append(TableCell(content=cast(list[Node], content)))
 

--- a/tests/unit/parsers/test_mediawiki_table_cells.py
+++ b/tests/unit/parsers/test_mediawiki_table_cells.py
@@ -1,0 +1,34 @@
+#  Copyright (c) 2025 Tom Villani, Ph.D.
+"""MediaWiki table cell attribute stripping."""
+
+from all2md.ast import Table, Text
+from all2md.parsers.mediawiki import MediaWikiParser
+
+
+class TestMediaWikiTableCellPipes:
+    def test_literal_pipe_in_cell_text_preserved(self) -> None:
+        wiki = "{|\n|-\n| pipe: a|b\n|}"
+        doc = MediaWikiParser().parse(wiki)
+        table = doc.children[0]
+        assert isinstance(table, Table)
+        cell = table.rows[0].cells[0]
+        assert isinstance(cell.content[0], Text)
+        assert cell.content[0].content == "pipe: a|b"
+
+    def test_style_attribute_still_stripped(self) -> None:
+        wiki = '{|\n|-\n| style="color:red"| red cell\n|}'
+        doc = MediaWikiParser().parse(wiki)
+        table = doc.children[0]
+        assert isinstance(table, Table)
+        cell = table.rows[0].cells[0]
+        assert isinstance(cell.content[0], Text)
+        assert cell.content[0].content == "red cell"
+
+    def test_wikilink_pipe_in_cell_preserved(self) -> None:
+        wiki = "{|\n|-\n| [[Target|label]]\n|}"
+        doc = MediaWikiParser().parse(wiki)
+        table = doc.children[0]
+        assert isinstance(table, Table)
+        cell = table.rows[0].cells[0]
+        assert isinstance(cell.content[0], Text)
+        assert cell.content[0].content == "[[Target|label]]"


### PR DESCRIPTION
MediaWikiParser stripped cell attributes with `re.sub(r"^\s*[^|]*\|\s*", …)`, which also matched any cell whose text merely contained a `|`. Cells like `pipe: a|b` became `b`, and `[[Target|label]]` lost the link target.

Only treat the leading segment as attributes when it contains `=`. Adds regressions for literal pipes, styled cells, and piped wikilinks.
