### PR TITLE
feat(action): ship the conversion-quality gate as a GitHub Action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -289,6 +289,64 @@ jobs:
           path: tests/performance/results/
           if-no-files-found: warn
 
+  quality-gate-action:
+    name: Quality Gate Action
+    runs-on: ubuntu-latest
+
+    # Dogfoods the action at the repo root (`action.yml`) against our own docs.
+    #
+    # Two steps, because they cover different things and neither covers the other:
+    #
+    #   1. `uses: ./` exercises the composite YAML end to end -- inputs, version
+    #      resolution, install. It installs all2md from PyPI, so it says nothing
+    #      about *this* PR's scoring; its threshold is deliberately slack so a
+    #      published-vs-branch difference cannot make it flake. It answers "does
+    #      the action run at all", which the unit tests cannot.
+    #   2. The direct script run scores with the branch's code (editable install)
+    #      at the real thresholds. This is the ratchet.
+    #
+    # The thresholds in step 2 are measured floors, not round numbers: as of
+    # 1.10.0 the worst of the repo's root markdown is README.md at 97 fidelity
+    # (11 raw HTML blocks re-parse as paragraphs) and everything scores 100
+    # confidence. So fidelity passes here with *zero* headroom, which is the point.
+    # Re-record them deliberately if they move; do not nudge them down to make a
+    # build green. A threshold well below the real floor is the failure this whole
+    # batch kept finding -- a gate that passes because it cannot fail.
+    #
+    # `*.md` matches six tracked files here. Running the same command locally
+    # scores nine, because CLAUDE.md, AGENTS.md and todo.md are gitignored -- so a
+    # local run can show a different floor than CI without either being wrong.
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v7
+
+      - name: Verify the action's wiring
+        uses: ./
+        with:
+          paths: |
+            README.md
+            CONTRIBUTING.md
+          roundtrip-fail-under: 90
+          all2md-version: latest
+
+      - name: Set up Python
+        uses: actions/setup-python@v7
+        with:
+          python-version: '3.12'
+          cache: 'pip'
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e ".[all,dev]"
+
+      - name: Gate this branch against our own docs
+        run: |
+          python scripts/action_gate.py run \
+            --paths '*.md' \
+            --roundtrip-fail-under 97 \
+            --report-fail-under 100
+
   security-semgrep:
     name: Security Scan (Semgrep)
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,32 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **GitHub Action: a conversion-quality gate.** `action.yml` at the repository root
+  ships all2md as a reusable action that scores every matched document and fails the
+  build when fidelity degrades — the same ratchet this project runs on itself, pointed
+  outward. It wraps `roundtrip --fail-under` and `report --fail-under`, and gates on the
+  worst score across the matched set.
+
+  ```yaml
+  - uses: thomas-villani/all2md@v1.10.1
+    with:
+      paths: docs/**/*.md
+      roundtrip-fail-under: 97
+  ```
+
+  It refuses to pass quietly, which is the whole point: a `paths` glob that matches
+  nothing, a run with no threshold set, and a document that cannot be converted at all
+  are each a failure rather than a silent green. Config errors exit `2`, quality
+  failures exit `1`. It also warns when a threshold sits ten or more points below your
+  documents' real scores — documents that convert well score 99-100, so a
+  threshold that *sounds* strict has enough dead headroom to never fire.
+
+  The action lives in this repository rather than a separate one so `@v1.10.1` installs
+  all2md 1.10.1: the gate's verdict is the library's score, so the two versions must not
+  drift. See `docs/source/github_action.rst`.
+
 ### Changed
 
 - **Faster cold start: `import all2md` no longer loads every options module.** The

