### PR TITLE
fix(latex): keep itemize/enumerate item text after \item

### DIFF
--- a/src/all2md/parsers/latex.py
+++ b/src/all2md/parsers/latex.py
@@ -677,33 +677,7 @@ class LatexParser(BaseParser):
             List node
 
         """
-        items = []
-        if hasattr(node, "nodelist"):
-            for child in node.nodelist:
-                if hasattr(child, "macroname") and child.macroname == "item":
-                    item_nodes = []
-                    # Get content after \item
-                    if hasattr(child, "nodeargd") and hasattr(child.nodeargd, "argnlist"):
-                        for arg in child.nodeargd.argnlist:
-                            if arg and hasattr(arg, "nodelist"):
-                                for item_child in arg.nodelist:
-                                    converted = self._convert_node(item_child)
-                                    if converted:
-                                        if isinstance(converted, list):
-                                            item_nodes.extend(converted)
-                                        else:
-                                            item_nodes.append(converted)
-
-                    # Wrap in paragraph if not empty
-                    if item_nodes:
-                        all_inline = all(isinstance(n, (Text, Strong, Emphasis, Code, Link, Image)) for n in item_nodes)
-                        content: list[Node] = (
-                            item_nodes if all_inline else [Text(content=self._extract_text(item_nodes))]
-                        )
-                        para = Paragraph(content=content)
-                        items.append(ListItem(children=[para]))
-
-        return List(ordered=False, items=items)
+        return self._convert_list_environment(node, ordered=False)
 
     def _convert_enumerate(self, node: Any) -> List:
         """Convert enumerate environment to ordered List.
@@ -719,33 +693,72 @@ class LatexParser(BaseParser):
             Ordered list node
 
         """
-        items = []
-        if hasattr(node, "nodelist"):
-            for child in node.nodelist:
-                if hasattr(child, "macroname") and child.macroname == "item":
-                    item_nodes = []
-                    # Get content after \item
-                    if hasattr(child, "nodeargd") and hasattr(child.nodeargd, "argnlist"):
-                        for arg in child.nodeargd.argnlist:
-                            if arg and hasattr(arg, "nodelist"):
-                                for item_child in arg.nodelist:
-                                    converted = self._convert_node(item_child)
-                                    if converted:
-                                        if isinstance(converted, list):
-                                            item_nodes.extend(converted)
-                                        else:
-                                            item_nodes.append(converted)
+        return self._convert_list_environment(node, ordered=True)
 
-                    # Wrap in paragraph
-                    if item_nodes:
-                        all_inline = all(isinstance(n, (Text, Strong, Emphasis, Code, Link, Image)) for n in item_nodes)
-                        content: list[Node] = (
-                            item_nodes if all_inline else [Text(content=self._extract_text(item_nodes))]
-                        )
-                        para = Paragraph(content=content)
-                        items.append(ListItem(children=[para]))
+    def _convert_list_environment(self, node: Any, *, ordered: bool) -> List:
+        """Convert itemize/enumerate by collecting sibling nodes after each ``\\item``.
 
-        return List(ordered=True, items=items)
+        In real LaTeX, ``\\item`` body text is sibling nodes until the next ``\\item``,
+        not braced macro arguments. Optional ``[label]`` args are still converted.
+
+        Parameters
+        ----------
+        node : LatexEnvironmentNode
+            Itemize or enumerate environment node
+        ordered : bool
+            Whether the list is ordered
+
+        Returns
+        -------
+        List
+            List node with converted items
+
+        """
+        items: list[ListItem] = []
+        nodelist = getattr(node, "nodelist", None) or []
+        i = 0
+        while i < len(nodelist):
+            child = nodelist[i]
+            if not (hasattr(child, "macroname") and child.macroname == "item"):
+                i += 1
+                continue
+
+            item_nodes: list[Node] = []
+
+            # Optional [label] for description-style items
+            if hasattr(child, "nodeargd") and hasattr(child.nodeargd, "argnlist"):
+                for arg in child.nodeargd.argnlist:
+                    if arg and hasattr(arg, "nodelist"):
+                        for item_child in arg.nodelist:
+                            converted = self._convert_node(item_child)
+                            if converted:
+                                if isinstance(converted, list):
+                                    item_nodes.extend(converted)
+                                else:
+                                    item_nodes.append(converted)
+
+            # Body text: siblings after \item until the next \item
+            j = i + 1
+            while j < len(nodelist):
+                sibling = nodelist[j]
+                if hasattr(sibling, "macroname") and sibling.macroname == "item":
+                    break
+                converted = self._convert_node(sibling)
+                if converted:
+                    if isinstance(converted, list):
+                        item_nodes.extend(converted)
+                    else:
+                        item_nodes.append(converted)
+                j += 1
+
+            if item_nodes:
+                all_inline = all(isinstance(n, (Text, Strong, Emphasis, Code, Link, Image)) for n in item_nodes)
+                content: list[Node] = item_nodes if all_inline else [Text(content=self._extract_text(item_nodes))]
+                items.append(ListItem(children=[Paragraph(content=content)]))
+
+            i = j
+
+        return List(ordered=ordered, items=items)
 
     def _convert_quote(self, node: Any) -> BlockQuote:
         """Convert quote environment to BlockQuote.

--- a/src/all2md/parsers/latex.py
+++ b/src/all2md/parsers/latex.py
@@ -696,10 +696,11 @@ class LatexParser(BaseParser):
         return self._convert_list_environment(node, ordered=True)
 
     def _convert_list_environment(self, node: Any, *, ordered: bool) -> List:
-        """Convert itemize/enumerate by collecting sibling nodes after each ``\\item``.
+        r"""Convert itemize/enumerate by collecting sibling nodes after each ``\item``.
 
