### PR TITLE
test(perf): ratchet what `import all2md` pulls in eagerly

### DIFF
--- a/tests/unit/test_eager_imports.py
+++ b/tests/unit/test_eager_imports.py
@@ -79,22 +79,58 @@ EAGER_OPTIONS_MODULES = frozenset(
 # number drops; raising it should need a reason in the commit message.
 MAX_EAGER_ALL2MD_MODULES = 64
 
+# Third-party top-level packages a bare ``import all2md`` costs the user, over
+# and above the stdlib. Currently lean, and the cheapest way to keep it that way:
+# a single eager ``import pandas`` would cost more than every options module
+# combined and is invisible to both gates above, which only count ``all2md.*``.
+#
+# ``yaml`` and ``tomli_w`` at import time are themselves R2 leads - neither is
+# obviously needed to print a version string.
+EAGER_THIRD_PARTY_PACKAGES = frozenset({"all2md", "tomli_w", "yaml"})
+
 # Enough modules that a broken probe (empty output, import failure swallowed
 # somewhere) is obviously distinguishable from a genuinely lean import.
 _SANITY_FLOOR = 10
 
 
-@functools.lru_cache(maxsize=1)
-def _eager_all2md_modules() -> tuple[str, ...]:
-    """``all2md.*`` modules present in ``sys.modules`` after a bare import.
+# Runs in a fresh interpreter on purpose: the test process has already imported
+# half the package, so probing in-process would report the test suite's imports
+# rather than the package's own. Pseudo-modules injected by C extensions (notably
+# ``cython_runtime``) have no ``__file__`` and are filtered out - whether they
+# appear depends on which wheels the platform installed, not on our code.
+_PROBE = """
+import json, sys
+before = set(sys.modules)
+import all2md
+new = set(sys.modules) - before
 
-    Must run in a fresh interpreter: the test process has already imported half
-    the package, so measuring in-process would report the test suite's imports
-    rather than the package's own.
-    """
-    probe = "import all2md, sys, json; print(json.dumps(sorted(m for m in sys.modules if m.startswith('all2md'))))"
-    out = subprocess.check_output([sys.executable, "-c", probe], text=True)
-    return tuple(json.loads(out))
+third_party = sorted(
+    top
+    for top in {m.split(".")[0] for m in new}
+    if top not in sys.stdlib_module_names
+    and not top.startswith("_")
+    and getattr(sys.modules.get(top), "__file__", None) is not None
+)
+print(json.dumps({
+    "all2md": sorted(m for m in sys.modules if m.startswith("all2md")),
+    "third_party": third_party,
+}))
+"""
+
+
+@functools.lru_cache(maxsize=1)
+def _probe() -> dict[str, list[str]]:
+    """What a bare ``import all2md`` leaves in ``sys.modules``."""
+    out = subprocess.check_output([sys.executable, "-c", _PROBE], text=True)
+    return json.loads(out)
+
+
+def _eager_all2md_modules() -> tuple[str, ...]:
+    return tuple(_probe()["all2md"])
+
+
+def _eager_third_party_packages() -> frozenset[str]:
+    return frozenset(_probe()["third_party"])
 
 
 def _paste_ready(modules: set[str]) -> str:
@@ -136,6 +172,27 @@ def test_eager_options_imports_match_the_allowlist() -> None:
                 "",
             ]
         lines += ["Updated allowlist:", "", _paste_ready(actual)]
