### PR TITLE
fix(corpus): retry the two large downloads, and report formats that matched nothing

### DIFF
--- a/benchmarks/corpus/README.md
+++ b/benchmarks/corpus/README.md
@@ -168,6 +168,25 @@ can click straight to source/output pairs.
 - Wall-clock timings depend on hardware and load — don't compare across
   machines, only across runs on the same machine.
 
+## Network failures, and what the run does about them
+
+The two large archives — the Enron tarball (423 MB) and the govdocs1 shard
+(~250 MB) — get **two retries with exponential backoff** before the source gives
+up. A DNS blip on either once failed a whole weekly run, and a gate that goes
+red on infrastructure gets ignored, at which point it has stopped being a gate.
+
+The bound is as deliberate as the retry. When the budget is spent the fetch
+still fails loudly and still caches nothing, so a broken network is reported as
+a broken network rather than smoothed into a thin corpus. Retries only cover
+transient failures — a 404 or a 403 is not retried, because retrying a wrong URL
+is only a slower way to fail. Per-document fetches get no retry at all: they are
+individually cheap to lose, and retrying each would multiply the run time of a
+source that is already hundreds of requests long.
+
+Separately, a source that yields **none** of a format its `corpus.toml` entry
+asks for now says so. That claim is the corpus's coverage claim, and a format
+that silently matched nothing misstates which gate covers what.
+
 ## Adding a source
 
 Add a `[sources.<name>]` block to `corpus.toml`, then implement a fetcher in

--- a/benchmarks/corpus/download.py
+++ b/benchmarks/corpus/download.py
@@ -13,7 +13,6 @@ import fnmatch
 import json
 import random
 import re
-import socket
 import sys
 import tarfile
 import time
@@ -29,6 +28,17 @@ from typing import Any, Callable, Iterable
 USER_AGENT = "all2md-corpus-benchmark/1.0 (mailto:thomas.villani@njii.com)"
 DEFAULT_TIMEOUT = 60
 POLITE_DELAY_SECONDS = 0.4
+
+# Retry budget for the two large archives (the ~423 MB Enron tarball and the
+# ~250 MB govdocs1 shard). Small per-document fetches do not get one: they are
+# individually cheap to lose and a per-file retry would multiply the run time of
+# a source that is already hundreds of requests long.
+LARGE_DOWNLOAD_RETRIES = 2
+RETRY_BACKOFF_SECONDS = 5
+
+# HTTP statuses worth a second attempt. A 404 or a 403 means the URL is wrong or
+# we are not allowed in; retrying that is just a slower way to fail.
+_RETRYABLE_STATUS = frozenset({408, 425, 429, 500, 502, 503, 504})
 
 
 @dataclass
@@ -131,23 +141,51 @@ def _try_download(
     label: str,
     timeout: int = DEFAULT_TIMEOUT,
     validator: "Callable[[Path], bool] | None" = None,
+    retries: int = 0,
 ) -> int | None:
-    try:
-        size = _download(url, dest, timeout=timeout)
-    except urllib.error.HTTPError as e:
-        print(f"    skip {label}: HTTP {e.code}", flush=True)
-        return None
-    except (urllib.error.URLError, socket.timeout, TimeoutError) as e:
-        print(f"    skip {label}: {e}", flush=True)
-        return None
-    except OSError as e:
-        print(f"    skip {label}: {e}", flush=True)
-        return None
-    if validator is not None and not validator(dest):
-        dest.unlink(missing_ok=True)
-        print(f"    skip {label}: failed content validation", flush=True)
-        return None
-    return size
+    """Download *url* to *dest*, returning its size or ``None`` on failure.
+
+    With ``retries`` above zero, transient network failures are retried with
+    exponential backoff. The bound is deliberate on both sides: a weekly gate
+    that goes red on a DNS blip gets ignored, and a gate that retries forever
+    stops being able to report that the network is broken. Once the budget is
+    spent this still returns ``None``, and the caller still fails loudly -- the
+    retry buys tolerance for flakiness, never silence about failure.
+
+    ``_download`` writes to a ``.part`` file and only ``replace()``s it on
+    success, so a retry can never resume onto a truncated archive.
+    """
+    attempts = max(1, retries + 1)
+    for attempt in range(1, attempts + 1):
+        last = attempt == attempts
+        try:
+            size = _download(url, dest, timeout=timeout)
+        except urllib.error.HTTPError as e:
+            if last or e.code not in _RETRYABLE_STATUS:
+                print(f"    skip {label}: HTTP {e.code}", flush=True)
+                return None
+            reason = f"HTTP {e.code}"
+        except OSError as e:
+            # URLError, socket.timeout and TimeoutError are all OSError subclasses.
+            if last:
+                print(f"    skip {label}: {e}", flush=True)
+                return None
+            reason = str(e)
+        else:
+            if validator is not None and not validator(dest):
+                dest.unlink(missing_ok=True)
+                print(f"    skip {label}: failed content validation", flush=True)
+                return None
+            return size
+
+        delay = RETRY_BACKOFF_SECONDS * 2 ** (attempt - 1)
+        print(
+            f"    {label}: attempt {attempt}/{attempts} failed ({reason}); retrying in {delay}s",
+            flush=True,
+        )
+        time.sleep(delay)
+
+    return None  # pragma: no cover - the loop always returns on its last attempt
 
 
 def _invalidate_cache_if_invalid(source_dir: Path, items: list[CorpusItem], validator: Callable[[Path], bool]) -> bool:
