### PR TITLE
fix(fb2): keep section titles in untitled notes bodies

### DIFF
--- a/src/all2md/parsers/fb2.py
+++ b/src/all2md/parsers/fb2.py
@@ -101,11 +101,14 @@ class Fb2ToAstConverter(BaseParser):
             body_nodes = self._process_body(body, heading_level=1)
             if self._is_notes_body(body):
                 if self.options.include_notes:
-                    # Drop only a body-level <title>; keep the first section heading.
-                    had_body_title = self._find_child(body, "title") is not None
+                    # Drop body-level title only when it emitted a Heading.
+                    body_title = self._find_child(body, "title")
+                    emitted_body_title = bool(
+                        body_title is not None and self._title_to_heading(body_title, heading_level=1)
+                    )
                     filtered = (
                         body_nodes[1:]
-                        if had_body_title and body_nodes and isinstance(body_nodes[0], Heading)
+                        if emitted_body_title and body_nodes and isinstance(body_nodes[0], Heading)
                         else body_nodes
                     )
                     note_children.extend(filtered)

--- a/src/all2md/parsers/fb2.py
+++ b/src/all2md/parsers/fb2.py
@@ -101,8 +101,13 @@ class Fb2ToAstConverter(BaseParser):
             body_nodes = self._process_body(body, heading_level=1)
             if self._is_notes_body(body):
                 if self.options.include_notes:
-                    # Drop leading heading to avoid duplicate "Notes" headings later
-                    filtered = body_nodes[1:] if body_nodes and isinstance(body_nodes[0], Heading) else body_nodes
+                    # Drop only a body-level <title>; keep the first section heading.
+                    had_body_title = self._find_child(body, "title") is not None
+                    filtered = (
+                        body_nodes[1:]
+                        if had_body_title and body_nodes and isinstance(body_nodes[0], Heading)
+                        else body_nodes
+                    )
                     note_children.extend(filtered)
             else:
                 children.extend(body_nodes)

--- a/tests/unit/parsers/test_fb2_parser.py
+++ b/tests/unit/parsers/test_fb2_parser.py
@@ -102,3 +102,44 @@ def test_fb2_can_exclude_notes(sample_fb2_path: Path) -> None:
     ]
     assert not notes_heading
     assert not any(isinstance(node, ThematicBreak) for node in document.children)
+
+
+def test_fb2_notes_body_without_title_keeps_section_headings() -> None:
+    fb2 = b"""<?xml version="1.0" encoding="utf-8"?>
+<FictionBook xmlns="http://www.gribuser.ru/xml/fictionbook/2.0">
+  <description>
+    <title-info>
+      <book-title>Notes Title Bug</book-title>
+    </title-info>
+  </description>
+  <body>
+    <section>
+      <title><p>Chapter</p></title>
+      <p>Main text.</p>
+    </section>
+  </body>
+  <body name="notes" type="notes">
+    <section id="n1">
+      <title><p>Footnote 1</p></title>
+      <p>Citation text here</p>
+    </section>
+    <section id="n2">
+      <title><p>Footnote 2</p></title>
+      <p>Second note</p>
+    </section>
+  </body>
+</FictionBook>
+"""
+    document = Fb2ToAstConverter().parse(fb2)
+    heading_texts = [extract_text(node, joiner=" ").strip() for node in document.children if isinstance(node, Heading)]
+    assert "Notes" in heading_texts
+    assert "Footnote 1" in heading_texts
+    assert "Footnote 2" in heading_texts
+    notes_index = next(
+        i
+        for i, node in enumerate(document.children)
+        if isinstance(node, Heading) and extract_text(node, joiner=" ").strip() == "Notes"
+    )
+    footnote_one = document.children[notes_index + 1]
+    assert isinstance(footnote_one, Heading)
+    assert extract_text(footnote_one, joiner=" ").strip() == "Footnote 1"

--- a/tests/unit/parsers/test_fb2_parser.py
+++ b/tests/unit/parsers/test_fb2_parser.py
@@ -143,3 +143,45 @@ def test_fb2_notes_body_without_title_keeps_section_headings() -> None:
     footnote_one = document.children[notes_index + 1]
     assert isinstance(footnote_one, Heading)
     assert extract_text(footnote_one, joiner=" ").strip() == "Footnote 1"
+
+
+def test_fb2_notes_body_with_empty_title_keeps_section_headings() -> None:
+    fb2 = b"""<?xml version="1.0" encoding="utf-8"?>
+<FictionBook xmlns="http://www.gribuser.ru/xml/fictionbook/2.0">
+  <description>
+    <title-info>
+      <book-title>Notes Empty Title Bug</book-title>
+    </title-info>
+  </description>
+  <body>
+    <section>
+      <title><p>Chapter</p></title>
+      <p>Main text.</p>
+    </section>
+  </body>
+  <body name="notes" type="notes">
+    <title><p></p></title>
+    <section id="n1">
+      <title><p>Footnote 1</p></title>
+      <p>Citation text here</p>
+    </section>
+    <section id="n2">
+      <title><p>Footnote 2</p></title>
+      <p>Second note</p>
+    </section>
+  </body>
+</FictionBook>
+"""
+    document = Fb2ToAstConverter().parse(fb2)
+    heading_texts = [extract_text(node, joiner=" ").strip() for node in document.children if isinstance(node, Heading)]
+    assert "Notes" in heading_texts
+    assert "Footnote 1" in heading_texts
+    assert "Footnote 2" in heading_texts
+    notes_index = next(
+        i
+        for i, node in enumerate(document.children)
+        if isinstance(node, Heading) and extract_text(node, joiner=" ").strip() == "Notes"
+    )
+    footnote_one = document.children[notes_index + 1]
+    assert isinstance(footnote_one, Heading)
+    assert extract_text(footnote_one, joiner=" ").strip() == "Footnote 1"


### PR DESCRIPTION
FB2 notes bodies without a usable body-level title dropped the first section heading (for example Footnote 1), including when an empty <title> was present.

Only skip a leading heading when the body title actually emitted one.