+        pytest.fail("\n".join(lines))
+
+
+def test_eager_third_party_packages_match_the_allowlist() -> None:
+    actual = _eager_third_party_packages()
+    added = actual - EAGER_THIRD_PARTY_PACKAGES
+    removed = EAGER_THIRD_PARTY_PACKAGES - actual
+
+    if added or removed:
+        lines = ["Third-party packages imported eagerly by `import all2md` changed.", ""]
+        if added:
+            lines += [
+                "NEW eager third-party imports. Every all2md user now pays this",
+                "package's import cost, whether or not they use the feature that",
+                "needs it - move it inside the function that uses it if you can:",
+                *(f"  + {m}" for m in sorted(added)),
+                "",
+            ]
+        if removed:
+            lines += ["No longer imported eagerly (record the win):", *(f"  - {m}" for m in sorted(removed)), ""]
+        lines += ["Updated allowlist:", "", f"EAGER_THIRD_PARTY_PACKAGES = frozenset({sorted(actual)!r})"]
         pytest.fail("\n".join(lines))
 
 

--- a/tests/unit/test_eager_imports.py
+++ b/tests/unit/test_eager_imports.py
@@ -86,7 +86,16 @@ MAX_EAGER_ALL2MD_MODULES = 64
 #
 # ``yaml`` and ``tomli_w`` at import time are themselves R2 leads - neither is
 # obviously needed to print a version string.
-EAGER_THIRD_PARTY_PACKAGES = frozenset({"all2md", "tomli_w", "yaml"})
+#
+# Backports are a property of the interpreter, not of our import graph: on 3.10
+# ``options/base.py`` falls back to ``typing_extensions`` for ``Self``, which the
+# stdlib provides from 3.11. Gating on it unconditionally would fail 3.10 for
+# being 3.10, so it is added per-version. The guard mirrors the dependency marker
+# in pyproject.toml (``typing_extensions>=4.0.0;python_version<'3.11'``) - if
+# that marker moves, this must move with it.
+_BACKPORTS = frozenset({"typing_extensions"}) if sys.version_info < (3, 11) else frozenset()
+
+EAGER_THIRD_PARTY_PACKAGES = frozenset({"all2md", "tomli_w", "yaml"}) | _BACKPORTS
 
 # Enough modules that a broken probe (empty output, import failure swallowed
 # somewhere) is obviously distinguishable from a genuinely lean import.
@@ -192,7 +201,10 @@ def test_eager_third_party_packages_match_the_allowlist() -> None:
             ]
         if removed:
             lines += ["No longer imported eagerly (record the win):", *(f"  - {m}" for m in sorted(removed)), ""]
-        lines += ["Updated allowlist:", "", f"EAGER_THIRD_PARTY_PACKAGES = frozenset({sorted(actual)!r})"]
+        # Backports are added per-version, so pasting them into the base set
+        # would break every other interpreter in the matrix.
+        base = sorted(actual - _BACKPORTS)
+        lines += ["Updated allowlist (version-specific backports excluded):", "", f"    frozenset({base!r})"]
         pytest.fail("\n".join(lines))
 
 

