### PR TITLE
bench(spread): exclude ungated scenarios from the tolerance floor

### DIFF
--- a/benchmarks/startup_baseline.json
+++ b/benchmarks/startup_baseline.json
@@ -40,9 +40,10 @@
       "the full parser or run the pipeline, so they load the options either way.",
       "",
       "observed_max_deviation_pct is over the *gated* scenarios only. The bare",
-      "interpreter spread 12.2% across the same six VMs, and startup_spread.py's",
-      "headline figure includes it - which overstates the floor for a gate that",
-      "reports the bare interpreter without gating on it."
+      "interpreter spread 12.2% across the same six VMs. startup_spread.py used to",
+      "fold that into its headline floor, reporting 12.2% for min_ms when every",
+      "gated scenario sat at 1.9-2.5%; it now excludes ungated scenarios and says",
+      "so, so a fresh run of the study will not reproduce that 12.2% figure."
     ]
   },
   "tolerance_pct": 20.0,

--- a/benchmarks/startup_spread.py
+++ b/benchmarks/startup_spread.py
@@ -16,6 +16,12 @@ sample noise within one machine) and it reports, per scenario:
   smallest tolerance that would not have flaked on this data**. A real threshold
   needs headroom on top of that, not equality with it.
 
+The per-metric floors at the bottom cover only the scenarios a gate would actually
+judge (see ``UNGATED_SCENARIOS``). A scenario that is measured but never gated
+cannot flake a gate, so letting it set the floor overstates what the data supports -
+which is what happened here before this was fixed. The report names any scenario it
+excluded, and what the floor would have been with it included.
+
 Three candidate metrics are tracked, because they trade off differently:
 
 - ``min_ms`` - raw wall clock. Simple, but scales with runner speed, so a slower
@@ -51,6 +57,14 @@ from pathlib import Path
 
 # Candidate gate metrics, in the order they are reported.
 METRICS = ("min_ms", "over_baseline_ms", "ratio_over_baseline")
+
+# Scenarios the gate measures but never gates on, so their spread must not set the
+# tolerance floor. ``baseline`` is the bare interpreter: it is reported as a
+# runner-speed signal, and it is *by far* the noisiest scenario here, being a ~14 ms
+# measurement of process spawn rather than of our code. Including it once produced a
+# headline floor of 12.2% when every gated scenario sat at 1.9-2.5% - a ~5x
+# overstatement, in the direction that argues for a uselessly wide gate.
+UNGATED_SCENARIOS = frozenset({"baseline"})
 
 
 @dataclass
@@ -193,14 +207,23 @@ def within_run_noise(runs: list[tuple[str, dict]]) -> dict[str, float]:
     return noise
 
 
-def min_safe_tolerance(spreads: list[Spread]) -> dict[str, float]:
-    """Per metric, the worst ``max_dev_pct`` across scenarios.
+def min_safe_tolerance(spreads: list[Spread], ungated: frozenset[str] = UNGATED_SCENARIOS) -> dict[str, float]:
+    """Per metric, the worst ``max_dev_pct`` across the scenarios a gate would judge.
 
     This is the floor for any tolerance built on that metric: set the gate below
     this and unchanged code would already have gone red somewhere in this data.
