### PR TITLE
fix(corpus): stop caching a failed download as an empty result

### DIFF
--- a/benchmarks/corpus/README.md
+++ b/benchmarks/corpus/README.md
@@ -200,6 +200,19 @@ documents, therefore fewer failures, therefore a green gate — so the most like
 infrastructure fault in the whole pipeline would read as success. The gate also
 refuses to report a pass when *no* gated sources are present, for the same reason.
 
+`MISSING_DOCS` earned its keep on the gate's first real run: a DNS failure fetching
+the Enron tarball left the run with 50 documents instead of 100, and nothing else in
+the pipeline objected. Two things changed as a result, so the same fault now stops
+earlier and louder:
+
+- **A failed fetch is not cached.** `_read_index` returns `[]`, not `None`, for an
+  empty `_index.json`, so writing one after a failed download made that source
+  permanently empty on any machine that keeps the cache. Fetchers now leave no index
+  when they failed to find out, and only cache emptiness they actually established
+  (a shard that downloaded fine and holds none of the requested formats).
+- **`download` exits non-zero** if a requested source cached nothing, rather than
+  printing `cached 0 item(s)` and returning 0.
+
 Bootstrap or re-record a baseline from a run:
 
 ```bash

--- a/benchmarks/corpus/download.py
+++ b/benchmarks/corpus/download.py
@@ -79,6 +79,24 @@ def _read_index(source_dir: Path) -> list[CorpusItem] | None:
     return [CorpusItem(**row) for row in rows]
 
 
+def _give_up(source_dir: Path, reason: str) -> list[CorpusItem]:
+    """Abandon a source *without* caching the emptiness.
+
+    Writing an empty ``_index.json`` here would be read back as a legitimate cache
+    hit -- :func:`_read_index` returns ``[]``, not ``None`` -- so one transient
+    network failure would zero the source out permanently on any machine that keeps
+    the cache between runs. That is not hypothetical: a DNS blip fetching the Enron
+    tarball produced ``[enron] cached 0 item(s)``, and every later run would have
+    read that back and re-reported zero without retrying.
+
+    Leaving no index costs a retry next run, which is the cheaper mistake. Use this
+    whenever emptiness means "we failed to find out" rather than "we looked, and the
+    answer is none".
+    """
+    print(f"  {source_dir.name}: {reason} - not caching, will retry next run", flush=True)
+    return []
+
+
 def _write_index(source_dir: Path, items: list[CorpusItem]) -> None:
     source_dir.mkdir(parents=True, exist_ok=True)
     (source_dir / "_index.json").write_text(
@@ -185,9 +203,9 @@ def fetch_arxiv(cfg: dict, source_dir: Path) -> list[CorpusItem]:
         pool.append(eid)
 
     if not pool:
-        print("  arxiv: empty pool, nothing to fetch", flush=True)
-        _write_index(source_dir, [])
-        return []
+        # A live query returning nothing is far more likely to be a bad day at the
+        # API than a genuinely empty arxiv.
+        return _give_up(source_dir, "empty pool, nothing to fetch")
 
     sampled = _seeded_sample(pool, sample_size, seed)
     items: list[CorpusItem] = []
@@ -306,8 +324,7 @@ def fetch_govdocs1(cfg: dict, source_dir: Path) -> list[CorpusItem]:
         print(f"  govdocs1: downloading shard {shard_name} (~250 MB)...", flush=True)
         size = _try_download(url, shard_path, label=shard_name, timeout=600)
         if size is None:
-            _write_index(source_dir, [])
-            return []
+            return _give_up(source_dir, f"could not download shard {shard_name}")
 
     print(f"  govdocs1: scanning {shard_name} for formats {formats}...", flush=True)
     with zipfile.ZipFile(shard_path) as zf:
@@ -317,6 +334,9 @@ def fetch_govdocs1(cfg: dict, source_dir: Path) -> list[CorpusItem]:
             if not info.is_dir() and Path(info.filename).suffix.lower().lstrip(".") in formats
         ]
         if not candidates:
+            # The one empty result worth caching: the shard downloaded fine and
+            # genuinely holds none of the requested formats. Deterministic, so
+            # re-deriving it every run buys nothing.
             print(f"  govdocs1: no matching files in shard {shard_name}", flush=True)
             _write_index(source_dir, [])
             return []
@@ -405,9 +425,8 @@ def fetch_poi(cfg: dict, source_dir: Path) -> list[CorpusItem]:
             pool.append((ep, ext))
 
     if not pool:
-        print("  poi: empty pool, nothing to fetch", flush=True)
-        _write_index(source_dir, [])
-        return []
+        # Same reasoning as arxiv: the pool comes off a live tree listing.
+        return _give_up(source_dir, "empty pool, nothing to fetch")
 
     sampled = _seeded_sample(pool, sample_size, seed)
     items: list[CorpusItem] = []
@@ -450,8 +469,7 @@ def fetch_enron(cfg: dict, source_dir: Path) -> list[CorpusItem]:
         print("  enron: downloading tarball (~423 MB)...", flush=True)
         size = _try_download(ENRON_URL, tarball, label=ENRON_TARBALL, timeout=900)
         if size is None:
-            _write_index(source_dir, [])
-            return []
+            return _give_up(source_dir, "could not download the tarball")
 
     names_cache = source_dir / ENRON_NAMES_CACHE
     if names_cache.exists():
@@ -467,8 +485,9 @@ def fetch_enron(cfg: dict, source_dir: Path) -> list[CorpusItem]:
         print(f"  enron: indexed {len(names)} files", flush=True)
 
     if not names:
-        _write_index(source_dir, [])
-        return []
+        # A 423 MB tarball holding no files means we read it wrong, not that the
+        # Enron release is empty.
+        return _give_up(source_dir, "tarball indexed to zero members")
 
     sampled = _seeded_sample(names, sample_size, seed)
     items: list[CorpusItem] = []

--- a/benchmarks/corpus/run.py
+++ b/benchmarks/corpus/run.py
@@ -216,6 +216,19 @@ def main(argv: list[str] | None = None) -> int:
                 file=sys.stderr,
             )
 
+    # A source we asked for and did not get is a failure, and saying so here beats
+    # discovering it an hour later: the run that prompted this printed
+    # "[enron] cached 0 item(s)", exited 0, then benchmarked half a corpus. Only the
+    # gate's MISSING_DOCS check stopped that reading as a pass.
+    if args.mode in ("download", "all"):
+        empty = sorted(name for name, lst in items.items() if not lst)
+        if empty:
+            print(
+                f"No documents cached for: {', '.join(empty)}. " "Check the download log above for the cause.",
+                file=sys.stderr,
+            )
+            return 1
+
     if args.mode == "download":
         if args.purge_after:
             print("--purge-after ignored: download mode populates the cache.", flush=True)

--- a/tests/unit/test_corpus_download_failures.py
+++ b/tests/unit/test_corpus_download_failures.py
@@ -1,0 +1,114 @@
+"""A failed corpus fetch must not be cached as an empty result.
+
+``_read_index`` returns ``[]`` -- not ``None`` -- for an empty ``_index.json``, and
+every fetcher opens with ``if cached is not None: return cached``. So writing an empty
+index after a failed download made that source permanently empty on any machine that
+keeps the cache: the next run read the emptiness back as a valid hit and never
+retried.
+
+This is not hypothetical. A DNS failure fetching the Enron tarball produced
+``[enron] cached 0 item(s)``, the download step exited 0, and the benchmark ran over
+half a corpus. Only the gate's ``MISSING_DOCS`` check kept that from reading as a
+pass, and the poisoned index would have reproduced it on every subsequent run.
+"""
+
+from __future__ import annotations
+
+import json
+import zipfile
+from pathlib import Path
+
+import pytest
+
+from benchmarks.corpus import download as dl
+from benchmarks.corpus import run as corpus_run
+
+pytestmark = pytest.mark.unit
+
+
+def test_an_empty_index_reads_back_as_a_cache_hit(tmp_path: Path) -> None:
+    """The trap the rest of this module exists to avoid.
+
+    If this ever returns ``None``, caching an empty result stops being dangerous and
+    the ``_give_up`` calls could be simplified away.
+    """
+    (tmp_path / "_index.json").write_text("[]", encoding="utf-8")
+    assert dl._read_index(tmp_path) == []
+    assert dl._read_index(tmp_path) is not None
+
+
+class TestFailuresAreNotCached:
+    def test_a_failed_enron_download_leaves_no_index(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(dl, "_try_download", lambda *a, **k: None)
+
+        items = dl.fetch_enron({"sample_size": 5, "seed": 42}, tmp_path)
+
+        assert items == []
+        assert not (tmp_path / "_index.json").exists(), "a failed download poisoned the cache"
+        assert dl._read_index(tmp_path) is None, "the next run would short-circuit instead of retrying"
+
+    def test_a_failed_govdocs1_download_leaves_no_index(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(dl, "_try_download", lambda *a, **k: None)
+
+        items = dl.fetch_govdocs1({"sample_size": 5, "seed": 42, "shard": 0, "formats": ["pdf"]}, tmp_path)
+
+        assert items == []
+        assert dl._read_index(tmp_path) is None
+
+    def test_the_retry_actually_happens_after_a_failure(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Not caching is only useful if the next call re-enters the fetch."""
+        attempts: list[str] = []
+
+        def failing(*a: object, **k: object) -> None:
+            attempts.append("tried")
+            return None
+
+        monkeypatch.setattr(dl, "_try_download", failing)
+        dl.fetch_enron({"sample_size": 5, "seed": 42}, tmp_path)
+        dl.fetch_enron({"sample_size": 5, "seed": 42}, tmp_path)
+
+        assert len(attempts) == 2, "the second run short-circuited on a cached failure"
+
+
+def test_a_genuinely_empty_shard_is_cached(tmp_path: Path) -> None:
+    """The one empty result that *should* stick.
+
+    The shard downloaded fine and holds none of the requested formats. That answer is
+    deterministic, so re-deriving it every run buys nothing -- and if this stopped
+    being cached, nothing would break except speed, which is why it is worth pinning
+    that the distinction is deliberate rather than accidental.
+    """
+    shard = tmp_path / "000.zip"
+    with zipfile.ZipFile(shard, "w") as zf:
+        zf.writestr("notes.txt", "no pdfs here")
+
+    items = dl.fetch_govdocs1({"sample_size": 5, "seed": 42, "shard": 0, "formats": ["pdf"]}, tmp_path)
+
+    assert items == []
+    assert (tmp_path / "_index.json").exists()
+    assert json.loads((tmp_path / "_index.json").read_text(encoding="utf-8")) == []
+
+
+class TestDownloadReportsFailure:
+    """``download`` exiting 0 with nothing cached is the earliest vacuous pass."""
+
+    def _invoke(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, fetched: dict) -> int:
+        monkeypatch.setattr(corpus_run, "fetch_all", lambda *a, **k: fetched)
+        return corpus_run.main(
+            [
+                "download",
+                "--cache-dir",
+                str(tmp_path / "cache"),
+                "--results-dir",
+                str(tmp_path / "results"),
+            ]
+        )
+
+    def test_a_source_that_returned_nothing_is_a_failure(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        assert self._invoke(tmp_path, monkeypatch, {"govdocs1": ["a"], "enron": []}) == 1
+
+    def test_all_sources_empty_is_a_failure(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        assert self._invoke(tmp_path, monkeypatch, {"govdocs1": [], "enron": []}) == 1
+
+    def test_a_full_download_still_succeeds(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        assert self._invoke(tmp_path, monkeypatch, {"govdocs1": ["a"], "enron": ["b"]}) == 0


### PR DESCRIPTION
Found by running the corpus gate for real, against #172's baseline. The run went red with `MISSING_DOCS: enron` — correctly.

```
[enron] Enron email corpus - 500k real-world EMLs from the public release
  enron: downloading tarball (~423 MB)...
    skip enron_mail_20150507.tar.gz: <urlopen error [Errno -3] Temporary failure in name resolution>