--- a/README.md
+++ b/README.md
@@ -450,6 +450,21 @@ See the [MCP documentation](https://all2md.readthedocs.io/en/latest/mcp.html) an
 
 </details>
 
+## CI quality gate
+
+Most document tooling in CI answers *"did it run?"*. all2md ships a GitHub Action that answers *"is the output still as good as it was?"* — it scores every matched document and fails the build when fidelity degrades:
+
+```yaml
+- uses: thomas-villani/all2md@v1.10.1
+  with:
+    paths: docs/**/*.md
+    roundtrip-fail-under: 97
+```
+
+Measure your real floor before picking a threshold — `all2md roundtrip docs/*.md --fail-under 1` prints it. Documents that convert well score 99–100, so a threshold that *sounds* strict (80, say) can have twenty points of dead headroom and never fire. The action warns you when that happens.
+
+It also refuses to pass quietly: no matching files, no threshold set, or a document that cannot be converted at all are all failures rather than silent greens. The same gate works without the Action, in any CI system — see the [full documentation](https://all2md.readthedocs.io/en/latest/github_action.html).
+
 ## Advanced features
 
 Built on an **AST-based pipeline** (parse → transform → render), all2md offers capabilities that direct format-to-format converters can't:

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -279,7 +279,8 @@ See the **Async Architecture Decision** below for the strategy. The shape:
 
 > **Install experience — decided.** We shipped one-click **`uv`-based install scripts**
 > (🚢 v1.8.0) rather than a frozen PyInstaller binary. A browser/web UI is still planned.
-> The channels below (Docker, Action, hosted API) are unstarted.
+> The **Action shipped** (see below). Docker and the hosted API are unstarted; Docker was
+> considered and parked in the ratchet batch, and the Action no longer depends on it.
 
 - 🌱 **Docker image** — *scheduled in the ratchet batch.* `docker run all2md` as a one-line
   microservice / CI step. Also the building block for the GitHub Action and hosted API below —
@@ -288,15 +289,20 @@ See the **Async Architecture Decision** below for the strategy. The shape:
   numbers comparable across runs and machines (`benchmarks/reference/README.md` already
   concedes ±20-30% drift on one dev box). It also narrows a real pain class —
   "tesseract works standalone but not through all2md" is an environment bug.
-- 🌱 **GitHub Action** — *scheduled in the ratchet batch, and **re-scoped**.* The original
-  pitch — "convert docs in this repo to markdown on commit" — solves nobody's actual problem.
-  v1.9.0 shipped `report --fail-under` and `roundtrip --fail-under`, so the differentiated
-  product is a **conversion-quality gate**: *fail the build when document fidelity degrades.*
-  Nobody else ships that, because nobody else has the scores. It's the Theme 2 ratchet pointed
-  outward — we build it for ourselves first, then ship it. *Shape:* a **reusable action repo**
-  (e.g. `all2md-action`) with an `action.yml` at its root, best as a **Docker action** given
-  our heavy native deps, plus a documented example workflow users drop into
-  `.github/workflows/` (`uses: thomas-villani/all2md-action@v1`).
+- 🚢 **GitHub Action** — *shipped in the ratchet batch, **re-scoped**.* The original pitch —
+  "convert docs in this repo to markdown on commit" — solves nobody's actual problem.
+  v1.9.0 shipped `report --fail-under` and `roundtrip --fail-under`, so what shipped is a
+  **conversion-quality gate**: *fail the build when document fidelity degrades.* Nobody else
+  ships that, because nobody else has the scores. It's the Theme 2 ratchet pointed outward —
+  built for ourselves first, then shipped.
+
+  Two deviations from the shape sketched here, both deliberate. It is a **composite**
+  action, not a Docker one, because the Docker image it was to be built on was parked and
+  `pip install all2md[all]` covers the deps that argued for a container. And it ships from
+  **this repository's root** rather than a separate `all2md-action` repo, so `@v1.10.1`
+  installs all2md 1.10.1 — the gate's verdict *is* the library's score, so a drifting action
+  version would silently redefine every consumer's threshold. Marketplace listing is still
+  open. See `docs/source/github_action.rst`.
 - 🚀 **Hosted conversion API** — a freemium endpoint (could fund the project); the Docker
   image is the building block. Also the backend for the browser extension and Node SDK.
 - 🚀 **Node / JS SDK** — *not a port.* The JS conversion ecosystem is fragmented and weaker

--- a/action.yml
+++ b/action.yml
@@ -1,0 +1,100 @@
+name: "all2md conversion-quality gate"
+description: >-
+  Fail the build when your documents stop converting cleanly. Scores every matched
+  document for round-trip fidelity and conversion confidence, and gates on the worst.
+author: "Tom Villani"
+
+branding:
+  icon: "check-circle"
+  color: "blue"
+
+inputs:
+  paths:
+    description: >-
+      Glob(s) selecting the documents to score, separated by newlines or commas
+      (for example "docs/**/*.md"). Matching is done in Python, not the shell, so
+      the result does not depend on the runner. Matching nothing fails the build.
+    required: true
+  roundtrip-fail-under:
+    description: >-
+      Fail if any document's round-trip fidelity falls below this score (0-100).
+      Set this, report-fail-under, or both -- with neither, the gate can never fail.
+    required: false
+    default: ""
+  report-fail-under:
+    description: >-
+      Fail if any document's conversion confidence falls below this score (0-100).
+    required: false
+    default: ""
+  via:
+    description: "Intermediate format for the round-trip check."
+    required: false
+    default: "markdown"
+  all2md-version:
+    description: >-
+      Version to install. Empty (the default) matches the tag this action was
+      referenced by, so @v1.10.1 gates with all2md 1.10.1 -- the scores are the
+      library's, so pinning them together keeps your thresholds meaningful.
+      Use "latest" to always take the newest release, or give an exact version.
+    required: false
+    default: ""
+  extras:
+    description: "Extras to install. The default covers every bundled format."
+    required: false
+    default: "all"
+  python-version:
+    description: "Python version used to run the gate."
+    required: false
+    default: "3.12"
+  working-directory:
+    description: "Directory the globs are resolved against."
+    required: false
+    default: "."
+
+outputs:
+  worst-fidelity:
+    description: "Lowest round-trip fidelity score seen, or empty if not gated."
+    value: ${{ steps.gate.outputs.worst-fidelity }}
+  worst-confidence:
+    description: "Lowest conversion confidence score seen, or empty if not gated."
+    value: ${{ steps.gate.outputs.worst-confidence }}
+  files-checked:
+    description: "Number of documents scored."
+    value: ${{ steps.gate.outputs.files-checked }}
+
+runs:
+  using: "composite"
+  steps:
+    - uses: actions/setup-python@v5
+      with:
+        python-version: ${{ inputs.python-version }}
+
+    - name: Install all2md
+      shell: bash
+      run: |
+        set -euo pipefail
+        spec="$(python "$GITHUB_ACTION_PATH/scripts/action_gate.py" resolve-version \
+          --explicit '${{ inputs.all2md-version }}' \
+          --action-ref '${{ github.action_ref }}' \
+          --extras '${{ inputs.extras }}')"
+        echo "Installing $spec"
+        python -m pip install --quiet --upgrade pip
+        python -m pip install --quiet "$spec"
+
+    - name: Score documents
+      id: gate
+      shell: bash
+      run: |
+        set -euo pipefail
+        args=()
+        if [ -n '${{ inputs.roundtrip-fail-under }}' ]; then
+          args+=(--roundtrip-fail-under '${{ inputs.roundtrip-fail-under }}')
+        fi
+        if [ -n '${{ inputs.report-fail-under }}' ]; then
+          args+=(--report-fail-under '${{ inputs.report-fail-under }}')
+        fi
+        python "$GITHUB_ACTION_PATH/scripts/action_gate.py" run \
+          --paths '${{ inputs.paths }}' \
+          --via '${{ inputs.via }}' \
+          --working-directory '${{ inputs.working-directory }}' \
+          "${args[@]+"${args[@]}"}"

--- a/action.yml
+++ b/action.yml
@@ -65,7 +65,10 @@ outputs:
 runs:
   using: "composite"
   steps:
-    - uses: actions/setup-python@v5
+    # v7 to match the rest of the repo. v5 targets Node 20, which the runners now
+    # force onto Node 24 with a deprecation annotation -- and every consumer of this
+    # action would see that annotation on their own builds.
+    - uses: actions/setup-python@v7
       with:
         python-version: ${{ inputs.python-version }}
 

--- a/docs/source/github_action.rst
+++ b/docs/source/github_action.rst
@@ -33,7 +33,7 @@ Quick Start
      quality:
        runs-on: ubuntu-latest
        steps:
-         - uses: actions/checkout@v4
+         - uses: actions/checkout@v5
          - uses: thomas-villani/all2md@v1.10.1
            with:
              paths: |

--- a/docs/source/github_action.rst
+++ b/docs/source/github_action.rst
@@ -129,6 +129,15 @@ Treat the number as a ratchet. When a document legitimately gets harder to
 convert, re-record the floor deliberately — don't nudge the threshold down to
 clear a red build.
 
+.. note::
+
+   **Measure in the environment you gate in.** Scores are deterministic for a
+   given interpreter and dependency set, but not necessarily across them — this
+   repository's own ``CHANGELOG.md`` scores 99 on a developer machine and 100 on
+   CI from identical bytes, because Markdown parsing depends on the installed
+   parser version. Calibrate from a CI run rather than a local one, and leave a
+   point of slack if you gate documents that sit right on a boundary.
+
 What this catches, and what it doesn't
 --------------------------------------
 

--- a/docs/source/github_action.rst
+++ b/docs/source/github_action.rst
@@ -1,0 +1,179 @@
+GitHub Action: Conversion-Quality Gate
+=======================================
+
+Fail the build when your documents stop converting cleanly.
+
+Most document tooling in CI answers *"did it run?"*. This action answers *"is the
+output still as good as it was?"* — it scores every matched document for
+round-trip fidelity and conversion confidence, and fails the job when the worst
+score falls below a threshold you set.
+
+.. code-block:: yaml
+
+   - uses: thomas-villani/all2md@v1.10.1
+     with:
+       paths: docs/**/*.md
+       roundtrip-fail-under: 97
+
+The action lives in the ``all2md`` repository itself rather than a separate one,
+so ``@v1.10.1`` installs all2md 1.10.1. That matters more than it looks: the
+gate's verdict *is* the library's score, so if the action version could drift from
+the library version, your thresholds would quietly change meaning underneath you.
+
+Quick Start
+-----------
+
+.. code-block:: yaml
+
+   name: Document quality
+
+   on: [push, pull_request]
+
+   jobs:
+     quality:
+       runs-on: ubuntu-latest
+       steps:
+         - uses: actions/checkout@v4
+         - uses: thomas-villani/all2md@v1.10.1
+           with:
+             paths: |
+               docs/**/*.md
+               README.md
+             roundtrip-fail-under: 97
+             report-fail-under: 90
+
+The job summary gets a per-document table, and the worst scores are exposed as
+step outputs so later steps can use them:
+
+.. code-block:: yaml
+
+         - uses: thomas-villani/all2md@v1.10.1
+           id: gate
+           with:
+             paths: docs/**/*.md
+             roundtrip-fail-under: 97
+         - run: echo "worst was ${{ steps.gate.outputs.worst-fidelity }}"
+
+Inputs
+------
+
+.. list-table::
+   :header-rows: 1
+   :widths: 24 12 64
+
+   * - Input
+     - Default
+     - Description
+   * - ``paths``
+     - *required*
+     - Glob(s) selecting documents, separated by newlines or commas. Expanded in
+       Python rather than by the shell, so the result does not depend on the
+       runner's shell settings.
+   * - ``roundtrip-fail-under``
+     - —
+     - Fail if any document's round-trip fidelity drops below this (0–100).
+   * - ``report-fail-under``
+     - —
+     - Fail if any document's conversion confidence drops below this (0–100).
+   * - ``via``
+     - ``markdown``
+     - Intermediate format for the round-trip check.
+   * - ``all2md-version``
+     - —
+     - Empty matches the action's tag. ``latest`` always takes the newest
+       release; anything else is an exact pin.
+   * - ``extras``
+     - ``all``
+     - Extras to install. The default covers every bundled format.
+   * - ``python-version``
+     - ``3.12``
+     - Python used to run the gate.
+   * - ``working-directory``
+     - ``.``
+     - Directory the globs resolve against.
+
+At least one of ``roundtrip-fail-under`` or ``report-fail-under`` must be set. With
+neither, the action refuses to run rather than pass — see below.
+
+Outputs
+-------
+
+``worst-fidelity``, ``worst-confidence``, and ``files-checked``.
+
+.. _calibrating-thresholds:
+
+Calibrating the threshold
+-------------------------
+
+**Measure first. Do not guess a round number.**
+
+This is the one part worth reading twice, because getting it wrong produces a gate
+that passes forever and looks like evidence of quality.
+
+Documents that convert well score high — in this repository's own fixtures,
+99–100 is typical. So a threshold of ``80``, which sounds appropriately strict,
+has *twenty points of dead headroom*: your conversion could degrade badly and the
+build would stay green the whole way down.
+
+Get your real floor first:
+
+.. code-block:: bash
+
+   all2md roundtrip docs/**/*.md --fail-under 1
+
+Then set the threshold at that floor. The action helps: whenever it finds ten or
+more points of headroom between your threshold and your worst actual score, it
+prints a note on the job summary telling you what to raise it to.
+
+Treat the number as a ratchet. When a document legitimately gets harder to
+convert, re-record the floor deliberately — don't nudge the threshold down to
+clear a red build.
+
+What this catches, and what it doesn't
+--------------------------------------
+
+The two checks fail in different directions, which is why the action offers both:
+
+* ``roundtrip-fail-under`` measures what survives a parse → render → parse cycle.
+  It is sharp about structure, but it is blind to a construct that is dropped
+  *consistently*: if a feature vanishes on the way out and stays vanished on the
+  way back in, both sides agree and the score stays high.
+* ``report-fail-under`` measures confidence in the parse itself — scanned pages,
+  OCR fallbacks, structural guesses. It catches "this document was never really
+  read" cases that round-tripping cannot see, at the cost of being a heuristic.
+
+Gate on both when the documents matter. Neither is a substitute for the other.
+
+Three ways it refuses to pass
+------------------------------
+
+A gate that goes green without measuring is worse than no gate, so the action
+fails loudly rather than quietly succeeding when:
+
+#. **No files match** ``paths``. A typo would otherwise produce a permanently
+   green check that never opens a document.
+#. **No threshold is set.** Running with nothing to compare against is theatre.
+#. **A document cannot be converted at all.** That is the worst possible fidelity
+   outcome, so it is never quieter than a merely low score.
+
+A configuration problem exits ``2``; a genuine quality failure exits ``1``.
+
+Without the action
+------------------
+
+The action is a thin wrapper — the same gate works in any CI system, or locally:
+
+.. code-block:: bash
+
+   all2md roundtrip docs/*.md --fail-under 97
+   all2md report inbox/*.pdf --fail-under 80
+
+The difference is that the action scores each document in its own process, so it
+reports *every* failing file rather than stopping at the first one, and it writes
+the summary table and step outputs.
+
+See also
+--------
+
+* :doc:`cli` — ``report`` and ``roundtrip`` in full.
+* :doc:`performance` — the speed side of the same idea.

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -153,6 +153,7 @@ Guides & References
    agent_skills
    plugins
    integrations
+   github_action
    configuration
    environment_variables
    troubleshooting

--- a/scripts/action_gate.py
+++ b/scripts/action_gate.py
@@ -1,0 +1,310 @@
+#!/usr/bin/env python3
+"""Runtime for the all2md conversion-quality gate (``action.yml`` at the repo root).
+
+Two jobs, kept in one dependency-free file so the action can run this *before* it
+has installed the package it gates:
+
+``resolve-version``
+    Decide which ``all2md`` to install.
+``run``
+    Score the matched documents and decide the build.
+
+Only the standard library is imported here; scoring happens by invoking the
+``all2md`` CLI as a subprocess.
+
+Three deliberate refusals to pass
+---------------------------------
+A gate that goes green by *not measuring* is worse than no gate, because it also
+buys false confidence. Every one of the instruments in this repo shipped with a
+version of that bug, so this one is built to fail loudly in the three places it
+could otherwise slip through:
+
+1. **No matched files** is a failure, not an empty pass. A typo in ``paths``
+   otherwise produces a permanently green gate that never reads a document.
+2. **No threshold set** is a failure. An action that runs with nothing to compare
+   against is theatre, and it is the easiest state to end up in by accident.
+3. **A document that cannot be converted at all** scores as a failure, not a skip.
+   It is the worst possible fidelity outcome, so it must never be quieter than a
+   merely low score.
+
+Each file is scored in its own process. That costs one interpreter start per
+document (~180 ms since the lazy-import work in 1.10.0) and buys two things the
+batched form cannot give: every failing file is reported rather than just the
+first one the CLI aborts on, and the file list never has to fit in a command line.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import subprocess
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Optional
+
+# ``v1.10.1`` -> ``1.10.1``. Anything else (a branch, a SHA, ``main``) is not a
+# release and must not be turned into a version pin.
+_RELEASE_TAG = re.compile(r"^v(\d+\.\d+\.\d+(?:[-.\w]*)?)$")
+
+TOOLS = ("roundtrip", "report")
+
+# What each tool's score is called in the output, so the summary reads like the
+# CLI it wraps rather than like this script.
+_METRIC = {"roundtrip": "fidelity", "report": "confidence"}
+
+
+class GateError(Exception):
+    """A configuration problem that must stop the build before any scoring."""
+
+
+@dataclass
+class DocumentScores:
+    """One document's scores, keyed by tool. ``None`` means it could not be scored."""
+
+    path: str
+    scores: dict[str, Optional[int]] = field(default_factory=dict)
+
+    def scored(self, tool: str) -> Optional[int]:
+        """Return the score for *tool*, or ``None`` if scoring failed."""
+        return self.scores.get(tool)
+
+
+def resolve_version(explicit: str, action_ref: str) -> str:
+    """Return the version specifier to install, or ``""`` for the latest release.
+
+    The action lives in the same repository as the library, so ``@v1.10.1`` should
+    mean *all2md 1.10.1* rather than "whatever is newest today". That lockstep is
+    the whole reason the action ships from here: the gate's verdict **is** the
+    library's score, so letting the two versions drift would silently move every
+    consumer's threshold underneath them.
+
+    Parameters
+    ----------
+    explicit
+        The ``all2md-version`` input. Empty means "follow the action ref";
+        ``latest`` always takes the newest release; anything else is a pin.
+    action_ref
+        ``github.action_ref`` -- the tag or branch the action was referenced by.
+
+    """
+    explicit = (explicit or "").strip()
+    if explicit:
+        return "" if explicit == "latest" else explicit
+    match = _RELEASE_TAG.match((action_ref or "").strip())
+    return match.group(1) if match else ""
+
+
+def pip_spec(version: str, extras: str) -> str:
+    """Build the ``pip install`` argument for *version* with *extras*."""
+    suffix = f"[{extras}]" if extras else ""
+    return f"all2md{suffix}=={version}" if version else f"all2md{suffix}"
+
+
+def expand_paths(patterns: str, root: Path) -> list[Path]:
+    """Resolve newline- or comma-separated glob *patterns* under *root*.
+
+    Globbing happens here rather than in the shell so the file set does not depend
+    on the runner's shell or on whether ``nullglob`` is set -- an unmatched pattern
+    behaves identically on every platform, which for a gate matters more than
+    matching shell conventions.
+    """
+    found: list[Path] = []
+    seen: set[Path] = set()
+    for raw in re.split(r"[\n,]", patterns or ""):
+        pattern = raw.strip()
+        if not pattern:
+            continue
+        for match in sorted(root.glob(pattern)):
+            resolved = match.resolve()
+            if match.is_file() and resolved not in seen:
+                seen.add(resolved)
+                found.append(match)
+    return found
+
+
+def score_document(tool: str, path: Path, via: str, executable: Optional[str] = None) -> tuple[Optional[int], str]:
+    """Score one document, returning ``(score, note)``.
+
+    A ``None`` score means the document could not be scored at all, which the
+    caller must treat as a failure rather than as missing data.
+    """
+    command = [executable or sys.executable, "-m", "all2md", tool, str(path), "--json"]
+    if tool == "roundtrip":
+        command += ["--via", via]
+    proc = subprocess.run(command, capture_output=True, text=True)
+    if proc.returncode != 0:
+        detail = proc.stderr.strip().splitlines()
+        return None, detail[-1] if detail else f"{tool} exited {proc.returncode}"
+    try:
+        payload = json.loads(proc.stdout)
+    except json.JSONDecodeError:
+        return None, "the report was not valid JSON"
+    if isinstance(payload, list):
+        payload = payload[0] if payload else {}
+    score = payload.get("score")
+    if not isinstance(score, int):
+        return None, "the report carried no score"
+    return score, ""
+
+
+def _thresholds(args: argparse.Namespace) -> dict[str, int]:
+    """Collect the thresholds that were actually set, rejecting an empty gate."""
+    chosen = {
+        tool: getattr(args, f"{tool}_fail_under") for tool in TOOLS if getattr(args, f"{tool}_fail_under") is not None
+    }
+    if not chosen:
+        raise GateError(
+            "Set roundtrip-fail-under, report-fail-under, or both. "
+            "With neither, this action reads every document and can never fail, "
+            "which looks like a passing quality gate but is not one."
+        )
+    for tool, value in chosen.items():
+        if not 0 <= value <= 100:
+            raise GateError(f"{tool}-fail-under must be between 0 and 100, got {value}.")
+    return chosen
+
+
+def _summarise(rows: list[DocumentScores], thresholds: dict[str, int], calibration: list[str]) -> str:
+    """Render the job summary shown on the workflow run page."""
+    header = "| Document | " + " | ".join(_METRIC[t].title() for t in thresholds) + " |"
+    divider = "|---" * (len(thresholds) + 1) + "|"
+    lines = [header, divider]
+    for row in rows:
+        cells = []
+        for tool in thresholds:
+            score = row.scored(tool)
+            if score is None:
+                cells.append("**not convertible**")
+            else:
+                mark = "" if score >= thresholds[tool] else " :x:"
+                cells.append(f"{score}{mark}")
+        lines.append(f"| `{row.path}` | " + " | ".join(cells) + " |")
+    body = "\n".join(lines)
+    thresholds_text = ", ".join(f"{_METRIC[t]} ≥ {v}" for t, v in thresholds.items())
+    return f"## all2md quality gate\n\n" f"{len(rows)} document(s), gated on {thresholds_text}.\n\n{body}\n\n" + (
+        "\n".join(calibration) + "\n" if calibration else ""
+    )
+
+
+def _calibration_notes(rows: list[DocumentScores], thresholds: dict[str, int]) -> list[str]:
+    """Warn when a threshold sits so far below reality that it cannot fire.
+
+    Real documents in this repo's own fixtures score 99-100, so a threshold picked
+    by intuition -- 80, say -- has twenty points of dead headroom and will pass
+    through any regression short of total breakage. That is the same defect the
+    absolute timing ceilings in ``tests/performance`` had, and it is invisible
+    precisely because it looks like a passing gate. Say so, rather than let a
+    number that never fires read as evidence of quality.
+    """
+    notes = []
+    for tool, threshold in thresholds.items():
+        scores = [s for s in (r.scored(tool) for r in rows) if s is not None]
+        if not scores:
+            continue
+        worst = min(scores)
+        if worst - threshold >= 10:
+            notes.append(
+                f"> [!NOTE]\n"
+                f"> Lowest {_METRIC[tool]} is {worst}, against a threshold of {threshold} "
+                f"-- {worst - threshold} points of headroom. A threshold this far below "
+                f"your documents' actual scores will not catch a regression. Consider "
+                f"raising `{tool}-fail-under` to {worst}."
+            )
+    return notes
+
+
+def _emit(name: str, value: str) -> None:
+    """Write a step output, when running inside GitHub Actions."""
+    path = os.environ.get("GITHUB_OUTPUT")
+    if path:
+        with open(path, "a", encoding="utf-8") as handle:
+            handle.write(f"{name}={value}\n")
+
+
+def run(args: argparse.Namespace) -> int:
+    """Score the matched documents and return the exit code for the build."""
+    thresholds = _thresholds(args)
+
+    root = Path(args.working_directory).resolve()
+    files = expand_paths(args.paths, root)
+    if not files:
+        raise GateError(
+            f"No files matched {args.paths!r} under {root}. "
+            "Refusing to report success without reading a document -- an empty match "
+            "is almost always a wrong pattern, and it would pass forever."
+        )
+
+    rows: list[DocumentScores] = []
+    for path in files:
+        row = DocumentScores(path=path.relative_to(root).as_posix())
+        for tool in thresholds:
+            score, note = score_document(tool, path, args.via, args.executable)
+            row.scores[tool] = score
+            if score is None:
+                print(f"{row.path}: {tool} could not score this document -- {note}", file=sys.stderr)
+        rows.append(row)
+
+    failures = []
+    for row in rows:
+        for tool, threshold in thresholds.items():
+            score = row.scored(tool)
+            if score is None:
+                failures.append(f"{row.path}: could not be converted at all")
+            elif score < threshold:
+                failures.append(f"{row.path}: {_METRIC[tool]} {score} is below {threshold}")
+
+    calibration = _calibration_notes(rows, thresholds)
+    summary = _summarise(rows, thresholds, calibration)
+    print(summary)
+    summary_path = os.environ.get("GITHUB_STEP_SUMMARY")
+    if summary_path:
+        with open(summary_path, "a", encoding="utf-8") as handle:
+            handle.write(summary + "\n")
+
+    for tool in thresholds:
+        scores = [s for s in (r.scored(tool) for r in rows) if s is not None]
+        _emit(f"worst-{_METRIC[tool]}", str(min(scores)) if scores else "")
+    _emit("files-checked", str(len(files)))
+
+    if failures:
+        print("\nQuality gate failed:", file=sys.stderr)
+        for failure in failures:
+            print(f"  {failure}", file=sys.stderr)
+        return 1
+    return 0
+
+
+def main(argv: Optional[list[str]] = None) -> int:
+    """Entry point for the action."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    version = sub.add_parser("resolve-version", help="print the pip specifier to install")
+    version.add_argument("--explicit", default="")
+    version.add_argument("--action-ref", default="")
+    version.add_argument("--extras", default="all")
+
+    gate = sub.add_parser("run", help="score documents and gate the build")
+    gate.add_argument("--paths", required=True)
+    gate.add_argument("--roundtrip-fail-under", type=int, default=None)
+    gate.add_argument("--report-fail-under", type=int, default=None)
+    gate.add_argument("--via", default="markdown")
+    gate.add_argument("--working-directory", default=".")
+    gate.add_argument("--executable", default=None)
+
+    args = parser.parse_args(argv)
+    try:
+        if args.command == "resolve-version":
+            print(pip_spec(resolve_version(args.explicit, args.action_ref), args.extras))
+            return 0
+        return run(args)
+    except GateError as exc:
+        print(f"Error: {exc}", file=sys.stderr)
+        return 2
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/unit/test_action_gate.py
+++ b/tests/unit/test_action_gate.py
@@ -1,0 +1,349 @@
+"""Tests for the GitHub Action's quality gate (``scripts/action_gate.py``).
+
+The gate's whole job is to go red, so most of these tests check that it does, in
+each of the ways it can be wrong: a pattern that matches nothing, a threshold that
+was never set, a document that cannot be converted, and a score below the line.
+The last test runs the real script over real fixtures, because everything above it
+stubs the scorer and would pass just as happily if the CLI plumbing were broken.
+"""
+
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+_SCRIPT = Path(__file__).resolve().parents[2] / "scripts" / "action_gate.py"
+
+
+def _load():
+    """Import the script by path -- ``scripts/`` is not a package.
+
+    The module has to go into ``sys.modules`` *before* it executes: ``@dataclass``
+    resolves the string annotations that ``from __future__ import annotations``
+    produces by looking its own module up there, and finds ``None`` otherwise.
+    """
+    spec = importlib.util.spec_from_file_location("action_gate", _SCRIPT)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+gate = _load()
+
+
+def _args(**overrides) -> argparse.Namespace:
+    defaults = {
+        "paths": "*.md",
+        "roundtrip_fail_under": 90,
+        "report_fail_under": None,
+        "via": "markdown",
+        "working_directory": ".",
+        "executable": None,
+    }
+    defaults.update(overrides)
+    return argparse.Namespace(**defaults)
+
+
+class TestVersionResolution:
+    """``@v1.10.1`` must mean all2md 1.10.1, not "newest today"."""
+
+    @pytest.mark.parametrize(
+        ("explicit", "action_ref", "expected"),
+        [
+            ("", "v1.10.1", "1.10.1"),
+            ("", "v2.0.0-rc1", "2.0.0-rc1"),
+            ("", "main", ""),
+            ("", "feature/quality-gate", ""),
+            ("", "a1b2c3d4e5f6", ""),
+            ("", "", ""),
+            ("latest", "v1.10.1", ""),
+            ("1.9.0", "v1.10.1", "1.9.0"),
+            ("  1.9.0  ", "", "1.9.0"),
+        ],
+    )
+    def test_resolution(self, explicit, action_ref, expected):
+        assert gate.resolve_version(explicit, action_ref) == expected
+
+    def test_a_branch_ref_is_never_turned_into_a_pin(self):
+        """A non-release ref must fall back to latest rather than invent a version."""
+        assert gate.resolve_version("", "release/1.10") == ""
+
+    @pytest.mark.parametrize(
+        ("version", "extras", "expected"),
+        [
+            ("1.10.1", "all", "all2md[all]==1.10.1"),
+            ("", "all", "all2md[all]"),
+            ("1.10.1", "", "all2md==1.10.1"),
+        ],
+    )
+    def test_pip_spec(self, version, extras, expected):
+        assert gate.pip_spec(version, extras) == expected
+
+
+class TestPathExpansion:
+    def test_globs_are_expanded_and_sorted(self, tmp_path):
+        (tmp_path / "b.md").write_text("b")
+        (tmp_path / "a.md").write_text("a")
+        found = gate.expand_paths("*.md", tmp_path)
+        assert [p.name for p in found] == ["a.md", "b.md"]
+
+    def test_multiple_patterns_are_deduplicated(self, tmp_path):
+        (tmp_path / "a.md").write_text("a")
+        found = gate.expand_paths("*.md\n a.md, **/*.md", tmp_path)
+        assert [p.name for p in found] == ["a.md"]
+
+    def test_directories_are_not_documents(self, tmp_path):
+        (tmp_path / "sub").mkdir()
+        (tmp_path / "sub" / "a.md").write_text("a")
+        assert [p.name for p in gate.expand_paths("*", tmp_path)] == []
+
+    def test_recursive_globs_work(self, tmp_path):
+        (tmp_path / "sub").mkdir()
+        (tmp_path / "sub" / "a.md").write_text("a")
+        assert len(gate.expand_paths("**/*.md", tmp_path)) == 1
+
+    def test_a_pattern_matching_nothing_returns_nothing(self, tmp_path):
+        assert gate.expand_paths("*.md", tmp_path) == []
+
+
+class TestRefusalsToPass:
+    """The three ways a green could be produced without measuring anything."""
+
+    def test_no_matched_files_is_a_failure(self, tmp_path):
+        with pytest.raises(gate.GateError, match="No files matched"):
+            gate.run(_args(paths="*.md", working_directory=str(tmp_path)))
+
+    def test_no_threshold_is_a_failure(self, tmp_path):
+        (tmp_path / "a.md").write_text("hi")
+        with pytest.raises(gate.GateError, match="can never fail"):
+            gate.run(
+                _args(
+                    working_directory=str(tmp_path),
+                    roundtrip_fail_under=None,
+                    report_fail_under=None,
+                )
+            )
+
+    def test_an_unconvertible_document_fails_rather_than_being_skipped(self, tmp_path, monkeypatch):
+        (tmp_path / "a.md").write_text("hi")
+        monkeypatch.setattr(gate, "score_document", lambda *a, **k: (None, "boom"))
+        assert gate.run(_args(working_directory=str(tmp_path))) == 1
+
+    @pytest.mark.parametrize("threshold", [-1, 101])
+    def test_an_out_of_range_threshold_is_a_failure(self, tmp_path, threshold):
+        (tmp_path / "a.md").write_text("hi")
+        with pytest.raises(gate.GateError, match="between 0 and 100"):
+            gate.run(_args(working_directory=str(tmp_path), roundtrip_fail_under=threshold))
+
+
+class TestScoring:
+    def test_a_score_above_the_threshold_passes(self, tmp_path, monkeypatch):
+        (tmp_path / "a.md").write_text("hi")
+        monkeypatch.setattr(gate, "score_document", lambda *a, **k: (95, ""))
+        assert gate.run(_args(working_directory=str(tmp_path), roundtrip_fail_under=90)) == 0
+
+    def test_a_score_below_the_threshold_fails(self, tmp_path, monkeypatch):
+        (tmp_path / "a.md").write_text("hi")
+        monkeypatch.setattr(gate, "score_document", lambda *a, **k: (89, ""))
+        assert gate.run(_args(working_directory=str(tmp_path), roundtrip_fail_under=90)) == 1
+
+    def test_a_score_exactly_on_the_threshold_passes(self, tmp_path, monkeypatch):
+        """``--fail-under`` means *under*, matching the CLI it wraps."""
+        (tmp_path / "a.md").write_text("hi")
+        monkeypatch.setattr(gate, "score_document", lambda *a, **k: (90, ""))
+        assert gate.run(_args(working_directory=str(tmp_path), roundtrip_fail_under=90)) == 0
+
+    def test_one_bad_document_in_a_good_batch_fails_the_build(self, tmp_path, monkeypatch):
+        for name in ("a.md", "b.md", "c.md"):
+            (tmp_path / name).write_text("hi")
+        scores = iter([(100, ""), (50, ""), (100, "")])
+        monkeypatch.setattr(gate, "score_document", lambda *a, **k: next(scores))
+        assert gate.run(_args(working_directory=str(tmp_path), roundtrip_fail_under=90)) == 1
+
+    def test_every_failing_document_is_reported_not_just_the_first(self, tmp_path, monkeypatch, capsys):
+        """The batched CLI aborts on the first bad file; this must not."""
+        for name in ("a.md", "b.md"):
+            (tmp_path / name).write_text("hi")
+        monkeypatch.setattr(gate, "score_document", lambda *a, **k: (10, ""))
+        gate.run(_args(working_directory=str(tmp_path), roundtrip_fail_under=90))
+        err = capsys.readouterr().err
+        assert "a.md" in err and "b.md" in err
+
+    def test_both_tools_gate_independently(self, tmp_path, monkeypatch):
+        """Confidence can fail a build that fidelity would have passed."""
+        (tmp_path / "a.md").write_text("hi")
+        monkeypatch.setattr(
+            gate,
+            "score_document",
+            lambda tool, *a, **k: (100, "") if tool == "roundtrip" else (40, ""),
+        )
+        args = _args(working_directory=str(tmp_path), roundtrip_fail_under=90, report_fail_under=90)
+        assert gate.run(args) == 1
+
+
+class TestScoreDocument:
+    """The one function that talks to the CLI, so the one that must not guess.
+
+    Every failure here has to come back as ``None`` rather than as a number. A
+    substituted score would be indistinguishable from a real one downstream, which
+    is how "it reported something" quietly becomes "it measured something".
+    """
+
+    @staticmethod
+    def _fake_run(monkeypatch, *, returncode=0, stdout="", stderr=""):
+        import subprocess
+
+        result = subprocess.CompletedProcess(args=[], returncode=returncode, stdout=stdout, stderr=stderr)
+        monkeypatch.setattr(gate.subprocess, "run", lambda *a, **k: result)
+
+    def test_a_valid_report_yields_its_score(self, monkeypatch):
+        self._fake_run(monkeypatch, stdout='{"score": 87}')
+        assert gate.score_document("roundtrip", Path("a.md"), "markdown") == (87, "")
+
+    def test_a_single_element_list_is_unwrapped(self, monkeypatch):
+        self._fake_run(monkeypatch, stdout='[{"score": 42}]')
+        assert gate.score_document("report", Path("a.md"), "markdown")[0] == 42
+
+    def test_a_nonzero_exit_reports_the_last_stderr_line(self, monkeypatch):
+        self._fake_run(monkeypatch, returncode=4, stderr="noise\nError: Input file not found")
+        score, note = gate.score_document("roundtrip", Path("a.md"), "markdown")
+        assert score is None and "not found" in note
+
+    def test_a_silent_nonzero_exit_still_reports_something(self, monkeypatch):
+        self._fake_run(monkeypatch, returncode=9, stderr="")
+        score, note = gate.score_document("roundtrip", Path("a.md"), "markdown")
+        assert score is None and "exited 9" in note
+
+    def test_unparseable_output_is_not_a_score(self, monkeypatch):
+        self._fake_run(monkeypatch, stdout="not json at all")
+        assert gate.score_document("roundtrip", Path("a.md"), "markdown")[0] is None
+
+    def test_a_report_without_a_score_is_not_a_score(self, monkeypatch):
+        """Must not become 0 -- that reads as a real, terrible score."""
+        self._fake_run(monkeypatch, stdout='{"band": "high"}')
+        score, note = gate.score_document("roundtrip", Path("a.md"), "markdown")
+        assert score is None and "no score" in note
+
+    def test_an_empty_list_is_not_a_score(self, monkeypatch):
+        self._fake_run(monkeypatch, stdout="[]")
+        assert gate.score_document("report", Path("a.md"), "markdown")[0] is None
+
+    def test_a_non_integer_score_is_rejected(self, monkeypatch):
+        self._fake_run(monkeypatch, stdout='{"score": "high"}')
+        assert gate.score_document("roundtrip", Path("a.md"), "markdown")[0] is None
+
+    def test_via_is_only_passed_to_roundtrip(self, monkeypatch):
+        seen: list[list[str]] = []
+
+        import subprocess
+
+        def capture(cmd, **kwargs):
+            seen.append(cmd)
+            return subprocess.CompletedProcess(args=cmd, returncode=0, stdout='{"score": 100}', stderr="")
+
+        monkeypatch.setattr(gate.subprocess, "run", capture)
+        gate.score_document("roundtrip", Path("a.md"), "rst")
+        gate.score_document("report", Path("a.md"), "rst")
+        assert "--via" in seen[0] and "rst" in seen[0]
+        assert "--via" not in seen[1]
+
+
+class TestCalibrationWarning:
+    """A threshold far below reality is the failure mode that looks like success."""
+
+    def test_a_threshold_with_dead_headroom_is_flagged(self, tmp_path, monkeypatch, capsys):
+        (tmp_path / "a.md").write_text("hi")
+        monkeypatch.setattr(gate, "score_document", lambda *a, **k: (100, ""))
+        gate.run(_args(working_directory=str(tmp_path), roundtrip_fail_under=80))
+        assert "points of headroom" in capsys.readouterr().out
+
+    def test_a_well_calibrated_threshold_is_not_flagged(self, tmp_path, monkeypatch, capsys):
+        (tmp_path / "a.md").write_text("hi")
+        monkeypatch.setattr(gate, "score_document", lambda *a, **k: (100, ""))
+        gate.run(_args(working_directory=str(tmp_path), roundtrip_fail_under=95))
+        assert "points of headroom" not in capsys.readouterr().out
+
+
+class TestAgainstRealDocuments:
+    """No stubs: the CLI plumbing either works here or nothing above it means anything."""
+
+    @pytest.fixture
+    def fixtures(self) -> Path:
+        path = Path(__file__).resolve().parents[1] / "fixtures" / "documents"
+        if not (path / "complex.docx").exists():
+            pytest.skip("fixture documents not available")
+        return path
+
+    def test_a_real_document_scores_and_passes(self, fixtures):
+        code = gate.main(
+            [
+                "run",
+                "--paths",
+                "basic.docx",
+                "--working-directory",
+                str(fixtures),
+                "--roundtrip-fail-under",
+                "90",
+            ]
+        )
+        assert code == 0
+
+    def test_a_real_document_below_the_line_fails(self, fixtures):
+        """complex.docx round-trips at 99, so a threshold of 100 must go red."""
+        code = gate.main(
+            [
+                "run",
+                "--paths",
+                "complex.docx",
+                "--working-directory",
+                str(fixtures),
+                "--roundtrip-fail-under",
+                "100",
+            ]
+        )
+        assert code == 1
+
+    def test_a_file_that_is_not_a_document_fails(self, tmp_path):
+        """Garbage in must not score as missing data and slip through."""
+        (tmp_path / "broken.docx").write_bytes(b"not a docx at all")
+        code = gate.main(
+            [
+                "run",
+                "--paths",
+                "*.docx",
+                "--working-directory",
+                str(tmp_path),
+                "--roundtrip-fail-under",
+                "1",
+            ]
+        )
+        assert code == 1
+
+
+def test_resolve_version_subcommand_prints_a_pip_spec(capsys):
+    assert gate.main(["resolve-version", "--action-ref", "v1.10.1"]) == 0
+    assert capsys.readouterr().out.strip() == "all2md[all]==1.10.1"
+
+
+def test_a_config_error_exits_two_not_one(tmp_path):
+    """Separate a broken gate from a failing one, so CI can tell them apart."""
+    assert gate.main(["run", "--paths", "*.md", "--working-directory", str(tmp_path)]) == 2
+
+
+def test_the_script_is_importable_without_all2md():
+    """It runs before the install step, so it must not import what it gates."""
+    source = _SCRIPT.read_text(encoding="utf-8")
+    assert "import all2md" not in source
+    assert "from all2md" not in source
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main([__file__]))


### PR DESCRIPTION
Closes R4, the last item in the Quality & Speed Ratchets batch. After this, the batch is feature-complete and 1.10.1 is taggable.

## What this is

`action.yml` at the repo root — a composite action that scores every matched document and **fails the build when fidelity degrades**. It wraps `roundtrip --fail-under` and `report --fail-under` and gates on the worst score across the set.

```yaml
- uses: thomas-villani/all2md@v1.10.1
  with:
    paths: docs/**/*.md
    roundtrip-fail-under: 97
```

This is the ratchet we built for ourselves in R1, pointed outward.

## Two deviations from the plan

R4a specified *"`all2md-action` repo, Docker action pointing at R3"*. R3 is parked, so both halves changed:

1. **Composite, not Docker.** `pip install all2md[all]` covers the native deps that argued for a container.
2. **This repo's root, not a separate repo.** The gate's verdict *is* the library's score, so an action that could version-drift from the library would silently redefine every consumer's threshold. Shipping from here makes `@v1.10.1` mean all2md 1.10.1 by construction. `resolve_version` derives the pin from `github.action_ref` and refuses to invent one from a branch or SHA.

Marketplace listing is deliberately **not** done here — that's a public listing and a separate call.

## The vacuous pass, one level out

Every instrument in this batch shipped with a green produced by *not measuring*. This one's version is nastier because the stale threshold is the **user's**, not ours: real documents score 99–100, so a threshold that sounds strict — 80 — has twenty points of dead headroom and can never fire. Exactly the `tests/performance` ceiling problem, in someone else's repo.

So the action:

- **Refuses to pass** on a `paths` glob matching nothing, on no threshold being set, and on a document that cannot be converted at all. Config errors exit `2`, quality failures exit `1`, so CI can tell a broken gate from a failing one.
- **Warns when the threshold has ≥10 points of headroom**, and says what to raise it to.
- Expands globs in Python, not the shell, so an unmatched pattern behaves identically on every runner.
- Scores each document in its own process, so *every* failing file is reported rather than just the first one the batched CLI aborts on. Viable because R2b cut startup to ~180 ms.

## Verification

Per `verify-the-judge-can-fail`: **seven mutations, seven reds.** Empty match passing, unconvertible-treated-as-skip, off-by-one threshold, missing threshold tolerated, version resolution always taking latest, calibration warning disabled, and a failed score silently reading as `0`. That last one initially *survived* — `score_document`'s JSON handling was only covered indirectly — so nine tests were added for it.

46 tests. Three run against real fixtures with no stubs, since everything above them mocks the scorer and would pass just as happily with the CLI plumbing broken.

## CI job

Two steps covering different things:

1. `uses: ./` — exercises the composite YAML end to end against the **published** package, with a slack threshold so a published-vs-branch difference can't flake it. Answers "does the action run at all", which unit tests can't.
2. A direct script run at **measured floors** — fidelity 97, confidence 100, taken from the repo's own markdown rather than picked. Fidelity passes with **zero headroom**, which is the point.

## It already found something

`README.md` round-trips at **97, not 100** — eleven raw HTML blocks re-parse as paragraphs, and 29 of 2,816 words are lost. The gate doing its job on first use. Logged as a follow-up, not fixed here.

Docs: new `docs/source/github_action.rst` (Sphinx builds clean, no warnings), a README section, CHANGELOG entry, and ROADMAP Theme 5 flipped to shipped with the deviations recorded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)