@@ -322,7 +360,7 @@ def fetch_govdocs1(cfg: dict, source_dir: Path) -> list[CorpusItem]:
     if not shard_path.exists():
         url = f"{GOVDOCS1_BASE}/{shard_name}"
         print(f"  govdocs1: downloading shard {shard_name} (~250 MB)...", flush=True)
-        size = _try_download(url, shard_path, label=shard_name, timeout=600)
+        size = _try_download(url, shard_path, label=shard_name, timeout=600, retries=LARGE_DOWNLOAD_RETRIES)
         if size is None:
             return _give_up(source_dir, f"could not download shard {shard_name}")
 
@@ -467,7 +505,7 @@ def fetch_enron(cfg: dict, source_dir: Path) -> list[CorpusItem]:
     tarball = source_dir / ENRON_TARBALL
     if not tarball.exists():
         print("  enron: downloading tarball (~423 MB)...", flush=True)
-        size = _try_download(ENRON_URL, tarball, label=ENRON_TARBALL, timeout=900)
+        size = _try_download(ENRON_URL, tarball, label=ENRON_TARBALL, timeout=900, retries=LARGE_DOWNLOAD_RETRIES)
         if size is None:
             return _give_up(source_dir, "could not download the tarball")
 
@@ -556,6 +594,45 @@ FETCHERS: dict[str, Callable[[dict, Path], list[CorpusItem]]] = {
 }
 
 
+def _report_unfulfilled_formats(name: str, cfg: dict, items: list[CorpusItem]) -> list[str]:
+    """Announce requested formats the source did not actually yield.
+
+    The corpus gate's whole value is its coverage claim, and until now a format
+    that matched nothing was simply absent: ``corpus.toml`` asks govdocs1 for
+    ``["pdf", "docx"]``, the shard hands back zero docx, and the run reports
+    success -- so the benchmark quietly covers a narrower format mix than its own
+    manifest advertises. That misstates which gate covers what, which matters
+    because ``Format Benchmarks`` exists specifically to reach the formats the
+    corpus cannot.
+
+    This warns rather than fails, on the distinction drawn when a failed fetch
+    stopped being cached as an empty result: "we looked, and there are none" is a
+    real finding to report, while "we never found out" must be loud. A source
+    that returned nothing at all has already said so via :func:`_give_up`, so
+    there is nothing to add here.
+
+    Returns
+    -------
+    list of str
+        The requested formats with no matching document, sorted; empty when the
+        manifest's claim held.
+
+    """
+    requested = {f.lower() for f in cfg.get("formats", [])}
+    if not requested or not items:
+        return []
+    missing = sorted(requested - {i.format.lower() for i in items})
+    if missing:
+        print(
+            f"[{name}] WARNING: corpus.toml requests {sorted(requested)} but this run "
+            f"produced no {', '.join(missing)} - the corpus covers less than the "
+            f"manifest claims. Fix the manifest or the fetcher; do not leave the "
+            f"claim standing.",
+            flush=True,
+        )
+    return missing
+
+
 def load_manifest(toml_path: Path) -> dict:
     if sys.version_info >= (3, 11):
         import tomllib