--- a/tests/unit/test_eager_imports.py
+++ b/tests/unit/test_eager_imports.py
@@ -1,0 +1,148 @@
+"""Ratchet on what ``import all2md`` drags in eagerly.
+
+Cold start is O(number of registered formats): importing the package pulls in an
+options module for essentially every format, so the cost of ``all2md --version``
+grows in proportion to how successful we are at adding formats. That is a scaling
+bug, and this is the gate that holds the line on it.
+
+**Why a test and not a benchmark.** The cost shows up as milliseconds, but the
+*cause* is a set of module names, and a set can be compared exactly. Measuring it
+as time means fighting a 6-7% runner variance floor (see the Startup Runner
+Variance workflow), which leaves enough slack for several new eager modules to
+land unnoticed - precisely the regression this exists to catch. Counting them
+instead is deterministic: zero flake, and it fails on the *first* offending
+module rather than the fourth.
+
+A timing gate still has its place for gross regressions; the two are complements,
+not alternatives.
+
+**Updating the allowlist.** ``EAGER_OPTIONS_MODULES`` is a ratchet, not a
+registry. Removing entries is the win R2 is chasing and needs no justification.
+*Adding* one means a new format made cold start slower for everyone who never
+uses that format - do it consciously, in the same commit, or make the import lazy
+instead. Note the deliberate exception recorded in ``all2md/__init__.py``:
+parsers must import eagerly to trigger registration. Options modules must not.
+"""
+
+from __future__ import annotations
+
+import functools
+import json
+import subprocess
+import sys
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+
+# Every ``all2md.options.*`` module pulled in by a bare ``import all2md``.
+# 31 modules to print a version string. Shrinking this list is the point of R2.
+EAGER_OPTIONS_MODULES = frozenset(
+    {
+        "all2md.options",
+        "all2md.options.asciidoc",
+        "all2md.options.ast_json",
+        "all2md.options.base",
+        "all2md.options.chm",
+        "all2md.options.common",
+        "all2md.options.csv",
+        "all2md.options.docx",
+        "all2md.options.dokuwiki",
+        "all2md.options.eml",
+        "all2md.options.epub",
+        "all2md.options.fb2",
+        "all2md.options.html",
+        "all2md.options.ipynb",
+        "all2md.options.jinja",
+        "all2md.options.latex",
+        "all2md.options.markdown",
+        "all2md.options.mediawiki",
+        "all2md.options.mhtml",
+        "all2md.options.odp",
+        "all2md.options.ods",
+        "all2md.options.odt",
+        "all2md.options.org",
+        "all2md.options.pdf",
+        "all2md.options.plaintext",
+        "all2md.options.pptx",
+        "all2md.options.rst",
+        "all2md.options.rtf",
+        "all2md.options.sourcecode",
+        "all2md.options.xlsx",
+        "all2md.options.zip",
+    }
+)
+
+# Backstop for the same bug appearing outside ``options`` - e.g. options go lazy
+# but a renderer subpackage starts importing eagerly instead. Lower it when the
+# number drops; raising it should need a reason in the commit message.
+MAX_EAGER_ALL2MD_MODULES = 64
+
+# Enough modules that a broken probe (empty output, import failure swallowed
+# somewhere) is obviously distinguishable from a genuinely lean import.
+_SANITY_FLOOR = 10
+
+
+@functools.lru_cache(maxsize=1)
+def _eager_all2md_modules() -> tuple[str, ...]:
+    """``all2md.*`` modules present in ``sys.modules`` after a bare import.
+
+    Must run in a fresh interpreter: the test process has already imported half
+    the package, so measuring in-process would report the test suite's imports
+    rather than the package's own.
+    """
+    probe = "import all2md, sys, json; print(json.dumps(sorted(m for m in sys.modules if m.startswith('all2md'))))"
+    out = subprocess.check_output([sys.executable, "-c", probe], text=True)
+    return tuple(json.loads(out))
+
+
+def _paste_ready(modules: set[str]) -> str:
+    body = "\n".join(f'        "{m}",' for m in sorted(modules))
+    return f"EAGER_OPTIONS_MODULES = frozenset(\n    {{\n{body}\n    }}\n)"
+
+
+def test_probe_reports_a_plausible_import_set() -> None:
+    """Guard the guard: a dead probe must not read as a lean import.
+
+    Verified by stubbing the probe to return nothing: the exact-set gate below
+    catches that on its own (an empty set has 31 entries *missing*), but the
+    ceiling gate passes vacuously, since zero modules is comfortably under any
+    ceiling. This test is what covers that hole.
+    """
+    modules = _eager_all2md_modules()
+    assert "all2md" in modules, "the probe did not import all2md at all"
+    assert len(modules) >= _SANITY_FLOOR, f"probe returned only {len(modules)} modules; it is probably broken, not fast"
+
+
+def test_eager_options_imports_match_the_allowlist() -> None:
+    actual = {m for m in _eager_all2md_modules() if m.startswith("all2md.options")}
+    added = actual - EAGER_OPTIONS_MODULES
+    removed = EAGER_OPTIONS_MODULES - actual
+
+    if added or removed:
+        lines = ["Eagerly-imported all2md.options.* modules changed.", ""]
+        if added:
+            lines += [
+                "NEW eager imports (each one makes cold start slower for every user,",
+                "including those who never touch that format - prefer a lazy import):",
+                *(f"  + {m}" for m in sorted(added)),
+                "",
+            ]
+        if removed:
+            lines += [
+                "No longer imported eagerly (this is the win - record it):",
+                *(f"  - {m}" for m in sorted(removed)),
+                "",
+            ]
+        lines += ["Updated allowlist:", "", _paste_ready(actual)]
+        pytest.fail("\n".join(lines))
+
+
+def test_total_eager_all2md_modules_stays_under_ceiling() -> None:
+    modules = _eager_all2md_modules()
+    assert len(modules) <= MAX_EAGER_ALL2MD_MODULES, (
+        f"import all2md now pulls in {len(modules)} all2md modules, ceiling is "
+        f"{MAX_EAGER_ALL2MD_MODULES}. Either make the new imports lazy or raise "
+        f"the ceiling deliberately.\nModules: {', '.join(modules)}"
+    )


