### PR TITLE
fix(asciidoc): parse colspan after leading space on table cells

### DIFF
--- a/src/all2md/parsers/asciidoc.py
+++ b/src/all2md/parsers/asciidoc.py
@@ -1887,7 +1887,8 @@ class AsciiDocParser(BaseParser):
                 # Also supports: 2* for duplication (treated as colspan)
 
                 span_pattern = r"^(\d+)?\.?(\d+)?([+*])\s*"
-                match = re.match(span_pattern, part.strip())
+                stripped = part.strip()
+                match = re.match(span_pattern, stripped)
 
                 if match:
                     col_spec = match.group(1)
@@ -1911,8 +1912,8 @@ class AsciiDocParser(BaseParser):
                         if col_spec:
                             colspan = int(col_spec)
 
-                    # Remove the span specification from content
-                    part = part[match.end() :]
+                    # Slice stripped text — match was against strip(), not raw part
+                    part = stripped[match.end() :]
 
             # Strip whitespace but preserve empty cells
             content_text = part.strip()

--- a/tests/unit/parsers/test_asciidoc_parser_improvements.py
+++ b/tests/unit/parsers/test_asciidoc_parser_improvements.py
@@ -190,6 +190,23 @@ class TestAsciiDocTableColspanRowspan:
         # Verify content is correct
         assert first_cell.content[0].content == "Spanning Cell"
 
+    def test_colspan_syntax_with_space_after_pipe(self) -> None:
+        """Leading space after | must not leave a stray '+' cell."""
+        asciidoc = """|===
+| 2+| spans two
+|Cell 1|Cell 2
+|==="""
+        parser = AsciiDocParser()
+        doc = parser.parse(asciidoc)
+
+        table = doc.children[0]
+        assert isinstance(table, Table)
+        assert table.header is not None
+        assert len(table.header.cells) == 1
+        first_cell = table.header.cells[0]
+        assert first_cell.colspan == 2
+        assert first_cell.content[0].content == "spans two"
+
     def test_rowspan_syntax(self) -> None:
         """Test .3+|cell creates rowspan=3."""
         asciidoc = """|===


### PR DESCRIPTION
AsciiDocParser._parse_table_row ran the span regex against `part.strip()` but then sliced the original `part` with `match.end()`. A leading space after `|` (e.g. `| 2+| spans two`) left a stray `+` as cell text and split the row wrong.

Slice the stripped text the match was computed on. Adds a regression for colspan with a space after the pipe.
