### PR TITLE
fix(ast): serialize Comment, CommentInline, and Mark nodes

### DIFF
--- a/src/all2md/ast/serialization.py
+++ b/src/all2md/ast/serialization.py
@@ -43,6 +43,8 @@ from all2md.ast.nodes import (
     BlockQuote,
     Code,
     CodeBlock,
+    Comment,
+    CommentInline,
     DefinitionDescription,
     DefinitionList,
     DefinitionTerm,
@@ -58,6 +60,7 @@ from all2md.ast.nodes import (
     Link,
     List,
     ListItem,
+    Mark,
     MathBlock,
     MathInline,
     Node,
@@ -405,6 +408,9 @@ _SERIALIZATION_DISPATCH: dict[type, Any] = {
     HTMLInline: lambda n: _serialize_text_content_node(n, "HTMLInline"),
     FootnoteReference: _serialize_footnote_reference,
     FootnoteDefinition: _serialize_footnote_definition,
+    Comment: lambda n: _serialize_text_content_node(n, "Comment"),
+    CommentInline: lambda n: _serialize_text_content_node(n, "CommentInline"),
+    Mark: lambda n: _serialize_inline_content_node(n, "Mark"),
 }
 
 
@@ -795,6 +801,33 @@ def _deserialize_footnote_definition(data: dict[str, Any]) -> FootnoteDefinition
     )
 
 
+def _deserialize_comment(data: dict[str, Any]) -> Comment:
+    """Deserialize Comment node."""
+    return Comment(
+        content=data.get("content", ""),
+        metadata=data.get("metadata", {}),
+        source_location=_deserialize_source_location(data.get("source_location")),
+    )
+
+
+def _deserialize_comment_inline(data: dict[str, Any]) -> CommentInline:
+    """Deserialize CommentInline node."""
+    return CommentInline(
+        content=data.get("content", ""),
+        metadata=data.get("metadata", {}),
+        source_location=_deserialize_source_location(data.get("source_location")),
+    )
+
+
+def _deserialize_mark(data: dict[str, Any]) -> Mark:
+    """Deserialize Mark node."""
+    return Mark(
+        content=_deserialize_children(data.get("content", [])),
+        metadata=data.get("metadata", {}),
+        source_location=_deserialize_source_location(data.get("source_location")),
+    )
+
+
 # Dispatch table mapping node type strings to deserializer functions
 _DESERIALIZATION_DISPATCH: dict[str, Any] = {
     "SourceLocation": _deserialize_source_location_node,
@@ -829,6 +862,9 @@ _DESERIALIZATION_DISPATCH: dict[str, Any] = {
     "MathBlock": _deserialize_math_block,
     "FootnoteReference": _deserialize_footnote_reference,
     "FootnoteDefinition": _deserialize_footnote_definition,
+    "Comment": _deserialize_comment,
+    "CommentInline": _deserialize_comment_inline,
+    "Mark": _deserialize_mark,
 }
 
 

--- a/tests/unit/ast/test_ast_serialization.py
+++ b/tests/unit/ast/test_ast_serialization.py
@@ -6,6 +6,8 @@ import json
 import pytest
 
 from all2md.ast import (
+    Comment,
+    CommentInline,
     DefinitionDescription,
     DefinitionList,
     DefinitionTerm,
@@ -18,6 +20,7 @@ from all2md.ast import (
     Link,
     List,
     ListItem,
+    Mark,
     MathBlock,
     MathInline,
     Paragraph,
@@ -635,3 +638,62 @@ class TestFootnoteSerialization:
         # Check definitions
         assert restored.children[1].metadata["author"] == "Smith"  # type: ignore
         assert restored.children[2].metadata["author"] == "Jones"  # type: ignore
+
+
+@pytest.mark.unit
+class TestCommentAndMarkSerialization:
+    """Test serialization of Comment, CommentInline, and Mark nodes."""
+
+    def test_comment_roundtrip(self) -> None:
+        """Block comments must serialize and restore with content and metadata."""
+        original = Comment(content="Needs review", metadata={"author": "Ada", "comment_type": "html"})
+        restored = json_to_ast(ast_to_json(original))
+
+        assert isinstance(restored, Comment)
+        assert restored.content == "Needs review"
+        assert restored.metadata["author"] == "Ada"
+        assert restored.metadata["comment_type"] == "html"
+
+    def test_comment_inline_roundtrip(self) -> None:
+        """Inline comments embedded in paragraphs must round-trip."""
+        original = Document(
+            children=[
+                Paragraph(
+                    content=[
+                        Text(content="Hello "),
+                        CommentInline(content="todo", metadata={"author": "Bob"}),
+                        Text(content=" world"),
+                    ]
+                )
+            ]
+        )
+        restored = json_to_ast(ast_to_json(original))
+
+        assert isinstance(restored, Document)
+        para = restored.children[0]
+        assert isinstance(para, Paragraph)
+        assert isinstance(para.content[1], CommentInline)
+        assert para.content[1].content == "todo"
+        assert para.content[1].metadata["author"] == "Bob"
+
+    def test_mark_roundtrip(self) -> None:
+        """Mark (highlight) nodes must serialize their inline children."""
+        original = Paragraph(content=[Mark(content=[Text(content="highlighted")])])
+        restored = json_to_ast(ast_to_json(original))
+
+        assert isinstance(restored, Paragraph)
+        assert isinstance(restored.content[0], Mark)
+        assert isinstance(restored.content[0].content[0], Text)
+        assert restored.content[0].content[0].content == "highlighted"
+
+    def test_document_with_comment_via_ast_json_renderer(self) -> None:
+        """AstJsonRenderer must accept documents that contain Comment nodes."""
+        from all2md.renderers.ast_json import AstJsonRenderer
+
+        doc = Document(children=[Comment(content="block note")])
+        json_str = AstJsonRenderer().render_to_string(doc)
+        restored = json_to_ast(json_str)
+
+        assert isinstance(restored, Document)
+        assert isinstance(restored.children[0], Comment)
+        assert restored.children[0].content == "block note"


### PR DESCRIPTION
ast_to_dict / ast_to_json had no dispatch entries for Comment, CommentInline, or Mark, so documents that already contain those nodes failed serialization.

```python
from all2md import convert
convert("<!-- note -->\n\nHi\n", source_format="markdown", target_format="ast")
# ValueError: Unknown node type for serialization: Comment
```

Markdown HTML comments, `==mark==`, AsciiDoc `//` comments, and RST `..` comments all parse into these node types today. Wire serialize/deserialize the same way as the other text/inline content nodes. Adds round-trip coverage for Comment, CommentInline, Mark, and AstJsonRenderer.
