### PR TITLE
fix(examples): correctness fixes in the vcs-converter example

### DIFF
--- a/examples/cli/vcs-converter/demo.py
+++ b/examples/cli/vcs-converter/demo.py
@@ -12,7 +12,7 @@ import tempfile
 from pathlib import Path
 
 from docx import Document as DocxDocument
-from docx.shared import Inches, Pt
+from docx.shared import Pt
 
 try:
     from vcs_converter import VCSConverter
@@ -28,14 +28,15 @@ def create_sample_docx(output_path: Path) -> None:
     ----------
     output_path : Path
         Where to save the document
+
     """
     doc = DocxDocument()
 
     # Add title
-    title = doc.add_heading("Sample Document for VCS Testing", 0)
+    doc.add_heading("Sample Document for VCS Testing", 0)
 
     # Add introduction
-    intro = doc.add_paragraph(
+    doc.add_paragraph(
         "This is a sample document created to demonstrate the VCS document "
         "converter. It contains various formatting elements to test the "
         "conversion process."
@@ -93,21 +94,22 @@ def demo_basic_conversion() -> None:
     print("=" * 70)
 
     with tempfile.TemporaryDirectory() as tmpdir:
-        tmpdir = Path(tmpdir)
+        # resolve() so short-path forms (Windows 8.3, symlinked /tmp) match
+        # the converter's resolved root.
+        tmpdir = Path(tmpdir).resolve()
 
         # Create sample document
         docx_path = tmpdir / "sample.docx"
         create_sample_docx(docx_path)
 
         # Initialize converter
-        converter = VCSConverter()
-        converter.markdown_dir = tmpdir / ".vcs-docs"
+        converter = VCSConverter(root=tmpdir)
 
         # Convert to markdown
         print("\nConverting to markdown...")
         md_path, metadata_path = converter.convert_to_markdown(docx_path)
 
-        print(f"\nGenerated files:")
+        print("\nGenerated files:")
         print(f"  - Markdown: {md_path}")
         print(f"  - Metadata: {metadata_path}")
 
@@ -137,7 +139,9 @@ def demo_batch_processing() -> None:
     print("=" * 70)
 
     with tempfile.TemporaryDirectory() as tmpdir:
-        tmpdir = Path(tmpdir)
+        # resolve() so short-path forms (Windows 8.3, symlinked /tmp) match
+        # the converter's resolved root.
+        tmpdir = Path(tmpdir).resolve()
 
         # Create multiple sample documents
         docs_dir = tmpdir / "docs"
@@ -150,16 +154,15 @@ def demo_batch_processing() -> None:
             create_sample_docx(doc_path)
 
         # Initialize converter
-        converter = VCSConverter()
-        converter.markdown_dir = tmpdir / ".vcs-docs"
+        converter = VCSConverter(root=tmpdir)
 
         # Batch convert
         print("\nScanning for documents...")
-        found_docs = converter.scan_repository(tmpdir)
+        found_docs = converter.scan_repository()
         print(f"Found {len(found_docs)} document(s)")
 
         print("\nBatch converting...")
-        converter.batch_convert(tmpdir)
+        converter.batch_convert()
 
         print("\nGenerated markdown files:")
         for md_file in converter.markdown_dir.rglob("*.vcs.md"):
@@ -173,15 +176,16 @@ def demo_bidirectional_conversion() -> None:
     print("=" * 70)
 
     with tempfile.TemporaryDirectory() as tmpdir:
-        tmpdir = Path(tmpdir)
+        # resolve() so short-path forms (Windows 8.3, symlinked /tmp) match
+        # the converter's resolved root.
+        tmpdir = Path(tmpdir).resolve()
 
         # Create original document
         original_docx = tmpdir / "original.docx"
         create_sample_docx(original_docx)
 
         # Initialize converter
-        converter = VCSConverter()
-        converter.markdown_dir = tmpdir / ".vcs-docs"
+        converter = VCSConverter(root=tmpdir)
 
         # Convert to markdown
         print("\nStep 1: Converting original DOCX to markdown...")
@@ -216,7 +220,9 @@ def demo_workflow_simulation() -> None:
     print("=" * 70)
 
     with tempfile.TemporaryDirectory() as tmpdir:
-        tmpdir = Path(tmpdir)
+        # resolve() so short-path forms (Windows 8.3, symlinked /tmp) match
+        # the converter's resolved root.
+        tmpdir = Path(tmpdir).resolve()
 
         # Setup repository structure
         repo_dir = tmpdir / "my-project"
@@ -230,8 +236,7 @@ def demo_workflow_simulation() -> None:
         create_sample_docx(doc_v1)
 
         # Initialize converter
-        converter = VCSConverter()
-        converter.markdown_dir = repo_dir / ".vcs-docs"
+        converter = VCSConverter(root=repo_dir)
 
         # Convert version 1
         print("Converting v1 to markdown...")

--- a/examples/cli/vcs-converter/pre-commit-hook.sh
+++ b/examples/cli/vcs-converter/pre-commit-hook.sh
@@ -1,45 +1,68 @@
 #!/bin/bash
 # Pre-commit hook for automatic document conversion
 #
-# This hook automatically converts binary documents (DOCX, PPTX, PDF) to
-# markdown before commit, making them git-friendly and easier to diff.
+# Converts staged binary documents (DOCX, PPTX, PDF) to markdown before commit,
+# making them git-friendly and easier to diff.
 #
 # Installation:
 #   cp pre-commit-hook.sh .git/hooks/pre-commit
 #   chmod +x .git/hooks/pre-commit
 
-set -e
+set -euo pipefail
 
-# Configuration
-CONVERTER_SCRIPT=".vcs-converter/vcs_converter.py"
-PYTHON="${PYTHON:-python}"
-BINARY_EXTENSIONS=("docx" "pptx" "pdf" "doc" "ppt")
+CONVERTER_SCRIPT="${CONVERTER_SCRIPT:-.vcs-converter/vcs_converter.py}"
 
-# Colors for output
+# Only formats all2md can parse. Legacy .doc/.ppt are deliberately absent:
+# they can never convert, so including them made this hook abort every commit
+# in any repository that contained one.
+BINARY_EXTENSIONS=("docx" "pptx" "pdf")
+
 RED='\033[0;31m'
 GREEN='\033[0;32m'
 YELLOW='\033[1;33m'
-NC='\033[0m' # No Color
+NC='\033[0m'
+
+# Resolve an interpreter rather than assuming `python` exists -- on many
+# systems (and most Linux distributions) only `python3` is on PATH.
+if [ -n "${PYTHON:-}" ]; then
+    :
+elif command -v python3 >/dev/null 2>&1; then
+    PYTHON=python3
+elif command -v python >/dev/null 2>&1; then
+    PYTHON=python
+else
+    echo -e "${RED}Error: no python interpreter found (set PYTHON=/path/to/python)${NC}"
+    exit 1
+fi
 
 echo "Running VCS document converter pre-commit hook..."
 
-# Check if converter script exists
 if [ ! -f "$CONVERTER_SCRIPT" ]; then
     echo -e "${RED}Error: VCS converter script not found at $CONVERTER_SCRIPT${NC}"
     exit 1
 fi
 
-# Get list of staged binary documents
-staged_binaries=()
-for ext in "${BINARY_EXTENSIONS[@]}"; do
-    while IFS= read -r file; do
-        if [ -n "$file" ]; then
-            staged_binaries+=("$file")
-        fi
-    done < <(git diff --cached --name-only --diff-filter=ACM | grep -i "\.$ext$" || true)
-done
+if ! "$PYTHON" -c "import all2md" >/dev/null 2>&1; then
+    echo -e "${RED}Error: all2md is not installed for $PYTHON${NC}"
+    echo "  pip install 'all2md[all]'"
+    exit 1
+fi
 
-# If no binary documents staged, exit successfully
+# Collect staged documents. -z plus a NUL-delimited read keeps paths with
+# spaces or non-ASCII characters intact.
+staged_binaries=()
+while IFS= read -r -d '' file; do
+    for ext in "${BINARY_EXTENSIONS[@]}"; do
+        shopt -s nocasematch
+        if [[ "$file" == *."$ext" ]]; then
+            staged_binaries+=("$file")
+            shopt -u nocasematch
+            break
+        fi
+        shopt -u nocasematch
+    done
+done < <(git diff --cached --name-only --diff-filter=ACM -z)
+
 if [ ${#staged_binaries[@]} -eq 0 ]; then
     echo -e "${GREEN}No binary documents to convert${NC}"
     exit 0
@@ -47,25 +70,36 @@ fi
 
 echo -e "${YELLOW}Found ${#staged_binaries[@]} binary document(s) to convert${NC}"
 
-# Convert each staged binary document
 conversion_failed=0
 for file in "${staged_binaries[@]}"; do
     echo "Converting: $file"
-    if ! $PYTHON "$CONVERTER_SCRIPT" to-md "$file"; then
+
+    # --staged converts what is about to be committed, not what happens to be
+    # on disk. With `git add -p` or an unstaged edit those differ, and
+    # converting the working tree would commit markdown describing content that
+    # was never committed.
+    if ! generated=$("$PYTHON" "$CONVERTER_SCRIPT" to-md "$file" --staged); then
         echo -e "${RED}Failed to convert: $file${NC}"
         conversion_failed=1
+        continue
     fi
+
+    # Stage exactly the files this conversion produced (the converter prints
+    # them on stdout), rather than blanket-adding the output directory and
+    # sweeping unrelated stale output into the commit.
+    while IFS= read -r path; do
+        # Strip a trailing CR: on Windows, Python's print() emits \r\n and the
+        # bare \r survives into the pathspec, so `git add` fails on a path that
+        # is plainly there.
+        path="${path%$'\r'}"
+        [ -n "$path" ] && git add -- "$path"
+    done <<< "$generated"
 done
 
-# Exit if any conversion failed
 if [ $conversion_failed -eq 1 ]; then
     echo -e "${RED}Some conversions failed. Commit aborted.${NC}"
     exit 1
 fi
-
-# Stage the generated markdown and metadata files
-echo "Staging generated markdown files..."
-git add .vcs-docs/ 2>/dev/null || true
 
 echo -e "${GREEN}Document conversion complete${NC}"
 exit 0

--- a/examples/cli/vcs-converter/vcs_converter.py
+++ b/examples/cli/vcs-converter/vcs_converter.py
@@ -1,31 +1,50 @@
 """Version Control System Document Converter.
 
