### PR TITLE
fix(renderers): render soft line breaks as spaces in binary formats

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Binary renderers: soft line breaks render as spaces, not hard breaks.** The
+  DOCX, PDF, PPTX, ODT, ODP, RTF and CSV renderers rendered soft breaks (plain
+  newlines inside a Markdown paragraph) as hard line breaks, so any hard-wrapped
+  Markdown source produced output with a visible line break at every wrap point —
+  214 stray breaks in one real-world memo. Soft breaks now render as a space,
+  matching the text renderers (HTML, LaTeX, RST, …) and CommonMark semantics;
+  hard breaks are unchanged.
+
 - **INI renderer: `DEFAULT` section no longer fails to render.** `configparser`
   reserves `DEFAULT`, so `add_section("DEFAULT")` raises `ValueError` — which meant
   any document whose keys landed in the default section (orphan key/value lists with

--- a/src/all2md/renderers/csv.py
+++ b/src/all2md/renderers/csv.py
@@ -359,7 +359,8 @@ class CsvRenderer(BaseRenderer):
             if isinstance(node, Text):
                 parts.append(node.content)
             elif isinstance(node, LineBreak):
-                parts.append("\n")
+                # Soft breaks are source-wrapping artifacts; render as a space
+                parts.append(" " if node.soft else "\n")
             elif isinstance(node, HTMLInline):
                 raw = node.content.strip().lower().replace(" ", "")
                 if raw in {"<br>", "<br/>"}:

--- a/src/all2md/renderers/docx.py
+++ b/src/all2md/renderers/docx.py
@@ -1211,8 +1211,11 @@ class DocxRenderer(NodeVisitor, BaseRenderer):
                 self._add_hyperlink(paragraph, node.url, link_text)
 
             elif isinstance(node, LineBreak):
-                # Both soft and hard breaks become line breaks in DOCX
-                paragraph.add_run().add_break()
+                if node.soft:
+                    # Soft breaks are source-wrapping artifacts; render as a space
+                    paragraph.add_run(" ")
+                else:
+                    paragraph.add_run().add_break()
 
             else:
                 # For other inline nodes, try to process if they have content
@@ -1506,8 +1509,11 @@ class DocxRenderer(NodeVisitor, BaseRenderer):
 
         """
         if self._current_paragraph:
-            # Both soft and hard breaks become line breaks in DOCX
-            self._current_paragraph.add_run().add_break()
+            if node.soft:
+                # Soft breaks are source-wrapping artifacts; render as a space
+                self._current_paragraph.add_run(" ")
+            else:
+                self._current_paragraph.add_run().add_break()
 
     def visit_strikethrough(self, node: Strikethrough) -> None:
         """Render a Strikethrough node.

--- a/src/all2md/renderers/odp.py
+++ b/src/all2md/renderers/odp.py
@@ -1001,7 +1001,11 @@ class OdpRenderer(NodeVisitor, BaseRenderer):
         from odf.text import LineBreak as OdfLineBreak
 
         if self._current_paragraph:
-            self._current_paragraph.addElement(OdfLineBreak())
+            if node.soft:
+                # Soft breaks are source-wrapping artifacts; render as a space
+                self._current_paragraph.addText(" ")
+            else:
+                self._current_paragraph.addElement(OdfLineBreak())
 
     def visit_underline(self, node: Underline) -> None:
         """Render underline."""

--- a/src/all2md/renderers/odt.py
+++ b/src/all2md/renderers/odt.py
@@ -991,7 +991,11 @@ class OdtRenderer(NodeVisitor, BaseRenderer):
         from odf.text import LineBreak as OdfLineBreak
 
         if self._current_paragraph:
-            self._current_paragraph.addElement(OdfLineBreak())
+            if node.soft:
+                # Soft breaks are source-wrapping artifacts; render as a space
+                self._current_paragraph.addText(" ")
+            else:
+                self._current_paragraph.addElement(OdfLineBreak())
 
     def visit_strikethrough(self, node: Strikethrough) -> None:
         """Render a Strikethrough node.

--- a/src/all2md/renderers/pdf.py
+++ b/src/all2md/renderers/pdf.py
@@ -456,7 +456,8 @@ class PdfRenderer(NodeVisitor, BaseRenderer):
                 inner = self._process_inline_content(node.content)
                 parts.append(f'<link href="{node.url}">{inner}</link>')
             elif isinstance(node, LineBreak):
-                parts.append("<br/>")
+                # Soft breaks are source-wrapping artifacts; render as a space
+                parts.append(" " if node.soft else "<br/>")
             elif isinstance(node, FootnoteReference):
                 # Get or assign a stable number for this footnote identifier
                 if node.identifier not in self._footnote_id_to_number:

--- a/src/all2md/renderers/pptx.py
+++ b/src/all2md/renderers/pptx.py
@@ -1369,7 +1369,8 @@ class PptxRenderer(NodeVisitor, BaseRenderer):
     def visit_line_break(self, node: LineBreak) -> None:
         """Render line break."""
         if self._current_paragraph:
-            self._current_paragraph.add_run().text = "\n"
+            # Soft breaks are source-wrapping artifacts; render as a space
+            self._current_paragraph.add_run().text = " " if node.soft else "\n"
 
     def visit_underline(self, node: Underline) -> None:
         """Render underline."""

--- a/src/all2md/renderers/rtf.py
+++ b/src/all2md/renderers/rtf.py
@@ -147,7 +147,8 @@ class RtfRenderer(NodeVisitor, BaseRenderer):
             elif isinstance(child, Code):
                 parts.append(child.content)
             elif isinstance(child, LineBreak):
-                parts.append("\n")
+                # Soft breaks are source-wrapping artifacts; render as a space
+                parts.append(" " if child.soft else "\n")
             elif isinstance(child, MathInline):
                 content, _ = child.get_preferred_representation("latex")
                 parts.append(content)
@@ -430,9 +431,9 @@ class RtfRenderer(NodeVisitor, BaseRenderer):
         """Render inline code as a literal text run."""
         return [self._create_text_run(node.content)]
 
-    def visit_line_break(self, node: LineBreak) -> Any:  # noqa: ARG002
-        """Render a soft or hard line break as a newline character."""
-        return [self._create_text_run("\n")]
+    def visit_line_break(self, node: LineBreak) -> Any:
+        """Render a hard line break as a newline and a soft break as a space."""
+        return [self._create_text_run(" " if node.soft else "\n")]
 
     def visit_strikethrough(self, node: Strikethrough) -> Any:
         """Render strikethrough content with the strike property."""

--- a/tests/unit/renderers/test_csv_renderer.py
+++ b/tests/unit/renderers/test_csv_renderer.py
@@ -403,6 +403,28 @@ class TestCellLineBreaks:
         result = CsvRenderer().render_to_string(Document(children=[table]))
         assert result == 'A,B\n"line1\nline2",x\n'
 
+    def test_soft_linebreak_node_renders_as_space(self) -> None:
+        """AST soft LineBreak between Text nodes is emitted as a space, not a newline."""
+        table = Table(
+            header=TableRow(cells=[TableCell(content=[Text(content="A")]), TableCell(content=[Text(content="B")])]),
+            rows=[
+                TableRow(
+                    cells=[
+                        TableCell(
+                            content=[
+                                Text(content="line1"),
+                                LineBreak(soft=True),
+                                Text(content="line2"),
+                            ]
+                        ),
+                        TableCell(content=[Text(content="x")]),
+                    ]
+                ),
+            ],
+        )
+        result = CsvRenderer().render_to_string(Document(children=[table]))
+        assert result == "A,B\nline1 line2,x\n"
+
     def test_html_inline_br_preserves_newline(self) -> None:
         """HTMLInline <br> between Text nodes is emitted as a CSV cell newline."""
         table = Table(

--- a/tests/unit/renderers/test_docx_renderer.py
+++ b/tests/unit/renderers/test_docx_renderer.py
@@ -779,7 +779,7 @@ class TestLineBreaks:
     """Tests for line break rendering."""
 
     def test_hard_line_break(self, tmp_path):
-        """Test hard line break rendering."""
+        """Test hard line break renders as a <w:br/> element."""
         doc = Document(
             children=[Paragraph(content=[Text(content="Line 1"), LineBreak(soft=False), Text(content="Line 2")])]
         )
@@ -791,9 +791,10 @@ class TestLineBreaks:
         para = docx_doc.paragraphs[0]
         assert "Line 1" in para.text
         assert "Line 2" in para.text
+        assert "<w:br/>" in para._p.xml
 
-    def test_soft_line_break_adds_break(self, tmp_path):
-        """Test soft line break adds a line break (not run together)."""
+    def test_soft_line_break_renders_as_space(self, tmp_path):
+        """Test soft line break renders as a space, not a hard line break."""
         doc = Document(
             children=[
                 Paragraph(content=[Text(content="Bold text"), LineBreak(soft=True), Text(content="continues here")])
@@ -805,9 +806,8 @@ class TestLineBreaks:
 
         docx_doc = DocxDocument(str(output_file))
         para = docx_doc.paragraphs[0]
-        # Text should contain both parts
-        assert "Bold text" in para.text
-        assert "continues here" in para.text
+        assert para.text == "Bold text continues here"
+        assert "<w:br/>" not in para._p.xml
 
 
 @pytest.mark.unit

--- a/tests/unit/renderers/test_odp_renderer.py
+++ b/tests/unit/renderers/test_odp_renderer.py
@@ -1263,6 +1263,32 @@ class TestAdditionalFormattingNodes:
 
         assert output_file.exists()
 
+    def test_render_soft_line_break(self, tmp_path):
+        """Test soft line break renders as a space, not a line-break element."""
+        import zipfile
+
+        from all2md.ast import LineBreak
+
+        doc = Document(
+            children=[
+                Paragraph(
+                    content=[
+                        Text(content="Line one"),
+                        LineBreak(soft=True),
+                        Text(content="Line two"),
+                    ]
+                ),
+            ]
+        )
+        renderer = OdpRenderer()
+        output_file = tmp_path / "soft_line_break.odp"
+        renderer.render(doc, output_file)
+
+        with zipfile.ZipFile(output_file) as zf:
+            content = zf.read("content.xml").decode("utf-8")
+        assert "Line one Line two" in content
+        assert "line-break" not in content
+
     def test_render_thematic_break(self, tmp_path):
         """Test rendering thematic break in content."""
         doc = Document(

--- a/tests/unit/renderers/test_odt_renderer.py
+++ b/tests/unit/renderers/test_odt_renderer.py
@@ -531,7 +531,9 @@ class TestLineBreaks:
     """Tests for line break rendering."""
 
     def test_hard_line_break(self, tmp_path):
-        """Test hard line break rendering."""
+        """Test hard line break renders as a text:line-break element."""
+        import zipfile
+
         doc = Document(
             children=[Paragraph(content=[Text(content="Line 1"), LineBreak(soft=False), Text(content="Line 2")])]
         )
@@ -540,9 +542,14 @@ class TestLineBreaks:
         renderer.render(doc, output_file)
 
         assert output_file.exists()
+        with zipfile.ZipFile(output_file) as zf:
+            content = zf.read("content.xml").decode("utf-8")
+        assert "line-break" in content
 
     def test_soft_line_break(self, tmp_path):
-        """Test soft line break rendering."""
+        """Test soft line break renders as a space, not a line-break element."""
+        import zipfile
+
         doc = Document(
             children=[Paragraph(content=[Text(content="Line 1"), LineBreak(soft=True), Text(content="Line 2")])]
         )
@@ -551,6 +558,10 @@ class TestLineBreaks:
         renderer.render(doc, output_file)
 
         assert output_file.exists()
+        with zipfile.ZipFile(output_file) as zf:
+            content = zf.read("content.xml").decode("utf-8")
+        assert "Line 1 Line 2" in content
+        assert "line-break" not in content
 
 
 @pytest.mark.unit

--- a/tests/unit/renderers/test_pdf_renderer.py
+++ b/tests/unit/renderers/test_pdf_renderer.py
@@ -1183,6 +1183,31 @@ class TestLineBreakInline:
         renderer.render(doc, output_file)
 
         assert output_file.exists()
+
+    def test_soft_line_break_renders_as_space(self, tmp_path):
+        """Test soft line break renders as a space, keeping text on one line."""
+        import fitz
+
+        from all2md.ast import LineBreak
+
+        doc = Document(
+            children=[
+                Paragraph(
+                    content=[
+                        Text(content="Line 1"),
+                        LineBreak(soft=True),
+                        Text(content="Line 2"),
+                    ]
+                )
+            ]
+        )
+        renderer = PdfRenderer()
+        output_file = tmp_path / "soft_line_break.pdf"
+        renderer.render(doc, output_file)
+
+        with fitz.open(str(output_file)) as pdf:
+            text = pdf[0].get_text()
+        assert "Line 1 Line 2" in text
         if PDF_VERIFICATION_AVAILABLE:
             text = get_pdf_text(output_file)
             assert "Line 1" in text

--- a/tests/unit/renderers/test_pptx_renderer.py
+++ b/tests/unit/renderers/test_pptx_renderer.py
@@ -1372,7 +1372,7 @@ class TestLineBreakRendering:
         assert len(prs.slides) == 1
 
     def test_soft_line_break(self, tmp_path):
-        """Test soft line break rendering."""
+        """Test soft line break renders as a space, not a newline."""
         from all2md.ast import LineBreak
 
         doc = Document(
@@ -1393,6 +1393,8 @@ class TestLineBreakRendering:
 
         prs = Presentation(str(output_file))
         assert len(prs.slides) == 1
+        all_text = "\n".join(shape.text_frame.text for shape in prs.slides[0].shapes if shape.has_text_frame)
+        assert "Line 1 Line 2" in all_text
 
 
 @pytest.mark.unit

--- a/tests/unit/renderers/test_rtf_renderer.py
+++ b/tests/unit/renderers/test_rtf_renderer.py
@@ -603,12 +603,21 @@ class TestRtfRendererMisc:
         assert "8212" in rtf_output or "—" in rtf_output
 
     def test_render_line_break(self) -> None:
-        """Render a line break."""
+        """Render a hard line break as \\line."""
         doc = Document(children=[Paragraph(content=[Text(content="Line 1"), LineBreak(), Text(content="Line 2")])])
         renderer = RtfRenderer()
         rtf_output = renderer.render_to_string(doc)
-        assert "Line 1" in rtf_output
-        assert "Line 2" in rtf_output
+        assert "Line 1\\line Line 2" in rtf_output
+
+    def test_render_soft_line_break(self) -> None:
+        """Render a soft line break as a space, not \\line."""
+        doc = Document(
+            children=[Paragraph(content=[Text(content="Line 1"), LineBreak(soft=True), Text(content="Line 2")])]
+        )
+        renderer = RtfRenderer()
+        rtf_output = renderer.render_to_string(doc)
+        assert "Line 1 Line 2" in rtf_output
+        assert "\\line" not in rtf_output
 
     def test_render_html_block(self) -> None:
         """Render an HTML block as literal text."""


### PR DESCRIPTION
## Summary

Markdown soft line breaks (plain newlines inside a paragraph, i.e. hard-wrapped source) were rendered as **hard line breaks** by every binary renderer — DOCX, PDF, PPTX, ODT, ODP, RTF and CSV. Converting a hard-wrapped Markdown file to DOCX produced a visible line break at every wrap point (214 stray `<w:br/>` elements in one real-world memo).

The Markdown parser correctly tags these as `LineBreak(soft=True)`, and all text renderers (HTML, LaTeX, RST, AsciiDoc, MediaWiki, DokuWiki, Org, Textile, plaintext) already check `node.soft` and emit a space — the binary renderers never did. The DOCX behavior was an explicit choice in cb93bac ("treat both soft and hard line breaks as line breaks"); the rest simply never distinguished them.

## Changes

- **docx**: soft → space run (both `visit_line_break` and the `_render_inlines` path); hard → `<w:br/>` unchanged
- **pdf**: soft → `" "` instead of `<br/>`
- **pptx**: soft → space run instead of `"\n"` run
- **odt / odp**: soft → `addText(" ")` instead of `text:line-break` element
- **rtf**: soft → space instead of `\line` (both `visit_line_break` and `_render_plain_text`)
- **csv**: soft → space instead of quoted newline in cell text

## Testing

- Strengthened the previously assertion-light soft/hard break tests for docx, pptx, odt, pdf, rtf and added new soft-break tests for odp, csv (now assert actual output content: XML elements, extracted PDF text, RTF control words)
- All touched renderer test files + markdown parser tests pass (415 tests)
- `tests/golden` passes (121 snapshots)
- End-to-end: the memo that surfaced this goes from 214 `<w:br/>` to 0, with wrapped words correctly joined by spaces
- ruff, mypy, black clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
