### PR TITLE
ci(corpus): record the corpus fidelity baseline

### DIFF
--- a/benchmarks/corpus/README.md
+++ b/benchmarks/corpus/README.md
@@ -209,3 +209,14 @@ Bootstrap or re-record a baseline from a run:
 
 Then replace each `TODO` reason with a real justification — a machine can record that
 something failed, but only a person can say whether it's acceptable.
+
+The committed baseline was recorded on 2026-07-26 from
+[run 30183702769](https://github.com/thomas-villani/all2md/actions/runs/30183702769)
+against 1.10.0, and its allowlist is **empty**: all 100 gated documents converted
+without raising. So any entry appearing in it later is a regression with a name, and
+the right response is a fix rather than a line in the list.
+
+Note what the gated half actually covers: 50 PDFs and 50 emails. `corpus.toml` asks
+govdocs1 for `pdf` and `docx`, but govdocs1 is a 2009 harvest of `.gov` sites and
+carries legacy `.doc`, so the `docx` request matches almost nothing. The gate is real,
+it is just narrower than the manifest reads.

--- a/benchmarks/corpus/corpus_baseline.json
+++ b/benchmarks/corpus/corpus_baseline.json
@@ -1,0 +1,28 @@
+{
+  "_comment": [
+    "Corpus fidelity baseline. Covers only the sources marked reproducible=true",
+    "in corpus.toml - arxiv and poi resolve against upstream state that moves, so",
+    "their documents differ run to run and cannot be compared against anything.",
+    "",
+    "expected_failures is an allowlist, not a record: an entry that starts passing",
+    "is red, and so is an entry for a document no longer in the corpus. Replace",
+    "each TODO with a real reason or fix the bug and delete the line.",
+    "",
+    "It is empty because the recording run converted all 100 gated documents",
+    "without raising. Keep it that way: the correct response to a new entry is a",
+    "fix, and an allowlist is the fallback for when that is not possible yet."
+  ],
+  "provenance": {
+    "recorded": "2026-07-26T02:03:08Z",
+    "workflow_run": "https://github.com/thomas-villani/all2md/actions/runs/30183702769",
+    "all2md_version": "1.10.0",
+    "git_commit": "50b8fc80b5db",
+    "python": "3.12.13",
+    "platform": "Linux-6.17.0-1020-azure-x86_64-with-glibc2.39"
+  },
+  "doc_counts": {
+    "enron": 50,
+    "govdocs1": 50
+  },
+  "expected_failures": {}
+}


### PR DESCRIPTION
Records the baseline the `Corpus Fidelity Gate` needs. Until now it exited 2 for want of one, so it was inert.

Recorded from a `record_baseline` dispatch, [run 30183702769](https://github.com/thomas-villani/all2md/actions/runs/30183702769), against 1.10.0 on Linux / Python 3.12.

## The allowlist is empty

All 100 gated documents converted without raising, and none produced empty output:

| source | n | ok | fail | bytes | p50 | p95 |
|---|---:|---:|---:|---:|---:|---:|
| govdocs1 (pdf) | 50 | 50 | 0 | 30.99 MB | 307ms | 5.75s |
| enron (eml) | 50 | 50 | 0 | 113.6 KB | 4ms | 12ms |

That was the number worth watching. A large accepted-failure list would have meant the corpus had been reporting failures nobody acted on, and would have changed what to do next. There was nothing to adjudicate, so no `TODO` reasons are committed unexamined — the ratchet starts in its ideal state, where any new entry is a regression with a name.

## Verified the baseline is a live tripwire

Not a vacuous pass. The committed file, run against deliberately mutated results:

| mutation | status | exit |
|---|---|---:|
| inject a conversion error into one document | `NEW_FAILURE` | 1 |
| drop govdocs1 entirely (truncated download) | `MISSING_DOCS` | 1 |
| allowlist a document that now passes | `FIXED` | 1 |
| allowlist a document not in the corpus | `STALE` | 1 |

## What the gated half actually covers

`corpus.toml` asks govdocs1 for `pdf` and `docx` and receives 50 pdf, 0 docx — govdocs1 is a 2009 harvest of `.gov` sites, so it carries legacy `.doc`. The gate is real, it is just narrower than the manifest reads. Recorded in the README rather than left for the next reader to rediscover.

🤖 Generated with [Claude Code](https://claude.com/claude-code)