-This module provides functionality to make binary documents (DOCX, PPTX, PDF)
-git-friendly by converting them to markdown for version control.
+Makes binary documents (DOCX, PPTX, PDF) git-friendly by maintaining parallel
+markdown versions alongside them, so ``git diff`` shows prose instead of
+``Binary files a/spec.docx and b/spec.docx differ``.
+
+This is the *committed sidecar* approach: the generated markdown is checked in.
+That is what makes ``git blame`` work and merge conflicts resolvable in text --
+which git's ``textconv`` cannot do -- at the cost of duplicated content in the
+repository. See README.md for when to prefer the alternatives.
 
 Features:
     - Convert binary formats to markdown for git tracking
-    - Preserve formatting metadata
-    - Bidirectional sync (markdown <-> binary)
-    - Batch processing
-    - Diff-friendly output
+    - Preserve structured metadata alongside each document
+    - Convert markdown back to a binary format (never in place by default)
+    - Batch processing with content-hash change detection
+    - Pre-commit hook integration that reads *staged* content
 """
 
 import argparse
 import fnmatch
+import hashlib
+import io
 import json
 import logging
 import shutil
+import subprocess
 import sys
 from pathlib import Path
 from typing import Any
 
 import all2md
+from all2md import roundtrippable_formats
 from all2md.ast import Document
 from all2md.ast.serialization import ast_to_dict
 
-logging.basicConfig(level=logging.INFO, format="%(levelname)s: %(message)s")
-logger = logging.getLogger(__name__)
+# Configure only this script's logger. Calling logging.basicConfig() would set
+# the level on the *root* logger and surface all2md's own INFO records
+# ("Starting pipeline execution", ...) in the middle of the hook's output.
+logger = logging.getLogger("vcs_converter")
+if not logger.handlers:
+    _handler = logging.StreamHandler()
+    _handler.setFormatter(logging.Formatter("%(levelname)s: %(message)s"))
+    logger.addHandler(_handler)
+logger.setLevel(logging.INFO)
+
+_HASH_CHUNK = 65536
 
 
 class VCSConverter:
@@ -35,16 +54,30 @@ class VCSConverter:
     ----------
     config_path : Path, optional
         Path to configuration file
+    root : Path, optional
+        Repository root that document paths are resolved against. Defaults to
+        the current working directory.
 
     """
 
