### PR TITLE
fix(bbcode): keep empty list items

### DIFF
--- a/src/all2md/parsers/bbcode.py
+++ b/src/all2md/parsers/bbcode.py
@@ -762,16 +762,15 @@ class BBCodeParser(BaseParser):
         ordered = list_type == "1"
         items: list[ListItem] = []
 
-        # Split by [*] markers
+        # Split by [*] markers. Leading split before the first [*] is not an item.
         parts = re.split(r"\[\*\]", content)
 
-        for part in parts:
-            part = part.strip()
-            if not part:
+        for index, part in enumerate(parts):
+            if index == 0:
                 continue
-
-            # Parse item content as inline
-            item_inline = self._parse_inline(part)
+            part = part.strip()
+            # Keep empty [*] items so list length matches the BBCode markers
+            item_inline = self._parse_inline(part) if part else []
             items.append(ListItem(children=[Paragraph(content=item_inline)]))
 
         return List(ordered=ordered, items=items)

--- a/tests/unit/parsers/test_bbcode_parser.py
+++ b/tests/unit/parsers/test_bbcode_parser.py
@@ -13,7 +13,6 @@ from all2md.ast import (
     LineBreak,
     Link,
     List,
-    ListItem,
     Paragraph,
     Strikethrough,
     Strong,

--- a/tests/unit/parsers/test_bbcode_parser.py
+++ b/tests/unit/parsers/test_bbcode_parser.py
@@ -13,6 +13,7 @@ from all2md.ast import (
     LineBreak,
     Link,
     List,
+    ListItem,
     Paragraph,
     Strikethrough,
     Strong,
@@ -496,3 +497,31 @@ This is a [b]quoted[/b] text.
         # Should create at least one paragraph
         assert len(doc.children) >= 1
         assert any(isinstance(child, Paragraph) for child in doc.children)
+
+    def test_keep_empty_list_item(self) -> None:
+        """Empty [*] markers must keep list items, not drop them."""
+        parser = BBCodeParser()
+        doc = parser.parse("[list][*]a[*][*]c[/list]")
+
+        lists = [c for c in doc.children if isinstance(c, List)]
+        assert len(lists) == 1
+        lst = lists[0]
+        assert lst.ordered is False
+        assert len(lst.items) == 3
+        assert isinstance(lst.items[0].children[0].content[0], Text)
+        assert lst.items[0].children[0].content[0].content == "a"
+        assert lst.items[1].children[0].content == []
+        assert isinstance(lst.items[2].children[0].content[0], Text)
+        assert lst.items[2].children[0].content[0].content == "c"
+
+    def test_keep_empty_ordered_list_item(self) -> None:
+        """Empty [*] in ordered lists must keep the blank item."""
+        parser = BBCodeParser()
+        doc = parser.parse("[list=1][*]a[*][*]c[/list]")
+
+        lists = [c for c in doc.children if isinstance(c, List)]
+        assert len(lists) == 1
+        lst = lists[0]
+        assert lst.ordered is True
+        assert len(lst.items) == 3
+        assert lst.items[1].children[0].content == []


### PR DESCRIPTION
Empty BBCode list items were dropped during parse.

Keep empty `[*]` items so list structure is preserved.