### PR TITLE
fix(latex): parse \paragraph title arguments

### DIFF
--- a/src/all2md/parsers/latex.py
+++ b/src/all2md/parsers/latex.py
@@ -176,14 +176,11 @@ class LatexParser(BaseParser):
                 "LaTeX parsing requires the 'pylatexenc' package. Install it with: pip install pylatexenc"
             ) from e
 
-        # Default pylatexenc context omits \paragraph (unlike \section/\subparagraph).
+        # Default pylatexenc context omits \paragraph (section/subparagraph are present).
         latex_context = get_default_latex_context_db()
         latex_context.add_context_category(
             "all2md-paragraph-titles",
-            macros=[
-                MacroSpec("paragraph", "*[{"),
-                MacroSpec("subparagraph", "*[{"),
-            ],
+            macros=[MacroSpec("paragraph", "*[{")],
             prepend=True,
         )
 

--- a/src/all2md/parsers/latex.py
+++ b/src/all2md/parsers/latex.py
@@ -169,15 +169,27 @@ class LatexParser(BaseParser):
 
         # Try to import pylatexenc
         try:
-            from pylatexenc.latexwalker import LatexWalker
+            from pylatexenc.latexwalker import LatexWalker, get_default_latex_context_db
+            from pylatexenc.macrospec import MacroSpec
         except ImportError as e:
             raise ParsingError(
                 "LaTeX parsing requires the 'pylatexenc' package. Install it with: pip install pylatexenc"
             ) from e
 
+        # Default pylatexenc context omits \paragraph (unlike \section/\subparagraph).
+        latex_context = get_default_latex_context_db()
+        latex_context.add_context_category(
+            "all2md-paragraph-titles",
+            macros=[
+                MacroSpec("paragraph", "*[{"),
+                MacroSpec("subparagraph", "*[{"),
+            ],
+            prepend=True,
+        )
+
         # Parse LaTeX using pylatexenc
         try:
-            walker = LatexWalker(content)
+            walker = LatexWalker(content, latex_context=latex_context)
             nodelist, pos, length = walker.get_latex_nodes()
         except Exception as e:
             if self.options.strict_mode:

--- a/tests/unit/parsers/test_latex_parser.py
+++ b/tests/unit/parsers/test_latex_parser.py
@@ -81,6 +81,23 @@ class TestLatexParser:
         assert title == "Introduction"
         assert title != "*"
 
+    def test_paragraph_title_not_split_to_sibling(self) -> None:
+        r"""\paragraph{Title} must be one level-4 heading, not empty #### + Title."""
+        parser = LatexParser()
+        doc = parser.parse(r"\paragraph{Title}")
+
+        headings = [child for child in doc.children if isinstance(child, Heading)]
+        assert len(headings) == 1
+        assert headings[0].level == 4
+        title = "".join(getattr(node, "content", "") for node in headings[0].content)
+        assert title == "Title"
+        assert not any(isinstance(child, Text) and child.content == "Title" for child in doc.children)
+        assert not any(
+            isinstance(child, Paragraph)
+            and any(isinstance(node, Text) and node.content == "Title" for node in child.content)
+            for child in doc.children
+        )
+
     def test_starred_subsection_with_short_title(self) -> None:
         """\\subsection*[short]{Long} must keep the mandatory long title."""
         parser = LatexParser()


### PR DESCRIPTION
Default pylatexenc has no MacroSpec for `\paragraph`, so `\paragraph{Title}` left `{Title}` as a sibling group. The parser emitted an empty level-4 heading plus loose `Title` text (`#### \n\nTitle`). LatexRenderer already emits `\paragraph{...}` for level-4 headings, so roundtrips broke.

```python
from all2md import convert
convert(r\"\\paragraph{Title}\", source_format=\"latex\", target_format=\"markdown\")
# was: '#### \\n\\nTitle'
# now: '#### Title'
```

Register `paragraph` / `subparagraph` with argspec `*{[` on the LatexWalker context so the title lands in `argnlist`.