-    BINARY_FORMATS = {".docx", ".pptx", ".pdf", ".doc", ".ppt"}
+    # Only formats all2md can actually parse. Legacy OLE formats (.doc, .ppt)
+    # are deliberately absent: listing them made `scan` advertise files that
+    # could never convert, and made the pre-commit hook abort *every* commit in
+    # any repository that contained one. Check `all2md list-formats` before
+    # adding to this set.
+    BINARY_FORMATS = {".docx", ".pptx", ".pdf"}
+
+    # Suffix -> all2md format name, used to ask the library what it can render.
+    SUFFIX_TO_FORMAT = {".docx": "docx", ".pptx": "pptx", ".pdf": "pdf"}
+
     MARKDOWN_SUFFIX = ".vcs.md"
     METADATA_SUFFIX = ".vcs.json"
 
-    def __init__(self, config_path: Path | None = None) -> None:
+    def __init__(self, config_path: Path | None = None, root: Path | None = None) -> None:
+        """Initialise the converter from *config_path*, resolving paths against *root*."""
         self.config = self._load_config(config_path)
-        self.markdown_dir = Path(self.config.get("markdown_dir", ".vcs-docs"))
+        self.root = (root or Path.cwd()).resolve()
+        self.markdown_dir = self.root / self.config.get("markdown_dir", ".vcs-docs")
         self.track_metadata = self.config.get("track_metadata", True)
 
     def _load_config(self, config_path: Path | None) -> dict[str, Any]:
