### PR TITLE
fix(org): clamp heading levels above six to the AST max

### DIFF
--- a/src/all2md/parsers/org.py
+++ b/src/all2md/parsers/org.py
@@ -548,8 +548,8 @@ class OrgParser(BaseParser):
         if not node.heading:
             return None
 
-        # Extract heading level (number of stars)
-        level = node.level
+        # Extract heading level (number of stars). Org allows >6 stars; AST caps at 6.
+        level = min(node.level, 6)
 
         # Extract TODO state
         todo_state, manually_extracted_todo = self._extract_todo_state(node)

--- a/tests/unit/parsers/test_org_parser.py
+++ b/tests/unit/parsers/test_org_parser.py
@@ -79,6 +79,19 @@ class TestBasicParsing:
         assert headings[1].level == 2
         assert headings[2].level == 3
 
+    def test_heading_levels_above_six_are_clamped(self) -> None:
+        """Org allows more than six stars; clamp to the AST max of 6."""
+        org = "******* Deep\n******** Deeper\n"
+        parser = OrgParser()
+        doc = parser.parse(org)
+
+        headings = [node for node in doc.children if isinstance(node, Heading)]
+        assert len(headings) == 2
+        assert headings[0].level == 6
+        assert headings[0].content[0].content == "Deep"
+        assert headings[1].level == 6
+        assert headings[1].content[0].content == "Deeper"
+
     def test_simple_paragraph(self) -> None:
         """Test parsing a simple paragraph."""
         org = "This is a simple paragraph."


### PR DESCRIPTION
Org headlines with seven or more stars raised ValueError (Heading level must be 1-6).

Clamp the level to 6, matching other parsers.