### PR TITLE
fix(html): skip empty table rows without cells

### DIFF
--- a/src/all2md/parsers/html.py
+++ b/src/all2md/parsers/html.py
@@ -1433,7 +1433,8 @@ class HtmlToAstConverter(BaseParser):
         extra_rows = []
         for tr in thead_rows[1:]:
             cells, _ = self._process_table_row_cells(tr)
-            extra_rows.append(TableRow(cells=cells))
+            if cells:
+                extra_rows.append(TableRow(cells=cells))
 
         return header, extra_rows, alignments
 
@@ -1454,10 +1455,12 @@ class HtmlToAstConverter(BaseParser):
             has_th = bool(tr.find("th"))
             if has_th and not has_header and not header:
                 cells, alignments = self._process_table_row_cells(tr, collect_alignments=True)
-                header = TableRow(cells=cells, is_header=True)
+                if cells:
+                    header = TableRow(cells=cells, is_header=True)
             else:
                 cells, _ = self._process_table_row_cells(tr)
-                rows.append(TableRow(cells=cells))
+                if cells:
+                    rows.append(TableRow(cells=cells))
 
         return header, rows, alignments
 
@@ -1469,7 +1472,8 @@ class HtmlToAstConverter(BaseParser):
         rows = []
         for tr in tfoot.find_all("tr", recursive=False):
             cells, _ = self._process_table_row_cells(tr)
-            rows.append(TableRow(cells=cells))
+            if cells:
+                rows.append(TableRow(cells=cells))
         return rows
 
     def _process_table_to_ast(self, node: Any) -> Table:

--- a/tests/unit/formats/html/test_html_table_parsing.py
+++ b/tests/unit/formats/html/test_html_table_parsing.py
@@ -120,6 +120,18 @@ class TestHtmlTableParsing:
         assert "| Value |  | Another Value |" in markdown
         assert "|  | Middle |  |" in markdown
 
+    def test_empty_tr_without_cells_omits_malformed_table(self):
+        """Rows with no td/th must not become a 0-column GFM table."""
+        from all2md import convert
+
+        empty_row = convert("<table><tr></tr></table>", source_format="html", target_format="markdown")
+        assert empty_row != "|  |\n||"
+        assert empty_row.strip() == ""
+        assert_markdown_valid(empty_row)
+
+        empty_td = convert("<table><tr><td></td></tr></table>", source_format="html", target_format="markdown")
+        assert empty_td == "|  |\n|---|"
+
     def test_table_cell_whitespace_normalization(self):
         """Test normalization of whitespace in table cells."""
         html = """

--- a/tests/unit/formats/html/test_html_table_parsing.py
+++ b/tests/unit/formats/html/test_html_table_parsing.py
@@ -125,8 +125,8 @@ class TestHtmlTableParsing:
         from all2md import convert
 
         empty_row = convert("<table><tr></tr></table>", source_format="html", target_format="markdown")
-        assert empty_row != "|  |\n||"
         assert empty_row.strip() == ""
+        assert "|" not in empty_row
         assert_markdown_valid(empty_row)
 
         empty_td = convert("<table><tr><td></td></tr></table>", source_format="html", target_format="markdown")

--- a/tests/unit/parsers/test_html_parser.py
+++ b/tests/unit/parsers/test_html_parser.py
@@ -531,6 +531,23 @@ class TestTables:
         assert len(table.header.cells) == 2
         assert len(table.rows) == 2
 
+    def test_empty_tr_without_cells_skipped(self) -> None:
+        """Empty <tr></tr> must not become a 0-cell header row."""
+        converter = HtmlToAstConverter()
+        doc = converter.convert_to_ast("<table><tr></tr></table>")
+
+        assert isinstance(doc.children[0], Table)
+        table = doc.children[0]
+        assert table.header is None
+        assert table.rows == []
+
+        doc_td = converter.convert_to_ast("<table><tr><td></td></tr></table>")
+        assert isinstance(doc_td.children[0], Table)
+        table_td = doc_td.children[0]
+        assert table_td.header is not None
+        assert len(table_td.header.cells) == 1
+        assert table_td.rows == []
+
     def test_table_without_thead_but_with_th(self) -> None:
         """Test table with th elements but no thead."""
         html = """


### PR DESCRIPTION
An HTML `<table><tr></tr></table>` became a zero-column header row and Markdown rendered invalid GFM (`|  |\n||`). A row with an empty `<td>` already worked.

```python
from all2md import convert
convert(\"<table><tr></tr></table>\", source_format=\"html\", target_format=\"markdown\")
# was: '|  |\\n||'
# now: ''
```

Skip `tr` elements that contain no `td`/`th` when building thead/tbody/tfoot.