### PR TITLE
fix(org): keep TODO-only headlines

### DIFF
--- a/src/all2md/parsers/org.py
+++ b/src/all2md/parsers/org.py
@@ -562,6 +562,7 @@ class OrgParser(BaseParser):
         if manually_extracted_todo and todo_state:
             heading_text = heading_text[len(todo_state) :].lstrip()
         # Empty title + TODO: put keyword in content so markdown keeps the state
+        content: list[Node]
         if not heading_text and todo_state:
             content = [Text(content=todo_state)]
         else:

--- a/src/all2md/parsers/org.py
+++ b/src/all2md/parsers/org.py
@@ -545,27 +545,27 @@ class OrgParser(BaseParser):
             Heading AST node with metadata for TODO state, priority, and tags
 
         """
-        if not node.heading:
+        # Extract TODO / priority / tags first: orgparse sets heading='' for ``* TODO``.
+        todo_state, manually_extracted_todo = self._extract_todo_state(node)
+        priority = node.priority if hasattr(node, "priority") and node.priority else None
+        tags = list(node.tags) if self.options.parse_tags and hasattr(node, "tags") and node.tags else []
+
+        if not node.heading and not todo_state and not priority and not tags:
             return None
 
         # Extract heading level (number of stars)
         level = node.level
-
-        # Extract TODO state
-        todo_state, manually_extracted_todo = self._extract_todo_state(node)
-
-        # Extract priority
-        priority = node.priority if hasattr(node, "priority") and node.priority else None
-
-        # Extract tags (controlled by parse_tags option)
-        tags = list(node.tags) if self.options.parse_tags and hasattr(node, "tags") and node.tags else []
 
         # Parse inline content from heading text
         # If we manually extracted TODO, remove it from the heading text
         heading_text = node.heading
         if manually_extracted_todo and todo_state:
             heading_text = heading_text[len(todo_state) :].lstrip()
-        content = self._parse_inline(heading_text)
+        # Empty title + TODO: put keyword in content so markdown keeps the state
+        if not heading_text and todo_state:
+            content = [Text(content=todo_state)]
+        else:
+            content = self._parse_inline(heading_text)
 
         # Build metadata
         heading_metadata: dict[str, Any] = {}

--- a/tests/unit/parsers/test_org_parser.py
+++ b/tests/unit/parsers/test_org_parser.py
@@ -169,6 +169,36 @@ class TestTodoHeadings:
         heading = doc.children[0]
         assert isinstance(heading, Heading)
         assert heading.metadata.get("org_todo_state") == "TODO"
+        assert isinstance(heading.content[0], Text)
+        assert heading.content[0].content == "Write documentation"
+
+    def test_todo_only_headline(self) -> None:
+        """TODO-only headlines (no title text) must not be dropped."""
+        org = "* TODO\n"
+        parser = OrgParser()
+        doc = parser.parse(org)
+
+        heading = doc.children[0]
+        assert isinstance(heading, Heading)
+        assert heading.metadata.get("org_todo_state") == "TODO"
+        assert isinstance(heading.content[0], Text)
+        assert heading.content[0].content == "TODO"
+
+    def test_todo_only_headline_with_body(self) -> None:
+        """TODO-only headline with body keeps TODO state and body text."""
+        org = "* TODO\nbody\n"
+        parser = OrgParser()
+        doc = parser.parse(org)
+
+        headings = [n for n in doc.children if isinstance(n, Heading)]
+        assert len(headings) == 1
+        assert headings[0].metadata.get("org_todo_state") == "TODO"
+        assert isinstance(headings[0].content[0], Text)
+        assert headings[0].content[0].content == "TODO"
+        paragraphs = [n for n in doc.children if isinstance(n, Paragraph)]
+        assert len(paragraphs) == 1
+        assert isinstance(paragraphs[0].content[0], Text)
+        assert paragraphs[0].content[0].content == "body"
 
     def test_done_heading(self) -> None:
         """Test parsing a DONE heading."""


### PR DESCRIPTION
Orgparse sets `heading=''` and `todo='TODO'` for `* TODO`. `_process_headline` returned None whenever heading text was empty, so keyword-only headlines disappeared and `* TODO\nbody` kept only a loose paragraph.

```python
from all2md import convert
convert(\"* TODO\\nbody\\n\", source_format=\"org\", target_format=\"markdown\")
# was: 'body'
# now: '# TODO\\n\\nbody'
```

When the title is empty but TODO/priority/tags are set, still emit a Heading (with the TODO keyword as content so markdown preserves it).