### PR TITLE
ci(corpus): gate the reproducible half of the corpus on failure set

### DIFF
--- a/.github/workflows/corpus-gate.yml
+++ b/.github/workflows/corpus-gate.yml
@@ -1,0 +1,95 @@
+name: Corpus Fidelity Gate
+
+# Converts ~100 real-world documents and fails if any of them starts or stops
+# failing without that being recorded. See benchmarks/corpus/gate.py for what is
+# gated and what deliberately is not.
+#
+# NOT part of the per-PR CI run, and not in release's needs:. The corpus is a
+# ~700 MB download from third-party hosts, so putting it on every PR would make
+# the whole pipeline hostage to Digital Corpora's and CMU's uptime. Scheduled
+# plus dispatch keeps the signal without that coupling.
+#
+# Only the sources marked reproducible=true in corpus.toml are downloaded here
+# (--only-reproducible): arxiv resolves against a live "most recent" query and
+# poi against a moving branch ref, so their samples differ run to run and cannot
+# be compared to a baseline. They stay available for manual exploratory runs.
+
+on:
+  schedule:
+    # 05:00 UTC Mondays. Weekly rather than nightly: the gated corpus is fixed, so
+    # the only thing that changes between runs is our code, and a week of commits
+    # is still a small enough range to bisect.
+    - cron: "0 5 * * 1"
+  workflow_dispatch:
+    inputs:
+      record_baseline:
+        description: "Upload a baseline candidate instead of gating (use for the first run)"
+        required: false
+        default: false
+        type: boolean
+
+concurrency:
+  group: corpus-gate-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  corpus:
+    name: Corpus Fidelity Gate
+    runs-on: ubuntu-latest
+    # The download dominates; conversion of 100 docs is minutes. Generous because
+    # a timeout here costs a rerun of the whole download.
+    timeout-minutes: 90
+
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v7
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+
+      - name: Install
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e ".[all,dev]"
+
+      - name: Download the gated corpus
+        run: python -m benchmarks.corpus.run download --only-reproducible
+
+      - name: Benchmark
+        run: python -m benchmarks.corpus.run benchmark --only-reproducible
+
+      - name: Render report
+        if: always()
+        run: python -m benchmarks.corpus.run report
+
+      # Runs even when the gate fails: the results JSON is the only way to see
+      # *what* failed, and it is most wanted precisely on a red run.
+      - name: Upload results
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: corpus-results-${{ github.run_number }}
+          path: benchmarks/corpus/results/
+          if-no-files-found: warn
+
+      - name: Summarize
+        if: always()
+        run: |
+          {
+            echo "## Corpus"
+            echo
+            echo '```'
+            tail -n 60 benchmarks/corpus/results/*.md 2>/dev/null || echo "no report produced"
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Gate
+        if: ${{ !inputs.record_baseline }}
+        run: |
+          latest=$(ls -t benchmarks/corpus/results/*.json | head -1)
+          python -m benchmarks.corpus.gate "$latest"

--- a/benchmarks/corpus/README.md
+++ b/benchmarks/corpus/README.md
@@ -18,12 +18,41 @@ break the parser, and producing comparable timing numbers across machines.
 
 All sources are HTTP-only — no AWS credentials required.
 
-| Source     | Format(s)   | Sample | Notes                                                        |
-| ---------- | ----------- | ------ | ------------------------------------------------------------ |
-| `arxiv`    | pdf         | 30     | Recent cs.CL papers; text + math heavy.                      |
-| `govdocs1` | pdf, docx   | 50     | Real-world docs harvested from .gov sites.                   |
-| `poi`      | docx, pptx  | 30     | Apache POI's curated test corpus — known-tricky office docs. |
-| `enron`    | eml         | 50     | Public Enron email release.                                  |
+| Source     | Format(s)   | Sample | Reproducible | Notes                                                        |
+| ---------- | ----------- | ------ | ------------ | ------------------------------------------------------------ |
+| `arxiv`    | pdf         | 30     | **no**       | Recent cs.CL papers; text + math heavy.                      |
+| `govdocs1` | pdf, docx   | 50     | yes          | Real-world docs harvested from .gov sites.                   |
+| `poi`      | docx, pptx  | 30     | **no**       | Apache POI's curated test corpus — known-tricky office docs. |
+| `enron`    | eml         | 50     | yes          | Public Enron email release.                                  |
+
+### Reproducibility, and why only half the corpus is gated
+
+Sampling is seeded (`random.Random(seed).sample`), which is deterministic **given a
+fixed pool**. Two of these pools are not fixed:
+
+- **`arxiv`** queries the live API sorted by `submittedDate` descending, so the pool
+  is "the 200 most recent cs.CL papers" and changes every day.
+- **`poi`** reads `apache/poi` at `ref = trunk`, which moves whenever POI edits its
+  test data.
+
+This is invisible locally: the fetchers short-circuit on a cached `_index.json`, so
+once your machine has run the benchmark its document set never changes again. CI gets
+a cold cache every run and re-resolves against upstream.
+
+So `reproducible = true` in `corpus.toml` marks the sources whose sample is fixed, and
+**only those are gated** — comparing a baseline against a corpus that changed
+composition reports document-mix noise as a regression. The other two still run and
+still appear in the report; they're an exploratory signal, not a ratchet.
+
+Making all four gateable would need a committed lockfile of resolved ids + content
+hashes, with `poi` pinned to a SHA. Note arxiv revises PDFs (`v1` → `v2`) under the
+same id, so ids alone would not be enough.
+
+Run just the gated half with `--only-reproducible` (this is what CI does):
+
+```bash
+.venv/Scripts/python.exe -m benchmarks.corpus.run --only-reproducible
+```
 
 **PMC** (PubMed Central biomedical articles) is currently disabled in the
 default manifest. NCBI's OA web service is not reliable for programmatic PDF
@@ -70,6 +99,7 @@ From the repo root, with the `.venv` active and `all2md` installed:
 | -------------------- | ------------------------------------------------------------------- |
 | `mode`               | `download`, `benchmark`, `report`, `all` (default), or `purge`.     |
 | `--sources`          | Comma-separated source names. Subset of `corpus.toml`.              |
+| `--only-reproducible`| Restrict to sources whose sample is fixed across cold runs (gated). |
 | `--formats`          | Comma-separated formats (e.g. `pdf,docx`).                          |
 | `--max-docs`         | Cap total docs benchmarked.                                         |
 | `--max-size-mb`      | Skip docs larger than this size.                                    |
@@ -129,8 +159,12 @@ can click straight to source/output pairs.
 - The arxiv and PMC pools come from live APIs and shift over time. The seed
   controls sampling within the pool, but the pool itself drifts. Two runs on
   different days won't pick the same papers — they'll pick a comparable mix.
-- govdocs1 / Enron / POI samples are stable: same shard, same git ref, same
-  tarball content.
+- **POI is not stable either**, despite what this section used to claim: `ref = trunk`
+  is a moving branch, not a pinned commit, so the file list changes as POI edits its
+  test data. Only govdocs1 (fixed shard of a frozen archive) and Enron (frozen
+  tarball) hand back the same documents on every cold run.
+- A warm `.cache/` hides all of the above — the fetchers reuse `_index.json` and never
+  re-resolve. Your machine will look perfectly reproducible while CI is not.
 - Wall-clock timings depend on hardware and load — don't compare across
   machines, only across runs on the same machine.
 
@@ -140,3 +174,38 @@ Add a `[sources.<name>]` block to `corpus.toml`, then implement a fetcher in
 `download.py` and wire it up in the `FETCHERS` dict. Each fetcher takes a
 config dict + cache dir and returns a list of `CorpusItem`. Caching via
 `_read_index` / `_write_index` keeps the pipeline idempotent.
+
+## The gate
+
+`benchmarks/corpus/gate.py` turns a results JSON into a pass/fail verdict, run
+weekly by the `Corpus Fidelity Gate` workflow (and on dispatch).
+
+It gates **which documents fail to convert** — a set of names, compared exactly, with
+no tolerance and no runner variance to argue about. It deliberately does **not** gate
+throughput: that needs a variance study on the runners it would run on before any
+threshold is defensible, and a flaky gate gets disabled, which leaves the appearance
+of coverage rather than coverage.
+
+Four ways to go red, so the baseline can't rot in any direction:
+
+| status | meaning |
+| --- | --- |
+| `NEW_FAILURE` | a document failed that the baseline doesn't accept |
+| `FIXED` | an accepted failure now converts — record the win |
+| `STALE` | the baseline accepts a document no longer in the corpus |
+| `MISSING_DOCS` | a gated source returned fewer docs than recorded |
+
+That last one is not about failures at all. A half-succeeded download produces fewer
+documents, therefore fewer failures, therefore a green gate — so the most likely
+infrastructure fault in the whole pipeline would read as success. The gate also
+refuses to report a pass when *no* gated sources are present, for the same reason.
+
+Bootstrap or re-record a baseline from a run:
+
+```bash
+.venv/Scripts/python.exe -m benchmarks.corpus.gate <results.json> --emit-baseline \
+  > benchmarks/corpus/corpus_baseline.json
+```
+
+Then replace each `TODO` reason with a real justification — a machine can record that
+something failed, but only a person can say whether it's acceptable.

--- a/benchmarks/corpus/corpus.toml
+++ b/benchmarks/corpus/corpus.toml
@@ -6,6 +6,27 @@
 # All sources are HTTP-only - no AWS credentials required.
 # Sample sizes are deliberately modest so a full run completes in roughly an
 # hour and the cache stays under ~1 GB. Bump them if you want a stress run.
+#
+# `reproducible` says whether this source hands back the SAME documents on every
+# cold run. Sampling is seeded (random.Random(seed).sample), which is deterministic
+# given a fixed pool - but two of these pools are not fixed:
+#
+#   - arxiv queries the live API sorted by submittedDate descending, so the pool
+#     is "the 200 most recent cs.CL papers" and changes daily.
+#   - poi reads apache/poi at ref=trunk, which moves as POI edits its test-data.
+#
+# Locally this is invisible: the fetchers short-circuit on a cached _index.json,
+# so once a machine has run the benchmark its document set never changes. CI gets
+# a cold cache every run and re-resolves against upstream.
+#
+# Only `reproducible = true` sources may be gated, because a baseline compared
+# against a corpus that changed composition reports document-mix noise as a
+# regression. The others still run and still appear in the report - they are a
+# useful exploratory signal, just not a ratchet.
+#
+# To make arxiv/poi gateable, a committed lockfile of resolved ids + content
+# hashes would be needed (and poi pinned to a SHA). Note arxiv revises PDFs
+# (v1 -> v2) under the same id, so ids alone would not be enough.
 
 [sources.arxiv]
 description = "arxiv academic papers (text- and math-heavy, single column)"
@@ -13,6 +34,8 @@ type        = "arxiv-api"
 formats     = ["pdf"]
 sample_size = 30
 seed        = 42
+# Pool is "most recent cs.CL", so a cold run gets different papers every day.
+reproducible = false
 # arxiv API search query - see https://arxiv.org/help/api/user-manual
 query       = "cat:cs.CL"
 # How many results to list before sampling sample_size from the pool.
@@ -39,6 +62,8 @@ type        = "govdocs1-shard"
 formats     = ["pdf", "docx"]
 sample_size = 50
 seed        = 42
+# Fixed shard of a frozen archive - same 50 files on every cold run.
+reproducible = true
 # Each shard is a ~250 MB zip with ~1000 mixed-format files.
 # Shard 0 is the smallest sample; later shards have similar character.
 shard       = 0
@@ -49,6 +74,8 @@ type        = "github-tree"
 formats     = ["docx", "pptx"]
 sample_size = 30
 seed        = 42
+# ref = trunk moves; pin to a commit SHA to make this gateable.
+reproducible = false
 repo        = "apache/poi"
 ref         = "trunk"
 # Subdirectories of the repo to scan for files.
@@ -64,3 +91,5 @@ type        = "enron-tarball"
 formats     = ["eml"]
 sample_size = 50
 seed        = 42
+# Frozen public tarball - same 50 messages on every cold run.
+reproducible = true

--- a/benchmarks/corpus/gate.py
+++ b/benchmarks/corpus/gate.py
@@ -1,0 +1,279 @@
+"""Turn a corpus benchmark run into a pass/fail verdict.
+
+**What this gates, and what it deliberately does not.**
+
+The sharp, non-flaky signal in a corpus run is *which documents fail to convert*.
+That is a set of names, and sets compare exactly - no tolerance, no runner
+variance, no threshold to argue about. So that is what this module gates.
+
+Throughput is the other thing a corpus run measures, and it is *not* gated here.
+It needs a variance study on the runners it will actually run on before any
+threshold is defensible; guessing buys a flaky gate, and a flaky gate gets
+disabled, which leaves the appearance of coverage. See ``benchmarks/startup_spread.py``
+for the instrument and what it cost to learn that lesson on a much quieter metric.
+
+**Only reproducible sources are judged.** ``corpus.toml`` marks each source with
+``reproducible``; ``arxiv`` and ``poi`` resolve against upstream state that moves
+(a live "most recent" query, and a branch ref), so a cold run gets different
+documents and a failure-set comparison against them would be pure churn. They
+still run and still appear in the report - they are an exploratory signal, not a
+ratchet. ``ungated`` in the verdict names exactly what was skipped, because a gate
+that silently judges 100 of 160 documents reads as judging all 160.
+
+**Red paths**, following the roundtrip gate's allowlist shape so the baseline
+cannot rot in any direction:
+
+- ``NEW_FAILURE`` - a document failed that the baseline does not accept. The
+  regression this exists to catch.
+- ``FIXED`` - an accepted failure now converts. Red on purpose: an unrecorded win
+  means the allowlist is describing a bug that no longer exists, and every later
+  reader trusts it anyway. Record it in the commit that earned it.
+- ``STALE`` - the baseline accepts a document the corpus no longer contains, so
+  the entry is guarding nothing.
+- ``MISSING_DOCS`` - a gated source returned fewer documents than the baseline
+  recorded. This one is not about failures at all: a download that half-succeeds
+  produces few documents, therefore few failures, therefore a green gate. Without
+  this check the most likely infrastructure problem in the whole pipeline reads
+  as success.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+DEFAULT_BASELINE = HERE / "corpus_baseline.json"
+
+RED_STATUSES = frozenset({"NEW_FAILURE", "FIXED", "STALE", "MISSING_DOCS"})
+
+
+@dataclass
+class Finding:
+    """One thing wrong with this run relative to the baseline."""
+
+    status: str
+    doc: str
+    detail: str = ""
+
+
+@dataclass
+class Verdict:
+    """The full comparison: what failed, what was skipped, and why."""
+
+    findings: list[Finding] = field(default_factory=list)
+    gated_sources: list[str] = field(default_factory=list)
+    ungated_sources: list[str] = field(default_factory=list)
+    gated_docs: int = 0
+    ungated_docs: int = 0
+
+    @property
+    def failed(self) -> bool:
+        return any(f.status in RED_STATUSES for f in self.findings)
+
+
+def doc_key(row: dict) -> str:
+    """Stable identity for a document across runs.
+
+    ``source_id`` rather than ``filename``: the filename is derived and could be
+    re-derived differently, while the source id is what the fetcher resolved
+    upstream.
+    """
+    return f"{row.get('source', '?')}/{row.get('source_id') or row.get('filename', '?')}"
+
+
+def reproducible_sources(manifest: dict) -> set[str]:
+    """Source names whose sample is fixed across cold runs.
+
+    Absent ``reproducible`` means *not* reproducible. Defaulting the other way
+    would silently gate a new source whose pool nobody has checked, and the whole
+    point of this flag is that the unsafe case is the one that looks fine.
+    """
+    return {name for name, cfg in manifest.get("sources", {}).items() if cfg.get("reproducible") is True}
+
+
+def compare(results: dict, baseline: dict, manifest: dict) -> Verdict:
+    """Judge a results payload against the committed baseline."""
+    gated = reproducible_sources(manifest)
+    rows = results.get("results", [])
+
+    verdict = Verdict()
+    seen_sources = {r.get("source", "?") for r in rows}
+    verdict.gated_sources = sorted(seen_sources & gated)
+    verdict.ungated_sources = sorted(seen_sources - gated)
+
+    gated_rows = [r for r in rows if r.get("source") in gated]
+    verdict.gated_docs = len(gated_rows)
+    verdict.ungated_docs = len(rows) - len(gated_rows)
+
+    accepted: dict[str, str] = baseline.get("expected_failures", {})
+    expected_counts: dict[str, int] = baseline.get("doc_counts", {})
+
+    # A truncated download yields few docs, therefore few failures, therefore a
+    # green gate. Check counts before looking at failures at all.
+    by_source: dict[str, int] = {}
+    for r in gated_rows:
+        by_source[r.get("source", "?")] = by_source.get(r.get("source", "?"), 0) + 1
+    for source, expected_n in sorted(expected_counts.items()):
+        actual_n = by_source.get(source, 0)
+        if actual_n < expected_n:
+            verdict.findings.append(
+                Finding(
+                    "MISSING_DOCS",
+                    source,
+                    f"benchmarked {actual_n} of {expected_n} documents; the download or cache is incomplete",
+                )
+            )
+
+    failing = {doc_key(r): (r.get("error_type") or "Error", r.get("error") or "") for r in gated_rows if r.get("error")}
+    present = {doc_key(r) for r in gated_rows}
+
+    for doc, (error_type, message) in sorted(failing.items()):
+        if doc not in accepted:
+            verdict.findings.append(Finding("NEW_FAILURE", doc, f"{error_type}: {message}"))
+
+    for doc, reason in sorted(accepted.items()):
+        if doc not in present:
+            verdict.findings.append(Finding("STALE", doc, f"accepted as failing ({reason}) but not in this run"))
+        elif doc not in failing:
+            verdict.findings.append(Finding("FIXED", doc, f"accepted as failing ({reason}) but now converts"))
+
+    return verdict
+
+
+def format_verdict(verdict: Verdict, baseline: dict) -> str:
+    lines: list[str] = []
+    lines.append(
+        f"Gated: {verdict.gated_docs} document(s) from {', '.join(verdict.gated_sources) or '(none)'}",
+    )
+    if verdict.ungated_sources:
+        # Never silent: a reader who does not know these were skipped will read
+        # the verdict as covering the whole corpus.
+        lines.append(
+            f"Not gated: {verdict.ungated_docs} document(s) from "
+            f"{', '.join(verdict.ungated_sources)} - sample is not reproducible across runs, "
+            f"so these are reported only."
+        )
+    lines.append("")
+
+    if not verdict.findings:
+        lines.append("OK - no new failures, no unrecorded fixes, no stale entries.")
+        return "\n".join(lines)
+
+    lines.append("CORPUS GATE FAILED")
+    for f in verdict.findings:
+        lines.append(f"  {f.status}: {f.doc}")
+        if f.detail:
+            lines.append(f"      {f.detail}")
+
+    if any(f.status == "FIXED" for f in verdict.findings):
+        lines += [
+            "",
+            "  A FIXED entry is a win, not a problem - remove it from expected_failures",
+            "  in the commit that earned it, so the list keeps describing real bugs.",
+        ]
+    prov = baseline.get("provenance", {})
+    if prov:
+        recorded = prov.get("recorded", "?")
+        run = prov.get("workflow_run", "unknown run")
+        lines += ["", f"  Baseline: recorded {recorded} from {run}"]
+    return "\n".join(lines)
+
+
+def emit_baseline(results: dict, manifest: dict, provenance: dict | None = None) -> dict:
+    """Derive a baseline from a results payload.
+
+    For bootstrapping and for re-recording after a deliberate change. Hand-writing
+    ~100 accepted failures is not realistic, and a list assembled by hand is a list
+    with typos in it that read as passing documents.
+
+    Every accepted failure carries the error type, so a document that keeps failing
+    for a *different* reason is visible in the diff when this is regenerated. The
+    reasons say ``TODO`` on purpose: a machine can record that something failed, but
+    only a person can say whether it is acceptable, and an entry nobody justified
+    should look unjustified.
+    """
+    gated = reproducible_sources(manifest)
+    rows = [r for r in results.get("results", []) if r.get("source") in gated]
+
+    counts: dict[str, int] = {}
+    for r in rows:
+        counts[r["source"]] = counts.get(r["source"], 0) + 1
+
+    failures = {
+        doc_key(r): f"{r.get('error_type') or 'Error'} - TODO: why is this acceptable?"
+        for r in sorted(rows, key=doc_key)
+        if r.get("error")
+    }
+
+    return {
+        "_comment": [
+            "Corpus fidelity baseline. Covers only the sources marked reproducible=true",
+            "in corpus.toml - arxiv and poi resolve against upstream state that moves, so",
+            "their documents differ run to run and cannot be compared against anything.",
+            "",
+            "expected_failures is an allowlist, not a record: an entry that starts passing",
+            "is red, and so is an entry for a document no longer in the corpus. Replace",
+            "each TODO with a real reason or fix the bug and delete the line.",
+        ],
+        "provenance": provenance or {"recorded": "TODO", "workflow_run": "TODO"},
+        "doc_counts": dict(sorted(counts.items())),
+        "expected_failures": failures,
+    }
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(prog="benchmarks.corpus.gate", description=__doc__)
+    p.add_argument("results", type=Path, help="Results JSON written by benchmarks.corpus.run")
+    p.add_argument("--baseline", type=Path, default=DEFAULT_BASELINE, help="Committed baseline to judge against")
+    p.add_argument("--manifest", type=Path, default=HERE / "corpus.toml", help="Path to corpus.toml")
+    p.add_argument(
+        "--emit-baseline",
+        action="store_true",
+        help="Print a baseline derived from RESULTS instead of gating. For bootstrapping and re-recording.",
+    )
+    return p
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _build_parser().parse_args(argv)
+
+    if sys.version_info >= (3, 11):
+        import tomllib
+    else:
+        import tomli as tomllib
+
+    results = json.loads(args.results.read_text(encoding="utf-8"))
+    with args.manifest.open("rb") as f:
+        manifest = tomllib.load(f)
+
+    if args.emit_baseline:
+        print(json.dumps(emit_baseline(results, manifest), indent=2))
+        return 0
+
+    if not args.baseline.exists():
+        print(
+            f"No baseline at {args.baseline}. Record one from a CI run " f"(--emit-baseline) before gating.",
+            file=sys.stderr,
+        )
+        return 2
+
+    baseline = json.loads(args.baseline.read_text(encoding="utf-8"))
+
+    verdict = compare(results, baseline, manifest)
+    print(format_verdict(verdict, baseline))
+
+    if not verdict.gated_sources:
+        # Zero gated documents cannot produce a failure, so "green" here would be
+        # vacuous. Almost always means the download stage did not run.
+        print("\nNo gated sources present in these results; refusing to report a pass.", file=sys.stderr)
+        return 2
+
+    return 1 if verdict.failed else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/benchmarks/corpus/run.py
+++ b/benchmarks/corpus/run.py
@@ -64,6 +64,15 @@ def _build_parser() -> argparse.ArgumentParser:
     p.add_argument("--cache-dir", type=Path, default=DEFAULT_CACHE, help="Where to cache downloaded docs")
     p.add_argument("--results-dir", type=Path, default=DEFAULT_RESULTS, help="Where to write JSON + report")
     p.add_argument("--sources", help="Comma-separated source names (default: all)")
+    p.add_argument(
+        "--only-reproducible",
+        action="store_true",
+        help=(
+            "Restrict to sources marked reproducible=true in the manifest - the ones whose "
+            "sample is identical on every cold run, and therefore the only ones a baseline "
+            "can be compared against. This is what the CI gate runs."
+        ),
+    )
     p.add_argument("--formats", help="Comma-separated formats to include (default: all)")
     p.add_argument("--max-docs", type=int, default=None, help="Cap total docs benchmarked")
     p.add_argument("--max-size-mb", type=float, default=None, help="Skip docs larger than this")
@@ -94,12 +103,35 @@ def _build_parser() -> argparse.ArgumentParser:
     return p
 
 
+def _selected_sources(args: argparse.Namespace, manifest: dict) -> list[str] | None:
+    """Resolve ``--sources`` and ``--only-reproducible`` into one source filter.
+
+    The two intersect rather than override, so ``--only-reproducible --sources
+    enron,arxiv`` yields just ``enron`` instead of quietly benchmarking a source
+    the gate cannot judge.
+    """
+    explicit = _split_csv(args.sources)
+    if not getattr(args, "only_reproducible", False):
+        return explicit
+
+    from .gate import reproducible_sources
+
+    gateable = reproducible_sources(manifest)
+    if explicit is None:
+        return sorted(gateable)
+
+    dropped = [s for s in explicit if s not in gateable]
+    if dropped:
+        print(f"  --only-reproducible: skipping {', '.join(dropped)} (sample is not fixed)", flush=True)
+    return sorted(set(explicit) & gateable)
+
+
 def _do_download(args: argparse.Namespace) -> dict:
     manifest = load_manifest(args.manifest)
     return fetch_all(
         manifest,
         cache_root=args.cache_dir,
-        source_filter=_split_csv(args.sources),
+        source_filter=_selected_sources(args, manifest),
         format_filter=_split_csv(args.formats),
     )
 
@@ -174,7 +206,7 @@ def main(argv: list[str] | None = None) -> int:
         items = load_cached(
             manifest,
             cache_root=args.cache_dir,
-            source_filter=_split_csv(args.sources),
+            source_filter=_selected_sources(args, manifest),
             format_filter=_split_csv(args.formats),
         )
         empty = [name for name, lst in items.items() if not lst]

--- a/tests/unit/test_corpus_gate.py
+++ b/tests/unit/test_corpus_gate.py
@@ -1,0 +1,237 @@
+#  Copyright (c) 2025 Tom Villani, Ph.D.
+"""Self-tests for the corpus benchmark's pass/fail logic.
+
+Two classes of test here, and the second matters more.
+
+The first is the obvious one: every red path actually goes red. The second is
+that the gate cannot pass *vacuously* - a corpus benchmark has several ways to
+produce "no failures" by producing no work, and every one of them would read as
+success. A download that half-succeeds, a results file with only ungated sources,
+a baseline whose accepted-failure list has quietly stopped matching the corpus:
+all of these are green under a naive implementation, and all of them mean the
+gate has stopped guarding.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from benchmarks.corpus import gate
+
+pytestmark = pytest.mark.unit
+
+
+MANIFEST = {
+    "sources": {
+        "govdocs1": {"reproducible": True},
+        "enron": {"reproducible": True},
+        "arxiv": {"reproducible": False},
+        "poi": {},  # absent flag must mean "not reproducible"
+    }
+}
+
+BASELINE = {
+    "provenance": {"recorded": "2026-07-25", "workflow_run": "run/1"},
+    "doc_counts": {"govdocs1": 2, "enron": 1},
+    "expected_failures": {"govdocs1/broken.pdf": "PdfSyntaxError - truncated xref upstream"},
+}
+
+
+def _row(source: str, source_id: str, *, error: str | None = None, error_type: str | None = None) -> dict:
+    return {
+        "source": source,
+        "format": "pdf",
+        "source_id": source_id,
+        "filename": source_id,
+        "size_bytes": 1024,
+        "duration_seconds": 0.5,
+        "output_chars": None if error else 500,
+        "error": error,
+        "error_type": error_type,
+    }
+
+
+def _results(rows: list[dict]) -> dict:
+    return {"run": {"timestamp": "2026-07-25T00:00:00Z"}, "results": rows}
+
+
+def _healthy_rows() -> list[dict]:
+    return [
+        _row("govdocs1", "ok.pdf"),
+        _row("govdocs1", "broken.pdf", error="truncated xref", error_type="PdfSyntaxError"),
+        _row("enron", "mail1.eml"),
+    ]
+
+
+# --- the green path -------------------------------------------------------------
+
+
+def test_a_run_matching_the_baseline_is_green() -> None:
+    verdict = gate.compare(_results(_healthy_rows()), BASELINE, MANIFEST)
+    assert verdict.findings == []
+    assert not verdict.failed
+
+
+def test_ungated_sources_run_but_are_not_judged() -> None:
+    # An arxiv doc failing must not fail the build: the arxiv sample is different
+    # documents every run, so its failures are not comparable to anything.
+    rows = [*_healthy_rows(), _row("arxiv", "2401.00001", error="boom", error_type="ValueError")]
+    verdict = gate.compare(_results(rows), BASELINE, MANIFEST)
+
+    assert not verdict.failed
+    assert verdict.ungated_sources == ["arxiv"]
+    assert verdict.ungated_docs == 1
+
+
+def test_a_source_with_no_reproducible_flag_is_not_gated() -> None:
+    # Defaulting to gated would silently judge a newly added source whose pool
+    # nobody has checked - and an unchecked pool is exactly the unsafe case.
+    rows = [*_healthy_rows(), _row("poi", "weird.docx", error="boom", error_type="ValueError")]
+    verdict = gate.compare(_results(rows), BASELINE, MANIFEST)
+    assert not verdict.failed
+    assert "poi" in verdict.ungated_sources
+
+
+# --- every red path -------------------------------------------------------------
+
+
+def test_a_new_failure_is_red() -> None:
+    rows = _healthy_rows()
+    rows[0] = _row("govdocs1", "ok.pdf", error="kaboom", error_type="ValueError")
+    verdict = gate.compare(_results(rows), BASELINE, MANIFEST)
+
+    assert verdict.failed
+    assert [(f.status, f.doc) for f in verdict.findings] == [("NEW_FAILURE", "govdocs1/ok.pdf")]
+
+
+def test_an_unrecorded_fix_is_red() -> None:
+    # The XPASS case. An accepted failure that now converts means the list is
+    # describing a bug that no longer exists, and readers keep trusting it.
+    rows = _healthy_rows()
+    rows[1] = _row("govdocs1", "broken.pdf")
+    verdict = gate.compare(_results(rows), BASELINE, MANIFEST)
+
+    assert verdict.failed
+    assert [(f.status, f.doc) for f in verdict.findings] == [("FIXED", "govdocs1/broken.pdf")]
+
+
+def test_a_stale_allowlist_entry_is_red() -> None:
+    # Everything in this run converts, so the only thing wrong is that the
+    # baseline still accepts a document the corpus no longer contains.
+    rows = [_row("govdocs1", "ok.pdf"), _row("enron", "mail1.eml")]
+    baseline = {
+        **BASELINE,
+        "expected_failures": {"govdocs1/gone.pdf": "was failing once"},
+        "doc_counts": {"govdocs1": 1, "enron": 1},
+    }
+    verdict = gate.compare(_results(rows), baseline, MANIFEST)
+
+    assert verdict.failed
+    assert [(f.status, f.doc) for f in verdict.findings] == [("STALE", "govdocs1/gone.pdf")]
+
+
+def test_every_red_status_actually_fails_the_gate() -> None:
+    # Guards against a status being reported in the table but forgotten in the
+    # exit decision - the gate would then print a problem and exit 0.
+    for status in sorted(gate.RED_STATUSES):
+        v = gate.Verdict(findings=[gate.Finding(status, "x")])
+        assert v.failed, f"{status} must fail the build"
+    assert not gate.Verdict(findings=[]).failed
+
+
+# --- the vacuous-pass modes -----------------------------------------------------
+
+
+def test_a_truncated_download_is_red_rather_than_green() -> None:
+    # Half a corpus means half the chances to fail. Without the doc-count check
+    # this is the single most likely infrastructure fault in the pipeline, and it
+    # reads as a clean pass.
+    rows = [_row("govdocs1", "ok.pdf"), _row("enron", "mail1.eml")]
+    verdict = gate.compare(_results(rows), BASELINE, MANIFEST)
+
+    statuses = {f.status for f in verdict.findings}
+    assert "MISSING_DOCS" in statuses
+    assert verdict.failed
+
+
+def test_a_run_with_no_gated_documents_at_all_refuses_to_pass(tmp_path) -> None:
+    # Zero gated docs cannot produce a failure, so a "pass" would be meaningless.
+    # main() must exit non-zero rather than report success.
+    import json
+
+    results = tmp_path / "results.json"
+    results.write_text(json.dumps(_results([_row("arxiv", "2401.00001")])), encoding="utf-8")
+    baseline = tmp_path / "baseline.json"
+    baseline.write_text(json.dumps(BASELINE), encoding="utf-8")
+    manifest = tmp_path / "corpus.toml"
+    manifest.write_text(
+        "[sources.arxiv]\nreproducible = false\n[sources.govdocs1]\nreproducible = true\n", encoding="utf-8"
+    )
+
+    rc = gate.main([str(results), "--baseline", str(baseline), "--manifest", str(manifest)])
+    assert rc == 2
+
+
+def test_a_missing_baseline_is_an_error_not_a_pass(tmp_path) -> None:
+    import json
+
+    results = tmp_path / "results.json"
+    results.write_text(json.dumps(_results(_healthy_rows())), encoding="utf-8")
+    rc = gate.main([str(results), "--baseline", str(tmp_path / "nope.json")])
+    assert rc == 2
+
+
+# --- reporting ------------------------------------------------------------------
+
+
+def test_the_report_names_what_it_did_not_gate() -> None:
+    rows = [*_healthy_rows(), _row("arxiv", "2401.00001")]
+    verdict = gate.compare(_results(rows), BASELINE, MANIFEST)
+    text = gate.format_verdict(verdict, BASELINE)
+
+    assert "Not gated" in text
+    assert "arxiv" in text.split("Not gated")[1]
+
+
+# --- bootstrapping a baseline ---------------------------------------------------
+
+
+def test_an_emitted_baseline_makes_its_own_run_green() -> None:
+    # The bootstrap property. If the emitter and the comparer disagree about doc
+    # keys, counts, or which sources count, the very first gated run goes red for
+    # no reason and the obvious fix is to stop trusting the gate.
+    rows = [*_healthy_rows(), _row("arxiv", "2401.00001", error="x", error_type="ValueError")]
+    emitted = gate.emit_baseline(_results(rows), MANIFEST)
+
+    verdict = gate.compare(_results(rows), emitted, MANIFEST)
+    assert verdict.findings == []
+    assert not verdict.failed
+
+
+def test_an_emitted_baseline_ignores_ungated_failures() -> None:
+    # An arxiv failure recorded as "expected" would go STALE the moment the arxiv
+    # sample rotates, which is daily.
+    rows = [*_healthy_rows(), _row("arxiv", "2401.00001", error="x", error_type="ValueError")]
+    emitted = gate.emit_baseline(_results(rows), MANIFEST)
+
+    assert not any(doc.startswith("arxiv/") for doc in emitted["expected_failures"])
+    assert "arxiv" not in emitted["doc_counts"]
+
+
+def test_an_emitted_baseline_records_the_error_type_and_demands_a_reason() -> None:
+    # The error type makes "still failing, but differently" visible in a re-record
+    # diff. The TODO makes an unjustified entry look unjustified.
+    emitted = gate.emit_baseline(_results(_healthy_rows()), MANIFEST)
+    reason = emitted["expected_failures"]["govdocs1/broken.pdf"]
+
+    assert "PdfSyntaxError" in reason
+    assert "TODO" in reason
+
+
+def test_a_fixed_finding_explains_what_to_do() -> None:
+    rows = _healthy_rows()
+    rows[1] = _row("govdocs1", "broken.pdf")
+    verdict = gate.compare(_results(rows), BASELINE, MANIFEST)
+    text = gate.format_verdict(verdict, BASELINE)
+
+    assert "expected_failures" in text, "a FIXED verdict must say how to record the win"


### PR DESCRIPTION
**R1c of the Quality & Speed Ratchets batch.**

## The blocker wasn't the one the plan named

The plan says R1c is blocked on `results/` being gitignored, so no run can compare against a prior one. That's real but secondary. **The corpus itself isn't reproducible**, so the comparison would have looked meaningful and actually measured document mix.

Sampling is seeded (`random.Random(42).sample`) — deterministic *given a fixed pool*. Two of four pools aren't fixed:

| source | docs | pool | reproducible? |
|---|---|---|---|
| `arxiv` | 30 | live API, `sortBy=submittedDate desc`, top 200 | **no — different papers daily** |
| `poi` | 30 | `apache/poi` at `ref=trunk` | **no — drifts as POI edits test-data** |
| `govdocs1` | 50 | static shard-0 zip | yes |
| `enron` | 50 | static tarball | yes |

**60 of 160 documents change between cold runs**, and it's invisible locally: the fetchers short-circuit on a cached `_index.json`, so once your machine has run the benchmark its document set never changes again. `.cache/` is gitignored and machine-local, so CI re-resolves against upstream every run. A dev box looks perfectly stable while CI would have been benchmarking a different corpus each time.

The README asserted the opposite — *"govdocs1 / Enron / POI samples are stable: same shard, same git ref"* — but `trunk` is a branch, not a ref. Corrected here.

## What this gates

`reproducible` in `corpus.toml` marks each source; only those are judged. **arxiv and poi still run and still appear in the report** as an exploratory signal. The verdict names what it skipped, because a gate that silently covers 100 of 160 documents reads as covering all 160.

What's gated is the **failure set** — which documents fail to convert. A set of names, compared exactly: no tolerance, no runner variance, cannot flake.

**Throughput is deliberately not gated.** It needs a variance study on the runners it would run on before any threshold is defensible, and #168 is a fresh reminder of what guessing costs. That's the natural follow-up once this has a baseline.

## Red paths

| status | meaning |
|---|---|
| `NEW_FAILURE` | a document failed that the baseline doesn't accept |
| `FIXED` | an accepted failure now converts — record the win |
| `STALE` | the baseline accepts a document no longer in the corpus |
| `MISSING_DOCS` | a gated source returned fewer docs than recorded |

`MISSING_DOCS` isn't about failures at all. A half-succeeded download produces fewer documents → fewer failures → **green gate**. Without it, the most likely infrastructure fault in the whole pipeline reads as success. Same reason the gate refuses to report a pass when no gated source is present.

`--emit-baseline` derives a baseline from a run — hand-writing ~100 accepted failures produces a list with typos in it that read as passing documents. It records each error type (so "still failing, but differently" shows up in a re-record diff) and writes `TODO` for each reason.

## Verification

Disarmed the doc-count guard and the `NEW_FAILURE` check → two tests go red, both vacuous-pass cases. 15 tests total.

## Rollout

Scheduled **weekly + dispatch**, not per-PR and not in `release`'s `needs:` — a ~700 MB third-party download shouldn't make the release pipeline hostage to Digital Corpora's uptime.

**No baseline is committed yet.** The first dispatch run (with `record_baseline: true`) produces one, which then lands in a follow-up commit with real reasons filled in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)