### PR TITLE
fix(fb2): render cite as blockquote like epigraph

### DIFF
--- a/src/all2md/parsers/fb2.py
+++ b/src/all2md/parsers/fb2.py
@@ -334,7 +334,7 @@ class Fb2ToAstConverter(BaseParser):
                 nodes.append(Paragraph(content=[]))
             elif local == "poem":
                 nodes.extend(self._process_poem(child))
-            elif local == "epigraph":
+            elif local in {"epigraph", "cite"}:
                 nodes.extend(self._process_epigraph(child))
             else:
                 fallback = self._build_paragraph(child)
@@ -358,7 +358,7 @@ class Fb2ToAstConverter(BaseParser):
                 continue
             if local == "section":
                 nodes.extend(self._process_section(child, min(heading_level + 1, 6)))
-            elif local in {"p", "subtitle", "text-author", "cite"}:
+            elif local in {"p", "subtitle", "text-author"}:
                 paragraph = self._build_paragraph(child)
                 if paragraph:
                     if local == "subtitle":
@@ -367,7 +367,8 @@ class Fb2ToAstConverter(BaseParser):
                         nodes.append(paragraph)
             elif local == "poem":
                 nodes.extend(self._process_poem(child))
-            elif local == "epigraph":
+            elif local in {"epigraph", "cite"}:
+                # cite shares epigraph shape: block children, not flattened inline text
                 nodes.extend(self._process_epigraph(child))
             elif local == "image":
                 image_node = self._process_image(child, inline=False)

--- a/tests/unit/parsers/test_fb2_parser.py
+++ b/tests/unit/parsers/test_fb2_parser.py
@@ -185,3 +185,52 @@ def test_fb2_notes_body_with_empty_title_keeps_section_headings() -> None:
     footnote_one = document.children[notes_index + 1]
     assert isinstance(footnote_one, Heading)
     assert extract_text(footnote_one, joiner=" ").strip() == "Footnote 1"
+
+
+def test_fb2_cite_becomes_blockquote_like_epigraph() -> None:
+    """<cite> with body + text-author must be a BlockQuote, not concatenated text."""
+    from all2md.ast import BlockQuote, Text
+
+    fb2 = b"""<?xml version="1.0" encoding="utf-8"?>
+<FictionBook xmlns="http://www.gribuser.ru/xml/fictionbook/2.0">
+  <body>
+    <section>
+      <cite>
+        <p>quoted</p>
+        <text-author>auth</text-author>
+      </cite>
+    </section>
+  </body>
+</FictionBook>
+"""
+    document = Fb2ToAstConverter().parse(fb2)
+    assert len(document.children) == 1
+    quote = document.children[0]
+    assert isinstance(quote, BlockQuote)
+    assert len(quote.children) == 2
+    assert isinstance(quote.children[0], Paragraph)
+    assert isinstance(quote.children[1], Paragraph)
+    assert extract_text(quote.children[0], joiner=" ").strip() == "quoted"
+    assert extract_text(quote.children[1], joiner=" ").strip() == "auth"
+
+
+def test_fb2_epigraph_still_blockquote() -> None:
+    """Epigraph sibling path remains a BlockQuote with separate paragraphs."""
+    from all2md.ast import BlockQuote
+
+    fb2 = b"""<?xml version="1.0" encoding="utf-8"?>
+<FictionBook xmlns="http://www.gribuser.ru/xml/fictionbook/2.0">
+  <body>
+    <section>
+      <epigraph>
+        <p>epi</p>
+        <text-author>auth</text-author>
+      </epigraph>
+    </section>
+  </body>
+</FictionBook>
+"""
+    document = Fb2ToAstConverter().parse(fb2)
+    assert isinstance(document.children[0], BlockQuote)
+    assert extract_text(document.children[0].children[0], joiner=" ").strip() == "epi"
+    assert extract_text(document.children[0].children[1], joiner=" ").strip() == "auth"

--- a/tests/unit/parsers/test_fb2_parser.py
+++ b/tests/unit/parsers/test_fb2_parser.py
@@ -189,7 +189,7 @@ def test_fb2_notes_body_with_empty_title_keeps_section_headings() -> None:
 
 def test_fb2_cite_becomes_blockquote_like_epigraph() -> None:
     """<cite> with body + text-author must be a BlockQuote, not concatenated text."""
-    from all2md.ast import BlockQuote, Text
+    from all2md.ast import BlockQuote
 
     fb2 = b"""<?xml version="1.0" encoding="utf-8"?>
 <FictionBook xmlns="http://www.gribuser.ru/xml/fictionbook/2.0">


### PR DESCRIPTION
FB2 `<cite>` content was flattened instead of becoming a blockquote.

Render cite like epigraph.