### PR TITLE
bench(startup): measure CI runner variance before gating on it

### DIFF
--- a/.github/workflows/startup-variance.yml
+++ b/.github/workflows/startup-variance.yml
@@ -1,0 +1,134 @@
+name: Startup Runner Variance
+
+# Measures how much benchmarks/startup.py's numbers move across GitHub runners on
+# *unchanged* code. This is the prerequisite for making startup a blocking gate:
+# a threshold picked without knowing runner variance is a guess, and a flaky gate
+# gets disabled, which leaves the appearance of coverage instead of coverage.
+#
+# Dispatch-only and non-blocking on purpose - it reports a spread, it never fails
+# a build on a number. Delete or repurpose it once the real gate exists.
+
+on:
+  workflow_dispatch:
+    inputs:
+      repeat:
+        description: "Timed samples per scenario within each run (default: 9)"
+        required: false
+        default: "9"
+        type: string
+
+concurrency:
+  group: startup-variance-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  measure:
+    name: Measure (run ${{ matrix.run }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    # Separate matrix jobs land on separate runner VMs, so the spread across them
+    # is the VM-to-VM variance a per-PR gate would actually face - which is the
+    # number we need. Repeating in one job would only measure sample noise.
+    strategy:
+      fail-fast: false
+      matrix:
+        run: [1, 2, 3, 4, 5, 6]
+
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v7
+
+      - name: Set up Python 3.12
+        uses: actions/setup-python@v7
+        with:
+          python-version: "3.12"
+          cache: 'pip'
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e ".[all,dev]"
+
+      - name: Record runner info
+        run: |
+          {
+            echo "### Run ${{ matrix.run }}"
+            echo ""
+            echo "- CPU: \`$(nproc) cores\`"
+            echo "- Model: \`$(grep -m1 'model name' /proc/cpuinfo | cut -d: -f2- | xargs)\`"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Run startup benchmark
+        env:
+          REPEAT: ${{ inputs.repeat }}
+        run: |
+          set -o pipefail
+          python -m benchmarks.startup --repeat "${REPEAT:-9}" --out "startup-${{ matrix.run }}.json" \
+            | tee "startup-${{ matrix.run }}.txt"
+
+      - name: Append table to job summary
+        if: always()
+        run: |
+          {
+            echo ""
+            echo '```'
+            cat "startup-${{ matrix.run }}.txt" || echo "no table produced"
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload raw result
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: startup-run-${{ matrix.run }}
+          path: startup-${{ matrix.run }}.json
+          if-no-files-found: error
+
+  spread:
+    name: Cross-run spread
+    runs-on: ubuntu-latest
+    needs: measure
+    # Report on whatever succeeded; a single dead runner shouldn't discard the study.
+    if: always()
+
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v7
+
+      - name: Set up Python 3.12
+        uses: actions/setup-python@v7
+        with:
+          python-version: "3.12"
+
+      - name: Download raw results
+        uses: actions/download-artifact@v7
+        with:
+          pattern: startup-run-*
+          path: startup-runs
+
+      - name: Compute spread
+        run: |
+          set -o pipefail
+          python -m benchmarks.startup_spread startup-runs --json startup-spread.json | tee spread.txt
+
+      - name: Append spread to job summary
+        if: always()
+        run: |
+          {
+            echo "## Cross-run spread"
+            echo ""
+            echo '```'
+            cat spread.txt || echo "no spread produced"
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload spread
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: startup-spread-${{ github.run_number }}
+          path: |
+            startup-spread.json
+            spread.txt
+          if-no-files-found: warn

--- a/benchmarks/startup_spread.py
+++ b/benchmarks/startup_spread.py
@@ -1,0 +1,275 @@
+"""Runner-variance study for the cold-start benchmark.
+
+**This is an instrument, not a gate.** It never fails a build on a threshold,
+because its whole job is to tell us what threshold is even defensible. Before
+``benchmarks/startup.py`` can become a blocking CI gate we have to know how much
+its numbers move on identical code, on the runners the gate would actually run
+on. Guessing here buys a flaky gate, and a flaky gate gets disabled, which leaves
+the *appearance* of coverage - strictly worse than no gate.
+
+Feed it several ``benchmarks.startup --out`` JSON files produced from unchanged
+code (ideally one per runner VM, so it captures VM-to-VM variance and not just
+sample noise within one machine) and it reports, per scenario:
+
+- the spread of each candidate gate metric across runs, and
+- ``max dev%`` - the largest deviation any run showed from the median, i.e. **the
+  smallest tolerance that would not have flaked on this data**. A real threshold
+  needs headroom on top of that, not equality with it.
+
+Three candidate metrics are tracked, because they trade off differently:
+
+- ``min_ms`` - raw wall clock. Simple, but scales with runner speed, so a slower
+  VM reads as a regression.
+- ``over_baseline_ms`` - ``min_ms`` minus the bare-interpreter minimum. Removes
+  interpreter startup, but is still in milliseconds, so it *also* scales with
+  runner speed - just from a lower floor.
+- ``ratio_over_baseline`` - ``over_baseline_ms / baseline_min_ms``. Dimensionless:
+  "all2md costs N bare interpreter startups". A uniformly slower VM cancels out.
+  The most stable in principle; whether that survives contact with real runners
+  is exactly what this script measures.
+
+``within-run%`` is a separate noise signal: how far each run's *median* sample sat
+above its *minimum* sample. Large values mean the samples themselves are noisy and
+``--repeat`` should go up; small values with a large ``max dev%`` mean the noise is
+between machines, and more repeats would not help.
+
+Usage::
+
+    python -m benchmarks.startup_spread artifacts/          # any dir tree of JSONs
+    python -m benchmarks.startup_spread a.json b.json c.json
+    python -m benchmarks.startup_spread artifacts/ --json spread.json
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import statistics
+import sys
+from dataclasses import asdict, dataclass
+from pathlib import Path
+
+# Candidate gate metrics, in the order they are reported.
+METRICS = ("min_ms", "over_baseline_ms", "ratio_over_baseline")
+
+
+@dataclass
+class Spread:
+    """How much one (scenario, metric) pair moved across runs of identical code."""
+
+    scenario: str
+    metric: str
+    n: int
+    median: float
+    lo: float
+    hi: float
+    max_dev_pct: float
+    cv_pct: float
+
+
+def load_runs(paths: list[Path]) -> list[tuple[str, dict]]:
+    """Load ``(label, payload)`` for every startup JSON under ``paths``.
+
+    Directories are searched recursively, which is what the CI job needs: the
+    artifact download produces one directory per matrix job.
+    """
+    files: list[Path] = []
+    for p in paths:
+        if p.is_dir():
+            files.extend(sorted(p.rglob("*.json")))
+        else:
+            files.append(p)
+
+    runs: list[tuple[str, dict]] = []
+    for f in files:
+        try:
+            payload = json.loads(f.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError) as exc:
+            print(f"skipping {f}: {exc}", file=sys.stderr)
+            continue
+        if not isinstance(payload, dict) or "results" not in payload:
+            print(f"skipping {f}: not a startup benchmark result", file=sys.stderr)
+            continue
+        runs.append((f.stem, payload))
+    return runs
+
+
+def metrics_for_run(payload: dict) -> dict[str, dict[str, float]]:
+    """Map ``scenario -> metric -> value`` for a single run.
+
+    ``baseline`` has no ``over_baseline_ms`` (it *is* the baseline), so it simply
+    carries fewer metrics rather than being special-cased downstream.
+    """
+    by_name = {r["name"]: r for r in payload.get("results", [])}
+    baseline_min = by_name.get("baseline", {}).get("min_ms")
+
+    out: dict[str, dict[str, float]] = {}
+    for name, r in by_name.items():
+        min_ms = float(r["min_ms"])
+        values: dict[str, float] = {"min_ms": min_ms}
+
+        over = r.get("over_baseline_ms")
+        if over is not None:
+            values["over_baseline_ms"] = float(over)
+            if baseline_min:
+                values["ratio_over_baseline"] = float(over) / float(baseline_min)
+
+        # Sample noise inside this one run, independent of the cross-run spread.
+        if min_ms:
+            values["within_run_spread_pct"] = (float(r["median_ms"]) - min_ms) / min_ms * 100.0
+        out[name] = values
+    return out
+
+
+def summarize(values: list[float]) -> tuple[float, float, float, float, float]:
+    """Return ``(median, lo, hi, max_dev_pct, cv_pct)`` for one metric's samples.
+
+    ``max_dev_pct`` is the largest relative distance from the median - the
+    smallest tolerance that would have survived this data. A zero median makes
+    the percentages meaningless rather than infinite, so they report as 0.0.
+    """
+    median = statistics.median(values)
+    lo, hi = min(values), max(values)
+    if median:
+        max_dev_pct = max(abs(v - median) / abs(median) for v in values) * 100.0
+    else:
+        max_dev_pct = 0.0
+    if len(values) > 1:
+        mean = statistics.fmean(values)
+        cv_pct = (statistics.stdev(values) / mean * 100.0) if mean else 0.0
+    else:
+        cv_pct = 0.0
+    return median, lo, hi, max_dev_pct, cv_pct
+
+
+def compute_spreads(runs: list[tuple[str, dict]]) -> list[Spread]:
+    """Cross-run spread for every (scenario, metric) present in at least one run.
+
+    Scenario order follows the first run so the report reads in pipeline order
+    (baseline, import, --version, ...) rather than alphabetically.
+    """
+    per_run = [metrics_for_run(payload) for _, payload in runs]
+
+    order: list[str] = []
+    for run in per_run:
+        for name in run:
+            if name not in order:
+                order.append(name)
+
+    spreads: list[Spread] = []
+    for scenario in order:
+        for metric in METRICS:
+            values = [run[scenario][metric] for run in per_run if scenario in run and metric in run[scenario]]
+            if not values:
+                continue
+            median, lo, hi, max_dev_pct, cv_pct = summarize(values)
+            spreads.append(
+                Spread(
+                    scenario=scenario,
+                    metric=metric,
+                    n=len(values),
+                    median=round(median, 3),
+                    lo=round(lo, 3),
+                    hi=round(hi, 3),
+                    max_dev_pct=round(max_dev_pct, 1),
+                    cv_pct=round(cv_pct, 1),
+                )
+            )
+    return spreads
+
+
+def within_run_noise(runs: list[tuple[str, dict]]) -> dict[str, float]:
+    """Median ``(median_sample - min_sample) / min_sample`` per scenario, in percent."""
+    per_run = [metrics_for_run(payload) for _, payload in runs]
+    noise: dict[str, float] = {}
+    for scenario in {s for run in per_run for s in run}:
+        values = [
+            run[scenario]["within_run_spread_pct"]
+            for run in per_run
+            if "within_run_spread_pct" in run.get(scenario, {})
+        ]
+        if values:
+            noise[scenario] = round(statistics.median(values), 1)
+    return noise
+
+
+def min_safe_tolerance(spreads: list[Spread]) -> dict[str, float]:
+    """Per metric, the worst ``max_dev_pct`` across scenarios.
+
+    This is the floor for any tolerance built on that metric: set the gate below
+    this and unchanged code would already have gone red somewhere in this data.
+    """
+    worst: dict[str, float] = {}
+    for s in spreads:
+        worst[s.metric] = max(worst.get(s.metric, 0.0), s.max_dev_pct)
+    return worst
+
+
+def format_report(runs: list[tuple[str, dict]], spreads: list[Spread]) -> str:
+    noise = within_run_noise(runs)
+    lines = [f"{len(runs)} run(s): {', '.join(label for label, _ in runs)}", ""]
+
+    header = (
+        f"{'scenario':<12} {'metric':<20} {'n':>2} {'median':>10} " f"{'lo':>10} {'hi':>10} {'max dev%':>9} {'cv%':>6}"
+    )
+    lines += [header, "-" * len(header)]
+    last_scenario = None
+    for s in spreads:
+        if last_scenario is not None and s.scenario != last_scenario:
+            lines.append("")
+        last_scenario = s.scenario
+        lines.append(
+            f"{s.scenario:<12} {s.metric:<20} {s.n:>2} {s.median:>10.3f} "
+            f"{s.lo:>10.3f} {s.hi:>10.3f} {s.max_dev_pct:>9.1f} {s.cv_pct:>6.1f}"
+        )
+
+    lines += ["", "Within-run sample noise (median sample vs min sample, %):"]
+    for scenario, pct in sorted(noise.items(), key=lambda kv: -kv[1]):
+        lines.append(f"  {scenario:<12} {pct:>6.1f}")
+
+    lines += ["", "Smallest tolerance that would NOT have flaked on this data:"]
+    for metric, pct in sorted(min_safe_tolerance(spreads).items(), key=lambda kv: kv[1]):
+        lines.append(f"  {metric:<20} > {pct:.1f}%")
+    lines += [
+        "",
+        "Pick the metric with the smallest floor, then add headroom - these runs are a",
+        "sample, not the worst case. Sensitivity matters too: a metric that carries a",
+        "large constant offset dilutes real regressions even when it looks stable.",
+    ]
+    return "\n".join(lines)
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(prog="benchmarks.startup_spread", description=__doc__)
+    p.add_argument("paths", nargs="+", type=Path, help="startup JSON files, or directories to search recursively")
+    p.add_argument("--json", type=Path, default=None, help="Write the computed spreads to this path")
+    return p
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _build_parser().parse_args(argv)
+
+    runs = load_runs(args.paths)
+    if len(runs) < 2:
+        print(f"Need at least 2 runs to measure spread, found {len(runs)}.", file=sys.stderr)
+        return 2
+
+    spreads = compute_spreads(runs)
+    print(format_report(runs, spreads))
+
+    if args.json is not None:
+        payload = {
+            "runs": [{"label": label, "machine": r.get("machine", {})} for label, r in runs],
+            "spreads": [asdict(s) for s in spreads],
+            "within_run_noise_pct": within_run_noise(runs),
+            "min_safe_tolerance_pct": min_safe_tolerance(spreads),
+        }
+        args.json.parent.mkdir(parents=True, exist_ok=True)
+        args.json.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+        print(f"\nWrote spreads to {args.json}")
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/unit/test_startup_spread.py
+++ b/tests/unit/test_startup_spread.py
@@ -1,0 +1,172 @@
+"""Self-tests for the startup runner-variance aggregator.
+
+``benchmarks/startup_spread.py`` is what will decide the threshold for the future
+startup gate, so its arithmetic has to be right *and* has to be able to report
+"no spread" when there genuinely isn't one - an instrument that always reports
+noise would push the threshold up until the gate is meaningless, and one that
+never reports noise would push it down until the gate flakes. Both directions are
+exercised here.
+
+The load-bearing test is ``test_ratio_cancels_a_uniformly_slower_runner``: the
+whole argument for gating on ``ratio_over_baseline`` rather than milliseconds is
+that a slower VM cancels out of it. If that stops being true, the metric choice
+is wrong, not just the number.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from benchmarks import startup_spread
+
+pytestmark = pytest.mark.unit
+
+
+def _payload(baseline_ms: float, scenarios: dict[str, float], *, median_factor: float = 1.0) -> dict:
+    """Build a startup-benchmark payload the way ``startup.py --out`` writes one.
+
+    ``over_baseline_ms`` is derived here exactly as the harness derives it, so the
+    fixture can't drift into being self-consistent but unlike real input.
+    """
+    results = [
+        {
+            "name": "baseline",
+            "command": "python -c pass",
+            "repeat": 9,
+            "min_ms": baseline_ms,
+            "median_ms": baseline_ms * median_factor,
+            "mean_ms": baseline_ms * median_factor,
+            "over_baseline_ms": None,
+            "returncodes": [0] * 9,
+        }
+    ]
+    for name, min_ms in scenarios.items():
+        results.append(
+            {
+                "name": name,
+                "command": f"python -m all2md {name}",
+                "repeat": 9,
+                "min_ms": min_ms,
+                "median_ms": min_ms * median_factor,
+                "mean_ms": min_ms * median_factor,
+                "over_baseline_ms": min_ms - baseline_ms,
+                "returncodes": [0] * 9,
+            }
+        )
+    return {"machine": {"python": "3.12.0"}, "results": results}
+
+
+def _spreads_by_metric(runs: list[dict], scenario: str) -> dict[str, startup_spread.Spread]:
+    labeled = [(f"run{i}", r) for i, r in enumerate(runs)]
+    return {s.metric: s for s in startup_spread.compute_spreads(labeled) if s.scenario == scenario}
+
+
+# --- the summary statistics themselves ----------------------------------------
+
+
+def test_summarize_reports_median_bounds_and_worst_deviation() -> None:
+    median, lo, hi, max_dev_pct, cv_pct = startup_spread.summarize([100.0, 100.0, 120.0])
+    assert (median, lo, hi) == (100.0, 100.0, 120.0)
+    assert max_dev_pct == pytest.approx(20.0)
+    assert cv_pct > 0
+
+
+def test_summarize_reports_no_spread_for_identical_values() -> None:
+    # The control: an instrument that invents noise here would inflate every
+    # threshold derived from it.
+    _, _, _, max_dev_pct, cv_pct = startup_spread.summarize([250.0, 250.0, 250.0])
+    assert max_dev_pct == 0.0
+    assert cv_pct == 0.0
+
+
+def test_summarize_survives_a_zero_median() -> None:
+    # over_baseline_ms can legitimately land on 0.0; percentages are meaningless
+    # then, but must not be infinite or a ZeroDivisionError.
+    _, _, _, max_dev_pct, _ = startup_spread.summarize([0.0, 0.0, 5.0])
+    assert max_dev_pct == 0.0
+
+
+# --- per-run metric extraction -------------------------------------------------
+
+
+def test_baseline_carries_no_derived_metrics() -> None:
+    metrics = startup_spread.metrics_for_run(_payload(100.0, {"import": 500.0}))
+    assert "over_baseline_ms" not in metrics["baseline"]
+    assert "ratio_over_baseline" not in metrics["baseline"]
+    assert metrics["import"]["over_baseline_ms"] == 400.0
+    assert metrics["import"]["ratio_over_baseline"] == pytest.approx(4.0)
+
+
+def test_within_run_noise_tracks_median_above_min() -> None:
+    runs = [("a", _payload(100.0, {"import": 500.0}, median_factor=1.1))]
+    assert startup_spread.within_run_noise(runs)["import"] == pytest.approx(10.0)
+
+
+# --- the metric-choice claim ---------------------------------------------------
+
+
+def test_ratio_cancels_a_uniformly_slower_runner() -> None:
+    # Same code, one VM 1.5x slower across the board. Milliseconds move; the
+    # dimensionless ratio must not - that is the entire case for gating on it.
+    fast = _payload(100.0, {"import": 500.0})
+    slow = _payload(150.0, {"import": 750.0})
+    spreads = _spreads_by_metric([fast, slow], "import")
+
+    assert spreads["min_ms"].max_dev_pct == pytest.approx(20.0)
+    assert spreads["over_baseline_ms"].max_dev_pct == pytest.approx(20.0)
+    assert spreads["ratio_over_baseline"].max_dev_pct == 0.0
+
+
+def test_real_regression_shows_up_in_the_ratio() -> None:
+    # The other half: a genuine slowdown on an identical VM must move the ratio,
+    # or the metric would be stable by being blind.
+    before = _payload(100.0, {"import": 500.0})
+    after = _payload(100.0, {"import": 900.0})
+    spreads = _spreads_by_metric([before, after], "import")
+    assert spreads["ratio_over_baseline"].max_dev_pct > 0
+
+
+# --- aggregation across scenarios ----------------------------------------------
+
+
+def test_min_safe_tolerance_takes_the_worst_scenario() -> None:
+    a = _payload(100.0, {"import": 500.0, "--help": 800.0})
+    b = _payload(100.0, {"import": 505.0, "--help": 1200.0})
+    labeled = [("a", a), ("b", b)]
+    worst = startup_spread.min_safe_tolerance(startup_spread.compute_spreads(labeled))
+    # --help moved far more than import; the floor must reflect the worse one.
+    per_scenario = {(s.scenario, s.metric): s.max_dev_pct for s in startup_spread.compute_spreads(labeled)}
+    assert worst["min_ms"] == pytest.approx(per_scenario[("--help", "min_ms")])
+    assert worst["min_ms"] > per_scenario[("import", "min_ms")]
+
+
+def test_scenarios_are_reported_in_pipeline_order() -> None:
+    run = _payload(100.0, {"import": 500.0, "--version": 520.0, "--help": 800.0})
+    order: list[str] = []
+    for s in startup_spread.compute_spreads([("a", run), ("b", run)]):
+        if s.scenario not in order:
+            order.append(s.scenario)
+    assert order == ["baseline", "import", "--version", "--help"]
+
+
+# --- loading -------------------------------------------------------------------
+
+
+def test_load_runs_reads_a_directory_tree_and_skips_foreign_json(tmp_path: Path) -> None:
+    (tmp_path / "job1").mkdir()
+    (tmp_path / "job2").mkdir()
+    (tmp_path / "job1" / "startup-1.json").write_text(json.dumps(_payload(100.0, {"import": 500.0})), encoding="utf-8")
+    (tmp_path / "job2" / "startup-2.json").write_text(json.dumps(_payload(110.0, {"import": 520.0})), encoding="utf-8")
+    # An unrelated artifact sharing the directory must not be mistaken for a run.
+    (tmp_path / "job2" / "coverage.json").write_text(json.dumps({"totals": {}}), encoding="utf-8")
+
+    runs = startup_spread.load_runs([tmp_path])
+    assert [label for label, _ in runs] == ["startup-1", "startup-2"]
+
+
+def test_main_refuses_to_report_a_spread_from_one_run(tmp_path: Path) -> None:
+    (tmp_path / "only.json").write_text(json.dumps(_payload(100.0, {"import": 500.0})), encoding="utf-8")
+    assert startup_spread.main([str(tmp_path)]) == 2


### PR DESCRIPTION
Groundwork for **R1a** (startup benchmark as a blocking CI gate). This PR deliberately does *not* add the gate — it adds the measurement the gate's threshold has to be derived from.

## Why measure first

`benchmarks/startup.py` has been gate-ready since it was written. What's missing isn't plumbing, it's a defensible number. Picking a tolerance by guess buys a flaky gate, and a flaky gate gets disabled — which leaves the *appearance* of coverage rather than coverage. This is the open question the batch plan flagged as needing runner data before anything else.

## What's here

- **`.github/workflows/startup-variance.yml`** — dispatch-only, non-blocking. Runs the existing harness on **six separate `ubuntu-latest` VMs** via a matrix. Matrix rather than repeats on purpose: the spread that matters for a per-PR gate is between machines, not within one.
- **`benchmarks/startup_spread.py`** — aggregates the six results and reports, per scenario, `max dev%`: the largest deviation any run showed from the median, i.e. **the smallest tolerance that would not have flaked on this data**. It reports numbers and never fails on a threshold, because it has none — that's the point.
- **`tests/unit/test_startup_spread.py`** — 11 tests on the arithmetic.

## Three candidate metrics

The gate has to pick one, and they trade off differently:

| metric | stable across runner speeds? | note |
|---|---|---|
| `min_ms` | no | raw wall clock; a slower VM reads as a regression |
| `over_baseline_ms` | no | subtracts interpreter startup, still in ms, still scales |
| `ratio_over_baseline` | should be | dimensionless — "all2md costs N bare interpreter startups" |

The plan said "baseline-relative, not an absolute ceiling" and pointed at `over_baseline_ms`. Worth noting that `over_baseline_ms` is a *subtraction*, so it still scales with runner speed — just from a lower floor. `ratio_over_baseline` is the one that actually cancels. That claim is load-bearing for the metric choice, so it's pinned as a test (`test_ratio_cancels_a_uniformly_slower_runner`) rather than left as a comment — along with its converse, that a genuine slowdown still moves the ratio, so it isn't stable by being blind.

Which metric wins is still an empirical question; the workflow answers it.

## Judge-can-fail

The aggregator isn't a gate, but its numbers will set one, so the same rule applies. Its tests were run against a gutted `summarize()` (`max_dev_pct = 0.0`) and 4 of them failed, including both directions of the ratio claim. Restored and green.

## Next

Merge, dispatch the workflow (dispatch requires the file on the default branch), read the spread, then open the actual gate PR with a committed CI-produced baseline and a threshold with headroom above the observed floor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
