### PR TITLE
fix(ci): make the lint gate able to fail

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,8 +40,11 @@ jobs:
           black --check src/ tests/
 
       - name: Run Ruff linter
+        # --no-fix is belt-and-braces: pyproject no longer sets `fix = true`, and
+        # this makes the gate report violations regardless of what the config says.
+        # A linter that repairs its findings in the runner and exits 0 is not a gate.
         run: |
-          ruff check src/ tests/
+          ruff check --no-fix src/ tests/
 
       - name: Run MyPy type checker
         run: |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -338,8 +338,13 @@ exclude = [
     "examples"
 ]
 
-# Enable fixing issues automatically when possible
-fix = true
+# Deliberately NOT `fix = true`. That setting applies to plain `ruff check`, not
+# just `ruff check --fix`, so `ruff check` stopped meaning "check": it rewrote
+# every auto-fixable violation and exited 0. In CI that made the lint gate unable
+# to fail -- the fix was applied inside the runner, thrown away with it, and the
+# violation stayed on main. Only rules with no auto-fix could ever go red.
+# Fixing is still one flag away: `ruff check --fix`, which the pre-commit hook
+# passes explicitly.
 
 [tool.ruff.lint]
 select = [

--- a/tests/unit/test_lint_gate.py
+++ b/tests/unit/test_lint_gate.py
@@ -1,0 +1,58 @@
+"""The lint gate must be able to fail.
+
+``fix = true`` in ``[tool.ruff]`` applies to plain ``ruff check``, not just
+``ruff check --fix``. With it set, CI's ``ruff check src/ tests/`` rewrote every
+auto-fixable violation inside the runner and exited 0: the job went green, the
+repair was discarded with the runner, and the violation stayed on ``main``. Only
+rules with no auto-fix -- a small minority -- could ever turn the gate red.
+
+That is the same shape as every other vacuous pass this project has found: a
+green produced by not measuring rather than by measuring well. It is worth a
+test because the setting is a one-line, entirely reasonable-looking convenience
+that would be easy to reintroduce, and because nothing else in the suite would
+notice if it came back.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+if sys.version_info >= (3, 11):
+    import tomllib
+else:  # pragma: no cover - exercised only on 3.10
+    import tomli as tomllib
+
+pytestmark = pytest.mark.unit
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+PYPROJECT = REPO_ROOT / "pyproject.toml"
+CI_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "ci.yml"
+
+
+def _ruff_config() -> dict:
+    with PYPROJECT.open("rb") as handle:
+        return tomllib.load(handle).get("tool", {}).get("ruff", {})
+
+
+def test_ruff_does_not_autofix_by_default() -> None:
+    """``ruff check`` must report, not repair."""
+    assert _ruff_config().get("fix") is not True, (
+        "`fix = true` makes plain `ruff check` rewrite violations and exit 0, "
+        "so the CI lint job cannot fail. Use `ruff check --fix` when you want "
+        "the repair."
+    )
+
+
+@pytest.mark.skipif(not CI_WORKFLOW.exists(), reason="CI workflow not present in this checkout")
+def test_ci_lints_with_no_fix() -> None:
+    """The gate should not depend on the config staying correct."""
+    workflow = CI_WORKFLOW.read_text(encoding="utf-8")
+
+    invocations = [line.strip() for line in workflow.splitlines() if line.strip().startswith("ruff check")]
+
+    assert invocations, "no `ruff check` invocation found in ci.yml"
+    for invocation in invocations:
+        assert "--no-fix" in invocation, f"CI lint invocation can be silenced by config: {invocation!r}"


### PR DESCRIPTION
Fixes #149.

## The defect

`fix = true` in `[tool.ruff]` applies to plain `ruff check`, not just `ruff check --fix`. CI runs `ruff check src/ tests/`, so any auto-fixable violation was **rewritten inside the runner and the job exited 0** — green build, repair discarded with the runner, violation still on `main`. Only rules with no auto-fix could ever turn the gate red, which is why #142's `D301` surfaced while nothing else did.

## Verified, not argued

A file whose only violation is `I001`:

```console
$ ruff check src/ tests/unit/test_zz_probe.py
Found 1 error (1 fixed, 0 remaining).
$ echo $?
0
```

…and the file on disk came back reordered. The same file under `--no-fix` exits **1** and is left alone.

## Two changes, because they fail independently

1. **Drop `fix = true`.** This is the actual defect — it makes the *verb* lie for every invocation anywhere, not just CI's. The issue also notes it dirties the working tree on each local run. Fixing is still one flag away, and the pre-commit hook already passes `--fix` explicitly, so local ergonomics are unchanged.
2. **Pass `--no-fix` in CI anyway,** so the gate reports violations regardless of what the config later says.

## The ratchet

`tests/unit/test_lint_gate.py` pins both. The setting is a one-line, entirely reasonable-looking convenience that would be easy to reintroduce, and nothing else in the suite would notice if it came back. **Both tests were run against the reintroduced defect and both go red.**

## Note on the issue's second half

#149 also asked to "land the pending `I001` fix on `main`" — that violation is already gone; `ruff check --no-fix src/ tests/` is clean as of this commit, so nothing was hiding behind the old behaviour.

This paid for itself immediately: while working #191 I left an `import socket` unused, and `--no-fix` is the only reason I saw it rather than shipping it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)