### PR TITLE
fix(mediawiki): keep table captions on one |+ line

### DIFF
--- a/src/all2md/renderers/mediawiki.py
+++ b/src/all2md/renderers/mediawiki.py
@@ -265,9 +265,11 @@ class MediaWikiRenderer(NodeVisitor, InlineContentMixin, BaseRenderer):
         """
         self._output.append('{| class="wikitable"\n')
 
-        # Render caption if present
+        # Render caption if present (single-line: newlines would break |+ markup)
         if node.caption:
-            self._output.append(f"|+ {node.caption}\n")
+            caption = " ".join(node.caption.split())
+            if caption:
+                self._output.append(f"|+ {caption}\n")
 
         # Render header
         if node.header:

--- a/tests/unit/renderers/test_mediawiki_parser.py
+++ b/tests/unit/renderers/test_mediawiki_parser.py
@@ -362,6 +362,24 @@ class TestMediaWikiRenderer:
 
         assert "|+ Table Caption" in output
 
+    def test_render_table_caption_flattens_newlines(self) -> None:
+        """Newlines in captions must not break the single-line |+ markup."""
+        doc = Document(
+            children=[
+                Table(
+                    caption="Summer\n2024",
+                    header=TableRow(cells=[TableCell(content=[Text(content="H")])]),
+                    rows=[TableRow(cells=[TableCell(content=[Text(content="1")])])],
+                )
+            ]
+        )
+        output = MediaWikiRenderer().render_to_string(doc)
+
+        assert "|+ Summer 2024\n" in output
+        assert "|+ Summer\n2024" not in output
+        # Caption stays on one wiki line; a bare "2024" row would be invalid markup.
+        assert "\n2024\n" not in output
+
     def test_render_definition_list(self) -> None:
         """Test rendering definition list."""
         doc = Document(


### PR DESCRIPTION
MediaWikiRenderer.visit_table emitted `|+ {caption}` with the caption string unchanged. HTML `<caption>` text can contain newlines, so convert produced:

```
|+ Summer
2024
! H
```

MediaWiki `|`+ captions are single-line; the split form is invalid wikitable markup and loses the rest of the caption. Collapse caption whitespace before emitting `|`+. Adds a regression for an embedded newline in the caption.
