### PR TITLE
fix(markdown): disambiguate insert (^^) from underline in the AST

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -86,7 +86,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **HTML parser: `<ins>` is no longer silently dropped.** It was listed as an inline
   element but had no handler, so it fell through to the generic unwrapping and lost
   its markup entirely — the counterpart `<del>` has always mapped to `Strikethrough`.
-  It now parses to an `Underline` node with `semantic="insert"` (#113).
+  It now parses to an `Underline` node with `semantic="insert"`. This also recovers
+  Textile's `+inserted+`, which python-textile renders as `<ins>` and which therefore
+  used to arrive as unmarked plain text (#113).
 - **Markdown parser: `<u>` and `<ins>` survive a Markdown round trip.** They came back
   as raw `HTMLInline`, which the default `html_passthrough_mode="escape"` then turned
   into `&lt;u&gt;` on the next render. Both tags are now read back into `Underline`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **`insert_mode` Markdown renderer option** (`--markdown-insert-mode`): how to render
+  insertions — `markdown` (`^^text^^`, the default, which round-trips), `html`
+  (`<ins>`), or `ignore` (#113).
+
 ### Fixed
 
 - **INI renderer: `DEFAULT` section no longer fails to render.** `configparser`
@@ -77,9 +83,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   a Markdown HTML comment, `==mark==`, an AsciiDoc `//` comment, or an RST `..`
   comment raised `ValueError: Unknown node type for serialization`. Thanks
   [@santhreal](https://github.com/santhreal) (#128).
+- **HTML parser: `<ins>` is no longer silently dropped.** It was listed as an inline
+  element but had no handler, so it fell through to the generic unwrapping and lost
+  its markup entirely — the counterpart `<del>` has always mapped to `Strikethrough`.
+  It now parses to an `Underline` node with `semantic="insert"` (#113).
+- **Markdown parser: `<u>` and `<ins>` survive a Markdown round trip.** They came back
+  as raw `HTMLInline`, which the default `html_passthrough_mode="escape"` then turned
+  into `&lt;u&gt;` on the next render. Both tags are now read back into `Underline`
+  nodes, so they round-trip losslessly. Tags carrying attributes, and unmatched or
+  stray tags, are still passed through untouched rather than guessed at. The remaining
+  inline tags (`<del>`, `<sup>`, `<sub>`, `<mark>`) still self-escape (#113).
 
 ### Changed
 
+- **`^^text^^` and underline are now distinct in the AST.** `^^` is pymdownx's
+  *insert* extension, not underline, but both parsed to the same `Underline` node, so
+  an insertion could not render as `<ins>` and a genuine underline emitted insert
+  syntax. `Underline` gained a `semantic: Literal["underline", "insert"]`
+  discriminator (default `"underline"`, omitted from serialized output when default,
+  so existing JSON is unaffected). The HTML renderer emits `<ins>` for insert and
+  `<u>` for underline (#113).
+- **`underline_mode` now defaults to `"html"` (`<u>`) instead of `"markdown"`
+  (`^^text^^`).** Markdown has no underline syntax of its own, and `^^` means insert;
+  `<u>` now round-trips losslessly thanks to the parser fix above. Set
+  `underline_mode="markdown"` to keep the pre-1.10 spelling (#113).
 - CI: bumped `actions/setup-python` 6 → 7 and `actions/setup-node` 6 → 7 (#120, #121).
 
 ## [1.9.0] - 2026-07-15

--- a/docs/source/ast_guide.rst
+++ b/docs/source/ast_guide.rst
@@ -148,7 +148,7 @@ Inline nodes represent inline formatting:
        Image,         # Images
        LineBreak,     # Line breaks
        Strikethrough, # Strikethrough text
-       Underline,     # Underlined text
+       Underline,     # Underlined text, or an insertion (semantic="insert")
        Mark,          # Highlighted/marked text (==text==)
        Superscript,   # Superscript
        Subscript,     # Subscript

--- a/docs/source/options.rst
+++ b/docs/source/options.rst
@@ -5229,7 +5229,16 @@ The Markdown format has no dedicated CLI flags. The common Markdown formatting f
 
 **underline_mode**
 
-   How to handle underlined text: markdown (^^text^^), html (<u>), or ignore
+   How to handle underlined text: html (<u>), markdown (^^text^^), or ignore
+
+   :Type: ``Literal['html', 'markdown', 'ignore']``
+   :Default: ``'html'``
+   :Choices: ``html``, ``markdown``, ``ignore``
+   :Importance: advanced
+
+**insert_mode**
+
+   How to handle inserted text: markdown (^^text^^), html (<ins>), or ignore
 
    :Type: ``Literal['html', 'markdown', 'ignore']``
    :Default: ``'markdown'``
@@ -11208,10 +11217,20 @@ modules to ensure consistent Markdown generation.
 
 **underline_mode**
 
-   How to handle underlined text: markdown (^^text^^), html (<u>), or ignore
+   How to handle underlined text: html (<u>), markdown (^^text^^), or ignore
 
    :Type: ``Literal['html', 'markdown', 'ignore']``
    :CLI flag: ``--markdown-underline-mode``
+   :Default: ``'html'``
+   :Choices: ``html``, ``markdown``, ``ignore``
+   :Importance: advanced
+
+**insert_mode**
+
+   How to handle inserted text: markdown (^^text^^), html (<ins>), or ignore
+
+   :Type: ``Literal['html', 'markdown', 'ignore']``
+   :CLI flag: ``--markdown-insert-mode``
    :Default: ``'markdown'``
    :Choices: ``html``, ``markdown``, ``ignore``
    :Importance: advanced

--- a/src/all2md/ast/nodes.py
+++ b/src/all2md/ast/nodes.py
@@ -1343,14 +1343,25 @@ class Mark(Node):
 
 @dataclass
 class Underline(Node):
-    """Underline node (non-standard extension).
+    r"""Underline node (non-standard extension).
 
-    Represents underlined text.
+    Represents underlined text, and -- via ``semantic`` -- the closely related
+    "insert" markup that shares the same rendering in most formats.
+
+    The two are distinct in meaning but identical in presentation nearly
+    everywhere, so they share a node: ``semantic="underline"`` is presentational
+    underline (HTML ``<u>``, Word underline, ``\\underline{}``), while
+    ``semantic="insert"`` is an edit-tracking insertion (HTML ``<ins>``, the
+    pymdownx ``^^text^^`` extension). Renderers for formats that cannot express
+    the difference may ignore ``semantic`` and underline both.
 
     Parameters
     ----------
     content : list of Node, default = empty list
         Inline nodes with underline
+    semantic : {"underline", "insert"}, default "underline"
+        Whether this is presentational underline or an insertion. Controls
+        ``<u>`` vs ``<ins>`` in HTML, and ``<u>`` vs ``^^text^^`` in Markdown.
     metadata : dict, default = empty dict
         Underline metadata
     source_location : SourceLocation or None, default = None
@@ -1359,6 +1370,7 @@ class Underline(Node):
     """
 
     content: list[Node] = field(default_factory=list)
+    semantic: Literal["underline", "insert"] = "underline"
     metadata: dict[str, Any] = field(default_factory=dict)
     source_location: Optional[SourceLocation] = None
 

--- a/src/all2md/ast/serialization.py
+++ b/src/all2md/ast/serialization.py
@@ -171,6 +171,30 @@ def _serialize_inline_content_node(node: Node, node_type: str) -> dict[str, Any]
     return result
 
 
+def _serialize_underline(node: Node) -> dict[str, Any]:
+    """Serialize an Underline node, including its ``semantic`` discriminator.
+
+    ``semantic`` is only emitted when it differs from the default, so documents
+    with no insert markup serialize identically to before the field existed.
+
+    Parameters
+    ----------
+    node : Node
+        Underline node to serialize
+
+    Returns
+    -------
+    dict
+        Serialized node
+
+    """
+    result = _serialize_inline_content_node(node, "Underline")
+    semantic = getattr(node, "semantic", "underline")
+    if semantic != "underline":
+        result["semantic"] = semantic
+    return result
+
+
 def _serialize_text_content_node(node: Node, node_type: str) -> dict[str, Any]:
     """Serialize nodes with a 'content' attribute containing text.
 
@@ -396,7 +420,7 @@ _SERIALIZATION_DISPATCH: dict[type, Any] = {
     Emphasis: lambda n: _serialize_inline_content_node(n, "Emphasis"),
     Strong: lambda n: _serialize_inline_content_node(n, "Strong"),
     Strikethrough: lambda n: _serialize_inline_content_node(n, "Strikethrough"),
-    Underline: lambda n: _serialize_inline_content_node(n, "Underline"),
+    Underline: _serialize_underline,
     Superscript: lambda n: _serialize_inline_content_node(n, "Superscript"),
     Subscript: lambda n: _serialize_inline_content_node(n, "Subscript"),
     MathInline: lambda n: _serialize_math_node(n, "MathInline"),
@@ -684,8 +708,10 @@ def _deserialize_strikethrough(data: dict[str, Any]) -> Strikethrough:
 
 def _deserialize_underline(data: dict[str, Any]) -> Underline:
     """Deserialize Underline node."""
+    semantic = data.get("semantic", "underline")
     return Underline(
         content=_deserialize_children(data.get("content", [])),
+        semantic="insert" if semantic == "insert" else "underline",
         metadata=data.get("metadata", {}),
         source_location=_deserialize_source_location(data.get("source_location")),
     )

--- a/src/all2md/constants.py
+++ b/src/all2md/constants.py
@@ -25,6 +25,7 @@ from typing import Literal
 # Markdown formatting types
 EmphasisSymbol = Literal["*", "_"]
 UnderlineMode = Literal["html", "markdown", "ignore"]
+InsertMode = Literal["html", "markdown", "ignore"]
 SuperscriptMode = Literal["html", "markdown", "ignore"]
 SubscriptMode = Literal["html", "markdown", "ignore"]
 MathMode = Literal["latex", "mathml", "html"]

--- a/src/all2md/options/markdown.py
+++ b/src/all2md/options/markdown.py
@@ -195,16 +195,14 @@ class MarkdownRendererOptions(BaseRendererOptions):
         How to render presentational underline (``Underline`` with
         ``semantic="underline"``). Markdown has no underline syntax of its own:
         - "html": Use <u>text</u> tags (roundtrips -- the parser reads <u> back)
-        - "markdown": Use ^^text^^ (the pymdownx *insert* spelling; renders as
-          underline in Material for MkDocs, but reparses as insert, so the
-          underline/insert distinction is lost)
+        - "markdown": Use ^^text^^, the pymdownx *insert* spelling (reparses as insert)
         - "ignore": Strip underline formatting
     insert_mode : {"html", "markdown", "ignore"}, default "markdown"
         How to render insertions (``Underline`` with ``semantic="insert"``, from
         ``^^text^^`` or ``<ins>``). Flavors that natively support ``^^text^^``
         (markdown_plus) always emit it; for the rest:
         - "markdown": Use ^^text^^ (roundtrips, needs an extension to render)
-        - "html": Use <ins>text</ins> tags (wider display support; also roundtrips)
+        - "html": Use <ins>text</ins> tags (wider support; also roundtrips)
         - "ignore": Strip insert formatting
     superscript_mode : {"html", "markdown", "ignore"}, default "markdown"
         Fallback for flavors that don't natively support superscript. Flavors

--- a/src/all2md/options/markdown.py
+++ b/src/all2md/options/markdown.py
@@ -37,6 +37,7 @@ from all2md.constants import (
     EmphasisSymbol,
     FlavorType,
     HtmlPassthroughMode,
+    InsertMode,
     LinkStyleType,
     MathMode,
     MetadataFormatType,
@@ -190,12 +191,21 @@ class MarkdownRendererOptions(BaseRendererOptions):
         Characters to cycle through for nested bullet lists.
     list_indent_width : int, default 4
         Number of spaces to use for each level of list indentation.
-    underline_mode : {"html", "markdown", "ignore"}, default "markdown"
-        Fallback for flavors that don't natively support underline. Flavors that
-        do (markdown_plus) always emit ``^^text^^``; for the rest:
-        - "markdown": Use ^^text^^ (the pymdownx insert spelling; roundtrips, needs an extension to render)
-        - "html": Use <u>text</u> tags (wider display support, but escaped on roundtrip)
+    underline_mode : {"html", "markdown", "ignore"}, default "html"
+        How to render presentational underline (``Underline`` with
+        ``semantic="underline"``). Markdown has no underline syntax of its own:
+        - "html": Use <u>text</u> tags (roundtrips -- the parser reads <u> back)
+        - "markdown": Use ^^text^^ (the pymdownx *insert* spelling; renders as
+          underline in Material for MkDocs, but reparses as insert, so the
+          underline/insert distinction is lost)
         - "ignore": Strip underline formatting
+    insert_mode : {"html", "markdown", "ignore"}, default "markdown"
+        How to render insertions (``Underline`` with ``semantic="insert"``, from
+        ``^^text^^`` or ``<ins>``). Flavors that natively support ``^^text^^``
+        (markdown_plus) always emit it; for the rest:
+        - "markdown": Use ^^text^^ (roundtrips, needs an extension to render)
+        - "html": Use <ins>text</ins> tags (wider display support; also roundtrips)
+        - "ignore": Strip insert formatting
     superscript_mode : {"html", "markdown", "ignore"}, default "markdown"
         Fallback for flavors that don't natively support superscript. Flavors
         that do (markdown_plus) always emit ``^text^``; for the rest:
@@ -298,13 +308,25 @@ class MarkdownRendererOptions(BaseRendererOptions):
         },
     )
     underline_mode: UnderlineMode = field(
+        # Default to HTML (``<u>``): Markdown has no underline syntax of its own,
+        # and ``^^text^^`` means *insert* (see insert_mode), not underline. The
+        # Markdown parser reads ``<u>`` back as an Underline node, so this
+        # roundtrips losslessly despite being raw HTML. Set to "markdown" to keep
+        # the pre-1.9 ``^^`` spelling, which conflates underline with insert.
+        default="html",
+        metadata={
+            "help": "How to handle underlined text: html (<u>), markdown (^^text^^), or ignore",
+            "choices": ["html", "markdown", "ignore"],
+            "importance": "advanced",
+        },
+    )
+    insert_mode: InsertMode = field(
         # Default to Markdown (``^^text^^``, the pymdownx "insert" spelling) so
-        # underline roundtrips: the HTML ``<u>`` alternative is escaped by the
-        # default html_passthrough policy on the next Markdown roundtrip. Mirrors
-        # superscript_mode/subscript_mode. Set to "html" for wider display support.
+        # insert roundtrips; the parser reads both ``^^`` and ``<ins>`` back.
+        # Mirrors superscript_mode/subscript_mode.
         default="markdown",
         metadata={
-            "help": "How to handle underlined text: markdown (^^text^^), html (<u>), or ignore",
+            "help": "How to handle inserted text: markdown (^^text^^), html (<ins>), or ignore",
             "choices": ["html", "markdown", "ignore"],
             "importance": "advanced",
         },

--- a/src/all2md/parsers/html.py
+++ b/src/all2md/parsers/html.py
@@ -869,6 +869,7 @@ class HtmlToAstConverter(BaseParser):
         "a": "_process_link_to_ast",
         "img": "_process_image_to_ast",
         "u": "_process_underline_to_ast",
+        "ins": "_process_insert_to_ast",
     }
 
     def _process_node_to_ast(self, node: Any) -> Node | list[Node] | None:
@@ -1611,6 +1612,28 @@ class HtmlToAstConverter(BaseParser):
         """
         content = self._process_children_to_inline(node)
         return Underline(content=content)
+
+    def _process_insert_to_ast(self, node: Any) -> Underline:
+        """Process ins element to an Underline node with insert semantics.
+
+        ``<ins>`` was previously unmapped, so it fell through to the generic
+        inline unwrapping and lost its markup entirely. It is the counterpart of
+        ``<del>`` (which maps to Strikethrough) and renders underlined in
+        browsers, so it shares the Underline node with ``semantic="insert"``.
+
+        Parameters
+        ----------
+        node : Any
+            INS element
+
+        Returns
+        -------
+        Underline
+            Underline node tagged as an insertion
+
+        """
+        content = self._process_children_to_inline(node)
+        return Underline(content=content, semantic="insert")
 
     def _process_strikethrough_to_ast(self, node: Any) -> Strikethrough:
         """Process del/s/strike element to Strikethrough node.

--- a/src/all2md/parsers/markdown.py
+++ b/src/all2md/parsers/markdown.py
@@ -204,6 +204,14 @@ class MarkdownToAstConverter(BaseParser):
 
     """
 
+    # Bare inline tags folded back into Underline nodes, mapped to the semantic
+    # they carry. Only these two: the other inline formatting tags (<del>, <sup>,
+    # <sub>, <mark>) have the same escaping problem but are tracked separately.
+    _FOLDABLE_INLINE_TAGS: dict[str, Literal["underline", "insert"]] = {"u": "underline", "ins": "insert"}
+    # Matches only attribute-free tags -- one with attributes carries information
+    # the Underline node cannot hold, so it stays raw HTML.
+    _FOLDABLE_TAG_RE = re.compile(r"^<\s*(/)?\s*(u|ins)\s*>$", re.IGNORECASE)
+
     def __init__(
         self, options: MarkdownParserOptions | None = None, progress_callback: Optional[ProgressCallback] = None
     ):
@@ -1013,7 +1021,91 @@ class MarkdownToAstConverter(BaseParser):
                 else:
                     nodes.append(node)
 
-        return nodes
+        return self._fold_underline_html(nodes)
+
+    def _fold_underline_html(self, nodes: list[Node]) -> list[Node]:
+        """Fold ``<u>``/``<ins>`` HTMLInline pairs back into Underline nodes.
+
+        mistune hands raw inline HTML straight through, so ``a <u>x</u> b``
+        would otherwise survive as loose HTMLInline nodes around the text and be
+        escaped to ``&lt;u&gt;`` by the default ``html_passthrough_mode`` on the
+        next render -- the self-escaping failure #107 fixed for ``^^``. Reading
+        the tags back as real nodes keeps both spellings lossless and recovers
+        the underline/insert distinction that ``<u>`` vs ``<ins>`` encodes.
+
+        Unmatched tags and tags carrying attributes are left as raw HTMLInline
+        rather than guessed at, so nothing is silently dropped.
+
+        Parameters
+        ----------
+        nodes : list of Node
+            Inline nodes, possibly containing tag-like HTMLInline nodes
+
+        Returns
+        -------
+        list of Node
+            Nodes with balanced ``<u>``/``<ins>`` spans folded into Underline
+
+        """
+        result: list[Node] = []
+        # Each entry is (tag name, start index in result, the raw open-tag node).
+        open_tags: list[tuple[str, int, Node]] = []
+
+        for node in nodes:
+            parsed = self._parse_foldable_tag(node)
+            if parsed is None:
+                result.append(node)
+                continue
+
+            name, is_closing = parsed
+            if not is_closing:
+                open_tags.append((name, len(result), node))
+                continue
+
+            match = next((i for i in range(len(open_tags) - 1, -1, -1) if open_tags[i][0] == name), None)
+            if match is None:
+                # Stray close tag with no opener; keep it verbatim.
+                result.append(node)
+                continue
+
+            # Anything still open *inside* this span never closed -- restore
+            # those raw tags (deepest first, so earlier indices stay valid)
+            # instead of swallowing them into the folded content.
+            for _, start, raw in reversed(open_tags[match + 1 :]):
+                result.insert(start, raw)
+            del open_tags[match + 1 :]
+
+            _, start, _ = open_tags.pop()
+            content = result[start:]
+            del result[start:]
+            result.append(Underline(content=content, semantic=self._FOLDABLE_INLINE_TAGS[name]))
+
+        # Openers that never closed: put their raw tags back where they were.
+        for _, start, raw in reversed(open_tags):
+            result.insert(start, raw)
+
+        return result
+
+    def _parse_foldable_tag(self, node: Node) -> tuple[str, bool] | None:
+        """Identify a bare ``<u>``/``<ins>`` open or close tag node.
+
+        Parameters
+        ----------
+        node : Node
+            Candidate inline node
+
+        Returns
+        -------
+        tuple of (str, bool), or None
+            ``(tag name, is_closing)``, or None if not a foldable bare tag
+
+        """
+        if not isinstance(node, HTMLInline):
+            return None
+        match = self._FOLDABLE_TAG_RE.match(node.content.strip())
+        if match is None:
+            return None
+        return match.group(2).lower(), bool(match.group(1))
 
     def _handle_text_token(self, token: dict[str, Any]) -> Text:
         """Handle text token."""
@@ -1094,10 +1186,15 @@ class MarkdownToAstConverter(BaseParser):
         return Mark(content=content)
 
     def _handle_insert_token(self, token: dict[str, Any]) -> Underline:
-        """Handle insert token (^^underline^^), represented as Underline."""
+        """Handle insert token (``^^text^^``), an Underline with insert semantics.
+
+        ``^^`` is pymdownx's *insert* spelling, not underline, so it is tagged
+        as such: that keeps it distinct from a genuine ``<u>`` and lets the
+        renderers emit ``<ins>``/``^^`` rather than ``<u>``.
+        """
         children = token.get("children", [])
         content = self._process_inline_tokens(children)
-        return Underline(content=content)
+        return Underline(content=content, semantic="insert")
 
     def _handle_superscript_token(self, token: dict[str, Any]) -> Superscript:
         """Handle superscript token (^text^)."""

--- a/src/all2md/renderers/html.py
+++ b/src/all2md/renderers/html.py
@@ -1173,7 +1173,8 @@ hr {
 
         """
         content = self._render_inline_content(node.content)
-        self._output.append(f"<u>{content}</u>")
+        tag = "ins" if node.semantic == "insert" else "u"
+        self._output.append(f"<{tag}>{content}</{tag}>")
 
     def visit_superscript(self, node: Superscript) -> None:
         """Render a Superscript node.

--- a/src/all2md/renderers/markdown.py
+++ b/src/all2md/renderers/markdown.py
@@ -1537,23 +1537,36 @@ class MarkdownRenderer(NodeVisitor, InlineContentMixin, BaseRenderer):
         """
         content = self._render_inline_content(node.content)
 
-        # A flavor that natively supports ^^text^^ (MarkdownPlus) emits it directly,
-        # like visit_superscript does for ^. Other flavors fall back per
-        # underline_mode (default "markdown", which roundtrips through the insert
-        # plugin; set "html" for wider display). Note "markdown" emits ^^ -- the
-        # pymdownx "insert" spelling the parser reads back as Underline -- not __,
-        # which every flavor parses as strong emphasis, silently losing the underline.
-        if self._flavor.supports_underline():
-            self._output.append(f"^^{content}^^")
+        if node.semantic == "insert":
+            # ``^^text^^`` is pymdownx's *insert* spelling, so it belongs to
+            # insert rather than underline. A flavor that supports it natively
+            # (MarkdownPlus) emits it directly, like visit_superscript does for
+            # ^; the rest fall back per insert_mode, whose "markdown" default
+            # roundtrips through the insert plugin.
+            if self._flavor.supports_underline():
+                self._output.append(f"^^{content}^^")
+                return
+
+            mode = self.options.insert_mode
+            if mode == "html":
+                self._output.append(f"<ins>{content}</ins>")
+            elif mode == "markdown":
+                self._output.append(f"^^{content}^^")
+            else:
+                self._output.append(content)
             return
 
+        # Genuine underline. Markdown has no underline syntax of its own -- ^^ is
+        # insert and __ is strong emphasis -- so the default is <u>, which the
+        # parser reads back as an Underline (see _fold_underline_html) and so
+        # roundtrips losslessly rather than escaping to &lt;u&gt;.
         mode = self.options.underline_mode
-        if mode == "html":
-            self._output.append(f"<u>{content}</u>")
-        elif mode == "markdown":
+        if mode == "markdown":
             self._output.append(f"^^{content}^^")
-        else:
+        elif mode == "ignore":
             self._output.append(content)
+        else:
+            self._output.append(f"<u>{content}</u>")
 
     def visit_superscript(self, node: Superscript) -> None:
         """Render a Superscript node.

--- a/src/all2md/utils/flavors.py
+++ b/src/all2md/utils/flavors.py
@@ -171,16 +171,19 @@ class MarkdownFlavor(ABC):
         return False
 
     def supports_underline(self) -> bool:
-        """Check if this flavor natively supports ``^^text^^`` underline syntax.
+        """Check if this flavor natively supports ``^^text^^`` syntax.
 
-        Concrete (default ``False``) rather than abstract: underline is the
-        pymdownx / Material "insert" extension, natively supported only by the
-        MarkdownPlus flavor. Other flavors fall back per ``underline_mode``.
+        ``^^`` is the pymdownx / Material *insert* extension -- it marks an
+        insertion, not presentational underline, and only MarkdownPlus supports
+        it natively. Other flavors fall back per ``insert_mode``; genuine
+        underline is governed by ``underline_mode`` and never uses ``^^`` unless
+        asked to. (The method keeps its historical name, from when the two were
+        the same node.)
 
         Returns
         -------
         bool
-            True if ``^^text^^`` underline syntax is supported
+            True if ``^^text^^`` syntax is supported
 
         """
         return False
@@ -989,7 +992,7 @@ class MarkdownPlusFlavor(MarkdownFlavor):
         return True
 
     def supports_underline(self) -> bool:
-        """MarkdownPlus supports ``^^text^^`` underline syntax.
+        """MarkdownPlus supports ``^^text^^`` insert syntax.
 
         Returns
         -------

--- a/tests/golden/__snapshots__/test_docx_golden.ambr
+++ b/tests/golden/__snapshots__/test_docx_golden.ambr
@@ -3,7 +3,7 @@
   '''
   # Formatting Test Document
   
-  This paragraph contains **bold text**, *italic text*, and ^^underlined text^^.
+  This paragraph contains **bold text**, *italic text*, and <u>underlined text</u>.
   
   This paragraph has ***bold and italic text*** together.
   
@@ -24,7 +24,7 @@
   '''
   # Formatting Test Document
   
-  This paragraph contains **bold text**, *italic text*, and ^^underlined text^^.
+  This paragraph contains **bold text**, *italic text*, and <u>underlined text</u>.
   
   This paragraph has ***bold and italic text*** together.
   
@@ -45,7 +45,7 @@
   '''
   # Formatting Test Document
   
-  This paragraph contains **bold text**, *italic text*, and ^^underlined text^^.
+  This paragraph contains **bold text**, *italic text*, and <u>underlined text</u>.
   
   This paragraph has ***bold and italic text*** together.
   
@@ -66,7 +66,7 @@
   '''
   # Formatting Test Document
   
-  This paragraph contains **bold text**, *italic text*, and ^^underlined text^^.
+  This paragraph contains **bold text**, *italic text*, and <u>underlined text</u>.
   
   This paragraph has ***bold and italic text*** together.
   
@@ -145,7 +145,7 @@
   
   Second paragraph with **bold** text and *italic* text and ***both***
   
-  Here’s some ^^underlined text^^.
+  Here’s some <u>underlined text</u>.
   
   Here we want a longer paragraph that can span a few lines in a document. It should be like 3 or 4 sentences, which is the normal length of a paragraph. We can even include some **formatting** for emphasis. It’s getting pretty long now, I think we’re almost done.
   

--- a/tests/golden/__snapshots__/test_other_formats_golden.ambr
+++ b/tests/golden/__snapshots__/test_other_formats_golden.ambr
@@ -130,7 +130,7 @@
   
   ## Second content slide
   
-  This one has**formatting**that is^^fancier^^*sometimes*even***too fancy***
+  This one has**formatting**that is<u>fancier</u>*sometimes*even***too fancy***
   
   * And we’ll do a nested list
   * Here’s the first nested item

--- a/tests/golden/__snapshots__/test_textual_formats_golden.ambr
+++ b/tests/golden/__snapshots__/test_textual_formats_golden.ambr
@@ -420,7 +420,7 @@
   
   Text with ^superscript^ and ~subscript~.
   
-  Text with ~~strikethrough~~ content and underline text.
+  Text with ~~strikethrough~~ content and ^^underline^^ text.
   
   ## Block Quote
   

--- a/tests/integration/test_roundtrip.py
+++ b/tests/integration/test_roundtrip.py
@@ -48,10 +48,26 @@ print("hi")
 """
 
 
+#: Raw inline HTML the Markdown parser has no node for, so it survives as an
+#: HTMLInline and is escaped on the way back out. ``<u>``/``<ins>`` deliberately
+#: do *not* belong here -- they parse into Underline nodes and roundtrip cleanly.
+ESCAPING_HTML_MARKDOWN = """# Title
+
+Here is some <span class="highlight">raw inline HTML</span> text.
+"""
+
+
 @pytest.fixture
 def rich_md(tmp_path) -> Path:
     path = tmp_path / "rich.md"
     path.write_text(RICH_MARKDOWN, encoding="utf-8")
+    return path
+
+
+@pytest.fixture
+def escaping_html_md(tmp_path) -> Path:
+    path = tmp_path / "escaping_html.md"
+    path.write_text(ESCAPING_HTML_MARKDOWN, encoding="utf-8")
     return path
 
 
@@ -94,27 +110,38 @@ class TestRoundTripApi:
         report = roundtrip_report(RICH_MARKDOWN.encode(), source_format="markdown")
         assert report.score == 100
 
-    def test_escaped_inline_html_is_priced_as_a_real_loss(self):
+    def test_escaped_inline_html_is_priced_as_a_real_loss(self, escaping_html_md):
         """Escaped raw HTML costs fidelity, and the score says so.
 
-        ``basic.md`` contains ``<u>...</u>``, and the Markdown renderer escapes raw
-        HTML by default (``html_passthrough_mode="escape"``, a security posture).
-        The round trip therefore cannot be perfect, and the score reports that
-        rather than quietly forgiving it.
+        The Markdown renderer escapes raw HTML by default
+        (``html_passthrough_mode="escape"``, a security posture), so a document
+        carrying a tag with no AST equivalent (``<span>``) cannot round trip
+        perfectly -- and the score reports that rather than quietly forgiving it.
         """
-        report = roundtrip_report(BASIC_MD)
+        report = roundtrip_report(escaping_html_md)
         assert report.score < 100
         assert {delta.kind for delta in report.deltas} == {"inline_lost", "text_lost"}
         assert any(delta.detail == "htmlinline" for delta in report.deltas)
 
-    def test_score_responds_to_converter_options(self):
+    def test_underline_html_roundtrips_losslessly(self):
+        """``<u>`` is not "raw HTML" to the scorer -- it is an Underline node.
+
+        ``basic.md`` contains ``<u>underlined text</u>``. The Markdown parser
+        reads that back into the AST, so it survives the round trip intact even
+        under the default escaping policy (#113).
+        """
+        report = roundtrip_report(BASIC_MD)
+        assert report.score == 100
+        assert report.deltas == []
+
+    def test_score_responds_to_converter_options(self, escaping_html_md):
         """The score must move when converter options move.
 
         This is what makes it usable as the ``optimize`` capstone's fitness
         function: flipping one renderer option recovers the lost points.
         """
-        escaped = roundtrip_report(BASIC_MD)
-        passed_through = roundtrip_report(BASIC_MD, html_passthrough_mode="pass-through")
+        escaped = roundtrip_report(escaping_html_md)
+        passed_through = roundtrip_report(escaping_html_md, html_passthrough_mode="pass-through")
 
         assert passed_through.score == 100
         assert passed_through.deltas == []

--- a/tests/unit/renderers/test_markdown_renderer.py
+++ b/tests/unit/renderers/test_markdown_renderer.py
@@ -296,33 +296,60 @@ class TestExtendedInlineFormatting:
         result = renderer.render_to_string(doc)
         assert result == "<del>deleted</del>"
 
-    def test_underline_default_roundtrips(self):
-        """The default underline_mode emits ^^ (roundtrips via the insert plugin).
+    def test_underline_default_is_html(self):
+        """The default underline_mode emits <u>, which the parser reads back.
 
-        A raw <u> is escaped by the default html_passthrough policy on the next
-        Markdown pass; ^^text^^ is read back as an Underline. __text__ is *not* a
-        safe alternative -- every flavor parses it as strong emphasis.
+        Markdown has no underline syntax of its own: ``^^text^^`` is pymdownx
+        *insert* (see the insert tests below) and ``__text__`` is strong emphasis
+        in every flavor. ``<u>`` is the only spelling that means underline and
+        survives a round trip (#113).
         """
         doc = Document(children=[Paragraph(content=[Underline(content=[Text(content="underlined")])])])
         renderer = MarkdownRenderer()
         result = renderer.render_to_string(doc)
+        assert result == "<u>underlined</u>"
+
+    def test_underline_markdown_mode_uses_insert_spelling(self):
+        """An explicit underline_mode='markdown' opts into the legacy ^^ spelling."""
+        doc = Document(children=[Paragraph(content=[Underline(content=[Text(content="underlined")])])])
+        options = MarkdownRendererOptions(underline_mode="markdown")
+        renderer = MarkdownRenderer(options)
+        result = renderer.render_to_string(doc)
         assert result == "^^underlined^^"
 
-    def test_underline_html_mode(self):
-        """An explicit underline_mode='html' opts into <u>."""
+    def test_underline_ignore_mode_strips_markup(self):
         doc = Document(children=[Paragraph(content=[Underline(content=[Text(content="underlined")])])])
-        options = MarkdownRendererOptions(underline_mode="html")
+        options = MarkdownRendererOptions(underline_mode="ignore")
+        renderer = MarkdownRenderer(options)
+        assert renderer.render_to_string(doc) == "underlined"
+
+    def test_underline_stays_html_in_markdown_plus(self):
+        """MarkdownPlus's native ^^ is *insert*, so underline still emits <u>."""
+        doc = Document(children=[Paragraph(content=[Underline(content=[Text(content="underlined")])])])
+        options = MarkdownRendererOptions(flavor="markdown_plus")
         renderer = MarkdownRenderer(options)
         result = renderer.render_to_string(doc)
         assert result == "<u>underlined</u>"
 
-    def test_underline_markdown_plus_flavor_is_native(self):
-        """MarkdownPlus supports ^^ natively, so it wins even over underline_mode='html'."""
-        doc = Document(children=[Paragraph(content=[Underline(content=[Text(content="underlined")])])])
-        options = MarkdownRendererOptions(flavor="markdown_plus", underline_mode="html")
+    def test_insert_default_roundtrips(self):
+        """Insert keeps ^^ by default -- the pymdownx spelling it came from."""
+        doc = Document(children=[Paragraph(content=[Underline(content=[Text(content="added")], semantic="insert")])])
+        renderer = MarkdownRenderer()
+        assert renderer.render_to_string(doc) == "^^added^^"
+
+    def test_insert_html_mode(self):
+        """An explicit insert_mode='html' opts into <ins>, distinct from <u>."""
+        doc = Document(children=[Paragraph(content=[Underline(content=[Text(content="added")], semantic="insert")])])
+        options = MarkdownRendererOptions(insert_mode="html")
         renderer = MarkdownRenderer(options)
-        result = renderer.render_to_string(doc)
-        assert result == "^^underlined^^"
+        assert renderer.render_to_string(doc) == "<ins>added</ins>"
+
+    def test_insert_markdown_plus_flavor_is_native(self):
+        """MarkdownPlus supports ^^ natively, so it wins even over insert_mode='html'."""
+        doc = Document(children=[Paragraph(content=[Underline(content=[Text(content="added")], semantic="insert")])])
+        options = MarkdownRendererOptions(flavor="markdown_plus", insert_mode="html")
+        renderer = MarkdownRenderer(options)
+        assert renderer.render_to_string(doc) == "^^added^^"
 
     def test_superscript_html_mode(self):
         """Test superscript with HTML mode."""


### PR DESCRIPTION
Closes #113.

## The problem

`^^text^^` is pymdownx's **insert** extension, not underline, but both it and a genuine `<u>` parsed to the same `Underline` node. Two consequences:

- an insertion could never render as `<ins>` — it came out as `<u>`;
- a genuine underline emitted `^^…^^` by default, i.e. insert markup.

## The shape

`Underline` gains `semantic: Literal["underline", "insert"]` rather than a separate `Insert` node. The two are distinct in meaning but identical in presentation nearly everywhere, and a new node type would require `visit_insert` in all sixteen renderers plus visitors, transforms, serialization, linter and manifest. Serialization emits `semantic` only when non-default, so existing serialized documents are byte-identical.

## Two bugs fixed on the way, both prerequisites

- **`<ins>` was silently dropped by the HTML parser.** It was listed in `INLINE_ELEMENTS` but had no entry in the tag dispatch map, so it fell through to generic inline unwrapping and lost its markup entirely — while its counterpart `<del>` has always mapped to `Strikethrough`.
- **`<u>`/`<ins>` self-escaped on a Markdown round trip.** mistune hands raw inline HTML straight through, so they survived as `HTMLInline` and the default `html_passthrough_mode="escape"` turned them into `&lt;u&gt;` on the next render — the same failure #107 fixed for `^^`. They now fold back into `Underline` nodes. Tags carrying attributes, unmatched openers and stray closers are left as raw HTML rather than guessed at, so nothing is silently dropped.

The remaining inline tags (`<del>`, `<sup>`, `<sub>`, `<mark>`) have the same self-escaping problem; that is pre-existing and tracked separately rather than folded onto this branch.

## User-visible changes

- `underline_mode` **default flips from `"markdown"` (`^^text^^`) to `"html"` (`<u>`)**. Markdown has no underline syntax of its own, `^^` means insert, and `<u>` now round-trips losslessly thanks to the parser fix. Set `underline_mode="markdown"` to keep the old spelling.
- New `insert_mode` option / `--markdown-insert-mode` flag, defaulting to `"markdown"` (`^^text^^`) so insert still round-trips.
- The HTML renderer emits `<ins>` for insert, `<u>` for underline.

## Verification

- Unit suite green (one unrelated Windows timing flake in `test_cli_watch.py::test_watch_mode_debounce_rapid_changes`, which passes in isolation).
- Round-trip checked over three generations for `<u>`, `^^`, and `<ins>`; folding edge cases exercised (unmatched open, stray close, attributed tags, nesting both ways, misnesting, empty tags, uppercase `<U>`).
- `test_roundtrip.py`'s escaping fixture moved from `basic.md` to a `<span>`-based document that genuinely still escapes — otherwise the fidelity oracle would have silently stopped being able to fail. A positive test now pins `basic.md` at 100.
- `docs/source/options.rst` regenerated; converter manifest regenerates to no diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