@@ -66,6 +99,38 @@ class VCSConverter:
                 return json.load(f)
         return {}
 
+    def _relative_to_root(self, path: Path) -> Path:
+        """Return *path* relative to the configured root.
+
+        Resolving against ``self.root`` rather than ``Path.cwd()`` is what makes
+        ``--root`` and absolute paths work: keying off the working directory
+        meant any document outside it failed with an opaque ``relative_to``
+        error, which took out ``batch --root`` entirely.
+
+        Parameters
+        ----------
+        path : Path
+            Path to a document
+
+        Returns
+        -------
+        Path
+            Path relative to the root
+
+        Raises
+        ------
+        ValueError
+            If *path* lies outside the root
+
+        """
+        resolved = path.resolve()
+        try:
+            return resolved.relative_to(self.root)
+        except ValueError:
+            raise ValueError(
+                f"{resolved} is outside the repository root {self.root}. Pass --root to point at the repository."
+            ) from None
+
     def _get_markdown_path(self, binary_path: Path) -> Path:
         """Get the markdown path for a binary document.
 
@@ -80,9 +145,8 @@ class VCSConverter:
             Path where markdown should be stored
 
         """
-        relative = binary_path.relative_to(Path.cwd()) if binary_path.is_absolute() else binary_path
-        md_path = self.markdown_dir / relative.parent / (relative.stem + self.MARKDOWN_SUFFIX)
-        return md_path
+        relative = self._relative_to_root(binary_path)
+        return self.markdown_dir / relative.parent / (relative.stem + self.MARKDOWN_SUFFIX)
 
     def _metadata_path_for(self, md_path: Path) -> Path:
         """Metadata path for a generated markdown path.
@@ -122,13 +186,65 @@ class VCSConverter:
         """
         return self._metadata_path_for(self._get_markdown_path(binary_path))
 
-    def convert_to_markdown(self, binary_path: Path) -> tuple[Path, Path | None]:
+    @staticmethod
+    def _hash_bytes(data: bytes) -> str:
+        """Return the SHA-256 hex digest of *data*."""
+        return hashlib.sha256(data).hexdigest()
+
+    @staticmethod
+    def _hash_file(path: Path) -> str:
+        """Return the SHA-256 hex digest of the file at *path*."""
+        digest = hashlib.sha256()
+        with open(path, "rb") as f:
+            for chunk in iter(lambda: f.read(_HASH_CHUNK), b""):
+                digest.update(chunk)
+        return digest.hexdigest()
+
+    def _read_staged(self, binary_path: Path) -> bytes:
+        """Read a document's *staged* content from the git index.
+
+        The pre-commit hook must convert what is about to be committed, not what
+        happens to be on disk. With partial staging (``git add -p``) or an
+        unstaged edit, those differ, and converting the working tree silently
+        commits markdown describing content that was never committed.
+
+        Parameters
+        ----------
+        binary_path : Path
+            Path to the document
+
+        Returns
+        -------
+        bytes
+            Staged file content
+
+        Raises
+        ------
+        ValueError
+            If the path has no staged content
+
+        """
+        relative = self._relative_to_root(binary_path).as_posix()
+        result = subprocess.run(  # noqa: S603
+            ["git", "show", f":{relative}"],  # noqa: S607
+            capture_output=True,
+            cwd=self.root,
+            check=False,
+        )
+        if result.returncode != 0:
+            message = result.stderr.decode("utf-8", "replace").strip()
+            raise ValueError(f"No staged content for {relative}: {message}")
+        return result.stdout
+
+    def convert_to_markdown(self, binary_path: Path, staged: bool = False) -> tuple[Path, Path | None]:
         """Convert a binary document to markdown.
 
         Parameters
         ----------
         binary_path : Path
             Path to binary document
+        staged : bool
+            Read the content from the git index rather than the working tree
 
         Returns
         -------
@@ -136,35 +252,40 @@ class VCSConverter:
             Paths to created markdown and metadata files
 
         """
-        logger.info(f"Converting {binary_path} to markdown...")
+        suffix = binary_path.suffix.lower()
+        if suffix not in self.BINARY_FORMATS:
+            raise ValueError(f"Unsupported format '{suffix}'. Supported: {', '.join(sorted(self.BINARY_FORMATS))}")
+
+        logger.info(f"Converting {binary_path}{' (staged)' if staged else ''} to markdown...")
+
+        content = self._read_staged(binary_path) if staged else binary_path.read_bytes()
 
         md_path = self._get_markdown_path(binary_path)
         md_path.parent.mkdir(parents=True, exist_ok=True)
 
         # Parse to the AST once so we can both render markdown and capture
         # structured metadata from the same parse.
-        with open(binary_path, "rb") as f:
-            doc = all2md.to_ast(f, source_format=binary_path.suffix.lstrip("."))
+        doc = all2md.to_ast(io.BytesIO(content), source_format=suffix.lstrip("."))
 
         # Render the AST to markdown (text formats return a str).
         markdown_content = all2md.from_ast(doc, "markdown")
