### PR TITLE
fix(json): preserve duplicate table column values

### DIFF
--- a/src/all2md/renderers/json.py
+++ b/src/all2md/renderers/json.py
@@ -338,10 +338,19 @@ class DataExtractor:
         """
         # Get column names from header
         columns: list[str] = []
+        used_columns: set[str] = set()
         if table.header:
             for cell in table.header.cells:
                 col_name = self._extract_cell_text(cell)
+                if col_name in used_columns:
+                    suffix = 2
+                    candidate = f"{col_name}_{suffix}"
+                    while candidate in used_columns:
+                        suffix += 1
+                        candidate = f"{col_name}_{suffix}"
+                    col_name = candidate
                 columns.append(col_name)
+                used_columns.add(col_name)
 
         if not columns:
             return []

--- a/tests/unit/renderers/test_json_renderer.py
+++ b/tests/unit/renderers/test_json_renderer.py
@@ -49,6 +49,17 @@ class TestJsonRendererBasic:
         # Should have a generic key like "table_1"
         assert "table_1" in data or any(key.startswith("table") for key in data.keys())
 
+    def test_render_table_with_duplicate_column_names(self):
+        """Test rendering preserves values from duplicate table columns."""
+        header = TableRow(cells=[TableCell(content=[Text(content="tag")]), TableCell(content=[Text(content="tag")])])
+        rows = [TableRow(cells=[TableCell(content=[Text(content="red")]), TableCell(content=[Text(content="blue")])])]
+        table = Table(header=header, rows=rows)
+        doc = Document(children=[table])
+
+        data = json.loads(JsonRenderer().render_to_string(doc))
+
+        assert data["table_1"] == [{"tag": "red", "tag_2": "blue"}]
+
     def test_render_list(self):
         """Test rendering lists to JSON."""
         items = [


### PR DESCRIPTION
JsonRenderer.DataExtractor turned table rows into dicts keyed by header text, so a Markdown table with two columns both named `tag` kept only the last cell (`blue`) and dropped `red`.

```python
from all2md.ast import Document, Table, TableRow, TableCell, Text
from all2md.renderers.json import JsonRenderer
import json

header = TableRow(cells=[TableCell(content=[Text(content="tag")]), TableCell(content=[Text(content="tag")])])
rows = [TableRow(cells=[TableCell(content=[Text(content="red")]), TableCell(content=[Text(content="blue")])])]
print(json.loads(JsonRenderer().render_to_string(Document(children=[Table(header=header, rows=rows)])))["table_1"])
# was: [{"tag": "blue"}]
```

Suffix duplicate headers (`tag`, `tag_2`, ...) so every cell is retained. Adds a regression for that case.