### PR TITLE
chore(release): prepare 1.10.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.10.1] - 2026-07-27
+
+A maintenance release. Almost all of it is infrastructure — the harnesses this
+project already had are now wired to CI as blocking gates — but wiring them up
+surfaced one real conversion bug, which is the reason to take the release.
+
 ### Added
 
 - **GitHub Action: a conversion-quality gate.** `action.yml` at the repository root
@@ -32,6 +38,45 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   The action lives in this repository rather than a separate one so `@v1.10.1` installs
   all2md 1.10.1: the gate's verdict is the library's score, so the two versions must not
   drift. See `docs/source/github_action.rst`.
+
+### Fixed
+
+- **Prose containing a `|` is no longer swallowed into a table.** mistune's
+  `_process_thead` never checks that the second line of a candidate table is a
+  delimiter row — it matches each cell against the three alignment patterns and
+  falls back to "no alignment" for anything else — so *any* line with the same
+  number of pipe-separated cells as the line above it was accepted as the
+  delimiter and then consumed. Two ordinary sentences that each happened to
+  contain a pipe became a two-column table, and **the second line was deleted
+  outright**. So did two fully-piped rows written without a delimiter, and two
+  lines whose pipes sat inside code spans (whose backticks were mangled on the
+  way through). A delimiter row is now required, per GFM, which is where the loss
+  stops. Found by the new quality-gate action, which scored a table-free
+  `CHANGELOG.md` as containing a table — the metric was right and the code was
+  wrong (#177).
+- CI: **the lint gate could not fail.** `fix = true` in `[tool.ruff]` applies to plain
+  `ruff check`, not just `ruff check --fix`, so CI rewrote every auto-fixable violation
+  inside the runner and exited 0 — green build, repair discarded with the runner,
+  violation still on `main`. Only rules with no auto-fix could ever turn it red. The
+  setting is gone and CI passes `--no-fix`; a test pins both (#149).
+- Benchmarks: a failed corpus download is no longer cached as an empty result. An empty
+  `_index.json` reads back as a valid cache hit, so one transient network failure zeroed
+  a source out permanently on any machine that keeps the cache. Found when a DNS blip
+  reduced the corpus to 50 documents and the run still exited 0.
+- Benchmarks: the two large corpus archives (Enron, ~423 MB; govdocs1, ~250 MB) now get
+  a **bounded** retry with backoff. Exhausting it still fails loudly — the retry buys
+  tolerance for flakiness, never silence about failure — and a 404 is not retried at all
+  (#182).
+- Benchmarks: a corpus source that yields **none** of a format its `corpus.toml` entry
+  requests now says so, instead of quietly covering a narrower format mix than the
+  manifest advertises (#181).
+- Tests: `pytest -m unit` works again. `tests/performance/conftest.py` overwrote
+  `markexpr` in `pytest_configure`, silently discarding any `-m` — the documented fast
+  path collected 7997 tests instead of 3857. CI never noticed because it passes no `-m`.
+- Tests: `TestSplitCLIE2E` no longer races under parallel workers. It used a fixed
+  directory under the project root, so concurrent xdist workers collided in it and a
+  crashed run left the directory behind. Thanks [@rkfshakti](https://github.com/rkfshakti)
+  (#185, #187).
 
 ### Changed
 
@@ -67,6 +112,35 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   raw milliseconds and milliseconds relative to the same run's bare interpreter — and
   goes red only when both agree, which is what separates a real regression from a
   runner that landed on a faster or slower CPU class.
+- CI: a weekly `Corpus Fidelity Gate` (also on dispatch) converts the corpus benchmark's
+  reproducible half and compares the **failure set** — which documents fail, by name —
+  against `benchmarks/corpus/corpus_baseline.json`. Only the two sources whose sample is
+  fixed across cold runs are gated; arxiv and POI resolve against upstream state that
+  moves, so a baseline would report document-mix churn as a regression. The recorded
+  baseline converts 100/100 gated documents, so its accepted-failure list is empty. A
+  short corpus is also a failure, which is what caught the download bug above.
+- CI: a `Format Benchmarks` job converts the small per-format fixtures across the dozen
+  formats the corpus gate cannot reach (it covers PDF and email only). It gates on
+  **conversion, not on time**: these fixtures run in 5–885 ms, and gating a 5 ms
+  measurement needs a variance study on these runners first. Timings are recorded to an
+  artifact, which is what such a study would be built from.
+- `tests/performance` is kept but disarmed. Its seven absolute ceilings had 106×–1170×
+  headroom on CI and its other seventeen assertions were `mean_time > 0`, true by
+  construction — so nothing there could ever have failed, and nothing had ever run it,
+  because a bare `pytest tests/` deselects `benchmark`. What is checked now is that every
+  format still converts to something non-empty: deterministic, and unable to flake.
+- Docs: `performance.rst` no longer reports throughput figures that came from no harness.
+  The old table gave pages/sec, a unit the benchmarks have never produced, beside one row
+  in MB/sec — measured and invented numbers side by side, which launders the invented
+  ones. They are replaced by figures that name their source, and by the advice to measure
+  your own corpus. It also documented PubMed Central as a live corpus source with runnable
+  commands, though `[sources.pmc]` is commented out, and described the Apache POI sample
+  as stable when `ref = trunk` is a moving branch. Adds the startup-cost section the page
+  never had (#180).
+- CI: bumped `actions/setup-python` 6 → 7 and `actions/download-artifact` 7 → 8 (#188,
+  #189). Created the `dependencies`, `github-actions` and `python` labels that
+  `dependabot.yml` had always referenced but that never existed on the repository, so
+  Dependabot could not apply them.
 
 ## [1.10.0] - 2026-07-24
 
@@ -77,19 +151,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   (`<ins>`), or `ignore` (#113).
 
 ### Fixed
-
-- **Prose containing a `|` is no longer swallowed into a table.** mistune's
-  `_process_thead` never checks that the second line of a candidate table is a
-  delimiter row — it matches each cell against the three alignment patterns and
-  falls back to "no alignment" for anything else — so *any* line with the same
-  number of pipe-separated cells as the line above it was accepted as the
-  delimiter and then consumed. Two ordinary sentences that each happened to
-  contain a pipe became a two-column table, and **the second line was deleted
-  outright**. So did two fully-piped rows written without a delimiter, and two
-  lines whose pipes sat inside code spans (whose backticks were mangled on the
-  way through). A delimiter row is now required, per GFM, which is where the
-  loss stops. Found by the new quality-gate action, which scored a table-free
-  `CHANGELOG.md` as containing a table.
 
 - **OCR'd PDF pages with links no longer crash conversion.** OCR-synthesized text
   spans omitted the `bbox` key that every real PyMuPDF span carries. On a page
@@ -1365,7 +1426,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - NumPy-style docstrings
 - Modular architecture with clear separation of concerns
 
-[Unreleased]: https://github.com/thomas-villani/all2md/compare/v1.10.0...HEAD
+[Unreleased]: https://github.com/thomas-villani/all2md/compare/v1.10.1...HEAD
+[1.10.1]: https://github.com/thomas-villani/all2md/releases/tag/v1.10.1
 [1.10.0]: https://github.com/thomas-villani/all2md/releases/tag/v1.10.0
 [1.9.0]: https://github.com/thomas-villani/all2md/releases/tag/v1.9.0
 [1.8.2]: https://github.com/thomas-villani/all2md/releases/tag/v1.8.2

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -6,13 +6,22 @@
 Legend: 🌱 natural next step · 🚀 ambitious · 🌙 moonshot · ✅ foundation already exists
 · 🚢 **shipped**
 
-**Status (2026-07-16).** The headline Theme 1 item — `all2md chunk` — is shipped, along with
+**Status (2026-07-27).** The headline Theme 1 item — `all2md chunk` — is shipped, along with
 mermaid/syntax highlighting in `view`/`serve` and one-click `uv` install scripts. The
 **Fidelity & Trust** batch landed in **v1.9.0**: the conversion cache, the confidence report
 (`all2md report`), DOCX character-style round-tripping, round-trip fidelity scoring
 (`all2md roundtrip`), and its capstone the conversion optimizer (`all2md optimize`). Shipped
-items are marked 🚢 inline below. The **next batch** is *Quality & Speed Ratchets* — see
-*Suggested sequencing*.
+items are marked 🚢 inline below.
+
+The **Quality & Speed Ratchets** batch landed in **v1.10.1**. Bet 1 below is now done: all
+three harnesses are wired to CI as blocking gates against committed baselines, cold start
+dropped ~28%, and the gate is pointed outward as a reusable GitHub Action. The lesson worth
+carrying forward is that **every one of those instruments already contained a vacuous pass**
+— a green produced by not measuring rather than by measuring well — and that finding them
+required demonstrating each gate red against deliberately-broken code before trusting it.
+Wiring the gates up is also what surfaced a silent data-loss bug in the Markdown parser.
+
+The **next batch is not yet chosen.** Bets 2 and 3 are now evaluable, which was the point.
 
 ---
 
@@ -26,10 +35,9 @@ scale to handle real corpora.
 
 Three bets stand out as highest-leverage:
 
-1. **A quality & speed ratchet** — we have three good benchmark harnesses (`corpus`,
-   `roundtrip`, `startup`) and automation on none of them. Making a regression *fail* is
-   cheaper than building anything new, and it is the precondition for honestly evaluating
-   bets 2 and 3 — every large item left in Theme 2 is currently unevaluable. See **Theme 2**.
+1. 🚢 **A quality & speed ratchet** — *shipped (v1.10.1).* All three benchmark harnesses
+   (`corpus`, `roundtrip`, `startup`) now gate CI against committed baselines, which was
+   the precondition for honestly evaluating bets 2 and 3. See **Theme 2**.
 2. **Positional fidelity** — OCR geometry → node-level provenance → layout-aware PDF. The
    single thread that makes RAG citations real; see **Theme 8**.
 3. **Async + scale** — unblocks the server/MCP story we've already started.
@@ -140,22 +148,32 @@ People star us because "it just converted my gnarly PDF perfectly." Protect and 
 - 🚀 **Math everywhere** — emit LaTeX from DOCX (OMML→LaTeX), PDF equation regions,
   HTML MathML, and (optionally) images of equations via OCR. Huge for academic/technical
   users and a natural pairing with the existing arxiv packager.
-- 🌱 **The ratchet: automate the harnesses we already built.** *This is the next batch.* We do
-  not need to *build* a benchmark; we have three good ones and **automation on none of them**:
-  - `benchmarks/corpus/` — throughput over ~160 real arxiv/govdocs1/POI/Enron docs
-    (🚢 v1.1.1). One **manual-dispatch** CI workflow. Results are gitignored, so cross-run
-    comparison is local-only and by hand.
-  - `benchmarks/roundtrip/` — MD→AST→MD fidelity, two independent oracles (🚢 v1.9.0).
-    **No CI job at all.** Exits non-zero on oracle failure, so it is gate-ready today.
-  - `benchmarks/startup.py` — cold start, fresh interpreter per sample. **No CI job**,
-    despite its own docstring calling it "the guard for the startup wins... so they can't
-    silently regress." The wins landed; the guard never ran.
+- 🚢 **The ratchet: automate the harnesses we already built.** *Shipped (v1.10.1).* The
+  diagnosis was that we did not need to *build* a benchmark — we had three good ones and
+  automation on none of them. All three now gate:
+  - `benchmarks/roundtrip/` — MD→AST→MD fidelity, two independent oracles (🚢 v1.9.0). Now
+    a **blocking gate** on every push and PR, with an `EXPECTED_FAILURES` allowlist where an
+    entry that starts passing, or goes stale, is *also* red.
+  - `benchmarks/startup.py` — cold start. Now **two** gates, because the cost is milliseconds
+    but the cause is an import graph: an exact module-set assertion that cannot flake, and a
+    wall-clock job that requires raw and interpreter-normalized deltas to agree before going
+    red (a CPU-class shift in the runner pool moves only one).
+  - `benchmarks/corpus/` — now a **weekly** `Corpus Fidelity Gate` over the reproducible half
+    only, comparing the failure set by name. The other half resolves against upstream state
+    that moves, so gating it would report document-mix churn as a regression.
 
-  So: **we have measurement and no ratchet.** Nothing fails when quality or speed degrades.
-  `tests/performance` has ~24 timing assertions, but all are loose absolute ceilings
-  (`< 10.0`, `< 5.0`) that catch a hang, not a 2× regression — and they are skipped unless
-  `--benchmark` is passed, so they never run in CI anyway. Making regressions fail is cheaper
-  than any new feature here, and it is what makes the rest of this theme evaluable.
+  `tests/performance` is kept but disarmed: its ceilings had 106×–1170× headroom on CI and
+  its other assertions were true by construction, so it could never have failed — and never
+  ran, because a bare `pytest tests/` deselects `benchmark`. It is now a `Format Benchmarks`
+  job that gates on conversion rather than time, covering the dozen formats the corpus gate
+  cannot reach.
+
+  **What this actually taught us**, and the reason to distrust the next green: every one of
+  these instruments already contained a *vacuous pass* — including, it turned out, the lint
+  gate, where `fix = true` meant CI repaired violations in the runner and exited 0. The
+  transferable rule is to pair a sharp instrument with a noisy one, because each is blind
+  where the other sees, and to demonstrate every gate red against deliberately-broken code
+  before trusting it.
 - 🚀 **External ground truth** — *the headline metric, once the ratchet exists.*
   `roundtrip_report` (🚢) is **self-referential**: it proves we invert our own parsers, not
   that we read the document correctly. A garbled table round-trips perfectly. So the open
@@ -479,38 +497,39 @@ conversion-cache correctness 🚢, conversion optimizer 🚢 (the batch capstone
 round-trip asymmetries #70/#71/#72 🚢, and the Markdown round-trip losses 🚢 that the new
 `benchmarks/roundtrip` harness surfaced.
 
-Ordered by leverage-per-effort:
+**Shipped in the Quality & Speed Ratchets batch** (**v1.10.1**, 2026-07-27). Deliberately
+*invisible* — no API change, no new library feature — so it cut as a patch release:
 
-**Next batch — Quality & Speed Ratchets.** Deliberately *invisible*: no API change, no new
-library feature, so it cuts as a **patch release**. The theme is turning quality and speed
-into ratchets instead of vibes.
+1. 🚢 **The three harnesses now gate CI against committed baselines** — `corpus`,
+   `roundtrip`, `startup` (Theme 2). Regressions fail.
+2. 🚢 **Startup performance** — the scaling bug was real: `all2md.options` re-exports lazily
+   now, options modules 31 → 4, `import all2md` 230 → 162 ms and `--version` 246 → 178 ms on
+   CI. `performance.rst` is reconciled — the hand-authored tables are gone rather than
+   restated, and the startup work finally has a docs page.
+3. ⏸️ **Docker image — parked**, and worth recording why so it isn't revived by accident. Its
+   stated justification was to be the reproducible environment the ratchet compares in. That
+   turned out to be wrong: the corpus benchmark's reproducibility problem was its *manifest*
+   (arxiv queries live, POI tracks `trunk`), not the environment, so no amount of VM pinning
+   would have helped. It also cuts against the one-click `uv` install direction. **Do not
+   restart this without a fresh, container-specific justification.**
+4. 🚢 **GitHub Action, re-scoped** — shipped as a conversion-quality gate. Two deviations,
+   both forced by (3) being parked and both improvements: **composite, not Docker**
+   (`pip install all2md[all]` covers the deps that argued for a container), and **`action.yml`
+   at this repo's root, not a separate repo** — the gate's verdict *is* the library's score,
+   so an action that could version-drift from the library would silently redefine every
+   consumer's threshold. A Marketplace listing is a separate, public call and is **not** done.
 
-1. **Wire the three harnesses to committed baselines in CI** — `corpus`, `roundtrip`,
-   `startup` all exist and all are unautomated (Theme 2). Make regressions *fail*. This also
-   converts our recurring unpinned-dependency drift from a mystery red CI into a number that
-   moved.
-2. **Startup performance** — the ratchet's first customer, and a *scaling* bug rather than a
-   micro-opt: `all2md --version` eagerly imports **31 options modules**, so cold start is
-   O(number of formats) and gets worse every time Theme 4 succeeds. Then reconcile
-   `performance.rst`, whose two headline tables are hand-authored estimates from before the
-   harness existed — source them from a real run or delete them.
-3. **Docker image** — the reproducible, version-pinned environment the ratchet needs to be
-   comparable across machines *and* the shared building block for the Action and a future
-   hosted API (Theme 5). Bakes PyMuPDF/tesseract in once.
-4. **GitHub Action, re-scoped** — a **conversion-quality gate** built on the
-   `report --fail-under` / `roundtrip --fail-under` flags shipped in v1.9.0: fail the build
-   when document fidelity degrades. It is the same ratchet as (1), pointed outward, and it
-   falls out of (1)+(3) nearly free.
+**Remaining, ordered by leverage-per-effort.** With (1) shipped, (5) is now the cheap next
+step it was always predicted to be:
 
-**Then, in rough order:**
-
-5. **External ground truth** (Theme 2) — OmniDocBench as the headline score. Cheap *after*
-   the ratchet, because by then it is just another oracle in a working socket. Heed the
+5. **External ground truth** (Theme 2) — OmniDocBench as the headline score. Cheap *now that*
+   the ratchet exists, because it is just another oracle in a working socket. Heed the
    caveat the optimizer taught us: pick the metric by measuring that it *varies* across the
    corpus, not by assuming it does. Be prepared for it to say something we don't want to hear
    — finding that out before sinking a batch into Theme 8 is the entire point.
-6. **Theme 8 — positional fidelity** (OCR geometry → provenance → layout). The big bet, and
-   the one that is currently unevaluable, which is exactly why it sits behind (1) and (5).
+6. **Theme 8 — positional fidelity** (OCR geometry → provenance → layout). The big bet. It
+   was unevaluable, which is why it sat behind (1); (1) is now done, so (5) is the only thing
+   still standing between here and a defensible go/no-go on it.
 7. **Async facade + async I/O edge** — unblocks the server/MCP story (see the Async
    Architecture Decision); the deferred-asset-resolution phase is the user-visible win. Also
    a prerequisite for clean multi-worker training-corpus loading (Theme 1).

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -37,7 +37,7 @@ if str(SCRIPTS_PATH) not in sys.path:
 project = "all2md"
 copyright = "2025, Tom Villani, Ph.D."
 author = "Tom Villani, Ph.D."
-release = "1.10.0"
+release = "1.10.1"
 
 # -- General configuration ---------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration

--- a/mcpb/manifest.json
+++ b/mcpb/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": "0.4",
   "name": "all2md",
   "display_name": "all2md",
-  "version": "1.10.0",
+  "version": "1.10.1",
   "description": "Convert PDFs, Office files, HTML, email, and 40+ formats to Markdown and back, directly inside Claude.",
   "long_description": "all2md's built-in MCP server, packaged for one-click install. Lets AI assistants read and convert documents across 40+ formats via an AST-based conversion pipeline, render Markdown back out to PDF/DOCX/PPTX/EPUB/HTML/RST, and edit documents section-by-section. Read-only query tools let assistants search across a corpus (grep + keyword/BM25), diff two documents, and outline a document's headings. Includes smart source auto-detection (file path, data URI, base64, plain text), section extraction, and security controls (a user-chosen workspace folder, network off by default, and path validation).",
   "author": {

--- a/mcpb/pyproject.toml
+++ b/mcpb/pyproject.toml
@@ -7,10 +7,10 @@
 # [tool.bumpversion] config — do NOT hand-edit the version strings below.
 [project]
 name = "all2md-mcpb"
-version = "1.10.0"
+version = "1.10.1"
 requires-python = ">=3.10"
 dependencies = [
-    "all2md[mcp,pdf,pdf_render,docx,html,xlsx,pptx,epub,rst,markdown,odf]>=1.10.0",
+    "all2md[mcp,pdf,pdf_render,docx,html,xlsx,pptx,epub,rst,markdown,odf]>=1.10.1",
     # The search_documents MCP tool defaults to keyword (BM25) mode, which needs
     # rank-bm25. Depend on it directly rather than via the `search` extra: that
     # extra also pulls faiss-cpu and sentence-transformers for vector/hybrid

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "all2md"
-version = "1.10.0"
+version = "1.10.1"
 description = "Rapid, lightweight conversion of various document formats to markdown for LLMs"
 readme = "README.md"
 authors = [
@@ -470,7 +470,7 @@ skips = [
 ]
 
 [tool.bumpversion]
-current_version = "1.10.0"
+current_version = "1.10.1"
 parse = "(?P<major>\\d+)\\.(?P<minor>\\d+)\\.(?P<patch>\\d+)"
 serialize = ["{major}.{minor}.{patch}"]
 commit = true

--- a/src/all2md/__init__.py
+++ b/src/all2md/__init__.py
@@ -85,7 +85,7 @@ if sys.version_info < (3, 10):
         f"all2md requires Python 3.10 or later. You are using Python {sys.version_info.major}.{sys.version_info.minor}."
     )
 
-__version__ = "1.10.0"
+__version__ = "1.10.1"
 
 from typing import TYPE_CHECKING, Any
 

--- a/uv.lock
+++ b/uv.lock
@@ -61,7 +61,7 @@ wheels = [
 
 [[package]]
 name = "all2md"
-version = "1.10.0"
+version = "1.10.1"
 source = { editable = "." }
 dependencies = [
     { name = "platformdirs" },


### PR DESCRIPTION
Release prep. **Merge this, then tag `v1.10.1` on `main`.**

## One correction to my own work

The table-delimiter fix from #190 was filed under `## [1.10.0]` — a section that has already shipped. I anchored the edit on the first `### Fixed` heading without checking which release owned it. Moved to 1.10.1.

## The Unreleased section was materially incomplete

It recorded the roundtrip and cold-start gates but not: the corpus fidelity gate, the format benchmarks job, the disarming of `tests/performance`, either corpus download fix, the `pytest -m` conftest bug, the lint gate, or the docs work.

That matters more than usual here because this release is *entirely* internal — a changelog that omits the internals would have said almost nothing. All of it is now recorded, with [@rkfshakti](https://github.com/rkfshakti) credited for #187.

Cross-checked commit-by-commit against `git log v1.10.0..HEAD`; every one of the 26 commits is now represented or is a sub-step of an entry that is.

## Version bump

Done via the configured `bump-my-version` targets rather than by hand — **six** files carry the version:

`pyproject.toml` · `src/all2md/__init__.py` · `docs/source/conf.py` · `mcpb/manifest.json` · `mcpb/pyproject.toml` · `uv.lock`

The mcpb bundle and the `uv.lock` self-reference are the two a manual edit misses, and per the config's own comment a lock recording the previous version has shipped before (v1.8.1 shipped one saying 1.8.0). I started editing by hand, noticed the config, and redid it properly.

## ROADMAP

Bet 1 and the Theme 2 ratchet bullet flipped to 🚢 — both still described the pre-batch state ("**No CI job at all**"), which is now false. Suggested sequencing records what shipped and, importantly, **why R3/Docker was parked**: its stated justification was to be the reproducible environment the corpus gate compares in, and that premise died when the corpus's reproducibility problem turned out to be its *manifest* (arxiv queries live, POI tracks `trunk`), not its environment. Written down so it isn't revived by accident.

## Verification

| check | result |
|---|---|
| quality gate, `*.md` | 9/9 — CHANGELOG 100, ROADMAP 100, README 97 (#178, expected) |
| docs build | clean |
| `ruff check --no-fix` + `black --check` | clean |
| targeted unit tests | green |
| version consistency across all 6 carriers | 1.10.1 everywhere |

## Post-merge checklist

1. Tag `v1.10.1` on `main` — `release.yml` publishes on `workflow_run` success, so let CI go green first.
2. Close #179 if a CI run shows `CHANGELOG.md` at fidelity 100 (see my comment there).

🤖 Generated with [Claude Code](https://claude.com/claude-code)