### PR TITLE
fix(mediawiki): parse table captions from |+ lines

### DIFF
--- a/src/all2md/parsers/mediawiki.py
+++ b/src/all2md/parsers/mediawiki.py
@@ -798,6 +798,7 @@ class MediaWikiParser(BaseParser):
 
         rows: list[TableRow] = []
         header: Optional[TableRow] = None
+        caption: Optional[str] = None
         current_row_cells: list[TableCell] = []
         in_header = False
 
@@ -816,7 +817,9 @@ class MediaWikiParser(BaseParser):
                 continue
 
             elif line.startswith("|+"):
-                # Caption - skip for now
+                caption_text = line[2:].strip()
+                if caption_text:
+                    caption = caption_text
                 continue
 
             elif line.startswith("!"):
@@ -852,7 +855,7 @@ class MediaWikiParser(BaseParser):
         if not rows and not header:
             return None
 
-        return Table(header=header, rows=rows)
+        return Table(header=header, rows=rows, caption=caption)
 
     def _is_block_quote(self, text: str) -> bool:
         """Check if text is a block quote.

--- a/tests/unit/parsers/test_mediawiki_parser.py
+++ b/tests/unit/parsers/test_mediawiki_parser.py
@@ -1,0 +1,32 @@
+#  Copyright (c) 2025 Tom Villani, Ph.D.
+"""Unit tests for MediaWiki parser."""
+
+from all2md.ast import Table
+from all2md.parsers.mediawiki import MediaWikiParser
+from all2md.renderers.mediawiki import MediaWikiRenderer
+
+
+class TestMediaWikiParserTables:
+    """Tests for MediaWiki table parsing."""
+
+    def test_parse_table_caption(self) -> None:
+        """Test that |+ caption lines populate Table.caption."""
+        wiki = """{|
+|+ Cap
+! Header
+|-
+| Cell
+|}"""
+        parser = MediaWikiParser()
+        doc = parser.parse(wiki)
+
+        assert len(doc.children) == 1
+        table = doc.children[0]
+        assert isinstance(table, Table)
+        assert table.caption == "Cap"
+
+        rendered = MediaWikiRenderer().render_to_string(doc)
+        assert "|+ Cap" in rendered
+        roundtrip = parser.parse(rendered)
+        assert isinstance(roundtrip.children[0], Table)
+        assert roundtrip.children[0].caption == "Cap"


### PR DESCRIPTION
MediaWikiParser._process_table treated `|+` lines as "Caption - skip for now", so Table.caption was always None even though the renderer already emits `|`+. Real wikitables with captions lost that text on parse and round-trip.

Store the `|+` text on Table.caption. Adds a parse + render round-trip regression for a captioned table.
