### PR TITLE
fix(markdown): require a delimiter row before parsing a table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Prose containing a `|` is no longer swallowed into a table.** mistune's
+  `_process_thead` never checks that the second line of a candidate table is a
+  delimiter row — it matches each cell against the three alignment patterns and
+  falls back to "no alignment" for anything else — so *any* line with the same
+  number of pipe-separated cells as the line above it was accepted as the
+  delimiter and then consumed. Two ordinary sentences that each happened to
+  contain a pipe became a two-column table, and **the second line was deleted
+  outright**. So did two fully-piped rows written without a delimiter, and two
+  lines whose pipes sat inside code spans (whose backticks were mangled on the
+  way through). A delimiter row is now required, per GFM, which is where the
+  loss stops. Found by the new quality-gate action, which scored a table-free
+  `CHANGELOG.md` as containing a table.
+
 - **OCR'd PDF pages with links no longer crash conversion.** OCR-synthesized text
   spans omitted the `bbox` key that every real PyMuPDF span carries. On a page
   that was OCR'd *and* held a link annotation (common in signed documents), link

--- a/docs/source/github_action.rst
+++ b/docs/source/github_action.rst
@@ -132,11 +132,11 @@ clear a red build.
 .. note::
 
    **Measure in the environment you gate in.** Scores are deterministic for a
-   given interpreter and dependency set, but not necessarily across them — this
-   repository's own ``CHANGELOG.md`` scores 99 on a developer machine and 100 on
-   CI from identical bytes, because Markdown parsing depends on the installed
-   parser version. Calibrate from a CI run rather than a local one, and leave a
-   point of slack if you gate documents that sit right on a boundary.
+   given interpreter and dependency set, but not guaranteed across them: parsing
+   depends on the installed parser version, so a document can score differently
+   on a developer machine than on CI from identical bytes. Calibrate from a CI
+   run rather than a local one, and leave a point of slack if you gate documents
+   that sit right on a boundary.
 
 What this catches, and what it doesn't
 --------------------------------------

--- a/src/all2md/parsers/markdown.py
+++ b/src/all2md/parsers/markdown.py
@@ -180,6 +180,39 @@ def _plugin_admonition(md: Any) -> None:
     md.block.register("admonition", _ADMONITION_HEADER.pattern, _parse_admonition_block, before="fenced_code")
 
 
