### PR TITLE
fix(latex): strip hline from tabular cell text

### DIFF
--- a/src/all2md/parsers/latex.py
+++ b/src/all2md/parsers/latex.py
@@ -849,6 +849,13 @@ class LatexParser(BaseParser):
             # Parse rows into cells
             table_rows = []
             for row_text in rows_raw:
+                # Rule macros are not cell content; strip before splitting on &
+                row_text = re.sub(r"\\hline\b", "", row_text)
+                row_text = re.sub(r"\\cline\{[^}]*\}", "", row_text)
+                row_text = row_text.strip()
+                if not row_text:
+                    continue
+
                 # Split by column delimiter (&)
                 cells_raw = row_text.split("&")
                 cells = []

--- a/tests/unit/parsers/test_latex_parser.py
+++ b/tests/unit/parsers/test_latex_parser.py
@@ -340,6 +340,20 @@ Bob & 25 & LA
         # Should have body rows
         assert len(table.rows) >= 1
 
+    def test_tabular_strips_hline_from_cell_text(self) -> None:
+        """\\hline / \\cline must not leak into markdown cell text."""
+        from all2md import to_markdown
+        from io import StringIO
+
+        latex = r"\begin{tabular}{cc} a & b \\ \hline c & d \end{tabular}"
+        md = to_markdown(StringIO(latex), source_format="latex")
+
+        assert "a" in md
+        assert "b" in md
+        assert "c" in md
+        assert "d" in md
+        assert "hline" not in md
+
     def test_unknown_macro_nonstrict_mode(self) -> None:
         """Test handling of unknown macros in non-strict mode."""
         parser = LatexParser(LatexOptions(strict_mode=False))


### PR DESCRIPTION
`_convert_tabular` split rows on `\\\\` and cells on `&` without removing rule commands, so `\hline` became part of the cell text (`\\hline c`).

```python
from all2md import convert
convert(r\"\\begin{tabular}{cc} a & b \\\\\\\\ \\hline c & d \\end{tabular}\", source_format=\"latex\", target_format=\"markdown\")
# was: '| a | b |\\n|---|---|\\n| \\\\\\\\hline c | d |'
# now: '| a | b |\\n|---|---|\\n| c | d |'
```

Strip `\hline` / `\cline{...}` before splitting cells; drop rule-only rows.