### PR DESCRIPTION
First half of **R1a**. Runs in the existing test job — no new CI job, no new artifact, zero flake.

## The finding that motivated this shape

The variance study ([run 30166465613](https://github.com/thomas-villani/all2md/actions/runs/30166465613)) put the runner-variance floor at **6–7%** across six `ubuntu-latest` VMs. On a 230 ms `import all2md`, a 20% timing gate leaves ~46 ms of slack — enough for several new eagerly-imported options modules to land unnoticed. That is precisely the regression a startup gate exists to catch, so a timing gate alone would have been the wrong instrument for it.

The cost is milliseconds, but the *cause* is a set of module names, and a set compares exactly.

## What it asserts

| gate | shape | why |
|---|---|---|
| eager `all2md.options.*` | exact set (31 entries) | the measured scaling bug; adding one has to be argued for, removing one is R2's win |
| eager third-party packages | exact set (`tomli_w`, `yaml`) | one `import pandas` costs more than every options module combined, and is invisible to the other two |
| total eager `all2md.*` | ceiling (64) | backstop for the same bug reappearing outside `options` |

Cold start is O(registered formats) — every new format currently adds an eager options module, so this gate will trip on new-format PRs. That's intended: it makes the scaling cost visible at the moment it's incurred, which is the plan's whole argument for fixing this before Theme 4 makes it worse. Failures print a paste-ready allowlist so the fix is a one-line decision, not a chore.

Respects the deliberate exception in `all2md/__init__.py`: parsers must import eagerly to trigger registration. Options modules must not.

Two incidental R2 leads: `yaml` and `tomli_w` are both imported eagerly, and neither is obviously needed to print a version string.

## Portability

Pseudo-modules with no `__file__` (notably `cython_runtime`) are filtered — whether they appear depends on which wheels a platform installed, not on our code. Stdlib membership resolves via `sys.stdlib_module_names`, so the allowlist holds across the 3.10–3.14 matrix. The allowlist itself was generated on Windows; if Linux differs, CI will say so and print the corrected list.

## Judge-can-fail

- `from all2md.options import bbcode` → **both** all2md gates red (`+ all2md.options.bbcode`, `65 <= 64` fails).
- `import packaging` → third-party gate red. An `import tomllib` injected alongside it correctly does *not* trip it — stdlib isn't the thing being ratcheted.
- Stubbed the probe to return nothing → the exact-set gate self-protects (an empty set has 31 entries *missing*), but the ceiling gate passes vacuously. That hole is what `test_probe_reports_a_plausible_import_set` covers; the docstring records the result rather than the tidier-sounding thing I first assumed.

All injections reverted.

## Next

Second half of R1a: the timing gate — `--baseline`/`--tolerance` in `startup.py`, a baseline built from the median of the six CI VMs, and a job at ~20%. Coarse by necessity, but it catches gross regressions these can't see (a slow parser build, an algorithmic regression in registration).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