-        assert isinstance(markdown_content, str)
+        if not isinstance(markdown_content, str):  # pragma: no cover - defensive
+            raise TypeError(f"Expected markdown renderer to return str, got {type(markdown_content).__name__}")
 
-        # Extract metadata
         metadata = None
         if self.track_metadata:
-            metadata = self._extract_metadata(doc, binary_path)
+            metadata = self._extract_metadata(doc, binary_path, self._hash_bytes(content))
 
-        # Write markdown
         with open(md_path, "w", encoding="utf-8") as f:
             f.write(markdown_content)
 
-        # Write metadata if enabled
         metadata_path = None
-        if self.track_metadata and metadata:
+        if metadata:
             metadata_path = self._get_metadata_path(binary_path)
             with open(metadata_path, "w", encoding="utf-8") as f:
-                json.dump(metadata, f, indent=2)
+                # default=str so a stray datetime in document metadata degrades
+                # to a string rather than aborting the commit.
+                json.dump(metadata, f, indent=2, default=str)
 
         logger.info(f"Created: {md_path}")
         if metadata_path:
@@ -172,7 +293,7 @@ class VCSConverter:
 
         return md_path, metadata_path
 
-    def _extract_metadata(self, doc: Document, binary_path: Path) -> dict[str, Any]:
+    def _extract_metadata(self, doc: Document, binary_path: Path, source_hash: str) -> dict[str, Any]:
         """Extract metadata from document AST.
 
         Parameters
@@ -181,6 +302,8 @@ class VCSConverter:
             Document AST
         binary_path : Path
             Path to original binary document
+        source_hash : str
+            SHA-256 of the source bytes that produced this markdown
 
         Returns
         -------
@@ -188,31 +311,47 @@ class VCSConverter:
             Document metadata
 
         """