-        In real LaTeX, ``\\item`` body text is sibling nodes until the next ``\\item``,
+        In real LaTeX, ``\item`` body text is sibling nodes until the next ``\item``,
         not braced macro arguments. Optional ``[label]`` args are still converted.
+        Nested lists stay as block children of the ``ListItem`` (not flattened to text).
 
         Parameters
         ----------
@@ -714,6 +715,7 @@ class LatexParser(BaseParser):
             List node with converted items
 
         """
+        inline_types = (Text, Strong, Emphasis, Code, Link, Image, MathInline, Underline, Subscript, Superscript)
         items: list[ListItem] = []
         nodelist = getattr(node, "nodelist", None) or []
         i = 0
@@ -752,9 +754,30 @@ class LatexParser(BaseParser):
                 j += 1
 
             if item_nodes:
-                all_inline = all(isinstance(n, (Text, Strong, Emphasis, Code, Link, Image)) for n in item_nodes)
-                content: list[Node] = item_nodes if all_inline else [Text(content=self._extract_text(item_nodes))]
-                items.append(ListItem(children=[Paragraph(content=content)]))
+                children: list[Node] = []
+                inline_content: list[Node] = []
+                for n in item_nodes:
+                    if isinstance(n, List):
+                        if inline_content:
+                            children.append(Paragraph(content=inline_content))
+                            inline_content = []
+                        children.append(n)
+                    elif isinstance(n, inline_types):
+                        if isinstance(n, Text):
+                            text = n.content.strip()
+                            if not text:
+                                continue
+                            n = Text(content=text)
+                        inline_content.append(n)
+                    else:
+                        if inline_content:
+                            children.append(Paragraph(content=inline_content))
+                            inline_content = []
+                        children.append(n)
+                if inline_content:
+                    children.append(Paragraph(content=inline_content))
+                if children:
+                    items.append(ListItem(children=children))
 
             i = j
 

--- a/tests/golden/__snapshots__/test_generated_fixtures_golden.ambr
+++ b/tests/golden/__snapshots__/test_generated_fixtures_golden.ambr
@@ -254,6 +254,11 @@
   
   # Lists
   
+  * First item
+  * Second item with a nested list
+    1. Nested entry one
+    2. Nested entry two
+  
   # Table
   
   | Name | Role | Score |

--- a/tests/golden/__snapshots__/test_textual_formats_golden.ambr
+++ b/tests/golden/__snapshots__/test_textual_formats_golden.ambr
@@ -109,6 +109,11 @@
   
   # Lists
   
+  * First item
+  * Second item with a nested list
+    1. Nested entry one
+    2. Nested entry two
+  
   # Table
   
   | Name | Role | Score |

--- a/tests/unit/parsers/test_latex_parser.py
+++ b/tests/unit/parsers/test_latex_parser.py
@@ -224,6 +224,33 @@ class TestLatexParser:
         assert len(lists) >= 1
         assert lists[0].ordered is True
 
+    def test_itemize_enumerate_item_sibling_text(self) -> None:
+        """Item body after \\item is sibling nodes, not braced args."""
+        from all2md.renderers.markdown import MarkdownRenderer
+
+        latex = r"""
+\begin{itemize}
+\item First point
+\item Second point
+\end{itemize}
+
+\begin{enumerate}
+\item \textbf{Bold} text support
+\item Second
+\end{enumerate}
+"""
+        doc = LatexParser().parse(latex)
+        lists = [child for child in doc.children if isinstance(child, List)]
+        assert len(lists) == 2
+        assert len(lists[0].items) == 2
+        assert len(lists[1].items) == 2
+
+        md = MarkdownRenderer().render_to_string(doc)
+        assert "First point" in md
+        assert "Second point" in md
+        assert "**Bold**" in md
+        assert "text support" in md
+
     def test_quote_environment(self) -> None:
         """Test parsing quote environment."""
         parser = LatexParser()

--- a/tests/unit/parsers/test_latex_parser.py
+++ b/tests/unit/parsers/test_latex_parser.py
@@ -251,6 +251,33 @@ class TestLatexParser:
         assert "**Bold**" in md
         assert "text support" in md
 
+    def test_itemize_keeps_nested_enumerate(self) -> None:
+        r"""Nested enumerate after an \\item must remain a nested list, not flat text."""
+        from all2md.renderers.markdown import MarkdownRenderer
+
+        latex = r"""
+\begin{itemize}
+\item Outer
+\begin{enumerate}
+\item Nested one
+\item Nested two
+\end{enumerate}
+\end{itemize}
+"""
+        doc = LatexParser().parse(latex)
+        lists = [child for child in doc.children if isinstance(child, List)]
+        assert len(lists) == 1
+        assert len(lists[0].items) == 1
+        nested = [c for c in lists[0].items[0].children if isinstance(c, List)]
+        assert len(nested) == 1
+        assert nested[0].ordered is True
+        assert len(nested[0].items) == 2
+
+        md = MarkdownRenderer().render_to_string(doc)
+        assert "Outer" in md
+        assert "Nested one" in md
+        assert "Nested two" in md
+
     def test_quote_environment(self) -> None:
         """Test parsing quote environment."""
         parser = LatexParser()


### PR DESCRIPTION
LatexParser only looked at braced arguments on `\item`. In real LaTeX the item body is the sibling nodes after `\item` until the next `\item`, so itemize/enumerate parsed as empty lists and convert-to-markdown dropped every bullet.

```python
from all2md import convert
convert(r\"\\begin{itemize}\\item alpha\\item beta\\end{itemize}\", source_format=\"latex\", target_format=\"markdown\")
# was: ''
# now: '* alpha\\n\\n* beta'
```

Collect sibling content after each `\item` for both itemize and enumerate.