### PR TITLE
fix(asciidoc): emit table cell colspan/rowspan prefixes

### DIFF
--- a/src/all2md/renderers/asciidoc.py
+++ b/src/all2md/renderers/asciidoc.py
@@ -537,21 +537,24 @@ class AsciiDocRenderer(NodeVisitor, InlineContentMixin, BaseRenderer):
                 return f".{cell.rowspan}+|"
             return ""
 
+        def render_row(cells: list[TableCell]) -> None:
+            # A span spec attaches to the cell after the `|` it precedes, so the
+            # first cell's spec has to replace the row-opening `|` rather than
+            # follow it — otherwise it would apply to a phantom empty cell.
+            self._output.append((cell_span(cells[0]) if cells else "") or "|")
+            for index, cell in enumerate(cells):
+                content = self._render_inline_content(cell.content)
+                prefix = "" if index == 0 else cell_span(cell)
+                self._output.append(f"{prefix}{content} |")
+            self._output.append("\n")
+
         # Render header
         if node.header:
-            self._output.append("|")
-            for cell in node.header.cells:
-                content = self._render_inline_content(cell.content)
-                self._output.append(f"{cell_span(cell)}{content} |")
-            self._output.append("\n")
+            render_row(node.header.cells)
 
         # Render rows
         for row in node.rows:
-            self._output.append("|")
-            for cell in row.cells:
-                content = self._render_inline_content(cell.content)
-                self._output.append(f"{cell_span(cell)}{content} |")
-            self._output.append("\n")
+            render_row(row.cells)
 
         self._output.append("|===")
 

--- a/src/all2md/renderers/asciidoc.py
+++ b/src/all2md/renderers/asciidoc.py
@@ -528,12 +528,21 @@ class AsciiDocRenderer(NodeVisitor, InlineContentMixin, BaseRenderer):
 
         self._output.append("|===\n")
 
+        def cell_span(cell: TableCell) -> str:
+            if cell.colspan > 1 and cell.rowspan > 1:
+                return f"{cell.colspan}.{cell.rowspan}+|"
+            if cell.colspan > 1:
+                return f"{cell.colspan}+|"
+            if cell.rowspan > 1:
+                return f".{cell.rowspan}+|"
+            return ""
+
         # Render header
         if node.header:
             self._output.append("|")
             for cell in node.header.cells:
                 content = self._render_inline_content(cell.content)
-                self._output.append(f"{content} |")
+                self._output.append(f"{cell_span(cell)}{content} |")
             self._output.append("\n")
 
         # Render rows
@@ -541,7 +550,7 @@ class AsciiDocRenderer(NodeVisitor, InlineContentMixin, BaseRenderer):
             self._output.append("|")
             for cell in row.cells:
                 content = self._render_inline_content(cell.content)
-                self._output.append(f"{content} |")
+                self._output.append(f"{cell_span(cell)}{content} |")
             self._output.append("\n")
 
         self._output.append("|===")

--- a/tests/unit/renderers/test_asciidoc_renderer.py
+++ b/tests/unit/renderers/test_asciidoc_renderer.py
@@ -32,6 +32,7 @@ from all2md.ast import (
     Text,
 )
 from all2md.options.asciidoc import AsciiDocRendererOptions
+from all2md.parsers.asciidoc import AsciiDocParser
 from all2md.renderers.asciidoc import AsciiDocRenderer
 
 
@@ -893,7 +894,16 @@ class TestTableRendering:
         )
         result = AsciiDocRenderer().render_to_string(doc)
 
-        assert result == "|===\n|2+|Wide |.3+|Tall |2.3+|Both |\n|===\n"
+        # The leading cell's spec replaces the row-opening `|`; a `|2+|Wide`
+        # form would read as an empty cell followed by a spanning one.
+        assert result == "|===\n2+|Wide |.3+|Tall |2.3+|Both |\n|===\n"
+
+        reparsed = AsciiDocParser().parse(result)
+        table = reparsed.children[0]
+        assert isinstance(table, Table)
+        cells = table.header.cells if table.header else table.rows[0].cells
+        assert [(c.colspan, c.rowspan) for c in cells[:3]] == [(2, 1), (1, 3), (2, 3)]
+        assert [c.content[0].content for c in cells[:3]] == ["Wide", "Tall", "Both"]
 
 
 @pytest.mark.unit

--- a/tests/unit/renderers/test_asciidoc_renderer.py
+++ b/tests/unit/renderers/test_asciidoc_renderer.py
@@ -873,6 +873,28 @@ class TestTableRendering:
 
         assert "|===" in result
 
+    def test_table_cell_colspan_rowspan_prefixes(self):
+        """Table cells emit AsciiDoc span prefixes (2+|, .3+|, 2.3+|)."""
+        doc = Document(
+            children=[
+                Table(
+                    header=None,
+                    rows=[
+                        TableRow(
+                            cells=[
+                                TableCell(content=[Text(content="Wide")], colspan=2),
+                                TableCell(content=[Text(content="Tall")], rowspan=3),
+                                TableCell(content=[Text(content="Both")], colspan=2, rowspan=3),
+                            ]
+                        )
+                    ],
+                )
+            ]
+        )
+        result = AsciiDocRenderer().render_to_string(doc)
+
+        assert result == "|===\n|2+|Wide |.3+|Tall |2.3+|Both |\n|===\n"
+
 
 @pytest.mark.unit
 class TestOptionsValidation:


### PR DESCRIPTION
AsciiDocRenderer.visit_table ignored TableCell.colspan/rowspan, so HTML tables with merged cells lost their spans on convert to AsciiDoc even though the AsciiDoc parser already understands `2+|`, `.3+|`, and `2.3+|`.

Emit those prefixes before cell content for header and body cells. Adds a regression that asserts the exact span prefix forms.