@@ -610,6 +687,7 @@ def fetch_all(
         print(f"[{name}] {cfg.get('description', '')}", flush=True)
         source_dir = cache_root / name
         items = fetcher(cfg, source_dir)
+        _report_unfulfilled_formats(name, cfg, items)
         if fmt_filter:
             items = [i for i in items if i.format.lower() in fmt_filter]
         selected[name] = items

--- a/tests/unit/test_corpus_download_failures.py
+++ b/tests/unit/test_corpus_download_failures.py
@@ -15,6 +15,7 @@ pass, and the poisoned index would have reproduced it on every subsequent run.
 from __future__ import annotations
 
 import json
+import urllib.error
 import zipfile
 from pathlib import Path
 
@@ -87,6 +88,118 @@ def test_a_genuinely_empty_shard_is_cached(tmp_path: Path) -> None:
     assert items == []
     assert (tmp_path / "_index.json").exists()
     assert json.loads((tmp_path / "_index.json").read_text(encoding="utf-8")) == []
+
+
+class TestLargeDownloadRetry:
+    """A weekly gate that goes red on a network blip gets ignored, and then it is not a gate.
+
+    The bound matters as much as the retry: this pins that the budget is finite and
+    that exhausting it still returns ``None``, so the caller still fails loudly.
+    """
+
+    @pytest.fixture(autouse=True)
+    def _no_real_sleep(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(dl.time, "sleep", lambda _: None)
+
+    def _failing_download(self, monkeypatch: pytest.MonkeyPatch, error: Exception, succeed_on: int = 0) -> list[int]:
+        calls: list[int] = []
+
+        def fake(url: str, dest: Path, **kwargs: object) -> int:
+            calls.append(len(calls) + 1)
+            if succeed_on and len(calls) >= succeed_on:
+                dest.parent.mkdir(parents=True, exist_ok=True)
+                dest.write_bytes(b"payload")
+                return 7
+            raise error
+
+        monkeypatch.setattr(dl, "_download", fake)
+        return calls
+
+    def test_a_transient_failure_is_retried_to_the_bound(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        calls = self._failing_download(monkeypatch, urllib.error.URLError("dns went away"))
+
+        size = dl._try_download("http://x/a.tar.gz", tmp_path / "a.tar.gz", label="a", retries=2)
+
+        assert size is None, "an exhausted retry budget must still report failure"
+        assert len(calls) == 3, "retries=2 means three attempts"
+
+    def test_a_recovered_download_returns_its_size(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        calls = self._failing_download(monkeypatch, urllib.error.URLError("blip"), succeed_on=2)
+
+        size = dl._try_download("http://x/a.tar.gz", tmp_path / "a.tar.gz", label="a", retries=2)
+
+        assert size == 7
+        assert len(calls) == 2, "it should stop retrying once it succeeds"
+
+    def test_a_404_is_not_retried(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Retrying a wrong URL is just a slower way to fail."""
+        error = urllib.error.HTTPError("http://x/a", 404, "Not Found", {}, None)  # type: ignore[arg-type]
+        calls = self._failing_download(monkeypatch, error)
+
+        assert dl._try_download("http://x/a", tmp_path / "a", label="a", retries=2) is None
+        assert len(calls) == 1
+
+    def test_a_503_is_retried(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        error = urllib.error.HTTPError("http://x/a", 503, "Unavailable", {}, None)  # type: ignore[arg-type]
+        calls = self._failing_download(monkeypatch, error)
+
+        assert dl._try_download("http://x/a", tmp_path / "a", label="a", retries=2) is None
+        assert len(calls) == 3
+
+    def test_small_fetches_do_not_retry_by_default(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Per-document fetches are cheap to lose; retrying each would multiply the run."""
+        calls = self._failing_download(monkeypatch, urllib.error.URLError("blip"))
+
+        assert dl._try_download("http://x/a", tmp_path / "a", label="a") is None
+        assert len(calls) == 1
+
+    def test_the_two_large_downloads_ask_for_retries(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        """The retry is worthless if the callers that need it do not pass it."""
+        seen: list[int] = []
+
+        def fake(*a: object, **kwargs: object) -> None:
+            seen.append(int(kwargs.get("retries", 0)))  # type: ignore[arg-type]
+            return None
+
+        monkeypatch.setattr(dl, "_try_download", fake)
+        dl.fetch_enron({"sample_size": 5, "seed": 42}, tmp_path / "enron")
+        dl.fetch_govdocs1({"sample_size": 5, "seed": 42, "shard": 0, "formats": ["pdf"]}, tmp_path / "gov")
+
+        assert seen == [dl.LARGE_DOWNLOAD_RETRIES, dl.LARGE_DOWNLOAD_RETRIES]
+
+
+class TestUnfulfilledFormatsAreReported:
+    """A requested format that matches nothing used to be simply absent.
+
+    ``corpus.toml`` asks govdocs1 for pdf *and* docx and gets zero docx, so the
+    benchmark covers a narrower format mix than its own manifest advertises.
+    """
+
+    def _items(self, *formats: str) -> list[dl.CorpusItem]:
+        return [
+            dl.CorpusItem(source="s", format=f, source_id=f"id-{f}", filename=f"f.{f}", size_bytes=1) for f in formats
+        ]
+
+    def test_a_format_that_matched_nothing_is_named(self, capsys: pytest.CaptureFixture[str]) -> None:
+        missing = dl._report_unfulfilled_formats("govdocs1", {"formats": ["pdf", "docx"]}, self._items("pdf"))
+
+        assert missing == ["docx"]
+        assert "docx" in capsys.readouterr().out
+
+    def test_a_fulfilled_manifest_says_nothing(self, capsys: pytest.CaptureFixture[str]) -> None:
+        missing = dl._report_unfulfilled_formats("poi", {"formats": ["docx", "pptx"]}, self._items("docx", "pptx"))
+
+        assert missing == []
+        assert capsys.readouterr().out == ""
+
+    def test_a_source_that_returned_nothing_is_left_to_give_up(self, capsys: pytest.CaptureFixture[str]) -> None:
+        """``_give_up`` already reported that failure; a second warning is noise."""
+        assert dl._report_unfulfilled_formats("enron", {"formats": ["eml"]}, []) == []
+        assert capsys.readouterr().out == ""
+
+    def test_case_differences_are_not_a_miss(self, capsys: pytest.CaptureFixture[str]) -> None:
+        assert dl._report_unfulfilled_formats("s", {"formats": ["PDF"]}, self._items("pdf")) == []
+        assert capsys.readouterr().out == ""
 
 
 class TestDownloadReportsFailure:


### PR DESCRIPTION
Fixes #182. Fixes #181.

Two ways the corpus fetch layer misreported its own coverage. Both are benchmark-only — no shipped code changes.

## #182 — a network blip failed the whole weekly run

The Enron tarball (423 MB) and the govdocs1 shard (~250 MB) got one attempt each. A DNS failure on either took the run down, which is exactly what happened on the run that recorded the corpus baseline.

Both now get two retries with exponential backoff. **The bound is as deliberate as the retry:** once the budget is spent `_try_download` still returns `None` and the caller still fails loudly, so a broken network is reported as a broken network rather than smoothed into a thin corpus.

- Only transient failures retry. A 404 or 403 is not retried — retrying a wrong URL is a slower way to fail.
- Per-document fetches keep their single attempt; they're cheap to lose individually, and retrying each would multiply a source that's already hundreds of requests long.
- No truncation risk: `_download` writes to `.part` and only `replace()`s on success, as noted on the issue.

## #181 — a requested format that matched nothing was silent

`corpus.toml` asks govdocs1 for `["pdf", "docx"]` and gets zero docx. The run reported success, so the corpus quietly covered a narrower format mix than its own manifest advertises — which misstates which gate covers what, precisely because `Format Benchmarks` exists to reach the formats the corpus can't.

`_report_unfulfilled_formats` now names them. It **warns rather than fails**, on the distinction drawn in #174: "we looked, and there are none" is a real finding to report, while "we never found out" must be loud — and a source that returned nothing at all has already said so via `_give_up`.

I deliberately did *not* also "fix" `corpus.toml` by dropping `docx` or adding `doc`. The manifest may be wrong, or the extension matching may be, and I'd be guessing which. The warning makes the next run say so with evidence.

## Verification

Six mutations run against the new tests, **all six go red**:

| mutation | result |
|---|---|
| drop `retries=` at both call sites | RED |
| collapse the budget to one attempt | RED |
| make every HTTP status retryable | RED |
| stub the missing-format set to empty | RED |
| compute the warning but never print it | RED |
| fail a recovered download anyway | RED |

My first pass at that harness reported three survivors — the harness was wrong, not the tests: it detected failure by grepping pytest's output for "failed", and this repo's `-q` config doesn't emit a totals line. Switched to exit codes, and added an assertion that each patch actually applied.

Side note: the refactor left `import socket` unused, and `ruff check --no-fix` is the only reason I saw it — under CI's current invocation it would have been auto-fixed in the runner and gone green with the import still on `main`. That's #149, fixed separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)