+
+    Scenarios in ``ungated`` are excluded, because a scenario nobody gates on
+    cannot flake a gate - and letting the noisiest measurement in the study set
+    the floor for measurements it has no authority over is how a study argues for
+    a tolerance five times wider than its own data supports. Pass an empty set to
+    see the unfiltered figure; ``format_report`` names what was excluded either
+    way, so the filtering is never silent.
     """
     worst: dict[str, float] = {}
     for s in spreads:
+        if s.scenario in ungated:
+            continue
         worst[s.metric] = max(worst.get(s.metric, 0.0), s.max_dev_pct)
     return worst
 
@@ -230,6 +253,24 @@ def format_report(runs: list[tuple[str, dict]], spreads: list[Spread]) -> str:
     lines += ["", "Smallest tolerance that would NOT have flaked on this data:"]
     for metric, pct in sorted(min_safe_tolerance(spreads).items(), key=lambda kv: kv[1]):
         lines.append(f"  {metric:<20} > {pct:.1f}%")
+
+    # Never let the exclusion be silent: a reader who does not know it happened
+    # would read these floors as covering every row in the table above.
+    excluded = sorted({s.scenario for s in spreads} & UNGATED_SCENARIOS)
+    if excluded:
+        gated = min_safe_tolerance(spreads)
+        unfiltered = min_safe_tolerance(spreads, ungated=frozenset())
+        # Per metric, not a single worst-of-all number: the excluded scenario
+        # typically moves one metric and leaves the others alone, and collapsing
+        # that into one figure misattributes the other metrics' own noise to it.
+        raised = [(m, gated.get(m, 0.0), v) for m, v in unfiltered.items() if v > gated.get(m, 0.0)]
+        lines += ["", f"Excluded from the floors above (measured, never gated): {', '.join(excluded)}."]
+        if raised:
+            lines.append("Including them would raise:")
+            lines += [f"  {m:<20} {before:.1f}% -> {after:.1f}%" for m, before, after in sorted(raised)]
+        else:
+            lines.append("Including them would not change any floor above.")
+
     lines += [
         "",
         "Pick the metric with the smallest floor, then add headroom - these runs are a",
@@ -263,6 +304,11 @@ def main(argv: list[str] | None = None) -> int:
             "spreads": [asdict(s) for s in spreads],
             "within_run_noise_pct": within_run_noise(runs),
             "min_safe_tolerance_pct": min_safe_tolerance(spreads),
+            # Carried explicitly so a consumer reading only this file sees the same
+            # caveat the printed report shows, rather than reading the floor above
+            # as covering every scenario in "spreads".
+            "ungated_scenarios": sorted(UNGATED_SCENARIOS),
+            "min_safe_tolerance_pct_including_ungated": min_safe_tolerance(spreads, ungated=frozenset()),
         }
         args.json.parent.mkdir(parents=True, exist_ok=True)
         args.json.write_text(json.dumps(payload, indent=2), encoding="utf-8")

--- a/tests/unit/test_startup_spread.py
+++ b/tests/unit/test_startup_spread.py
@@ -143,6 +143,47 @@ def test_min_safe_tolerance_takes_the_worst_scenario() -> None:
     assert worst["min_ms"] > per_scenario[("import", "min_ms")]
 
 
+def test_a_noisy_ungated_scenario_does_not_set_the_floor() -> None:
+    # Replays variance run 30180080149, which reported "min_ms > 12.2%" while every
+    # gated scenario sat at 1.9-2.5%. The bare interpreter is a ~14ms measurement of
+    # process spawn, so it is the noisiest row in the study and the one nothing
+    # gates on. Letting it set the floor argued for a ~5x wider gate than the data
+    # supports - and, worse, ranked min_ms *last* when it was in fact the steadiest.
+    a = _payload(13.2, {"import": 162.0})
+    b = _payload(15.2, {"import": 163.0})
+    spreads = startup_spread.compute_spreads([("a", a), ("b", b)])
+
+    per_scenario = {(s.scenario, s.metric): s.max_dev_pct for s in spreads}
+    assert per_scenario[("baseline", "min_ms")] > 6.0, "the ungated scenario really is the noisy one"
+
+    floor = startup_spread.min_safe_tolerance(spreads)
+    assert floor["min_ms"] == pytest.approx(per_scenario[("import", "min_ms")])
+    assert floor["min_ms"] < per_scenario[("baseline", "min_ms")]
+
+
+def test_the_unfiltered_floor_is_still_available_and_still_worse() -> None:
+    # The exclusion is a reporting decision, not a claim the noise is not there.
+    a = _payload(13.2, {"import": 162.0})
+    b = _payload(15.2, {"import": 163.0})
+    spreads = startup_spread.compute_spreads([("a", a), ("b", b)])
+
+    gated = startup_spread.min_safe_tolerance(spreads)
+    everything = startup_spread.min_safe_tolerance(spreads, ungated=frozenset())
+    assert everything["min_ms"] > gated["min_ms"]
+
+
+def test_the_report_names_what_it_excluded() -> None:
+    # A floor that quietly covers fewer rows than the table above it reads as
+    # covering all of them. Whatever the number, the exclusion must be on the page.
+    a = _payload(13.2, {"import": 162.0})
+    b = _payload(15.2, {"import": 163.0})
+    runs = [("a", a), ("b", b)]
+    report = startup_spread.format_report(runs, startup_spread.compute_spreads(runs))
+
+    assert "Excluded from the floors above" in report
+    assert "baseline" in report.split("Excluded from the floors above")[1]
+
+
 def test_scenarios_are_reported_in_pipeline_order() -> None:
     run = _payload(100.0, {"import": 500.0, "--version": 520.0, "--help": 800.0})
     order: list[str] = []


### PR DESCRIPTION
Follow-up found while recording the R2b baseline (#169). Small, but it lands right before R1c picks a threshold using this exact tool.

## The bug

`startup_spread.py`'s headline — *"smallest tolerance that would NOT have flaked"* — took the worst deviation across **every** scenario, including `baseline`: the bare interpreter, which the gate measures and prints but never gates on. It's also the noisiest row in the study, being a ~14 ms measurement of process spawn rather than of our code.

On variance run 30180080149 that printed:

```
min_ms               > 12.2%
```

while every gated scenario sat at **1.9–2.5%**. A ~5x overstatement, in the direction that argues for a uselessly wide gate.

## Why it mattered more than the number

It **inverted the recommendation**. The three floors read `min_ms 12.2%`, `over_baseline_ms 3.0%`, `ratio 13.9%` — so `min_ms` ranked last of three when it was in fact the steadiest. The script's own closing advice is *"pick the metric with the smallest floor"*, so the bug actively pointed the reader at the wrong metric.

For context on how easy that is to act on: the earlier six-VM study is what talked us into shipping the timing gate on a single metric, and #168 had to fix the consequence.

## The fix

A scenario nobody gates on cannot flake a gate, so it's excluded from the floor — **not silently**:

```
Smallest tolerance that would NOT have flaked on this data:
  min_ms               > 0.3%
  over_baseline_ms     > 0.3%
  ratio_over_baseline  > 7.4%

Excluded from the floors above (measured, never gated): baseline.
Including them would raise:
  min_ms               0.3% -> 7.0%
```

Reported **per metric** rather than as one worst-of-all figure: the excluded scenario typically moves one metric and leaves the others alone, and collapsing that would misattribute `ratio`'s own 7.4% noise to the exclusion — the same class of error as the original bug. The `--json` payload carries `ungated_scenarios` and the unfiltered floors for the same reason.

`UNGATED_SCENARIOS` is a module constant and `min_safe_tolerance` takes it as a parameter, so R1c can point this at a corpus harness with a different set.

## Verification

Disarmed the exclusion; both new tests go red, the first reporting 7.0% where the gated floor is 0.3%. Third test asserts the exclusion is named in the report at all.

Also updates the note in `startup_baseline.json` that warned about this defect, which this PR makes stale.

🤖 Generated with [Claude Code](https://claude.com/claude-code)