### PR TITLE
fix(yaml): preserve duplicate table column values

### DIFF
--- a/src/all2md/renderers/yaml.py
+++ b/src/all2md/renderers/yaml.py
@@ -346,10 +346,19 @@ class DataExtractor:
         """
         # Get column names from header
         columns: list[str] = []
+        used_columns: set[str] = set()
         if table.header:
             for cell in table.header.cells:
                 col_name = self._extract_cell_text(cell)
+                if col_name in used_columns:
+                    suffix = 2
+                    candidate = f"{col_name}_{suffix}"
+                    while candidate in used_columns:
+                        suffix += 1
+                        candidate = f"{col_name}_{suffix}"
+                    col_name = candidate
                 columns.append(col_name)
+                used_columns.add(col_name)
 
         if not columns:
             return []

--- a/tests/unit/renderers/test_yaml_renderer.py
+++ b/tests/unit/renderers/test_yaml_renderer.py
@@ -21,6 +21,7 @@ from io import StringIO
 from pathlib import Path
 
 import pytest
+import yaml
 
 from all2md.ast import (
     Document,
@@ -110,6 +111,17 @@ class TestYamlBasicRendering:
         assert "Users:" in result
         assert "name:" in result
         assert "Alice" in result
+
+    def test_render_table_with_duplicate_column_names(self) -> None:
+        """Test rendering preserves values from duplicate table columns."""
+        header = TableRow(cells=[TableCell(content=[Text(content="tag")]), TableCell(content=[Text(content="tag")])])
+        rows = [TableRow(cells=[TableCell(content=[Text(content="red")]), TableCell(content=[Text(content="blue")])])]
+        table = Table(header=header, rows=rows)
+        doc = Document(children=[table])
+
+        data = yaml.safe_load(YamlRenderer().render_to_string(doc))
+
+        assert data["table_1"] == [{"tag": "red", "tag_2": "blue"}]
 
     def test_render_empty_document(self) -> None:
         """Test rendering empty document."""


### PR DESCRIPTION
Markdown tables with duplicate headers lost earlier cell values when rendered to YAML (tag:red overwritten by tag:blue).

Suffix duplicate columns the same way JSON already does (tag_2).