[enron] cached 0 item(s)
```

The download step **exited 0**. The benchmark then ran over 50 documents instead of 100. Only the gate's `MISSING_DOCS` check kept that from reading as a pass — which is the one part of this that worked as designed.

## Defect 1: a failed download poisoned the cache permanently

`_read_index` returns `[]`, not `None`, for an empty `_index.json`, and every fetcher opens with `if cached is not None: return cached`. So `_write_index(dir, [])` after a failed download wasn't a note-to-self, it was a cache hit: the next run read the emptiness back as valid and never retried.

On anything that keeps the cache between runs — a dev box, or `benchmark.yml`, which caches keyed on the manifest hash — one transient blip zeroed that source out until someone manually purged.

Six sites wrote an empty index, and they were not equivalent:

| site | cause | now |
|---|---|---|
| `enron`, `govdocs1` | download failed | no index, retry |
| `arxiv`, `poi` | live API returned an empty pool | no index, retry |
| `enron` | tarball indexed to zero members | no index, retry |
| `govdocs1` | shard has none of the requested formats | **still cached** — deterministic |

## Defect 2: `download` reported success with nothing cached

It returned 0 regardless. Asking for a source and not getting it is a failure, and saying so at the download step beats discovering it an hour later — the job now stops before benchmarking half a corpus, with a message naming the source.

## Verification

Reverting both fixes fails 5 of the 8 new tests, including the retry check and both exit codes. The three that stay green assert behaviour this PR doesn't change — one of them being that an empty index still reads back as a cache hit, the trap itself, pinned so the reasoning stays visible.

## Known follow-up, not in this PR

A transient network failure still turns the weekly cron red. That's the right *direction* — a broken run should not report green — but without a retry it will recur, and a gate that cries wolf gets ignored. Worth a bounded retry on the two large downloads. Left out to keep this change to the correctness bug.

Depends on nothing; independent of #172 and #173.

🤖 Generated with [Claude Code](https://claude.com/claude-code)