### PR TITLE
ci: make the roundtrip fidelity benchmark a blocking gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,6 +109,61 @@ jobs:
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
+  roundtrip:
+    name: Roundtrip Fidelity Gate
+    runs-on: ubuntu-latest
+
+    # Blocking fidelity gate: Markdown -> AST -> Markdown must survive both oracles
+    # (idempotency + mistune HTML-equivalence) over benchmarks/roundtrip's corpus.
+    # Single Python version on purpose - fidelity is a property of the renderer, not
+    # of the interpreter, so the 5-version matrix would buy nothing for 5x the time.
+    # Accepted failures live in EXPECTED_FAILURES in benchmarks/roundtrip/run.py; that
+    # list going stale fails the build too, so it can't rot into a silent excuse.
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v7
+
+      - name: Set up Python
+        uses: actions/setup-python@v7
+        with:
+          python-version: '3.12'
+          cache: 'pip'
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e ".[all,dev]"
+
+      - name: Run roundtrip fidelity benchmark
+        run: |
+          set -o pipefail
+          python -m benchmarks.roundtrip --json roundtrip-results.json | tee roundtrip-table.txt
+
+      # Only on red, so green runs stay quiet but a failure arrives with the diffs
+      # already in the log instead of needing a local reproduction.
+      - name: Show diffs for failures
+        if: failure()
+        run: python -m benchmarks.roundtrip --show-diff
+
+      - name: Write summary
+        if: always()
+        run: |
+          {
+            echo "## Roundtrip fidelity"
+            echo
+            echo '```'
+            cat roundtrip-table.txt || echo "benchmark did not produce a table"
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload results
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: roundtrip-results-${{ github.run_number }}
+          path: roundtrip-results.json
+          if-no-files-found: warn
+
   security-semgrep:
     name: Security Scan (Semgrep)
     runs-on: ubuntu-latest
@@ -164,7 +219,7 @@ jobs:
     # (The Release created here uses GITHUB_TOKEN, whose `release: published`
     # event would not start release.yml anyway.)
     if: startsWith(github.ref, 'refs/tags/v')
-    needs: [lint-and-typecheck, docs, test, security-semgrep, security-bandit]
+    needs: [lint-and-typecheck, docs, test, roundtrip, security-semgrep, security-bandit]
     runs-on: ubuntu-latest
 
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- CI: the Markdown roundtrip fidelity benchmark (`benchmarks/roundtrip`) now runs as a
+  **blocking gate** on every push and PR, and is required before a release. A
+  `Markdown -> AST -> Markdown` regression that either oracle can see now fails the
+  build instead of waiting to be noticed. Knowingly-accepted failures are declared in
+  `EXPECTED_FAILURES` (currently one: raw HTML, which the `html_passthrough_mode="escape"`
+  policy makes lossy by design); the gate also fails if such an entry starts passing or
+  goes stale, so the list can't decay into a permanent excuse.
+
 ## [1.10.0] - 2026-07-24
 
 ### Added

--- a/benchmarks/roundtrip/README.md
+++ b/benchmarks/roundtrip/README.md
@@ -15,6 +15,38 @@ python -m benchmarks.roundtrip --json out.json
 Exit code is non-zero if any oracle failed (policy skips don't count), so it can
 double as an ad-hoc check.
 
+## It is a blocking CI gate
+
+The `Roundtrip Fidelity Gate` job in `.github/workflows/ci.yml` runs this on every
+push and PR, and `release` lists it in `needs:` — so a fidelity regression fails
+the build and blocks a release rather than waiting for someone to notice. On red,
+CI re-runs with `--show-diff` so the diffs are already in the log.
+
+### Expected failures
+
+`main` is green with one known failure, so the gate needs a way to say "this one
+is accepted" without going blind. `EXPECTED_FAILURES` in `run.py` maps
+`(document, oracle) -> reason`:
+
+| Status | Meaning |
+|---|---|
+| `pass` / `FAIL` | not allowlisted; `FAIL` is red |
+| `XFAIL` | allowlisted and still failing — green, as documented |
+| `XPASS` | allowlisted but now **passing** — **red** |
+| `SKIP` | a policy skip; never judged, never counted |
+
+`XPASS` is red on purpose, and so is a **stale** entry (one no document/oracle
+evaluates any more, e.g. after a rename or a newly-added policy skip). Both mean
+the table has started lying about the codebase, so it must be updated in the same
+commit that changes the behavior. Without that, an allowlist decays into a
+permanent excuse list and the ratchet quietly stops being one.
+
+Currently allowlisted: **`raw-html:idempotency`** — the escape policy
+(`html_passthrough_mode="escape"`) turns `<div>` into `&lt;div&gt;` on the second
+pass. That is a deliberate security posture, not a roundtrip bug; it is the same
+root cause as the `html_equivalence` policy skip below. Never add an entry to
+silence a genuine regression.
+
 ## Two oracles
 
 Each document is judged by two independent oracles (`oracles.py`); a loss has to
@@ -56,3 +88,14 @@ fail: each is exercised on a faithful case and a deliberately broken one, and th
 HTML normalizer is checked to ignore incidental whitespace while still detecting
 a collapsed paragraph (the #85 loss shape). An oracle that cannot fail is
 worthless.
+
+The same file pins the **gate's** three red paths (`gate_failed`): a real oracle
+failure, an `XPASS`, and a stale allowlist entry. A gate that cannot go red is
+worse than no gate, because it launders "we didn't measure" into "we measured and
+it's fine."
+
+Worth knowing when you extend this: dropping a construct *entirely* is trivially
+idempotent — both passes lack it — so `idempotency` stays green and only
+`html_equivalence` catches it. Verified by deleting thematic-break rendering,
+which failed 2 documents on the HTML oracle and 0 on idempotency. Neither oracle
+subsumes the other; keep both.

--- a/benchmarks/roundtrip/run.py
+++ b/benchmarks/roundtrip/run.py
@@ -1,16 +1,16 @@
 """CLI for the Markdown roundtrip fidelity benchmark.
 
 Runs both oracles (idempotency + HTML-equivalence) over the synthetic corpus and
-prints a per-document table. This is a diagnostic / triage tool - it surfaces
-which constructs currently fail to roundtrip, which is the point of Phase 0/1.
-A blocking CI gate (Phase 3) will consume the same oracles + corpus later.
+prints a per-document table. It is both a diagnostic / triage tool and the
+**blocking CI gate** (see ``.github/workflows/ci.yml``): a fidelity regression is
+a red build rather than something a human might notice.
 
     python -m benchmarks.roundtrip                 # table to stdout
     python -m benchmarks.roundtrip --show-diff      # + unified diffs for failures
     python -m benchmarks.roundtrip --json out.json  # machine-readable results
 
-Exit code is non-zero iff any oracle failed (skips don't count), so the tool can
-double as an ad-hoc check while we burn issues down.
+Exit code is non-zero if any oracle failed, if an ``EXPECTED_FAILURES`` entry
+unexpectedly passed, or if such an entry is stale. Policy skips never count.
 """
 
 from __future__ import annotations
@@ -23,6 +23,22 @@ from pathlib import Path
 
 from .corpus import Case, load_synthetic_corpus
 from .oracles import CheckResult, html_equivalence_check, idempotency_check
+
+# Oracle failures we knowingly accept, keyed by (document, oracle) -> why.
+#
+# This is a ratchet, not an excuse list. `main` is green with these failing, but
+# the run also goes red if an entry here starts *passing* (XPASS) or stops being
+# evaluated at all (stale) - either means this table has begun lying about the
+# codebase, so it must be updated in the same commit that changes the behavior.
+# An expected failure is for behavior we have *decided* to accept; never add an
+# entry to silence a genuine regression.
+EXPECTED_FAILURES: dict[tuple[str, str], str] = {
+    ("raw-html", "idempotency"): (
+        "all2md escapes raw HTML by policy (html_passthrough_mode='escape'), so pass 2 sees "
+        "&lt;div&gt; where pass 1 saw <div>. Deliberate - the escape policy is a security "
+        "posture, not a roundtrip bug. Same root cause as the html_equivalence policy skip."
+    ),
+}
 
 
 def evaluate_case(case: Case) -> list[CheckResult]:
@@ -57,10 +73,19 @@ def evaluate_case(case: Case) -> list[CheckResult]:
     return results
 
 
-def _status(result: CheckResult) -> str:
+def _status(case_name: str, result: CheckResult) -> str:
+    """One of SKIP / pass / FAIL / XFAIL / XPASS.
+
+    XFAIL is an ``EXPECTED_FAILURES`` entry failing as documented; XPASS is one
+    that has started passing, which is a gate failure because the table is now
+    stale (see ``EXPECTED_FAILURES``).
+    """
     if result.skipped:
         return "SKIP"
-    return "pass" if result.passed else "FAIL"
+    expected = (case_name, result.oracle) in EXPECTED_FAILURES
+    if result.passed:
+        return "XPASS" if expected else "pass"
+    return "XFAIL" if expected else "FAIL"
 
 
 def _format_table(rows: list[tuple[Case, list[CheckResult]]]) -> str:
@@ -70,23 +95,42 @@ def _format_table(rows: list[tuple[Case, list[CheckResult]]]) -> str:
     lines = [header, "-" * len(header)]
     for case, results in rows:
         by_oracle = {r.oracle: r for r in results}
-        idem = _status(by_oracle["idempotency"])
-        html = _status(by_oracle["html_equivalence"])
+        idem = _status(case.name, by_oracle["idempotency"])
+        html = _status(case.name, by_oracle["html_equivalence"])
         lines.append(f"{case.name:<{name_w}}  {idem:>12}  {html:>12}")
     return "\n".join(lines)
 
 
-def _summary(rows: list[tuple[Case, list[CheckResult]]]) -> tuple[int, int, int]:
-    passed = failed = skipped = 0
-    for _, results in rows:
+def _summary(rows: list[tuple[Case, list[CheckResult]]]) -> dict[str, int]:
+    """Count outcomes by the same five statuses ``_status`` reports."""
+    counts = {"passed": 0, "failed": 0, "xfailed": 0, "xpassed": 0, "skipped": 0}
+    key = {"SKIP": "skipped", "pass": "passed", "FAIL": "failed", "XFAIL": "xfailed", "XPASS": "xpassed"}
+    for case, results in rows:
         for r in results:
-            if r.skipped:
-                skipped += 1
-            elif r.passed:
-                passed += 1
-            else:
-                failed += 1
-    return passed, failed, skipped
+            counts[key[_status(case.name, r)]] += 1
+    return counts
+
+
+def _stale_expected_failures(rows: list[tuple[Case, list[CheckResult]]]) -> list[tuple[str, str]]:
+    """``EXPECTED_FAILURES`` keys that no oracle actually evaluated.
+
+    Catches the third way the table can rot: a document renamed or deleted, or an
+    oracle that now policy-skips the case, leaves an entry that can never fail and
+    so silently stops guarding anything.
+    """
+    evaluated = {(case.name, r.oracle) for case, results in rows for r in results if not r.skipped}
+    return sorted(k for k in EXPECTED_FAILURES if k not in evaluated)
+
+
+def gate_failed(counts: dict[str, int], stale: list[tuple[str, str]]) -> bool:
+    """Whether this run should fail the build.
+
+    Three ways to go red: a genuine oracle failure, an expected failure that has
+    started passing, or a stale expected-failure entry. The last two are gate
+    *hygiene* rather than fidelity problems, but they are equally fatal - an
+    allowlist nobody has to maintain is how a ratchet stops being one.
+    """
+    return bool(counts["failed"] or counts["xpassed"] or stale)
 
 
 def _build_parser() -> argparse.ArgumentParser:
@@ -113,18 +157,43 @@ def main(argv: list[str] | None = None) -> int:
     rows = [(case, evaluate_case(case)) for case in cases]
 
     print(_format_table(rows))
-    passed, failed, skipped = _summary(rows)
+    counts = _summary(rows)
+    stale = _stale_expected_failures(rows)
     print()
-    print(f"{passed} passed, {failed} failed, {skipped} skipped  ({len(cases)} documents x 2 oracles)")
+    # Only surface the categories that actually occurred, so a clean run reads as
+    # "40 passed" rather than a row of zeros.
+    parts = [f"{counts['passed']} passed"] + [f"{n} {label}" for label, n in counts.items() if label != "passed" and n]
+    print(f"{', '.join(parts)}  ({len(cases)} documents x 2 oracles)")
 
     if args.show_diff:
         for case, results in rows:
             for r in results:
                 if not r.passed and not r.skipped:
-                    print(f"\n=== {case.name} :: {r.oracle} ===")
+                    print(f"\n=== {case.name} :: {r.oracle} [{_status(case.name, r)}] ===")
                     print(r.detail)
                     if r.diff:
                         print(r.diff)
+
+    # An expected failure that passed, or that nothing evaluated, means the table
+    # above is out of date. Report it as loudly as a real failure - a rotting
+    # allowlist is how a ratchet quietly stops being one.
+    for case, results in rows:
+        for r in results:
+            if _status(case.name, r) == "XPASS":
+                print(
+                    f"\nERROR: {case.name}:{r.oracle} passed but is listed as an expected failure.\n"
+                    f"  Recorded reason: {EXPECTED_FAILURES[case.name, r.oracle]}\n"
+                    f"  If this was fixed on purpose, delete the entry from EXPECTED_FAILURES\n"
+                    f"  in benchmarks/roundtrip/run.py so the gate protects the fix.",
+                    file=sys.stderr,
+                )
+    for name, oracle in stale:
+        print(
+            f"\nERROR: expected failure {name}:{oracle} was never evaluated - the document is "
+            f"missing/renamed, or that oracle now skips it.\n"
+            f"  Update or remove the EXPECTED_FAILURES entry in benchmarks/roundtrip/run.py.",
+            file=sys.stderr,
+        )
 
     if args.json is not None:
         payload = {
@@ -133,17 +202,24 @@ def main(argv: list[str] | None = None) -> int:
                     "name": case.name,
                     "source": case.source,
                     "has_raw_html": case.has_raw_html,
-                    "results": [asdict(r) for r in results],
+                    "results": [
+                        {
+                            **asdict(r),
+                            "status": _status(case.name, r),
+                            "expected_failure_reason": EXPECTED_FAILURES.get((case.name, r.oracle)),
+                        }
+                        for r in results
+                    ],
                 }
                 for case, results in rows
             ],
-            "summary": {"passed": passed, "failed": failed, "skipped": skipped},
+            "summary": {**counts, "stale_expected_failures": [list(k) for k in stale]},
         }
         args.json.parent.mkdir(parents=True, exist_ok=True)
         args.json.write_text(json.dumps(payload, indent=2), encoding="utf-8")
         print(f"\nWrote results to {args.json}", flush=True)
 
-    return 1 if failed else 0
+    return 1 if gate_failed(counts, stale) else 0
 
 
 if __name__ == "__main__":

--- a/tests/unit/test_roundtrip_benchmark.py
+++ b/tests/unit/test_roundtrip_benchmark.py
@@ -9,14 +9,19 @@ relying on a current all2md bug, so the tests stay valid as all2md is fixed.
 The HTML semantic normalizer is additionally checked to (a) ignore incidental
 whitespace and (b) still distinguish the exact loss shape - a collapsed
 paragraph - that motivated this benchmark (#85).
+
+The last section guards the *CI gate* built on those oracles: that it goes red on
+a real failure, on an expected failure that has started passing, and on an
+expected-failure entry that nothing evaluates any more.
 """
 
 from __future__ import annotations
 
 import pytest
 
-from benchmarks.roundtrip import corpus, oracles
+from benchmarks.roundtrip import corpus, oracles, run
 from benchmarks.roundtrip.oracles import (
+    CheckResult,
     html_equivalence_check,
     idempotency_check,
 )
@@ -155,3 +160,84 @@ def test_evaluate_case_skips_html_oracle_for_admonitions() -> None:
     assert results["html_equivalence"].skipped
     # Idempotency still runs and should pass for a well-formed admonition.
     assert results["idempotency"].passed
+
+
+# --- the CI gate itself can go red --------------------------------------------
+#
+# The gate is only worth having if it fails when it should, so its three red
+# paths are pinned here rather than demonstrated once by hand: a genuine oracle
+# failure, an expected failure that started passing (XPASS), and an
+# expected-failure entry nothing evaluates any more (stale).
+
+
+def _result(oracle: str, *, passed: bool, skipped: bool = False) -> CheckResult:
+    return CheckResult(oracle, passed=passed, skipped=skipped, detail="synthetic")
+
+
+def test_status_distinguishes_expected_from_unexpected(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setitem(run.EXPECTED_FAILURES, ("doc", "idempotency"), "accepted for test")
+
+    # Same failing result is XFAIL when allowlisted, FAIL when not.
+    assert run._status("doc", _result("idempotency", passed=False)) == "XFAIL"
+    assert run._status("other", _result("idempotency", passed=False)) == "FAIL"
+    # Same passing result is XPASS when allowlisted, pass when not.
+    assert run._status("doc", _result("idempotency", passed=True)) == "XPASS"
+    assert run._status("other", _result("idempotency", passed=True)) == "pass"
+    # A policy skip outranks the allowlist - it was never judged either way.
+    assert run._status("doc", _result("idempotency", passed=True, skipped=True)) == "SKIP"
+
+
+def test_gate_is_green_on_expected_failures_only() -> None:
+    counts = {"passed": 37, "failed": 0, "xfailed": 1, "xpassed": 0, "skipped": 2}
+    assert run.gate_failed(counts, []) is False
+
+
+@pytest.mark.parametrize(
+    ("counts_delta", "stale", "why"),
+    [
+        ({"failed": 1}, [], "a genuine oracle failure"),
+        ({"xpassed": 1}, [], "an expected failure that started passing"),
+        ({}, [("gone", "idempotency")], "a stale expected-failure entry"),
+    ],
+)
+def test_gate_goes_red(counts_delta: dict[str, int], stale: list[tuple[str, str]], why: str) -> None:
+    counts = {"passed": 37, "failed": 0, "xfailed": 1, "xpassed": 0, "skipped": 2, **counts_delta}
+    assert run.gate_failed(counts, stale) is True, f"gate should fail on {why}"
+
+
+def test_stale_detection_flags_unevaluated_entries(monkeypatch: pytest.MonkeyPatch) -> None:
+    case = corpus.Case(name="present", markdown="hi\n")
+    rows = [(case, [_result("idempotency", passed=False)])]
+
+    # An entry for a document that no longer exists is stale...
+    monkeypatch.setitem(run.EXPECTED_FAILURES, ("renamed-away", "idempotency"), "x")
+    assert ("renamed-away", "idempotency") in run._stale_expected_failures(rows)
+    # ...while the entry that did get evaluated is not.
+    monkeypatch.setitem(run.EXPECTED_FAILURES, ("present", "idempotency"), "x")
+    assert ("present", "idempotency") not in run._stale_expected_failures(rows)
+
+
+def test_stale_detection_flags_entry_hidden_by_a_skip(monkeypatch: pytest.MonkeyPatch) -> None:
+    # The subtle rot case: the oracle now policy-skips the case, so the allowlist
+    # entry can never fail again and silently guards nothing.
+    case = corpus.Case(name="doc", markdown="<div>raw</div>\n", has_raw_html=True)
+    rows = [(case, [_result("html_equivalence", passed=True, skipped=True)])]
+    monkeypatch.setitem(run.EXPECTED_FAILURES, ("doc", "html_equivalence"), "x")
+    assert ("doc", "html_equivalence") in run._stale_expected_failures(rows)
+
+
+def test_every_expected_failure_records_a_reason() -> None:
+    # The allowlist is a decision log; an entry without a justification is how it
+    # decays into "this has always been broken".
+    for key, reason in run.EXPECTED_FAILURES.items():
+        assert reason.strip(), f"{key} has no recorded reason"
+
+
+def test_summary_counts_match_the_reported_statuses(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setitem(run.EXPECTED_FAILURES, ("doc", "idempotency"), "accepted for test")
+    rows = [
+        (corpus.Case(name="doc", markdown="a\n"), [_result("idempotency", passed=False)]),
+        (corpus.Case(name="ok", markdown="b\n"), [_result("idempotency", passed=True)]),
+        (corpus.Case(name="bad", markdown="c\n"), [_result("idempotency", passed=False)]),
+    ]
+    assert run._summary(rows) == {"passed": 1, "failed": 1, "xfailed": 1, "xpassed": 0, "skipped": 0}


### PR DESCRIPTION
First deliverable of the **Quality & Speed Ratchets** batch (R1b). We wrote the
thermometer and never hung it on the wall; this hangs one of them.

`benchmarks/roundtrip` has exited non-zero on oracle failure since it landed, but
nothing ever ran it. It's now the `Roundtrip Fidelity Gate` job and is in
`release`'s `needs:`, so a `Markdown -> AST -> Markdown` regression fails the
build and blocks a release instead of waiting to be noticed.

## The corpus got healthier while the plan sat

v1.10.0's #113 (insert/underline AST disambiguation) fixed what was deferred as
 #101, so `extended-inline` now passes both oracles:

```
37 passed, 1 xfailed, 2 skipped  (20 documents x 2 oracles)
```

## Expected failures, and why XPASS is red

The one remaining failure — `raw-html:idempotency` — is the deliberate
`html_passthrough_mode="escape"` policy, not a bug, so the gate needs to accept it
without going blind. `EXPECTED_FAILURES` maps `(document, oracle) -> reason`:

| Status | Meaning |
|---|---|
| `pass` / `FAIL` | not allowlisted; `FAIL` is red |
| `XFAIL` | allowlisted and still failing — green, as documented |
| `XPASS` | allowlisted but now **passing** — **red** |
| `SKIP` | policy skip; never judged, never counted |

`XPASS` and **stale** entries (nothing evaluates them any more — a rename, or a
newly-added policy skip) are both red. Either means the table has begun lying
about the codebase, so it must be updated in the same commit that changes the
behavior. Without that, an allowlist decays into a permanent excuse list and the
ratchet stops being one.

## The gate was verified to go red

A gate that can't fail is worse than no gate — it launders "we didn't measure"
into "we measured and it's fine." All three red paths were demonstrated by hand:

- **real regression** — patched out `MarkdownRenderer.visit_thematic_break`: 2
  documents failed, exit 1
- **XPASS** — allowlisted a passing case: exit 1, with an actionable message
- **stale** — allowlisted a nonexistent document: exit 1

Then pinned as tests against an extracted `gate_failed()`, and *those* were
verified by gutting it to `return False` and watching all three fail.

## One finding worth keeping

Dropping a construct entirely is trivially idempotent — both passes lack it — so
`idempotency` stayed **green** on the injected regression and only
`html_equivalence` caught it. Neither oracle subsumes the other; a single-oracle
gate would have been blind here. Recorded in the README, and relevant to how much
we trust any single metric in the remaining ratchet work.

## Notes for review

- Single Python version (3.12) on purpose — fidelity is a property of the
  renderer, not the interpreter, so the 5-version matrix would cost 5x for nothing.
- CI re-runs with `--show-diff` only on failure, so green runs stay quiet but a red
  one arrives with diffs already in the log.
- No `src/` changes; no public API or behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
