### PR TITLE
fix(dokuwiki): emit empty cells for table colspan

### DIFF
--- a/src/all2md/renderers/dokuwiki.py
+++ b/src/all2md/renderers/dokuwiki.py
@@ -304,13 +304,14 @@ class DokuWikiRenderer(NodeVisitor, InlineContentMixin, BaseRenderer):
         delimiter = "^" if is_header else "|"
 
         self._output.append(delimiter)
-        for _, cell in enumerate(row.cells):
-            # Render cell content
+        for cell in row.cells:
             content = self._render_inline_content(cell.content)
-            # Escape content for table context
             content = escape_dokuwiki(content, context="table")
             self._output.append(f" {content} ")
             self._output.append(delimiter)
+            # DokuWiki colspan: empty continuation cells (trailing ||).
+            for _ in range(max(cell.colspan, 1) - 1):
+                self._output.append(delimiter)
         self._output.append("\n")
 
     def visit_table_row(self, node: TableRow) -> None:

--- a/tests/unit/renderers/test_dokuwiki_renderer.py
+++ b/tests/unit/renderers/test_dokuwiki_renderer.py
@@ -516,6 +516,25 @@ class TestDokuWikiTables:
 
         assert "| Cell 1 |" in output or "| Cell 1  |" in output
 
+    def test_render_table_colspan_empty_continuations(self) -> None:
+        """Colspan>1 must emit empty continuation cells (DokuWiki || syntax)."""
+        doc = Document(
+            children=[
+                Table(
+                    rows=[
+                        TableRow(
+                            cells=[
+                                TableCell(content=[Text(content="Wide")], colspan=2),
+                                TableCell(content=[Text(content="Tall")]),
+                            ]
+                        ),
+                    ]
+                )
+            ]
+        )
+        output = DokuWikiRenderer().render_to_string(doc)
+        assert output == "| Wide || Tall |\n"
+
 
 @pytest.mark.unit
 class TestDokuWikiLinks:


### PR DESCRIPTION
DokuWikiRenderer._render_table_row ignored TableCell.colspan, so HTML tables with merged columns lost their span when converting to DokuWiki. DokuWiki expresses colspan with empty continuation cells (trailing `||`).

Emit `colspan - 1` empty delimiters after each cell. Adds a regression that a colspan=2 cell renders as `| Wide || Tall |`.
