### PR TITLE
fix(latex): map \chapter to heading

### DIFF
--- a/src/all2md/parsers/latex.py
+++ b/src/all2md/parsers/latex.py
@@ -60,7 +60,7 @@ class LatexParser(BaseParser):
     Supported LaTeX Features
     ------------------------
     Sectioning Commands:
-        - \section, \subsection, \subsubsection
+        - \chapter, \section, \subsection, \subsubsection
         - \paragraph, \subparagraph
 
     Text Formatting:
@@ -335,7 +335,14 @@ class LatexParser(BaseParser):
         macro_name = node.macroname
 
         # Sectioning commands
-        if macro_name in ("section", "subsection", "subsubsection", "paragraph", "subparagraph"):
+        if macro_name in (
+            "chapter",
+            "section",
+            "subsection",
+            "subsubsection",
+            "paragraph",
+            "subparagraph",
+        ):
             return self._convert_section(node)
 
         # Text formatting
@@ -401,6 +408,7 @@ class LatexParser(BaseParser):
         """
         # Map LaTeX sections to heading levels
         level_map = {
+            "chapter": 1,
             "section": 1,
             "subsection": 2,
             "subsubsection": 3,

--- a/tests/unit/parsers/test_latex_parser.py
+++ b/tests/unit/parsers/test_latex_parser.py
@@ -105,6 +105,7 @@ class TestLatexParser:
         assert headings[0].level == 1
         title = "".join(getattr(node, "content", "") for node in headings[0].content)
         assert title == "Title"
+        assert not any(isinstance(child, Text) and child.content == "Title" for child in doc.children)
         assert MarkdownRenderer().render_to_string(doc).strip() == "# Title"
 
     def test_starred_chapter_keeps_title(self) -> None:

--- a/tests/unit/parsers/test_latex_parser.py
+++ b/tests/unit/parsers/test_latex_parser.py
@@ -27,6 +27,7 @@ from all2md.ast import (
 from all2md.options.latex import LatexOptions, LatexRendererOptions
 from all2md.parsers.latex import LatexParser
 from all2md.renderers.latex import LatexRenderer
+from all2md.renderers.markdown import MarkdownRenderer
 
 
 class TestLatexParser:
@@ -93,6 +94,31 @@ class TestLatexParser:
         assert title == "Long Title"
         assert "short" not in title
         assert "*" not in title
+
+    def test_chapter_heading(self) -> None:
+        """\\chapter{Title} must become a level-1 heading (book/report class)."""
+        parser = LatexParser()
+        doc = parser.parse(r"\chapter{Title}")
+
+        headings = [child for child in doc.children if isinstance(child, Heading)]
+        assert len(headings) == 1
+        assert headings[0].level == 1
+        title = "".join(getattr(node, "content", "") for node in headings[0].content)
+        assert title == "Title"
+        assert MarkdownRenderer().render_to_string(doc).strip() == "# Title"
+
+    def test_starred_chapter_keeps_title(self) -> None:
+        """\\chapter*{Title} must keep the title, not the '*' marker."""
+        parser = LatexParser()
+        doc = parser.parse(r"\chapter*{Title}")
+
+        headings = [child for child in doc.children if isinstance(child, Heading)]
+        assert len(headings) == 1
+        assert headings[0].level == 1
+        title = "".join(getattr(node, "content", "") for node in headings[0].content)
+        assert title == "Title"
+        assert title != "*"
+        assert MarkdownRenderer().render_to_string(doc).strip() == "# Title"
 
     def test_textbf_bold(self) -> None:
         """Test parsing bold text."""


### PR DESCRIPTION
`\chapter{Title}` is parsed by pylatexenc with the title in `argnlist`, but LatexParser only routed section/subsection/subsubsection/paragraph/subparagraph through `_convert_section`. With the default `parse_custom_commands=False`, chapters were dropped entirely.

```python
from all2md import convert
convert(r\"\\chapter{Title}\", source_format=\"latex\", target_format=\"markdown\")
# was: ''
# now: '# Title'
```

Route `\chapter` (including starred form) through `_convert_section` at heading level 1.