### PR TITLE
fix(org): keep priority-only headlines

### DIFF
--- a/src/all2md/parsers/org.py
+++ b/src/all2md/parsers/org.py
@@ -561,10 +561,12 @@ class OrgParser(BaseParser):
         heading_text = node.heading
         if manually_extracted_todo and todo_state:
             heading_text = heading_text[len(todo_state) :].lstrip()
-        # Empty title + TODO: put keyword in content so markdown keeps the state
+        # Empty title + TODO/priority: put marker in content so markdown keeps it
         content: list[Node]
         if not heading_text and todo_state:
             content = [Text(content=todo_state)]
+        elif not heading_text and priority:
+            content = [Text(content=f"[#{priority}]")]
         else:
             content = self._parse_inline(heading_text)
 

--- a/tests/unit/parsers/test_org_parser.py
+++ b/tests/unit/parsers/test_org_parser.py
@@ -213,6 +213,34 @@ class TestTodoHeadings:
         assert isinstance(paragraphs[0].content[0], Text)
         assert paragraphs[0].content[0].content == "body"
 
+    def test_priority_only_headline(self) -> None:
+        """Priority-only headlines (no title text) must keep [#A] in content."""
+        org = "* [#A]\n"
+        parser = OrgParser()
+        doc = parser.parse(org)
+
+        heading = doc.children[0]
+        assert isinstance(heading, Heading)
+        assert heading.metadata.get("org_priority") == "A"
+        assert isinstance(heading.content[0], Text)
+        assert heading.content[0].content == "[#A]"
+
+    def test_priority_only_headline_with_body(self) -> None:
+        """Priority-only headline with body keeps [#A] and body text."""
+        org = "* [#A]\nbody\n"
+        parser = OrgParser()
+        doc = parser.parse(org)
+
+        headings = [n for n in doc.children if isinstance(n, Heading)]
+        assert len(headings) == 1
+        assert headings[0].metadata.get("org_priority") == "A"
+        assert isinstance(headings[0].content[0], Text)
+        assert headings[0].content[0].content == "[#A]"
+        paragraphs = [n for n in doc.children if isinstance(n, Paragraph)]
+        assert len(paragraphs) == 1
+        assert isinstance(paragraphs[0].content[0], Text)
+        assert paragraphs[0].content[0].content == "body"
+
     def test_done_heading(self) -> None:
         """Test parsing a DONE heading."""
         org = "* DONE Implement feature"


### PR DESCRIPTION
Org headlines that are only a priority cookie (`* [#A]`) were dropped.

Keep priority-only headlines in the AST.