### PR TITLE
perf(options): re-export lazily instead of importing every submodule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Faster cold start: `import all2md` no longer loads every options module.** The
+  `all2md.options` package re-exports lazily (PEP 562) instead of importing all 30-odd
+  submodules at package-init time. Because `from all2md.options.base import ...` executes
+  that package init first, *any* options import used to cost the whole set — which is how
+  a bare `import all2md` ended up loading 31 options modules to reach the two classes
+  `all2md/api.py` actually needs. Now 4. Total eagerly-imported `all2md` modules drops
+  from 64 to 37. **No API change:** `from all2md.options import PdfOptions` works exactly
+  as before, and `dir()` still lists every export.
+
 - CI: the Markdown roundtrip fidelity benchmark (`benchmarks/roundtrip`) now runs as a
   **blocking gate** on every push and PR, and is required before a release. A
   `Markdown -> AST -> Markdown` regression that either oracle can see now fails the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   from 64 to 37. **No API change:** `from all2md.options import PdfOptions` works exactly
   as before, and `dir()` still lists every export.
 
+  Measured on CI (median of six runner VMs, nine samples each): `import all2md`
+  **230 ms → 162 ms (−29%)** and `all2md --version` **246 ms → 178 ms (−28%)**. `--help`
+  and a small conversion are roughly unchanged, as expected — both build the full parser
+  or run the pipeline, so they load the options either way. The win lands on the
+  per-invocation path that CLI and agent workflows actually pay.
+
 - CI: the Markdown roundtrip fidelity benchmark (`benchmarks/roundtrip`) now runs as a
   **blocking gate** on every push and PR, and is required before a release. A
   `Markdown -> AST -> Markdown` regression that either oracle can see now fails the

--- a/benchmarks/startup_baseline.json
+++ b/benchmarks/startup_baseline.json
@@ -28,19 +28,41 @@
   ],
   "provenance": {
     "recorded": "2026-07-25",
-    "workflow_run": "https://github.com/thomas-villani/all2md/actions/runs/30166465613",
-    "commit": "b22973216c87",
-    "runner": "github-hosted ubuntu-latest, Linux-6.17.0-1020-azure-x86_64-with-glibc2.39",
+    "workflow_run": "https://github.com/thomas-villani/all2md/actions/runs/30180080149",
+    "commit": "53be26308b12",
+    "runner": "github-hosted ubuntu-latest",
     "python": "3.12.13",
     "method": "median of min_ms across 6 independent runner VMs, 9 timed samples each",
-    "observed_max_deviation_pct": 7.2
+    "observed_max_deviation_pct": 2.5,
+    "note": [
+      "Re-recorded for the lazy all2md.options re-export (R2b), which is why import",
+      "and --version drop ~28% while --help and convert barely move: those two build",
+      "the full parser or run the pipeline, so they load the options either way.",
+      "",
+      "observed_max_deviation_pct is over the *gated* scenarios only. The bare",
+      "interpreter spread 12.2% across the same six VMs, and startup_spread.py's",
+      "headline figure includes it - which overstates the floor for a gate that",
+      "reports the bare interpreter without gating on it."
+    ]
   },
   "tolerance_pct": 20.0,
   "scenarios": {
-    "baseline": 13.9,
-    "import": 230.35,
-    "--version": 246.1,
-    "--help": 377.1,
-    "convert": 407.65
+    "baseline": 13.55,
+    "import": 162.35,
+    "--version": 177.95,
+    "--help": 370.7,
+    "convert": 397.6
+  },
+  "previous": {
+    "commit": "b22973216c87",
+    "recorded": "2026-07-25",
+    "note": "pre-R2b, when a bare import loaded 31 options modules",
+    "scenarios": {
+      "baseline": 13.9,
+      "import": 230.35,
+      "--version": 246.1,
+      "--help": 377.1,
+      "convert": 407.65
+    }
   }
 }

--- a/src/all2md/options/__init__.py
+++ b/src/all2md/options/__init__.py
@@ -7,43 +7,137 @@ default values, and a clean API for configuring conversion behavior.
 
 Each converter module has its own Options dataclass with module-specific
 parameters.
