### PR TITLE
fix(tests): stop the benchmark conftest from hijacking -m

### DIFF
--- a/tests/performance/conftest.py
+++ b/tests/performance/conftest.py
@@ -421,7 +421,12 @@ def pytest_addoption(parser: pytest.Parser) -> None:
 
 
 def pytest_configure(config: pytest.Config) -> None:
-    """Configure pytest for benchmark tests.
+    """Hide benchmark tests unless ``--benchmark`` was passed.
+
+    Narrows any existing ``-m`` expression rather than replacing it. Assigning to
+    ``markexpr`` outright silently discarded the caller's selection: ``pytest -m unit``
+    used to collect the whole suite (7997 tests instead of 3857), because this hook
+    runs after argument parsing and overwrote ``unit`` with ``not benchmark``.
 
     Parameters
     ----------
@@ -429,5 +434,7 @@ def pytest_configure(config: pytest.Config) -> None:
         Pytest configuration object
 
     """
-    if not config.getoption("--benchmark"):
-        config.option.markexpr = "not benchmark"
+    if config.getoption("--benchmark", default=False):
+        return
+    existing = config.option.markexpr
+    config.option.markexpr = f"({existing}) and not benchmark" if existing else "not benchmark"

--- a/tests/unit/test_benchmark_marker_selection.py
+++ b/tests/unit/test_benchmark_marker_selection.py
@@ -1,0 +1,109 @@
+"""The benchmark conftest must hide benchmarks without hijacking ``-m``.
+
+``tests/performance/conftest.py`` hides its benchmarks by rewriting ``markexpr`` in
+``pytest_configure``. That hook runs *after* argument parsing, so assigning to
+``markexpr`` outright threw away whatever the caller asked for: ``pytest -m unit``
+collected the entire suite (7997 tests rather than 3857), quietly turning the
+documented fast path into a full run. CI never noticed because it passes no ``-m``,
+which makes the overwrite a no-op there.
+
+Two instruments, because neither sees what the other does:
+
+* the parametrized cases below pin the *expression*, and cannot flake;
+* :func:`test_a_real_collection_honours_the_marker` runs real pytest, and would catch
+  the hook being dropped, renamed, or never registered -- none of which the
+  expression tests can see.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import subprocess
+import sys
+from pathlib import Path
+from types import ModuleType, SimpleNamespace
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+BENCHMARK_CONFTEST = REPO_ROOT / "tests" / "performance" / "conftest.py"
+
+pytestmark = pytest.mark.unit
+
+
+def _load_benchmark_conftest() -> ModuleType:
+    """Import the benchmark conftest by path.
+
+    ``tests/`` is not a package, so the usual dotted import is not available.
+    """
+    spec = importlib.util.spec_from_file_location("_benchmark_conftest", BENCHMARK_CONFTEST)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+class _StubConfig:
+    """The two bits of ``pytest.Config`` the hook touches."""
+
+    def __init__(self, markexpr: str, benchmark: bool) -> None:
+        self.option = SimpleNamespace(markexpr=markexpr)
+        self._benchmark = benchmark
+
+    def getoption(self, name: str, default: object = None) -> object:
+        assert name == "--benchmark"
+        return self._benchmark
+
+
+@pytest.mark.parametrize(
+    ("markexpr", "benchmark", "expected"),
+    [
+        # No selection to preserve: the historical behaviour, and what CI hits.
+        ("", False, "not benchmark"),
+        # A selection *is* present, so it has to survive. This is the regression.
+        ("unit", False, "(unit) and not benchmark"),
+        ("integration", False, "(integration) and not benchmark"),
+        # Parenthesised because `not` binds tighter than `or`; without the parens
+        # `unit or integration` would widen to `unit or (integration and not benchmark)`.
+        ("unit or integration", False, "(unit or integration) and not benchmark"),
+        ("not slow", False, "(not slow) and not benchmark"),
+        # --benchmark means the caller wants them; leave the expression alone.
+        ("", True, ""),
+        ("pdf", True, "pdf"),
+    ],
+)
+def test_the_hook_narrows_rather_than_replaces(markexpr: str, benchmark: bool, expected: str) -> None:
+    config = _StubConfig(markexpr=markexpr, benchmark=benchmark)
+    _load_benchmark_conftest().pytest_configure(config)  # type: ignore[arg-type]
+    assert config.option.markexpr == expected
+
+
+def test_a_real_collection_honours_the_marker() -> None:
+    """Collect a benchmark file and a unit file together, asking for neither.
+
+    ``-m integration`` over this pair must select nothing. Under the overwrite bug the
+    expression became a bare ``not benchmark``, which selects the 10 unit tests --
+    so this asserts on the exact discrepancy, not merely on "something was filtered".
+    """
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "pytest",
+            "tests/performance",
+            "tests/unit/utils/test_fingerprint.py",
+            "-m",
+            "integration",
+            "--collect-only",
+            "-q",
+            "-p",
+            "no:cacheprovider",
+        ],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+    )
+    assert "test_fingerprint" not in result.stdout, (
+        "asked for integration tests and got unit tests back; the benchmark conftest "
+        f"is overwriting -m again.\n{result.stdout}"
+    )


### PR DESCRIPTION
Found while working R1d (the fate of `tests/performance`'s timing assertions). Separable from that decision, and worth landing on its own.

## The bug

`tests/performance/conftest.py` hides its benchmarks by rewriting `markexpr` in `pytest_configure`. That hook runs *after* argument parsing, so assigning to `markexpr` outright discarded whatever the caller selected:

| command | before | after |
|---|---:|---:|
| `pytest tests/` | 7997 | 7997 |
| `pytest tests/ -m unit` | **7997** | 3857 |
| `pytest tests/ -m integration` | **7997** | 989 |

`-m unit` is documented in `CLAUDE.md` as "run only unit tests (fast)". It was silently running the entire suite — integration and golden included, at roughly twice the tests — which matters most on the machines where someone reaches for the fast path.

CI is unaffected either way: it passes no `-m`, which makes the overwrite a no-op there. That is why this survived.

## The fix

Narrow the expression instead of replacing it. The parenthesising is load-bearing: `not` binds tighter than `or`, so an unparenthesised `unit or integration` would *widen* to `unit or (integration and not benchmark)`.

## Tests

Two instruments, because neither sees the other's failure mode:

- parametrized cases pin the rewritten expression, and cannot flake;
- a real pytest collection catches the hook being dropped, renamed, or never registered — which the expression tests structurally cannot see.

Both confirmed red against the overwrite before being trusted: 5 of 8 fail, including the end-to-end one.

## Note

This does not settle R1d. `tests/performance` still never runs in CI (plain `pytest tests/` collects 0 of its tests), and its 24 assertions are 17 tautologies plus 7 absolute ceilings 40–160x looser than actual runtimes. That decision is separate and follows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)