### PR TITLE
fix(csv): preserve inline code and alt text in table cells

### DIFF
--- a/src/all2md/renderers/csv.py
+++ b/src/all2md/renderers/csv.py
@@ -24,12 +24,15 @@ from pathlib import Path
 from typing import IO, Union
 
 from all2md.ast.nodes import (
+    Code,
     Comment,
     CommentInline,
     Document,
     Heading,
     HTMLInline,
+    Image,
     LineBreak,
+    MathInline,
     Node,
     Table,
     TableRow,
@@ -358,6 +361,13 @@ class CsvRenderer(BaseRenderer):
         for node in nodes:
             if isinstance(node, Text):
                 parts.append(node.content)
+            elif isinstance(node, Code):
+                parts.append(node.content)
+            elif isinstance(node, MathInline):
+                parts.append(node.content)
+            elif isinstance(node, Image):
+                if node.alt_text:
+                    parts.append(node.alt_text)
             elif isinstance(node, LineBreak):
                 parts.append("\n")
             elif isinstance(node, HTMLInline):

--- a/tests/unit/renderers/test_csv_renderer.py
+++ b/tests/unit/renderers/test_csv_renderer.py
@@ -16,7 +16,20 @@ Tests cover:
 import pytest
 
 from all2md import convert
-from all2md.ast import Document, Heading, HTMLInline, LineBreak, Paragraph, Table, TableCell, TableRow, Text
+from all2md.ast import (
+    Code,
+    Document,
+    Heading,
+    HTMLInline,
+    Image,
+    LineBreak,
+    MathInline,
+    Paragraph,
+    Table,
+    TableCell,
+    TableRow,
+    Text,
+)
 from all2md.exceptions import RenderingError
 from all2md.options.csv import CsvRendererOptions
 from all2md.renderers.csv import CsvRenderer
@@ -424,3 +437,41 @@ class TestCellLineBreaks:
         )
         result = CsvRenderer().render_to_string(Document(children=[table]))
         assert result == 'A,B\n"line1\nline2",x\n'
+
+
+@pytest.mark.unit
+class TestCellInlineLeaves:
+    """String-leaf inlines in table cells must survive CSV export."""
+
+    def test_markdown_inline_code_preserved(self) -> None:
+        """Backtick code in a markdown table cell is emitted as CSV text."""
+        source = "| Col |\n| --- |\n| `a,b` |\n"
+        result = convert(source, source_format="markdown", target_format="csv")
+        assert result == 'Col\n"a,b"\n'
+
+    def test_code_node_preserved(self) -> None:
+        """AST Code leaf content is emitted as CSV text."""
+        table = Table(
+            header=TableRow(cells=[TableCell(content=[Text(content="Col")])]),
+            rows=[TableRow(cells=[TableCell(content=[Code(content="a,b")])])],
+        )
+        result = CsvRenderer().render_to_string(Document(children=[table]))
+        assert result == 'Col\n"a,b"\n'
+
+    def test_image_alt_text_preserved(self) -> None:
+        """Image alt text in a table cell is emitted as CSV text."""
+        table = Table(
+            header=TableRow(cells=[TableCell(content=[Text(content="Col")])]),
+            rows=[TableRow(cells=[TableCell(content=[Image(url="x.png", alt_text="hello")])])],
+        )
+        result = CsvRenderer().render_to_string(Document(children=[table]))
+        assert result == "Col\nhello\n"
+
+    def test_math_inline_preserved(self) -> None:
+        """MathInline leaf content is emitted as CSV text."""
+        table = Table(
+            header=TableRow(cells=[TableCell(content=[Text(content="Col")])]),
+            rows=[TableRow(cells=[TableCell(content=[MathInline(content="a^2")])])],
+        )
+        result = CsvRenderer().render_to_string(Document(children=[table]))
+        assert result == "Col\na^2\n"


### PR DESCRIPTION
CSV export dropped inline code and image alt text from Markdown table cells, leaving empty fields.

Include Code, MathInline, and Image alt text when extracting cell text.