+
+Every name below is re-exported lazily. Importing this package used to pull in all
+30-odd options submodules, and because ``from all2md.options.base import ...``
+executes this ``__init__`` first, *any* options import cost the whole set - which
+is how a bare ``import all2md`` ended up loading 31 options modules to reach the
+two classes in ``all2md/api.py``. The public API is unchanged: ``from
+all2md.options import PdfOptions`` still works, it just no longer drags in
+PowerPoint and LaTeX with it.
+
+Adding an export means adding a ``_LAZY_EXPORTS`` entry *and* an ``__all__``
+entry; ``tests/unit/test_options_lazy_exports.py`` fails if the two disagree or
+if an entry does not resolve.
 """
 
 from __future__ import annotations
 
 from dataclasses import replace
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
-from all2md.options.asciidoc import AsciiDocOptions, AsciiDocRendererOptions
-from all2md.options.ast_json import AstJsonParserOptions, AstJsonRendererOptions
-from all2md.options.base import UNSET, BaseParserOptions, BaseRendererOptions, CloneFrozenMixin
-from all2md.options.chm import ChmOptions
-from all2md.options.common import AttachmentOptionsMixin, LocalFileAccessOptions, NetworkFetchOptions
-from all2md.options.csv import CsvOptions
-from all2md.options.docx import DocxOptions, DocxRendererOptions
-from all2md.options.dokuwiki import DokuWikiOptions, DokuWikiParserOptions
-from all2md.options.eml import EmlOptions
-from all2md.options.epub import EpubOptions, EpubRendererOptions
-from all2md.options.fb2 import Fb2Options
-from all2md.options.html import HtmlOptions, HtmlRendererOptions
-from all2md.options.ipynb import IpynbOptions, IpynbRendererOptions
-from all2md.options.jinja import JinjaRendererOptions
-from all2md.options.latex import LatexOptions, LatexRendererOptions
-from all2md.options.markdown import MarkdownParserOptions, MarkdownRendererOptions
-from all2md.options.mediawiki import MediaWikiOptions
-from all2md.options.mhtml import MhtmlOptions
-from all2md.options.odp import OdpOptions, OdpRendererOptions
-from all2md.options.ods import OdsSpreadsheetOptions
-from all2md.options.odt import OdtOptions, OdtRendererOptions
-from all2md.options.org import OrgParserOptions, OrgRendererOptions
-from all2md.options.pdf import PdfOptions, PdfRendererOptions
-from all2md.options.plaintext import PlainTextOptions
-from all2md.options.pptx import PptxOptions, PptxRendererOptions
-from all2md.options.rst import RstParserOptions, RstRendererOptions
-from all2md.options.rtf import RtfOptions, RtfRendererOptions
-from all2md.options.sourcecode import SourceCodeOptions
-from all2md.options.xlsx import XlsxOptions
-from all2md.options.zip import ZipOptions
+if TYPE_CHECKING:
+    # Imported eagerly for type checkers and IDEs only - at runtime these names
+    # are resolved on demand by __getattr__ below.
+    from all2md.options.asciidoc import AsciiDocOptions, AsciiDocRendererOptions
+    from all2md.options.ast_json import AstJsonParserOptions, AstJsonRendererOptions
+    from all2md.options.base import UNSET, BaseParserOptions, BaseRendererOptions, CloneFrozenMixin
+    from all2md.options.chm import ChmOptions
+    from all2md.options.common import AttachmentOptionsMixin, LocalFileAccessOptions, NetworkFetchOptions
+    from all2md.options.csv import CsvOptions
+    from all2md.options.docx import DocxOptions, DocxRendererOptions
+    from all2md.options.dokuwiki import DokuWikiOptions, DokuWikiParserOptions
+    from all2md.options.eml import EmlOptions
+    from all2md.options.epub import EpubOptions, EpubRendererOptions
+    from all2md.options.fb2 import Fb2Options
+    from all2md.options.html import HtmlOptions, HtmlRendererOptions
+    from all2md.options.ipynb import IpynbOptions, IpynbRendererOptions
+    from all2md.options.jinja import JinjaRendererOptions
+    from all2md.options.latex import LatexOptions, LatexRendererOptions
+    from all2md.options.markdown import MarkdownParserOptions, MarkdownRendererOptions
+    from all2md.options.mediawiki import MediaWikiOptions
+    from all2md.options.mhtml import MhtmlOptions
+    from all2md.options.odp import OdpOptions, OdpRendererOptions
+    from all2md.options.ods import OdsSpreadsheetOptions
+    from all2md.options.odt import OdtOptions, OdtRendererOptions
+    from all2md.options.org import OrgParserOptions, OrgRendererOptions
+    from all2md.options.pdf import PdfOptions, PdfRendererOptions
+    from all2md.options.plaintext import PlainTextOptions
+    from all2md.options.pptx import PptxOptions, PptxRendererOptions
+    from all2md.options.rst import RstParserOptions, RstRendererOptions
+    from all2md.options.rtf import RtfOptions, RtfRendererOptions
+    from all2md.options.sourcecode import SourceCodeOptions
+    from all2md.options.xlsx import XlsxOptions
+    from all2md.options.zip import ZipOptions
+
+#: Exported name -> the ``all2md.options`` submodule that defines it.
+_LAZY_EXPORTS: dict[str, str] = {
+    "AsciiDocOptions": "asciidoc",
+    "AsciiDocRendererOptions": "asciidoc",
+    "AstJsonParserOptions": "ast_json",
+    "AstJsonRendererOptions": "ast_json",
+    "UNSET": "base",
+    "BaseParserOptions": "base",
+    "BaseRendererOptions": "base",
+    "CloneFrozenMixin": "base",
+    "ChmOptions": "chm",
+    "AttachmentOptionsMixin": "common",
+    "LocalFileAccessOptions": "common",
+    "NetworkFetchOptions": "common",
+    "CsvOptions": "csv",
+    "DocxOptions": "docx",
+    "DocxRendererOptions": "docx",
+    "DokuWikiOptions": "dokuwiki",
+    "DokuWikiParserOptions": "dokuwiki",
+    "EmlOptions": "eml",
+    "EpubOptions": "epub",
+    "EpubRendererOptions": "epub",
+    "Fb2Options": "fb2",
+    "HtmlOptions": "html",
+    "HtmlRendererOptions": "html",
+    "IpynbOptions": "ipynb",
+    "IpynbRendererOptions": "ipynb",
+    "JinjaRendererOptions": "jinja",
+    "LatexOptions": "latex",
+    "LatexRendererOptions": "latex",
+    "MarkdownParserOptions": "markdown",
+    "MarkdownRendererOptions": "markdown",
+    "MediaWikiOptions": "mediawiki",
+    "MhtmlOptions": "mhtml",
+    "OdpOptions": "odp",
+    "OdpRendererOptions": "odp",
+    "OdsSpreadsheetOptions": "ods",
+    "OdtOptions": "odt",
+    "OdtRendererOptions": "odt",
+    "OrgParserOptions": "org",
+    "OrgRendererOptions": "org",
+    "PdfOptions": "pdf",
+    "PdfRendererOptions": "pdf",
+    "PlainTextOptions": "plaintext",
+    "PptxOptions": "pptx",
+    "PptxRendererOptions": "pptx",
+    "RstParserOptions": "rst",
+    "RstRendererOptions": "rst",
+    "RtfOptions": "rtf",
+    "RtfRendererOptions": "rtf",
+    "SourceCodeOptions": "sourcecode",
+    "XlsxOptions": "xlsx",
+    "ZipOptions": "zip",
+}
+
+
+def __getattr__(name: str) -> Any:
+    """Resolve a re-exported options class on first access (PEP 562).
+
+    The resolved object is cached in module globals, so this runs once per name
+    and subsequent lookups go through the normal fast path.
+    """
+    module_name = _LAZY_EXPORTS.get(name)
+    if module_name is None:
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+    import importlib
+
+    # nosemgrep: python.lang.security.audit.non-literal-import.non-literal-import
+    module = importlib.import_module(f"all2md.options.{module_name}")
+    value = getattr(module, name)
+    globals()[name] = value
+    return value
+
+
+def __dir__() -> list[str]:
+    """Include the lazy names in ``dir()`` so tab-completion still finds them."""
+    return sorted(set(globals()) | set(_LAZY_EXPORTS))
 
 
 def create_updated_options(options: Any, **kwargs: Any) -> Any:

--- a/src/all2md/utils/input_sources.py
+++ b/src/all2md/utils/input_sources.py
@@ -20,7 +20,7 @@ from urllib.parse import urlparse
 
 from all2md.constants import DEFAULT_ROBOTS_TXT_POLICY, DEFAULT_USER_AGENT, RobotsTxtPolicy
 from all2md.exceptions import DependencyError, NetworkSecurityError, ValidationError
-from all2md.options import CloneFrozenMixin
+from all2md.options.base import CloneFrozenMixin
 from all2md.progress import ProgressCallback, ProgressEvent
 from all2md.utils.network_security import fetch_content_securely, is_network_disabled
 

--- a/tests/unit/test_eager_imports.py
+++ b/tests/unit/test_eager_imports.py
@@ -41,43 +41,21 @@ pytestmark = pytest.mark.unit
 EAGER_OPTIONS_MODULES = frozenset(
     {
         "all2md.options",
-        "all2md.options.asciidoc",
-        "all2md.options.ast_json",
         "all2md.options.base",
-        "all2md.options.chm",
         "all2md.options.common",
-        "all2md.options.csv",
-        "all2md.options.docx",
-        "all2md.options.dokuwiki",
-        "all2md.options.eml",
-        "all2md.options.epub",
-        "all2md.options.fb2",
-        "all2md.options.html",
-        "all2md.options.ipynb",
-        "all2md.options.jinja",
-        "all2md.options.latex",
         "all2md.options.markdown",
-        "all2md.options.mediawiki",
-        "all2md.options.mhtml",
-        "all2md.options.odp",
-        "all2md.options.ods",
-        "all2md.options.odt",
-        "all2md.options.org",
-        "all2md.options.pdf",
-        "all2md.options.plaintext",
-        "all2md.options.pptx",
-        "all2md.options.rst",
-        "all2md.options.rtf",
-        "all2md.options.sourcecode",
-        "all2md.options.xlsx",
-        "all2md.options.zip",
     }
 )
 
 # Backstop for the same bug appearing outside ``options`` - e.g. options go lazy
 # but a renderer subpackage starts importing eagerly instead. Lower it when the
 # number drops; raising it should need a reason in the commit message.
-MAX_EAGER_ALL2MD_MODULES = 64
+#
+# Lowered 64 -> 40 when R2b made the options package lazy (actual: 37). Left with
+# a little slack rather than pinned to 37, because unlike the allowlists above
+# this is a *ceiling*, and pinning it exactly would turn every legitimate new
+# module into a failure of this test instead of a decision someone makes.
+MAX_EAGER_ALL2MD_MODULES = 40
 
 # Third-party top-level packages a bare ``import all2md`` costs the user, over
 # and above the stdlib. Currently lean, and the cheapest way to keep it that way:

--- a/tests/unit/test_options_lazy_exports.py
+++ b/tests/unit/test_options_lazy_exports.py
@@ -1,0 +1,79 @@
+#  Copyright (c) 2025 Tom Villani, Ph.D.
+"""The ``all2md.options`` package re-exports lazily; these tests keep it honest.
+
+``options/__init__.py`` used to import every submodule eagerly, so ``__all__``
+could not drift out of sync with reality - a name was either imported at the top
+or it did not exist. Replacing those imports with a ``_LAZY_EXPORTS`` table buys
+startup time and gives that guarantee away: a name can now sit in ``__all__``
+pointing at nothing, and nobody finds out until a user imports it.
+
+These tests buy the guarantee back. They are the reason the lazy table is safe to
+hand-maintain.
+"""
+
+from __future__ import annotations
+
+import importlib
+
+import pytest
+
+from all2md import options
+from all2md.options import _LAZY_EXPORTS
+
+pytestmark = pytest.mark.unit
+
+
+# Names ``options/__init__.py`` defines itself rather than re-exporting.
+_DEFINED_LOCALLY = frozenset({"create_updated_options"})
+
+
+@pytest.mark.parametrize("name", sorted(_LAZY_EXPORTS))
+def test_every_lazy_export_resolves_to_the_real_object(name: str) -> None:
+    # A wrong submodule in the table is invisible until someone imports the name,
+    # so resolve every one and check it is the same object a direct import gives.
+    module = importlib.import_module(f"all2md.options.{_LAZY_EXPORTS[name]}")
+    assert getattr(options, name) is getattr(module, name)
+
+
+def test_all_and_the_lazy_table_agree() -> None:
+    # Either direction is a bug: a name in __all__ with no table entry raises
+    # AttributeError on import, and a table entry missing from __all__ is a class
+    # that `from all2md.options import *` silently will not deliver.
+    declared = set(options.__all__)
+    provided = set(_LAZY_EXPORTS) | _DEFINED_LOCALLY
+
+    assert declared - provided == set(), "in __all__ but not resolvable"
+    assert provided - declared == set(), "resolvable but missing from __all__"
+
+
+def test_the_package_init_pulls_in_no_submodules_of_its_own() -> None:
+    # The point of the exercise. Measured as a *delta*, because `import
+    # all2md.options` necessarily imports `all2md` first, and the parent legitimately
+    # reaches for a few submodules on its own - attributing those here would make
+    # this test fail for someone else's reason. Guards the mechanism only;
+    # test_eager_imports.py owns the absolute count.
+    import subprocess
+    import sys
+
+    probe = (
+        "import sys\n"
+        "import all2md\n"
+        "before = {m for m in sys.modules if m.startswith('all2md.options.')}\n"
+        "import all2md.options\n"
+        "after = {m for m in sys.modules if m.startswith('all2md.options.')}\n"
+        "print(len(after - before))\n"
+    )
+    added = int(subprocess.run([sys.executable, "-c", probe], capture_output=True, text=True, check=True).stdout)
+    assert added == 0, f"all2md/options/__init__.py imported {added} submodules; the lazy table is being bypassed"
+
+
+def test_an_unknown_attribute_still_raises_attribute_error() -> None:
+    # __getattr__ must not swallow typos into ImportError or None.
+    with pytest.raises(AttributeError, match="no attribute 'NotAnOptionsClass'"):
+        options.NotAnOptionsClass  # noqa: B018
+
+
+def test_dir_includes_the_lazy_names() -> None:
+    # Without __dir__, tab-completion and introspection would show only whatever
+    # happened to have been resolved already - which varies by import order.
+    assert set(_LAZY_EXPORTS) <= set(dir(options))


### PR DESCRIPTION
**R2b of the Quality & Speed Ratchets batch.**

A bare `import all2md` loaded **31 options modules** to reach the two classes `api.py` imports.

The cause was not that anything imported the package for its own sake — it's that `from all2md.options.base import ...` executes `options/__init__.py` first, and that module imported all 30-odd submodules eagerly. So every options import, however narrow, cost the whole set.

## Result

| | before | after |
|---|---|---|
| `all2md.options.*` modules | 31 | **4** |
| total eager `all2md` modules | 64 | **37** |

No API change: `from all2md.options import PdfOptions` works exactly as before, `__dir__` still lists every export, and the names stay statically resolvable for mypy/IDEs via a `TYPE_CHECKING` block.

## The guarantee this gives up, and how it's bought back

Eager imports meant `__all__` *could not* drift — a name was either imported at the top or it did not exist. A hand-maintained lazy table can point at nothing, and nobody finds out until a user imports that name.

So `tests/unit/test_options_lazy_exports.py` resolves every entry and compares it against a direct import, and checks `__all__` against the table in **both** directions. Verified by pointing `PdfOptions` at the `pptx` module and deleting `ZipOptions` from the table — both caught, with usable messages.

## Ratchets

Both moved deliberately; this is the mechanism from #167/#168 working as designed:

- `EAGER_OPTIONS_MODULES` drops the 27 modules.
- `MAX_EAGER_ALL2MD_MODULES` 64 → 40. Left at 40 rather than pinned to 37 because it's a *ceiling*, not an allowlist — pinning would make every legitimate new module a failure of this test instead of a decision someone makes.
- **The Cold Start Gate will report `FAST` until the baseline is re-recorded** from the six-VM variance workflow. That's R2d, landing in this PR before merge.

## Note, unrelated

`tests/integration/test_cli_split.py::TestSplitCLIE2E::test_split_by_parts` races under `-n 3` on a shared `tmp_split_e2e/` directory at the repo root. Confirmed pre-existing (fails with these changes stashed); not addressed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)