### PR TITLE
fix(pdf): give OCR-synthesized spans a bbox to prevent KeyError

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **OCR'd PDF pages with links no longer crash conversion.** OCR-synthesized text
+  spans omitted the `bbox` key that every real PyMuPDF span carries. On a page
+  that was OCR'd *and* held a link annotation (common in signed documents), link
+  resolution read `span["bbox"]` and aborted the whole file with
+  `KeyError('bbox')`. OCR spans now carry the page-rect bbox, so link resolution
+  runs normally (and a page-sized span never spuriously matches a small link).
+
 - **Markdown tables with ragged rows no longer vanish.** mistune rejects any body
   row whose cell count differs from the header's, and then discards the *entire*
   table and re-emits it as a literal paragraph — so one row with a missing or extra

--- a/src/all2md/parsers/pdf.py
+++ b/src/all2md/parsers/pdf.py
@@ -1271,7 +1271,16 @@ class PdfToAstConverter(BaseParser):
                     "bbox": page.rect,
                     "lines": [
                         {
-                            "spans": [{"text": ocr_text, "font": "OCR", "size": 11, "flags": 0, "color": 0}],
+                            "spans": [
+                                {
+                                    "text": ocr_text,
+                                    "font": "OCR",
+                                    "size": 11,
+                                    "flags": 0,
+                                    "color": 0,
+                                    "bbox": tuple(page.rect),
+                                }
+                            ],
                             "bbox": page.rect,
                             "dir": (1, 0),  # Horizontal text direction
                         }
@@ -1290,7 +1299,16 @@ class PdfToAstConverter(BaseParser):
                         "bbox": page.rect,
                         "lines": [
                             {
-                                "spans": [{"text": ocr_text, "font": "OCR", "size": 11, "flags": 0, "color": 0}],
+                                "spans": [
+                                    {
+                                        "text": ocr_text,
+                                        "font": "OCR",
+                                        "size": 11,
+                                        "flags": 0,
+                                        "color": 0,
+                                        "bbox": tuple(page.rect),
+                                    }
+                                ],
                                 "bbox": page.rect,
                                 "dir": (1, 0),  # Horizontal text direction
                             }

--- a/tests/unit/parsers/test_pdf_ocr.py
+++ b/tests/unit/parsers/test_pdf_ocr.py
@@ -456,6 +456,57 @@ class TestApplyOCRDehyphenation:
         assert self._run(merge=False) == "be-\nwusst sein"
 
 
+class TestOCRSpanBbox:
+    """OCR-synthesized spans must carry a bbox (regression for KeyError('bbox')).
+
+    Real PyMuPDF spans always expose a ``bbox``; downstream code such as
+    ``_resolve_link_for_span`` reads ``span["bbox"]`` directly. When a page
+    that also has link annotations was OCR'd, the bbox-less OCR span raised
+    ``KeyError('bbox')`` and aborted the whole conversion.
+    """
+
+    def _ocr_blocks(self, *, preserve: bool, extracted: str) -> list[dict]:
+        import fitz
+
+        options = PdfOptions(
+            ocr=OCROptions(enabled=True, mode="force", preserve_existing_text=preserve),
+        )
+        converter = PdfToAstConverter(options=options)
+
+        mock_page = Mock()
+        mock_page.rect = fitz.Rect(0, 0, 612, 792)
+
+        with patch.object(PdfToAstConverter, "_ocr_page_to_text", return_value="scanned text"):
+            blocks, applied = converter._apply_ocr_if_needed(mock_page, [], extracted_text=extracted)
+
+        assert applied is True
+        return blocks
+
+    def test_replace_path_span_has_bbox(self) -> None:
+        blocks = self._ocr_blocks(preserve=False, extracted="")
+        span = blocks[0]["lines"][0]["spans"][0]
+        assert span["bbox"] == (0.0, 0.0, 612.0, 792.0)
+
+    def test_preserve_path_span_has_bbox(self) -> None:
+        # preserve_existing_text appends the OCR block after existing ones.
+        blocks = self._ocr_blocks(preserve=True, extracted="existing page text")
+        span = blocks[-1]["lines"][0]["spans"][0]
+        assert span["bbox"] == (0.0, 0.0, 612.0, 792.0)
+
+    def test_resolve_link_for_span_handles_ocr_span(self) -> None:
+        """The OCR span no longer crashes link resolution (issue: KeyError('bbox'))."""
+        import fitz
+
+        converter = PdfToAstConverter(options=PdfOptions(ocr=OCROptions(enabled=True, mode="force")))
+        span = self._ocr_blocks(preserve=False, extracted="")[0]["lines"][0]["spans"][0]
+
+        # A small hyperlink hotspot on the page (as returned by page.get_links()).
+        links = [{"from": fitz.Rect(100, 100, 200, 120), "uri": "https://example.com/"}]
+
+        # Must not raise, and a page-sized span must not spuriously match a tiny link.
+        assert converter._resolve_link_for_span(links, span, average_line_height=12.0) is None
+
+
 class TestPdfOptionsWithOCR:
     """Test PdfOptions integration with OCR."""
 


### PR DESCRIPTION
## Summary

Fixes an uncaught `KeyError('bbox')` that aborted PDF conversion for OCR'd pages that also carry a link annotation (common in **signed** PDFs).

## Root cause

When OCR runs on a page, `_apply_ocr_if_needed` synthesizes a fake text block whose **spans** were missing the `"bbox"` key that every real PyMuPDF span carries. If the same page also holds a link, `_process_text_spans_to_inline` calls `_resolve_link_for_span`, which does `fitz.Rect(span["bbox"])` → `KeyError`. The crash therefore needed *both* conditions: OCR applied **and** a link on that page. The same latent access exists in the paragraph indent heuristics (`spans[0]["bbox"][0]`).

## Fix

Both OCR span constructions (the replace and preserve-existing-text paths) now set `"bbox": tuple(page.rect)`, matching the containing line's bbox and the real span shape. A page-sized span never exceeds the link overlap threshold against a small hotspot, so link resolution correctly returns "no link" rather than crashing — no spurious links are introduced.

## Verification

- Both originally-failing PDFs now convert cleanly with `--pdf-ocr-enabled`.
- Added `TestOCRSpanBbox` (3 tests). Confirmed they reproduce the exact `KeyError('bbox')` at `pdf.py:2490` against the unfixed code and pass with the fix.
- Full `test_pdf_ocr.py` suite passes; ruff, black, and mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