-        metadata = {
-            "source_file": str(binary_path),
-            "source_format": binary_path.suffix,
+        metadata: dict[str, Any] = {
+            # Stored root-relative so the sidecar stays valid in every clone,
+            # regardless of where the repository sits on disk.
+            "source_file": self._relative_to_root(binary_path).as_posix(),
+            "source_format": binary_path.suffix.lower(),
+            "source_sha256": source_hash,
             "ast_version": "1.0",
         }
 
-        # Extract document metadata if present
-        if hasattr(doc, "metadata") and doc.metadata:
+        if getattr(doc, "metadata", None):
             metadata["document_metadata"] = doc.metadata
 
-        # Store AST structure for perfect reconstruction
+        # Off by default on purpose: a serialised AST is a large, churn-heavy
+        # blob in a file whose entire point is to produce readable diffs.
         if self.config.get("store_ast", False):
             metadata["ast"] = ast_to_dict(doc)
 
         return metadata
 
-    def convert_to_binary(self, markdown_path: Path, output_path: Path | None = None) -> Path:
-        """Convert markdown back to binary format.
+    def convert_to_binary(
+        self,
+        markdown_path: Path,
+        output_path: Path | None = None,
+        in_place: bool = False,
+    ) -> Path:
+        """Convert markdown back to its original binary format.
+
+        By default this writes a *new* file next to the original
+        (``report.rebuilt.docx``) rather than overwriting it. Rendering markdown
+        back to DOCX/PDF/PPTX cannot restore what markdown never carried --
+        styles, images, layout, tracked changes, embedded objects -- so writing
+        over the source silently destroys it. Pass ``in_place`` to accept that.
 
         Parameters
         ----------
         markdown_path : Path
             Path to markdown file
         output_path : Path, optional
-            Output path for binary document
+            Explicit output path for the binary document
+        in_place : bool
+            Overwrite the original document instead of writing a copy
 
         Returns
         -------
@@ -220,7 +359,6 @@ class VCSConverter:
             Path to created binary document
 
         """
-        # Load metadata to determine target format
         metadata_path = self._metadata_path_for(markdown_path)
         if not metadata_path.exists():
             raise ValueError(f"No metadata found for {markdown_path}")
@@ -229,73 +367,44 @@ class VCSConverter:
             metadata = json.load(f)
 
         source_format = metadata.get("source_format", ".docx")
+        target = self.SUFFIX_TO_FORMAT.get(source_format)
+        if target is None:
+            raise ValueError(f"Unsupported target format: {source_format}")
+
+        # Ask the library what it can render rather than hardcoding a list. The
+        # previous hardcoded "PPTX not supported" outlived the renderer that
+        # made it untrue.
+        if target not in roundtrippable_formats():
+            raise ValueError(
+                f"all2md cannot render back to {target} in this installation. "
+                f"Run 'all2md list-formats' to see what is available."
+            )
+
+        source_file = Path(metadata["source_file"])
+        if not source_file.is_absolute():
+            source_file = self.root / source_file
 
         if output_path is None:
-            # Reconstruct original path
-            source_file = Path(metadata["source_file"])
-            output_path = source_file
+            if in_place:
+                output_path = source_file
+                logger.warning(
+                    f"Overwriting {output_path} in place. Formatting the markdown could not carry "
+                    f"(styles, images, layout, tracked changes) will be lost."
+                )
+            else:
+                output_path = source_file.with_name(f"{source_file.stem}.rebuilt{source_file.suffix}")
 
         logger.info(f"Converting {markdown_path} to {source_format}...")
 
-        # Read markdown
-        with open(markdown_path, encoding="utf-8") as f:
-            markdown_content = f.read()
-
-        # Convert based on target format
-        if source_format in {".docx", ".doc"}:
-            self._markdown_to_docx(markdown_content, output_path, metadata)
-        elif source_format == ".pdf":
-            self._markdown_to_pdf(markdown_content, output_path, metadata)
-        elif source_format in {".pptx", ".ppt"}:
-            logger.warning("PPTX conversion from markdown not yet implemented")
-            raise NotImplementedError("PPTX conversion not supported")
-        else:
-            raise ValueError(f"Unsupported target format: {source_format}")
+        markdown_content = markdown_path.read_text(encoding="utf-8")
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        all2md.from_markdown(markdown_content, target, output=str(output_path))
 
         logger.info(f"Created: {output_path}")
         return output_path
 
-    def _markdown_to_docx(self, markdown: str, output_path: Path, metadata: dict[str, Any]) -> None:
-        """Convert markdown to DOCX format.
-
-        Parameters
-        ----------
-        markdown : str
-            Markdown content
-        output_path : Path
-            Output path for DOCX file
-        metadata : dict[str, Any]
-            Document metadata
-
-        """
-        # Render markdown straight to DOCX (parse + render in one call).
-        output_path.parent.mkdir(parents=True, exist_ok=True)
-        all2md.from_markdown(markdown, "docx", output=str(output_path))
-
-    def _markdown_to_pdf(self, markdown: str, output_path: Path, metadata: dict[str, Any]) -> None:
-        """Convert markdown to PDF format.
-
-        Parameters
-        ----------
-        markdown : str
-            Markdown content
-        output_path : Path
-            Output path for PDF file
-        metadata : dict[str, Any]
-            Document metadata
-
-        """
-        # Render markdown straight to PDF (parse + render in one call).
-        output_path.parent.mkdir(parents=True, exist_ok=True)
-        all2md.from_markdown(markdown, "pdf", output=str(output_path))
-
-    def scan_repository(self, root_dir: Path | None = None) -> list[Path]:
-        """Scan repository for binary documents.
-
-        Parameters
-        ----------
-        root_dir : Path, optional
-            Root directory to scan
+    def scan_repository(self) -> list[Path]:
+        """Scan the repository root for binary documents.
 
         Returns
         -------
@@ -303,14 +412,11 @@ class VCSConverter:
             List of binary document paths
 
         """
-        if root_dir is None:
-            root_dir = Path.cwd()
-
         binary_docs = []
         exclude_dirs = {".git", ".vcs-docs", "venv", ".venv", "node_modules", "__pycache__"}
         exclude_patterns = self.config.get("exclude_patterns", [])
 
-        for path in root_dir.rglob("*"):
+        for path in self.root.rglob("*"):
             if any(excluded in path.parts for excluded in exclude_dirs):
                 continue
             # Honour user-supplied glob patterns (match the bare name and the
@@ -323,58 +429,81 @@ class VCSConverter:
 
         return binary_docs
 
-    def batch_convert(self, root_dir: Path | None = None, force: bool = False) -> None:
-        """Convert all binary documents in repository.
+    def _is_unchanged(self, doc_path: Path, md_path: Path) -> bool:
+        """Return True when *doc_path* already has up-to-date generated markdown.
+
+        Compares a stored content hash rather than modification times. Git does
+        not preserve mtimes, so after a clone every file carries its checkout
+        time in arbitrary order -- an mtime comparison would skip documents that
+        genuinely changed and reconvert ones that did not.
 
         Parameters
         ----------
-        root_dir : Path, optional
-            Root directory to scan
-        force : bool
-            Force reconversion even if markdown exists
+        doc_path : Path
+            Path to the binary document
+        md_path : Path
+            Path to its generated markdown
+
+        Returns
+        -------
+        bool
+            True if conversion can be skipped
 
         """
-        binary_docs = self.scan_repository(root_dir)
+        if not md_path.exists():
+            return False
+        metadata_path = self._metadata_path_for(md_path)
+        if not metadata_path.exists():
+            return False
+        try:
+            with open(metadata_path, encoding="utf-8") as f:
+                stored = json.load(f).get("source_sha256")
+        except (OSError, json.JSONDecodeError):
+            return False
+        return bool(stored) and stored == self._hash_file(doc_path)
 
+    def batch_convert(self, force: bool = False) -> int:
+        """Convert all binary documents under the repository root.
+
+        Parameters
+        ----------
+        force : bool
+            Force reconversion even if the markdown is up to date
+
+        Returns
+        -------
+        int
+            Number of documents that failed to convert
+
+        """
+        binary_docs = self.scan_repository()
         logger.info(f"Found {len(binary_docs)} binary document(s)")
 
+        failures = 0
         for doc_path in binary_docs:
-            md_path = self._get_markdown_path(doc_path)
-
-            # Skip if markdown exists and is newer (unless force)
-            if not force and md_path.exists():
-                if md_path.stat().st_mtime > doc_path.stat().st_mtime:
-                    logger.info(f"Skipping {doc_path} (already converted)")
-                    continue
-
+            if not force and self._is_unchanged(doc_path, self._get_markdown_path(doc_path)):
+                logger.info(f"Skipping {doc_path} (unchanged)")
+                continue
             try:
                 self.convert_to_markdown(doc_path)
             except Exception as e:
                 logger.error(f"Failed to convert {doc_path}: {e}")
+                failures += 1
 
-    def clean(self, root_dir: Path | None = None) -> None:
-        """Remove all generated markdown and metadata files.
+        return failures
 
-        Parameters
-        ----------
-        root_dir : Path, optional
-            Root directory
-
-        """
-        if root_dir is None:
-            root_dir = Path.cwd()
-
-        markdown_dir = root_dir / self.markdown_dir
-        if markdown_dir.exists():
-            logger.info(f"Removing {markdown_dir}...")
-            shutil.rmtree(markdown_dir)
+    def clean(self) -> None:
+        """Remove all generated markdown and metadata files."""
+        if self.markdown_dir.exists():
+            logger.info(f"Removing {self.markdown_dir}...")
+            shutil.rmtree(self.markdown_dir)
             logger.info("Cleaned all VCS markdown files")
         else:
             logger.info("No VCS markdown directory found")
 
 
 def main() -> int:
-    """Main entry point for VCS converter.
+    """Run the VCS converter command line interface.
 
     Returns
     -------
@@ -393,7 +522,10 @@ Examples:
   # Convert specific document
   python vcs_converter.py to-md document.docx
 
-  # Convert markdown back to binary
+  # Convert the *staged* version (what pre-commit hooks should do)
+  python vcs_converter.py to-md document.docx --staged
+
+  # Rebuild a binary alongside the original (document.rebuilt.docx)
   python vcs_converter.py to-binary .vcs-docs/document.vcs.md
 
   # Clean generated files
@@ -406,32 +538,34 @@ Examples:
         type=Path,
         help="Path to configuration file",
     )
+    parser.add_argument(
+        "--root",
+        type=Path,
+        help="Repository root that document paths resolve against (default: current directory)",
+    )
 
     subparsers = parser.add_subparsers(dest="command", help="Command to run")
 
-    # Batch convert command
     batch_parser = subparsers.add_parser("batch", help="Convert all binary documents")
-    batch_parser.add_argument(
-        "--root",
-        type=Path,
-        help="Root directory to scan",
-    )
     batch_parser.add_argument(
         "--force",
         action="store_true",
-        help="Force reconversion even if markdown exists",
+        help="Force reconversion even if the generated markdown is up to date",
     )
 
-    # To-markdown command
     to_md_parser = subparsers.add_parser("to-md", help="Convert binary to markdown")
     to_md_parser.add_argument(
         "file",
         type=Path,
         help="Binary document to convert",
     )
+    to_md_parser.add_argument(
+        "--staged",
+        action="store_true",
+        help="Convert the staged content from the git index rather than the working tree",
+    )
 
-    # To-binary command
-    to_binary_parser = subparsers.add_parser("to-binary", help="Convert markdown to binary")
+    to_binary_parser = subparsers.add_parser("to-binary", help="Convert markdown back to a binary format")
     to_binary_parser.add_argument(
         "file",
         type=Path,
@@ -440,24 +574,16 @@ Examples:
     to_binary_parser.add_argument(
         "--output",
         type=Path,
-        help="Output path for binary document",
+        help="Output path for the binary document (default: alongside the original, named *.rebuilt.*)",
+    )
+    to_binary_parser.add_argument(
+        "--in-place",
+        action="store_true",
+        help="Overwrite the original document. Destroys anything markdown could not carry.",
     )
 
-    # Clean command
-    clean_parser = subparsers.add_parser("clean", help="Remove all generated markdown files")
-    clean_parser.add_argument(
-        "--root",
-        type=Path,
-        help="Root directory",
-    )
-
-    # Scan command
-    scan_parser = subparsers.add_parser("scan", help="Scan for binary documents")
-    scan_parser.add_argument(
-        "--root",
-        type=Path,
-        help="Root directory to scan",
-    )
+    subparsers.add_parser("clean", help="Remove all generated markdown files")
+    subparsers.add_parser("scan", help="Scan for binary documents")
 
     args = parser.parse_args()
 
@@ -465,19 +591,24 @@ Examples:
         parser.print_help()
         return 1
 
-    converter = VCSConverter(args.config)
+    converter = VCSConverter(args.config, root=args.root)
 
     try:
         if args.command == "batch":
-            converter.batch_convert(args.root, args.force)
-        elif args.command == "to-md":
-            converter.convert_to_markdown(args.file)
+            return 1 if converter.batch_convert(args.force) else 0
+        if args.command == "to-md":
+            # Generated paths go to stdout (logs go to stderr) so the
+            # pre-commit hook can stage exactly these files instead of
+            # blanket-adding the whole output directory.
+            for path in converter.convert_to_markdown(args.file, staged=args.staged):
+                if path is not None:
+                    print(path)
         elif args.command == "to-binary":
-            converter.convert_to_binary(args.file, args.output)
+            converter.convert_to_binary(args.file, args.output, in_place=args.in_place)
         elif args.command == "clean":
-            converter.clean(args.root)
+            converter.clean()
         elif args.command == "scan":
-            docs = converter.scan_repository(args.root)
+            docs = converter.scan_repository()
             print(f"Found {len(docs)} binary document(s):")
             for doc in docs:
                 print(f"  - {doc}")


### PR DESCRIPTION
Five defects in the `vcs-converter` example, found by **running** it rather than reading it. Each fix is verified against a scratch git repository.

## 1. `to-binary` destroyed the original document

The default output path was the source file, so the invocation documented in the CLI epilog replaced a 44,171-byte DOCX with a 38,102-byte regeneration — no prompt, no backup, different md5. Rendering markdown back cannot restore what markdown never carried (styles, images, layout, tracked changes, embedded objects).

Now writes alongside the original as `*.rebuilt.*`. `--in-place` is an explicit opt-in that warns first.

## 2. The pre-commit hook converted the working tree, not the index

It selected paths with `git diff --cached` and then read them from disk. With `git add -p`, or any unstaged edit made while a commit was in flight, the committed markdown described content that was never committed — silently wrong history, which is precisely what the tool exists to prevent.

`to-md --staged` now reads the blob from the git index.

## 3. `.doc` / `.ppt` were advertised but unsupported

all2md parses neither (`all2md list-formats` has only `.docx`/`.pptx`). `scan` listed files that could never convert, and a single legacy `.doc` in a repository made the hook set `conversion_failed=1` and **abort every commit**, with no way out except editing the hook.

## 4. Paths resolved against the cwd

`_get_markdown_path` called `relative_to(Path.cwd())`, so an absolute path outside the working directory raised an opaque error and `batch --root` failed on every document it found. Paths now resolve against a configurable root; `--root` moved to the top-level parser so it applies uniformly.

## 5. Batch skipped on mtime

Git does not preserve mtimes, so after a clone every file carries its checkout time in arbitrary order — the comparison could skip a document that genuinely changed. Change detection now compares a SHA-256 stored in the sidecar metadata.

## Also

- The hardcoded `NotImplementedError("PPTX conversion not supported")` outlived the renderer that made it untrue; capability is now a `roundtrippable_formats()` lookup, so that class of staleness cannot recur.
- The hook resolves `python3` before `python`, and checks all2md is importable.
- The hook stages exactly the files each conversion produced (printed on stdout) instead of blanket-adding `.vcs-docs/`, which used to sweep stale output into unrelated commits.
- `basicConfig` no longer raises the **root** log level, which had been leaking all2md's internal INFO records into hook output.

## Verification

| Fix | Evidence |
| --- | --- |
| Non-destructive `to-binary` | original md5 `995c9bbf52` unchanged; `spec.rebuilt.docx` created |
| `--staged` | 3836 bytes from the index vs 1419 from the diverged worktree copy |
| Legacy `.doc` | `touch docs/legacy.doc && git commit` now succeeds |
| `--root` | 0 errors from an unrelated cwd, where it previously failed on every document |
| Content hash | 3 documents correctly skipped as unchanged on rerun |

`demo.py` runs all four demos clean. Two Windows-only bugs surfaced during testing and are fixed here: `print()` emits `\r\n`, and the bare `\r` corrupted the hook's `git add` pathspec; and `tempfile` returns an 8.3 short path (`THOMAS~1.VIL`) that no longer matched the converter's resolved root.

Also clears 7 pre-existing ruff findings in the two files touched, since pre-commit runs ruff on staged files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)