+# A GFM delimiter cell: optional leading colon, one or more dashes, optional
+# trailing colon. Whitespace around it is insignificant.
+_DELIMITER_CELL = re.compile(r"^\s*:?-+:?\s*$")
+
+
+def _is_delimiter_row(text: str) -> bool:
+    """Return whether *text* is a table delimiter row (``---|:---:|---:``).
+
+    mistune does not check this. Its ``_process_thead`` splits the second line
+    into cells, matches each against the three alignment patterns, and falls back
+    to ``align=None`` for anything that matches none of them -- so *any* line with
+    the same number of pipe-separated cells as the header is accepted as the
+    delimiter and then consumed. Two ordinary prose lines that happen to contain a
+    pipe become a table, and the second line is deleted outright::
+
+        we support a|b syntax        | we support a | b syntax |
+        and also c|d syntax     ->   |---|---|
+
+    GFM requires the delimiter row, so checking for it here restores both halves
+    of the correct behaviour: real tables still parse, and prose stays prose.
+
+    Parameters
+    ----------
+    text : str
+        The candidate delimiter line, with the outer pipes already stripped.
+
+    """
+    from mistune.plugins.table import _split_table_cells
+
+    cells = _split_table_cells(text)
+    return bool(cells) and all(_DELIMITER_CELL.match(cell) for cell in cells)
+
+
 def _process_row_lenient(text: str, aligns: list[Optional[str]]) -> dict[str, Any]:
     """Build a table row token, reconciling the cell count with the header.
 
@@ -240,6 +273,10 @@ def _parse_table_lenient(block: Any, m: re.Match[str], state: Any) -> Optional[i
     align = _strip_pipe_table_row(align_line)
     if align is None:
         return None
+    if not _is_delimiter_row(align):
+        # Not a table at all -- let the paragraph rule take the whole run of
+        # lines, rather than eating this one as a delimiter row.
+        return None
 
     thead, aligns = _process_thead(header, align)
     if not thead or aligns is None:
@@ -272,6 +309,8 @@ def _parse_nptable_lenient(block: Any, m: re.Match[str], state: Any) -> Optional
     align_line = state.get_line(pos)
     align = _strip_table_line(align_line)
     if align is None:
+        return None
+    if not _is_delimiter_row(align):
         return None
 
     thead, aligns = _process_thead(header, align)

--- a/tests/unit/ast/test_markdown2ast.py
+++ b/tests/unit/ast/test_markdown2ast.py
@@ -426,6 +426,58 @@ class TestTables:
         assert len(quote_tables) == 1
         assert len(quote_tables[0].rows[0].cells) == 2
 
+    def test_prose_lines_containing_pipes_are_not_a_table(self) -> None:
+        """Two prose lines that merely contain a pipe stay prose.
+
+        Regression: mistune's ``_process_thead`` never checks that the second line
+        is a delimiter row -- it falls back to ``align=None`` for any cell it does
+        not recognise -- so it accepted any equally-wide line as the delimiter and
+        consumed it. The second line was then **deleted outright**, silently, on
+        the default Markdown path.
+        """
+        markdown = "we support a|b syntax\nand also c|d syntax\n"
+        doc = markdown_to_ast(markdown)
+
+        assert not any(isinstance(child, Table) for child in doc.children)
+        # Both lines survive; the bug dropped the second one entirely.
+        text = "".join(node.content for node in doc.children[0].content if isinstance(node, Text))
+        assert "we support a|b syntax" in text
+        assert "and also c|d syntax" in text
+
+    def test_pipe_rows_without_a_delimiter_are_not_a_table(self) -> None:
+        """Fully-piped rows still need a delimiter row to become a table.
+
+        This is the shape most likely to hide the data loss: it *looks* like a
+        table the author forgot the delimiter on, so losing the second row reads
+        as intentional rather than as a bug.
+        """
+        doc = markdown_to_ast("| alpha | beta |\n| gamma | delta |\n")
+
+        assert not any(isinstance(child, Table) for child in doc.children)
+        text = "".join(node.content for node in doc.children[0].content if isinstance(node, Text))
+        assert "gamma" in text
+
+    def test_code_span_pipes_do_not_start_a_table(self) -> None:
+        """Pipes inside code spans are prose, and their backticks stay intact."""
+        doc = markdown_to_ast("use `a|b` here\nand `c|d` there\n")
+
+        assert not any(isinstance(child, Table) for child in doc.children)
+        codes = [node for node in doc.children[0].content if isinstance(node, Code)]
+        assert [node.content for node in codes] == ["a|b", "c|d"]
+
+    def test_delimiter_row_variants_still_parse(self) -> None:
+        """The delimiter check must not reject the forms GFM actually allows."""
+        for delimiter in ("|---|---|", "| --- | --- |", "|:--|--:|", "|:-:|:-:|", "|-|-|"):
+            doc = markdown_to_ast(f"| A | B |\n{delimiter}\n| 1 | 2 |\n")
+            tables = [child for child in doc.children if isinstance(child, Table)]
+            assert len(tables) == 1, f"{delimiter!r} should still parse as a table"
+
+    def test_delimiter_like_line_without_dashes_is_not_a_delimiter(self) -> None:
+        """A colon-only or empty second row is not a delimiter row."""
+        for second in ("| : | : |", "|  |  |"):
+            doc = markdown_to_ast(f"| A | B |\n{second}\n")
+            assert not any(isinstance(child, Table) for child in doc.children), f"{second!r} is not a delimiter"
+
 
 class TestMiscellaneous:
     """Test miscellaneous elements."""


### PR DESCRIPTION
Fixes #177.

## The bug

mistune's `_process_thead` never validates that the second line of a candidate table is a delimiter row. It splits the line into cells, matches each against the three alignment patterns, and falls back to `align=None` for anything that matches none of them — so **any** line with the same number of pipe-separated cells as the line above it is accepted as the delimiter and then consumed.

Three shapes lost text on the default Markdown path:

| input | before | after |
|---|---|---|
| two prose lines with a pipe | second line **deleted** | both survive |
| two fully-piped rows, no delimiter | second row **deleted** | both survive |
| two lines with pipes in code spans | second line deleted, backticks mangled | both survive, code spans intact |

The middle one is the most dangerous: it looks like a table whose author forgot the delimiter, so losing a row reads as intentional.

## The fix

We already replace mistune's `table`/`nptable` rules wholesale (for ragged-row tolerance), so the check goes in ours. `_is_delimiter_row` requires every cell to match `:?-+:?` per GFM; both parsers return `None` when it fails, letting the paragraph rule take the whole run of lines.

## Verification

The four behavioural tests were run against the pre-fix parser and **all four fail**; `test_delimiter_row_variants_still_parse` is the guard in the other direction and pins that `|---|`, `| --- |`, `|:--|--:|`, `|:-:|:-:|` and `|-|-|` all still parse.

- `tests/unit` — green
- `tests/golden` — green (no snapshot movement)
- `benchmarks/roundtrip` — 39 passed, 1 xfailed, 2 skipped
- This repo's own `CHANGELOG.md` goes **99 → 100**, which is the exact discrepancy #179 was recorded from.

## One finding worth keeping

I wrote a `pipes-in-prose` case for the roundtrip benchmark corpus, then checked it against the pre-fix parser: **it passes identically before and after the fix.** Both oracles are self-consistency checks — the buggy parse is perfectly stable under idempotency, and the HTML-equivalence reference *is* mistune, which shares the bug. So the sharp instrument is structurally blind to this entire bug class, exactly as the batch's "pair a sharp gate with a noisy one" note predicted.

I removed the case rather than ship a test that cannot fail. The unit tests are the gate. Worth filing the oracle gap separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)