### PR TITLE
fix(mediawiki): strip attributes from |+ table captions

### DIFF
--- a/src/all2md/parsers/mediawiki.py
+++ b/src/all2md/parsers/mediawiki.py
@@ -827,7 +827,7 @@ class MediaWikiParser(BaseParser):
                 continue
 
             elif line.startswith("|+"):
-                caption_text = line[2:].strip()
+                caption_text = self._strip_cell_attributes(line[2:])
                 if caption_text:
                     caption = caption_text
                 continue

--- a/tests/unit/parsers/test_mediawiki_parser.py
+++ b/tests/unit/parsers/test_mediawiki_parser.py
@@ -30,3 +30,19 @@ class TestMediaWikiParserTables:
         roundtrip = parser.parse(rendered)
         assert isinstance(roundtrip.children[0], Table)
         assert roundtrip.children[0].caption == "Cap"
+
+    def test_parse_table_caption_strips_attributes(self) -> None:
+        """|+ attrs | caption must keep caption text only, like cell attrs."""
+        wiki = '{|\n|+ style="color:red" | Cap Title\n| a\n|}'
+        doc = MediaWikiParser().parse(wiki)
+        table = doc.children[0]
+        assert isinstance(table, Table)
+        assert table.caption == "Cap Title"
+
+    def test_parse_table_caption_keeps_literal_pipe_without_attrs(self) -> None:
+        """Caption text with a pipe but no key=value attrs must stay intact."""
+        wiki = "{|\n|+ Cap with | pipe\n| a\n|}"
+        doc = MediaWikiParser().parse(wiki)
+        table = doc.children[0]
+        assert isinstance(table, Table)
+        assert table.caption == "Cap with | pipe"


### PR DESCRIPTION
MediaWiki |+ style="..." | Caption left the attributes in Table.caption.

Strip caption attributes the same way cell attributes are already stripped.