### PR TITLE
docs(examples): add drop-in CI workflows for the conversion-quality gate

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -20,6 +20,7 @@ examples/
   web/        Web app serving Markdown (Flask)
   templates/  Custom output via Jinja2 templates
   plugins/    Writing your own parser/renderer/transform plugins
+  workflows/  GitHub Actions: conversion-quality gates for CI
 ```
 
 ## Start here
@@ -94,6 +95,21 @@ Real Claude calls need `pip install anthropic` and an `ANTHROPIC_API_KEY`.
 - `simpledoc-plugin/` -- a complete bidirectional format plugin (parser +
   renderer + options + tests). The template for adding a new format.
 - `watermark-plugin/` -- a transform plugin that watermarks document images.
+
+### `workflows/` -- conversion quality in CI
+
+Drop-in GitHub Actions workflows for the conversion-quality gate. See
+`workflows/README.md` for how the three fit together.
+
+- `calibrate-thresholds.yml` -- **start here.** Measures your real floor and
+  reports it without gating, so you don't guess a round number. A threshold that
+  *sounds* strict (80, say) usually has twenty points of dead headroom and can
+  never fire.
+- `docs-portability.yml` -- PR gate, pinned to an exact version so the only
+  variable is your documents.
+- `dependency-canary.yml` -- scheduled run against fixed fixtures on `latest`,
+  to catch upstream conversion regressions before you adopt them. Deliberately
+  never runs on your PRs.
 
 ---
 

--- a/examples/workflows/README.md
+++ b/examples/workflows/README.md
@@ -1,0 +1,104 @@
+# CI workflows -- conversion quality in GitHub Actions
+
+Copy-paste workflows for the [`all2md` conversion-quality
+gate](https://all2md.readthedocs.io/en/latest/github_action.html). Drop one into
+`.github/workflows/` in your own repository and adjust the paths.
+
+```
+examples/workflows/
+  calibrate-thresholds.yml   Start here -- measure your real floor before gating
+  docs-portability.yml       PR gate: your documents changed
+  dependency-canary.yml      Scheduled: your dependencies changed
+```
+
+## Start with calibration
+
+The threshold is the whole gate, and guessing it is the one mistake that
+produces a workflow which passes forever and looks like evidence of quality.
+Documents that convert well score 99-100, so a threshold of `80` -- which
+*sounds* strict -- has twenty points of dead headroom: conversion can degrade
+badly and the build stays green the entire way down.
+
+`calibrate-thresholds.yml` is a manual (`workflow_dispatch`) run that scores your
+documents and reports the floor **without gating on anything**. Run it once, read
+the number off the job summary, then paste that number into one of the gating
+workflows.
+
+Measure on CI, not locally. Scores are deterministic for a given interpreter and
+dependency set but not guaranteed across them, so a document can score
+differently on your laptop than on a runner from identical bytes.
+
+## Two workflows, opposite pinning strategies
+
+This is the part worth understanding before you copy anything. The two gating
+workflows answer different questions and are deliberately pinned in opposite
+directions.
+
+| | `docs-portability.yml` | `dependency-canary.yml` |
+| --- | --- | --- |
+| Trigger | pull request | schedule + dependency PRs |
+| `all2md-version` | **pinned exactly** | **`latest`** |
+| Turns red when | *your documents* regress | *upstream* regresses |
+| Blocks a merge | yes | no |
+
+**The PR gate is pinned** so the only variable is your documents. A pinned action
+tag gives a deterministic score, which is what makes a red build actionable:
+someone changed a document.
+
+**The canary floats to `latest`** on purpose, and runs on a schedule rather than
+on your PRs. This is where the gate earns its keep, because the failure it
+catches is otherwise invisible: a parser dependency ships a new version,
+extraction quietly degrades on two-column PDFs or nested tables, and nothing
+anywhere goes red. Your RAG index gets worse and someone notices in six weeks.
+
+Put differently: **this gate's value peaks when your dependencies change, not
+when your documents change.** A canary that fails tells you not to adopt the new
+version yet -- and because it never runs on a PR, it can never block a merge on
+something that isn't your fault.
+
+Running both is the point. Neither substitutes for the other.
+
+## Which check to use
+
+The two thresholds fail in different directions:
+
+- **`roundtrip-fail-under`** scores what survives a parse -> render -> parse
+  cycle. Sharp about structure, but blind to a construct dropped *consistently*:
+  if a feature vanishes on the way out and stays vanished on the way back in,
+  both sides agree and the score stays high.
+- **`report-fail-under`** scores confidence in the parse itself -- scanned pages,
+  OCR fallbacks, structural guesses. It catches "this document was never really
+  read", which round-tripping cannot see, at the cost of being a heuristic.
+
+Gate on both when the documents matter.
+
+If your documents are **already Markdown**, `roundtrip` is really a *portability*
+check: it tells you which constructs survive being processed by tooling. That is
+genuinely useful if you publish to several destinations, but it is not a
+statement about whether your documentation is good.
+
+## Treat the number as a ratchet
+
+When a document legitimately gets harder to convert, re-run calibration and
+re-record the floor deliberately. Do not nudge the threshold down to clear a red
+build -- that converts a working instrument into a decoration.
+
+## Without the Action
+
+Every one of these runs the same CLI you can run anywhere, including locally and
+on CI systems that aren't GitHub:
+
+```bash
+all2md roundtrip docs/*.md --fail-under 97
+all2md report inbox/*.pdf --fail-under 80
+```
+
+The Action adds a per-document summary table, step outputs, and scoring each
+document in its own process so it reports *every* failing file rather than
+stopping at the first.
+
+## See also
+
+- [Action documentation](https://all2md.readthedocs.io/en/latest/github_action.html)
+- `examples/cli/diff-in-ci.sh` -- semantic cross-format diffing as a CI gate
+- `examples/cli/vcs-converter/` -- keeping binary documents git-friendly

--- a/examples/workflows/calibrate-thresholds.yml
+++ b/examples/workflows/calibrate-thresholds.yml
@@ -1,0 +1,116 @@
+# Calibrate your gate thresholds -- run this BEFORE you add a gating workflow.
+#
+# Scores your documents and reports the floor without failing on anything. Read
+# the numbers off the job summary and paste them into docs-portability.yml or
+# dependency-canary.yml.
+#
+# Why this exists: the docs correctly tell you to measure your real floor rather
+# than guess a round number, but you cannot measure it from a gating workflow --
+# that needs the threshold you are trying to discover. This is the missing first
+# step. It uses the CLI directly rather than the Action, because the Action
+# refuses to run without a threshold (by design: a gate with nothing to compare
+# against is theatre).
+#
+# Run it from the Actions tab -> "Calibrate conversion thresholds" -> Run workflow.
+
+name: Calibrate conversion thresholds
+
+on:
+  workflow_dispatch:
+    inputs:
+      paths:
+        description: "Glob(s) to score, space-separated (e.g. 'docs/**/*.md README.md')"
+        required: true
+        default: "docs/**/*.md"
+
+permissions:
+  contents: read
+
+jobs:
+  calibrate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: actions/setup-python@v7
+        with:
+          python-version: "3.12"
+
+      - name: Install all2md
+        run: pip install --quiet "all2md[all]"
+
+      - name: Score documents
+        env:
+          # Passed through the environment rather than interpolated into the
+          # script body. A ${{ }} expression inside `run:` is substituted as raw
+          # text before bash sees it, so a crafted input could inject shell.
+          PATHS: ${{ inputs.paths }}
+        run: |
+          set -uo pipefail
+
+          # globstar makes '**' recursive; nullglob makes a non-matching pattern
+          # expand to nothing instead of to itself as a literal filename.
+          shopt -s globstar nullglob
+          # shellcheck disable=SC2086
+          files=( $PATHS )
+
+          if [ ${#files[@]} -eq 0 ]; then
+            echo "::error::No files matched: $PATHS"
+            exit 1
+          fi
+          echo "Scoring ${#files[@]} document(s)"
+
+          # No --fail-under anywhere: this run reports, it does not gate.
+          all2md roundtrip "${files[@]}" --json > roundtrip.json || true
+          all2md report    "${files[@]}" --json > report.json    || true
+
+      - name: Report the floor
+        run: |
+          python - <<'PY' >> "$GITHUB_STEP_SUMMARY"
+          import json, pathlib
+
+          def load(name):
+              raw = pathlib.Path(name).read_text(encoding="utf-8").strip()
+              if not raw:
+                  return []
+              data = json.loads(raw)
+              # One input yields an object; several yield an array.
+              return data if isinstance(data, list) else [data]
+
+          def table(rows, label):
+              print(f"### {label}\n")
+              if not rows:
+                  print("_No results._\n")
+                  return None
+              scored = [r for r in rows if isinstance(r.get("score"), int)]
+              print("| Document | Score | Band |")
+              print("| --- | --- | --- |")
+              for r in sorted(rows, key=lambda r: r.get("score") if isinstance(r.get("score"), int) else -1):
+                  score = r.get("score", "—")
+                  print(f"| `{r.get('input', '?')}` | {score} | {r.get('band', '—')} |")
+              print()
+              if not scored:
+                  return None
+              floor = min(r["score"] for r in scored)
+              worst = [r["input"] for r in scored if r["score"] == floor]
+              print(f"**Floor: {floor}** — set by `{worst[0]}`"
+                    + (f" and {len(worst) - 1} other(s)" if len(worst) > 1 else "") + "\n")
+              return floor
+
+          print("## Calibration\n")
+          rt = table(load("roundtrip.json"), "Round-trip fidelity")
+          rp = table(load("report.json"), "Conversion confidence")
+
+          print("### Thresholds to copy\n")
+          print("```yaml")
+          if rt is not None:
+              print(f"roundtrip-fail-under: {rt}")
+          if rp is not None:
+              print(f"report-fail-under: {rp}")
+          print("```\n")
+          print("Set the threshold **at** the floor, not below it. A threshold with ten or")
+          print("more points of headroom can never fire before the conversion is already broken.\n")
+          print("If a document scores far below the rest, fix or exclude that document rather")
+          print("than lowering the threshold for everything — one bad file should not set the")
+          print("floor for the whole corpus.")
+          PY

--- a/examples/workflows/dependency-canary.yml
+++ b/examples/workflows/dependency-canary.yml
@@ -1,0 +1,88 @@
+# Dependency canary -- catch upstream conversion regressions before you adopt them.
+#
+# This is where the gate earns its keep, because the failure it catches is
+# otherwise completely invisible. A parser dependency ships a new version,
+# extraction quietly degrades on two-column PDFs or nested tables, and nothing
+# anywhere turns red. Your RAG index gets worse and someone notices in six weeks.
+#
+# Two deliberate inversions of the PR gate (docs-portability.yml):
+#
+#   1. all2md-version: latest -- floats on purpose. The whole point is to detect
+#      upstream drift, so upstream must be the moving part.
+#   2. It never runs on your pull requests, so it can never block a merge on a
+#      regression that isn't yours. A red canary says "don't adopt yet", not
+#      "your change is bad".
+#
+# Point it at a small, stable set of *representative* documents -- the awkward
+# ones: a scanned page, a nested table, a two-column layout, a form. Fixtures
+# that never change are the ideal canary, because then the only thing that can
+# move the score is the library.
+
+name: Conversion canary
+
+on:
+  schedule:
+    # Mondays 06:00 UTC. Cron on GitHub is best-effort and can be delayed under
+    # load; this is a canary, not a deadline.
+    - cron: "0 6 * * 1"
+  pull_request:
+    paths:
+      # Also run on dependency bumps, so a Dependabot/Renovate PR that moves a
+      # parser gets scored before it merges.
+      - "requirements*.txt"
+      - "pyproject.toml"
+      - "uv.lock"
+      - "poetry.lock"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  canary:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: thomas-villani/all2md@v1.10.1
+        id: gate
+        with:
+          # Representative fixtures, not your whole corpus. This should be fast
+          # and the file set should be stable.
+          paths: |
+            tests/fixtures/canary/**/*.pdf
+            tests/fixtures/canary/**/*.docx
+
+          # Floats deliberately -- see the header.
+          all2md-version: latest
+
+          # Confidence in the parse itself: scanned pages, OCR fallbacks,
+          # structural guesses. This is the check that catches "this document
+          # was never really read", which round-tripping cannot see because a
+          # construct dropped consistently on both sides still scores high.
+          report-fail-under: 88
+
+          # Round-trip too: the two fail in different directions and neither
+          # substitutes for the other.
+          roundtrip-fail-under: 95
+
+      - name: Explain a red canary
+        if: failure()
+        run: |
+          cat >> "$GITHUB_STEP_SUMMARY" <<'EOF'
+
+          ---
+
+          ### A failure here is probably not your change
+
+          This job installs the **latest** all2md against a fixed set of fixtures,
+          so the documents did not move -- the library or one of its parsers did.
+
+          What to do:
+          1. Check the per-document table above for which fixture dropped.
+          2. Pin the previous version in your own pipeline until it is resolved.
+          3. Report it upstream with the fixture, if it looks like a regression.
+
+          Do **not** lower the threshold to clear this. The number is a ratchet;
+          lowering it turns a working instrument into a decoration.
+          EOF

--- a/examples/workflows/docs-portability.yml
+++ b/examples/workflows/docs-portability.yml
@@ -1,0 +1,59 @@
+# PR gate -- fail the build when a document stops converting cleanly.
+#
+# Answers "did *our documents* regress?", so everything else is held still: the
+# action tag is pinned exactly, which pins the all2md version with it, which
+# makes the score deterministic. A red build here means someone changed a
+# document, and that is what makes it worth blocking a merge on.
+#
+# For "did *upstream* regress?", see dependency-canary.yml -- that one floats to
+# latest on purpose and never blocks a PR.
+#
+# Get your thresholds from calibrate-thresholds.yml first. The numbers below are
+# placeholders and will be wrong for your corpus.
+
+name: Document quality
+
+on:
+  pull_request:
+    paths:
+      # Only run when documents actually change. Without this, the job installs
+      # all2md on every PR to spend two minutes confirming nothing moved.
+      - "docs/**"
+      - "README.md"
+      - ".github/workflows/docs-portability.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  quality:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      # Pinned exactly. @v1.10.1 installs all2md 1.10.1, because the gate's
+      # verdict *is* the library's score -- if the version could drift, your
+      # threshold would quietly change meaning underneath you.
+      - uses: thomas-villani/all2md@v1.10.1
+        id: gate
+        with:
+          paths: |
+            docs/**/*.md
+            README.md
+
+          # Round-trip fidelity: what survives parse -> render -> parse.
+          # On Markdown sources this is really a *portability* check -- it tells
+          # you which constructs survive being processed by tooling, which
+          # matters if you publish to more than one destination. It is not a
+          # statement about whether the writing is good.
+          roundtrip-fail-under: 97
+
+          # Narrow the extras to what your documents actually need. The default
+          # ('all') installs every format and is the bulk of this job's runtime.
+          extras: markdown
+
+      - name: Show the worst score
+        if: always()
+        run: |
+          echo "Checked ${{ steps.gate.outputs.files-checked }} document(s)"
+          echo "Worst fidelity: ${{ steps.gate.outputs.worst-fidelity }}"


### PR DESCRIPTION
Three copy-pasteable workflows for the GitHub Action, plus a README explaining how they fit together.

## Why

The gate documentation tells you to measure your real floor rather than guess a round number — but there was no way to do that from a workflow, because the Action refuses to run without the threshold you are trying to discover. `calibrate-thresholds.yml` closes that loop by driving the CLI directly: it scores, reports the floor and a copy-pasteable threshold block, and gates on nothing.

## The two gating workflows are pinned in opposite directions, on purpose

| | `docs-portability.yml` | `dependency-canary.yml` |
| --- | --- | --- |
| Trigger | pull request | schedule + dependency PRs |
| `all2md-version` | pinned exactly | `latest` |
| Turns red when | *your documents* regress | *upstream* regresses |
| Blocks a merge | yes | no |

The canary is where the gate earns its keep, because the regression it catches is otherwise invisible: a parser ships a new version, extraction quietly degrades, and nothing anywhere turns red. It never runs on pull requests, so it cannot block a merge on something that isn't yours.

## Notes

- All three YAML files parse (`yaml.safe_load`).
- `calibrate-thresholds.yml` passes its `paths` input through `env:` rather than interpolating `${{ }}` into the script body, since that substitutes as raw text before bash sees it.
- Verified `roundtrip`/`report` both support `--json` and `--fail-under`, and that the JSON carries `input`/`score`/`band`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)