### PR TITLE
fix(server): document the intentional stat() fallback in the file listing

### DIFF
--- a/src/all2md/cli/commands/server.py
+++ b/src/all2md/cli/commands/server.py
@@ -433,6 +433,8 @@ def _generate_directory_index(
                 if created_ts is not None:
                     created_str = _format_timestamp(created_ts)
             except OSError:
+                # File vanished or became unreadable between listing and stat;
+                # keep the "?"/"—" placeholders rather than dropping the row.
                 pass
             rows += (
                 f"<tr><td><a href='{url}'>{name}</a></td>"


### PR DESCRIPTION
Closes code-scanning alert #306 (`py/empty-except`, note).

CodeQL flagged the bare `except OSError: pass` in the directory-index file table. The swallow is intentional — a file that vanishes between the directory scan and `stat()` should still render as a row with its `?`/`—` placeholders rather than silently disappear from the listing — so a comment now records that, which is what satisfies the query.

Matches the identical, already-documented fallback in `_scan_directory_for_documents` (the fix applied for alert #291 in this same file). No behaviour change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)