### PR TITLE
fix(mediawiki): keep empty list items

### DIFF
--- a/src/all2md/parsers/mediawiki.py
+++ b/src/all2md/parsers/mediawiki.py
@@ -706,9 +706,9 @@ class MediaWikiParser(BaseParser):
                     if "\n" in text_content:
                         text_content = text_content.split("\n")[0].strip()
 
-                    if text_content:
-                        item_content = [Text(content=text_content)]
-                        items.append(ListItem(children=[Paragraph(content=cast(list[Node], item_content))]))
+                    # Keep empty items (bare "*" / "#") so list length matches the wikitext
+                    item_content: list[Node] = [Text(content=text_content)] if text_content else []
+                    items.append(ListItem(children=[Paragraph(content=cast(list[Node], item_content))]))
 
                     i += 1
                 else:

--- a/tests/unit/parsers/test_mediawiki_parser.py
+++ b/tests/unit/parsers/test_mediawiki_parser.py
@@ -46,3 +46,41 @@ class TestMediaWikiParserTables:
         table = doc.children[0]
         assert isinstance(table, Table)
         assert table.caption == "Cap with | pipe"
+
+
+class TestMediaWikiParserLists:
+    """Tests for MediaWiki list parsing."""
+
+    def test_keep_empty_unordered_list_item(self) -> None:
+        """Bare '*' lines must keep an empty list item, not drop it."""
+        parser = MediaWikiParser()
+        doc = parser.parse("* \n* b\n")
+
+        assert len(doc.children) == 1
+        lst = doc.children[0]
+        from all2md.ast import List, ListItem, Paragraph, Text
+
+        assert isinstance(lst, List)
+        assert lst.ordered is False
+        assert len(lst.items) == 2
+        assert isinstance(lst.items[0], ListItem)
+        assert isinstance(lst.items[0].children[0], Paragraph)
+        assert lst.items[0].children[0].content == []
+        assert isinstance(lst.items[1].children[0].content[0], Text)
+        assert lst.items[1].children[0].content[0].content == "b"
+
+    def test_keep_empty_ordered_list_item(self) -> None:
+        """Bare '#' lines must keep an empty ordered list item."""
+        parser = MediaWikiParser()
+        doc = parser.parse("# \n# b\n")
+
+        from all2md.ast import List, Text
+
+        assert len(doc.children) == 1
+        lst = doc.children[0]
+        assert isinstance(lst, List)
+        assert lst.ordered is True
+        assert len(lst.items) == 2
+        assert lst.items[0].children[0].content == []
+        assert isinstance(lst.items[1].children[0].content[0], Text)
+        assert lst.items[1].children[0].content[0].content == "b"


### PR DESCRIPTION
Empty MediaWiki list items were dropped, so blank bullets disappeared from the AST.

Keep empty list items like the DokuWiki path.