### PR TITLE
test(roundtrip): generative round-trip fuzzing across the format matrix

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -321,6 +321,67 @@ Available test markers (see `pytest.ini`):
 - Follow existing test patterns in the codebase
 - Use NumPy-style docstrings for test documentation
 
+### Property-Based Tests
+
+Tests marked `fuzzing` use [Hypothesis](https://hypothesis.readthedocs.io/) to
+generate inputs instead of hard-coding them. Run them like any other marker:
+
+```bash
+python -m pytest -m fuzzing
+```
+
+How many examples each test generates depends on the profile, which you select
+with the `HYPOTHESIS_PROFILE` environment variable (see `tests/conftest.py`):
+
+- `dev` (the default) runs 20 examples per test, fast enough to leave on while
+  you work.
+- `ci` runs 100 examples and prints each one.
+- `debug` runs 10 examples with verbose output, for when a failure is hard to
+  read.
+
+```bash
+HYPOTHESIS_PROFILE=ci python -m pytest -m fuzzing
+```
+
+To generate whole documents, compose the strategies in
+`tests/document_strategies.py` rather than building ASTs by hand:
+
+```python
+from hypothesis import given
+
+from document_strategies import documents
+
+
+@given(documents())
+def test_markdown_round_trips(doc):
+    assert roundtrip_report(doc, via="markdown").score == 100
+```
+
+`tests/unit/test_roundtrip_fuzzing.py` uses those strategies to push generated
+documents through every renderer and parser pair. It carries two allowlists,
+`KNOWN_CRASHES` and `KNOWN_INVARIANT_GAPS`, that record the asymmetries present
+today so the suite can tell an existing defect from one your change introduced.
+
+Its crash gates run with a fixed seed so they fail only when a change breaks
+something, never because a run happened to draw a shape that was already
+broken. That makes them a regression guard rather than a search. To search,
+ask for a random seed on purpose:
+
+```bash
+HYPOTHESIS_PROFILE=ci python -m pytest -m fuzzing --hypothesis-seed=random
+```
+
+If that finds a crash the allowlist does not name, you have found a real bug.
+Shrink it to a minimal document, add it to `KNOWN_CRASHES` with a reproduction,
+and open an issue.
+
+Both allowlists are ratchets, and they may only shrink. If a change of yours
+turns one of those tests red, the fix is the renderer or the parser, not the
+allowlist. Adding an entry means you are recording a new defect, so say what
+breaks and link the issue. Entries are marked `xfail(strict=True)`, so fixing an
+asymmetry turns its test into an `XPASS` and fails the run until you delete the
+entry. That is deliberate: it is how the list stays honest.
+
 ## Documentation
 
 ### Building Documentation

--- a/tests/document_strategies.py
+++ b/tests/document_strategies.py
@@ -1,0 +1,296 @@
+"""Hypothesis strategies that build ``Document`` ASTs.
+
+The round-trip scorer in :mod:`all2md.roundtrip` takes a ``Document`` directly,
+so generating ASTs lets a property test drive every renderer/parser pair from a
+single source of truth. That is the gap these strategies fill: the AST is the
+one input shape shared by all 24 round-trippable formats, and the fixture
+documents under ``tests/fixtures/`` only ever cover the shapes somebody thought
+to write down.
+
+Using it
+--------
+
+Compose ``documents()`` into a ``@given`` and round-trip the result::
+
+    from hypothesis import given
+    from document_strategies import documents
+
+    @given(documents())
+    def test_markdown_round_trips(doc):
+        assert roundtrip_report(doc, via="markdown").score == 100
+
+Every strategy takes a bound on how deep it may recurse, because an unbounded
+list-inside-list-inside-table generates documents that take longer to render
+than they do to shrink, and a slow shrink is what makes a property test
+unpleasant to own.
+
+Why the text alphabet is so narrow
+----------------------------------
+
+``safe_words()`` emits letters, digits and single spaces, and nothing else. It
+is tempting to generate ``|``, ``*`` and ``#`` too, on the theory that more
+adversarial text finds more bugs. It does, but they are all the *same* bug:
+"format X did not escape metacharacter Y". That class swamps the structural
+signal these strategies exist to measure, and it needs a different oracle
+anyway, one that knows each format's escaping rules rather than comparing block
+skeletons.
+
+So metacharacters live in their own opt-in strategy, :func:`metacharacter_text`.
+Use it when you are specifically testing escaping. Do not wire it into
+:func:`documents`, or the structural properties start failing for reasons that
+have nothing to do with structure.
+"""
+
+from hypothesis import strategies as st
+
+from all2md.ast.nodes import (
+    BlockQuote,
+    Code,
+    CodeBlock,
+    Document,
+    Emphasis,
+    Heading,
+    Image,
+    LineBreak,
+    Link,
+    List,
+    ListItem,
+    Paragraph,
+    Strikethrough,
+    Strong,
+    Table,
+    TableCell,
+    TableRow,
+    Text,
+    ThematicBreak,
+)
+
+#: Characters that carry no special meaning in any format we render to, so a
+#: round trip that loses them lost structure rather than an escape.
+SAFE_ALPHABET = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
+
+#: Metacharacters that at least one target format treats as syntax. Kept out of
+#: the default strategies on purpose -- see the module docstring.
+METACHARACTERS = "|*_#`~[]()<>&\\\"'{}$%^=+!?:;,.@/"
+
+
+def safe_words(min_words: int = 1, max_words: int = 4) -> st.SearchStrategy[str]:
+    """Return a strategy for plain text with no format metacharacters.
+
+    Words are joined by single spaces and never lead or trail with whitespace,
+    because leading and trailing whitespace is normalised by most renderers and
+    would make every property test fail for an uninteresting reason.
+    """
+    word = st.text(alphabet=SAFE_ALPHABET, min_size=1, max_size=8)
+    return st.lists(word, min_size=min_words, max_size=max_words).map(" ".join)
+
+
+def metacharacter_text() -> st.SearchStrategy[str]:
+    """Return a strategy for text that mixes safe words with format syntax.
+
+    Opt in to this only when the property under test is about escaping. It will
+    fail structural round-trip properties by design.
+    """
+    return st.text(alphabet=SAFE_ALPHABET + METACHARACTERS, min_size=1, max_size=24)
+
+
+def urls() -> st.SearchStrategy[str]:
+    """Return a strategy for absolute http(s) URLs.
+
+    Absolute only: relative URLs get resolved against a base by some renderers
+    and left alone by others, which is a real asymmetry but not one a structural
+    property should be asserting about.
+    """
+    host = st.text(alphabet="abcdefghijklmnopqrstuvwxyz", min_size=1, max_size=10)
+    path = st.text(alphabet="abcdefghijklmnopqrstuvwxyz0123456789", min_size=0, max_size=10)
+    return st.builds(lambda s, h, p: f"{s}://{h}.example.com/{p}", st.sampled_from(["http", "https"]), host, path)
+
+
+def text_nodes() -> st.SearchStrategy[Text]:
+    """Return a strategy for :class:`Text` leaves."""
+    return st.builds(Text, content=safe_words())
+
+
+def inline_nodes(max_depth: int = 2) -> st.SearchStrategy[object]:
+    """Return a strategy for inline nodes, nesting at most ``max_depth`` deep.
+
+    Depth matters here: ``Strong(Emphasis(Text))`` is the shape that PR #158
+    (bbcode dropping nested inlines when stripping colour) regressed on, so the
+    default allows one level of wrapping rather than none.
+    """
+    leaves = st.one_of(
+        text_nodes(),
+        st.builds(Code, content=safe_words(max_words=2)),
+        st.builds(Image, url=urls(), alt_text=safe_words(max_words=2)),
+        st.just(LineBreak()),
+    )
+    if max_depth <= 0:
+        return leaves
+
+    child = st.lists(inline_nodes(max_depth - 1), min_size=1, max_size=3)
+    return st.one_of(
+        leaves,
+        st.builds(Emphasis, content=child),
+        st.builds(Strong, content=child),
+        st.builds(Strikethrough, content=child),
+        st.builds(Link, url=urls(), content=child),
+    )
+
+
+def inline_content(min_size: int = 1, max_size: int = 4) -> st.SearchStrategy[list]:
+    """Return a strategy for a list of inline nodes, suitable as block content."""
+    return st.lists(inline_nodes(), min_size=min_size, max_size=max_size)
+
+
+def headings() -> st.SearchStrategy[Heading]:
+    """Return a strategy for headings at every legal level.
+
+    Levels run the full 1 to 6 because clamping above the AST maximum is its own
+    defect class: PR #155 fixed org emitting levels above six.
+    """
+    return st.builds(Heading, level=st.integers(min_value=1, max_value=6), content=inline_content())
+
+
+def paragraphs() -> st.SearchStrategy[Paragraph]:
+    """Return a strategy for paragraphs."""
+    return st.builds(Paragraph, content=inline_content())
+
+
+def code_blocks() -> st.SearchStrategy[CodeBlock]:
+    """Return a strategy for fenced code blocks, with and without a language."""
+    return st.builds(
+        CodeBlock,
+        content=st.lists(safe_words(), min_size=1, max_size=3).map("\n".join),
+        language=st.one_of(st.none(), st.sampled_from(["python", "rust", "text"])),
+    )
+
+
+def list_items(max_depth: int = 1) -> st.SearchStrategy[ListItem]:
+    """Return a strategy for list items, including deliberately empty ones.
+
+    ``children=[]`` is generated on purpose. An empty list item is the single
+    most-regressed shape in this project's history: PRs #160 (bbcode), #159
+    (mediawiki) and #119 (dokuwiki) all fixed a renderer that silently dropped
+    it. A strategy that only builds non-empty items cannot see that class.
+    """
+    body = st.lists(st.one_of(paragraphs(), code_blocks()), min_size=1, max_size=2)
+    if max_depth > 0:
+        body = st.lists(
+            st.one_of(paragraphs(), lists(max_depth - 1)),
+            min_size=1,
+            max_size=2,
+        )
+    return st.builds(
+        ListItem,
+        children=st.one_of(st.just([]), body),
+        task_status=st.one_of(st.none(), st.sampled_from(["checked", "unchecked"])),
+    )
+
+
+def lists(max_depth: int = 1) -> st.SearchStrategy[List]:
+    """Return a strategy for ordered and unordered lists.
+
+    ``start`` varies because an ordered list that does not begin at 1 is a
+    distinct defect class (PR #87 fixed HTML resetting ``<ol start="N">``), and
+    ``tight`` varies because loose lists collapse differently (PR #85).
+    """
+    return st.builds(
+        List,
+        ordered=st.booleans(),
+        items=st.lists(list_items(max_depth), min_size=1, max_size=3),
+        start=st.integers(min_value=1, max_value=5),
+        tight=st.booleans(),
+    )
+
+
+def table_cells(allow_span: bool = True) -> st.SearchStrategy[TableCell]:
+    """Return a strategy for table cells, including empty ones.
+
+    Empty cells are generated because a renderer that emits nothing for an empty
+    cell shifts every later cell left (PR #127, dokuwiki colspan).
+    """
+    span = st.integers(min_value=1, max_value=2) if allow_span else st.just(1)
+    return st.builds(
+        TableCell,
+        content=st.one_of(st.just([]), inline_content(max_size=2)),
+        colspan=span,
+        rowspan=span,
+    )
+
+
+def tables(allow_span: bool = True) -> st.SearchStrategy[Table]:
+    """Return a strategy for rectangular tables with an optional caption.
+
+    Rectangular means every row declares the same cell count, before spans are
+    applied. Ragged tables are a separate concern with a different oracle: the
+    scorer compares declared dimensions, so a ragged source is indistinguishable
+    from a round trip that lost a cell.
+
+    Captions vary because caption loss is its own class (PRs #157, #129, #132
+    all fixed mediawiki ``|+`` handling), and duplicate header labels are
+    generated because collapsing them loses a column (PRs #153, #137).
+    """
+
+    @st.composite
+    def _table(draw: st.DrawFn) -> Table:
+        width = draw(st.integers(min_value=1, max_value=3))
+        height = draw(st.integers(min_value=1, max_value=3))
+        labels = draw(
+            st.one_of(
+                st.lists(safe_words(max_words=1), min_size=width, max_size=width),
+                # Duplicate labels across every column.
+                safe_words(max_words=1).map(lambda w: [w] * width),
+            )
+        )
+        header = TableRow(
+            cells=[TableCell(content=[Text(content=label)]) for label in labels],
+            is_header=True,
+        )
+        rows = [TableRow(cells=[draw(table_cells(allow_span)) for _ in range(width)]) for _ in range(height)]
+        return Table(
+            header=header,
+            rows=rows,
+            caption=draw(st.one_of(st.none(), safe_words(max_words=3))),
+        )
+
+    return _table()
+
+
+def blocks(max_depth: int = 1) -> st.SearchStrategy[object]:
+    """Return a strategy for any block-level node."""
+    simple = st.one_of(
+        headings(),
+        paragraphs(),
+        code_blocks(),
+        st.just(ThematicBreak()),
+        lists(max_depth),
+        tables(),
+    )
+    if max_depth <= 0:
+        return simple
+    return st.one_of(
+        simple,
+        st.builds(BlockQuote, children=st.lists(blocks(max_depth - 1), min_size=1, max_size=2)),
+    )
+
+
+def documents(min_blocks: int = 1, max_blocks: int = 5) -> st.SearchStrategy[Document]:
+    """Return a strategy for whole documents.
+
+    The block count stays small by default. A 40-block document does not find
+    defects a 5-block document misses, it just makes the failing example harder
+    to read, and a property test is only as useful as the repro it prints.
+    """
+    return st.builds(Document, children=st.lists(blocks(), min_size=min_blocks, max_size=max_blocks))
+
+
+def documents_of(*strategies: st.SearchStrategy) -> st.SearchStrategy[Document]:
+    """Return a strategy for documents built only from ``strategies``.
+
+    Use this to aim a property at one node class, so a failure names that class
+    instead of whatever else happened to be in the document::
+
+        @given(documents_of(tables()))
+        def test_table_captions_survive(doc): ...
+    """
+    return st.builds(Document, children=st.lists(st.one_of(*strategies), min_size=1, max_size=3))

--- a/tests/unit/test_roundtrip_fuzzing.py
+++ b/tests/unit/test_roundtrip_fuzzing.py
@@ -1,0 +1,627 @@
+"""Generative round-trip fuzzing across the renderer/parser matrix.
+
+Why this file exists
+-------------------
+
+``all2md`` ships 24 formats that can be both rendered to and parsed back from,
+and the interesting defects live in the *pairs*: a renderer writes something its
+own parser cannot read, or reads back as a different shape. The existing fuzz
+suites (``test_filename_fuzzing``, ``test_url_validation_fuzzing``,
+``test_html_sanitizer_fuzzing``, ``test_pdf_html_edge_case_fuzzing``) all aim at
+security surfaces. Nothing generated documents and pushed them through the
+matrix, so the whole "renderer and parser disagree" class was only ever covered
+by fixture documents somebody had already thought to write.
+
+The AST is the natural input: :func:`all2md.roundtrip_report` accepts a
+``Document`` directly and scores what survived, so one strategy drives every
+format. ``tests/document_strategies.py`` builds those documents.
+
+How the gates work
+------------------
+
+Three gates, in increasing tightness:
+
+``test_ast_round_trip_is_lossless``
+    The ``ast`` format must score exactly 100 on every generated document. This
+    is the control. If it ever drops, the harness is measuring wrong and every
+    other number in this file is suspect.
+
+``test_no_unrecognised_crash``
+    No format may raise an exception that is not already in
+    :data:`KNOWN_CRASHES`. This is the ratchet that matters: a new renderer that
+    emits output its parser rejects fails here on the next CI run, instead of
+    surfacing as a user bug report months later.
+
+``test_structural_invariant``
+    Specific document shapes, each drawn from a defect this project has actually
+    shipped a fix for, must survive a round trip. Known gaps are marked
+    ``xfail(strict=True)`` rather than deleted, so fixing one turns it into an
+    XPASS and CI tells the contributor to remove the marker. The allowlist can
+    only shrink.
+
+Adding to the allowlists
+------------------------
+
+Do not widen an allowlist to make a red suite green. A new entry means a new
+defect, so it needs a comment saying what breaks and, once filed, the issue
+number. If a fix removes the last entry for a format, delete the entry rather
+than leaving it as documentation.
+"""
+
+import io
+
+import pytest
+from document_strategies import documents, documents_of, lists, tables
+from hypothesis import HealthCheck, given, settings
+from hypothesis import strategies as st
+
+from all2md import from_ast, roundtrip_report, roundtrippable_formats, to_ast
+from all2md.ast.nodes import (
+    CodeBlock,
+    Document,
+    Heading,
+    Link,
+    List,
+    ListItem,
+    Paragraph,
+    Table,
+    TableCell,
+    TableRow,
+    Text,
+)
+
+# --------------------------------------------------------------------------- #
+# Format groups
+# --------------------------------------------------------------------------- #
+
+#: Text formats, fast enough to round-trip inside a property test. Roughly
+#: 3-30 ms each, so the whole group costs well under a second per example.
+TEXT_FORMATS = (
+    "ast",
+    "markdown",
+    "html",
+    "rst",
+    "org",
+    "asciidoc",
+    "textile",
+    "mediawiki",
+    "dokuwiki",
+    "latex",
+    "plaintext",
+)
+
+#: Container and binary formats. Each writes a real archive or document, so they
+#: cost 4-90 ms and are exercised in a ``slow``-marked test rather than on every
+#: run.
+BINARY_FORMATS = ("docx", "odt", "odp", "pptx", "epub", "rtf", "ipynb", "pdf")
+
+#: Data-serialization formats, deliberately excluded from the matrix. They carry
+#: key-value data, not document structure, so "the heading did not survive" is
+#: their designed behaviour and not a defect. ``csv`` goes further and raises
+#: outright on a document with no table, which is also correct.
+DATA_FORMATS = ("csv", "ini", "json", "toml", "yaml")
+
+#: Formats whose round trip is expected to be exactly lossless.
+LOSSLESS_FORMATS = ("ast",)
+
+
+# --------------------------------------------------------------------------- #
+# Known crashes
+# --------------------------------------------------------------------------- #
+
+#: Exceptions the matrix currently raises, as ``(format, substring)``.
+#:
+#: Each entry is a live defect, not an accepted behaviour: a renderer emitting
+#: output its own parser rejects is always a bug. They are listed so the gate can
+#: distinguish "already known" from "newly introduced". Minimal reproductions for
+#: every entry are pinned in :class:`TestKnownCrashRepros` below.
+KNOWN_CRASHES: dict[tuple[str, str], str] = {
+    # The AsciiDoc renderer numbers nested list markers by absolute depth, so an
+    # ordered list inside an unordered item is written `..` with no `.` parent.
+    # AsciiDoc counts depth per list type, so its own parser rejects the output.
+    ("asciidoc", "Cannot nest to level"): "asciidoc renderer emits an orphaned level-2 list marker",
+    # Spanning cells that overflow the declared grid width reach python-docx as
+    # a merge whose target cell was never created.
+    ("docx", "no `tc` element"): "docx renderer merges spanning cells past the grid width",
+    # Same root shape, different downstream library.
+    ("pptx", "merged cells"): "pptx renderer re-merges cells that are already merged",
+    # An empty list item nested inside another list leaves the RTF renderer
+    # emitting a group the RTF parser walks off the end of.
+    ("rtf", "IndexError"): "rtf round trip of a nested empty list item indexes out of range",
+    # Same shape carrying a task status takes a different path and raises a bare
+    # KeyError, which also means the error escapes without being wrapped in
+    # ParsingError or RenderingError the way the API contract implies.
+    ("rtf", "KeyError"): "rtf round trip of a nested task list item raises an unwrapped KeyError",
+    # Nested links reach odfpy as <text:a> inside <text:a>, which ODF forbids.
+    # Not a generator artifact: browsers accept nested <a>, the HTML parser
+    # keeps the nesting, so `all2md page.html -t odt` fails on real pages.
+    ("odt", "IllegalChild"): "odt renderer emits nested text:a for a nested Link",
+    ("odp", "IllegalChild"): "odp renderer emits nested text:a for a nested Link",
+}
+
+
+def is_known(fmt: str, exc: BaseException) -> bool:
+    """Return whether ``exc`` from ``fmt`` is already on the allowlist."""
+    text = f"{type(exc).__name__}: {exc}"
+    return any(needle in text for (known_fmt, needle) in KNOWN_CRASHES if known_fmt == fmt)
+
+
+# --------------------------------------------------------------------------- #
+# Gate 0: coverage of the matrix itself
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.unit
+@pytest.mark.fuzzing
+class TestMatrixCoverage:
+    """The format groups above must account for every round-trippable format."""
+
+    def test_every_roundtrippable_format_is_classified(self) -> None:
+        """Every format is in exactly one group, so none escapes the fuzzer.
+
+        Without this, adding a 25th format silently opts it out of every gate in
+        this file: the groups are hand-written tuples, and nothing else would
+        notice the omission. Failing here forces a deliberate choice, either
+        "fuzz it" or "it is data, not documents, and here is why".
+        """
+        classified = TEXT_FORMATS + BINARY_FORMATS + DATA_FORMATS
+        assert len(classified) == len(set(classified)), "a format appears in more than one group"
+        assert set(classified) == set(roundtrippable_formats())
+
+
+# --------------------------------------------------------------------------- #
+# Gate 1: the control
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.unit
+@pytest.mark.fuzzing
+class TestLosslessFormatsAreLossless:
+    """The formats that claim exactness are the harness's control."""
+
+    @pytest.mark.parametrize("fmt", LOSSLESS_FORMATS)
+    @settings(deadline=None, suppress_health_check=[HealthCheck.too_slow])
+    @given(doc=documents())
+    def test_round_trip_scores_exactly_100(self, fmt: str, doc: Document) -> None:
+        """Property: a lossless format round trip loses nothing, ever.
+
+        ``ast`` is a direct JSON encoding of the node tree, so any loss is a bug
+        in the encoder, the decoder, or the scorer. This test is what makes the
+        other numbers in this file trustworthy: if it fails, a low score
+        elsewhere might be measurement error rather than a real asymmetry.
+        """
+        report = roundtrip_report(doc, via=fmt)
+        assert report.score == 100, f"{fmt} round trip lost structure: {[d.to_dict() for d in report.deltas]}"
+
+
+# --------------------------------------------------------------------------- #
+# Gate 2: the crash ratchet
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.unit
+@pytest.mark.fuzzing
+class TestNoUnrecognisedCrash:
+    """No format may fail in a way that is not already documented.
+
+    Both gates run ``derandomize=True``, so the examples are a fixed function of
+    the strategy rather than a fresh random draw each run. That is deliberate.
+    A ratchet has to fail only when someone breaks something, and a randomised
+    gate fails the first time it happens to draw a shape that was always broken,
+    which reads as a flaky test and trains people to re-run CI until it passes.
+
+    The cost is that these gates stop discovering new defects once the seed is
+    fixed. Discovery is a separate activity, run on purpose rather than on every
+    commit::
+
+        HYPOTHESIS_PROFILE=ci python -m pytest -m fuzzing --hypothesis-seed=random
+
+    Anything that finds belongs in :data:`KNOWN_CRASHES` with a reproduction.
+    """
+
+    @settings(
+        deadline=None,
+        max_examples=25,
+        derandomize=True,
+        suppress_health_check=[HealthCheck.too_slow],
+    )
+    @given(documents(), st.sampled_from(TEXT_FORMATS))
+    def test_text_formats_raise_nothing_new(self, doc: Document, fmt: str) -> None:
+        """Property: a text-format round trip either works or fails a known way.
+
+        Locks the current crash surface in place. A renderer change that makes
+        output its own parser cannot read fails here, which is the whole point:
+        that class of defect is invisible to fixture-based tests because nobody
+        writes a fixture for a shape they did not know was broken.
+        """
+        try:
+            roundtrip_report(doc, via=fmt)
+        except Exception as exc:  # noqa: BLE001 - the assertion is about the class
+            if not is_known(fmt, exc):
+                pytest.fail(f"new crash class for {fmt!r}: {type(exc).__name__}: {exc}")
+
+    @pytest.mark.slow
+    @settings(
+        deadline=None,
+        max_examples=10,
+        derandomize=True,
+        suppress_health_check=[HealthCheck.too_slow],
+    )
+    @given(documents(max_blocks=3), st.sampled_from(BINARY_FORMATS))
+    def test_binary_formats_raise_nothing_new(self, doc: Document, fmt: str) -> None:
+        """Property: the same guarantee for container and binary formats.
+
+        Split out and marked ``slow`` because each example writes a real archive
+        or PDF. Same gate, fewer examples, so a full run stays usable locally.
+        """
+        try:
+            roundtrip_report(doc, via=fmt)
+        except Exception as exc:  # noqa: BLE001 - the assertion is about the class
+            if not is_known(fmt, exc):
+                pytest.fail(f"new crash class for {fmt!r}: {type(exc).__name__}: {exc}")
+
+
+# --------------------------------------------------------------------------- #
+# Known-crash reproductions
+# --------------------------------------------------------------------------- #
+
+
+def _cell(text: str = "", **kwargs: object) -> TableCell:
+    """Build a table cell, empty when ``text`` is empty."""
+    return TableCell(content=[Text(content=text)] if text else [], **kwargs)  # type: ignore[arg-type]
+
+
+#: A table whose spanning cells overflow the declared grid width.
+SPANNING_GRID_OVERFLOW = Document(
+    children=[
+        Table(
+            header=TableRow(is_header=True, cells=[_cell("0"), _cell("0")]),
+            rows=[
+                TableRow(cells=[_cell(colspan=2, rowspan=2), _cell()]),
+                TableRow(cells=[_cell(colspan=1, rowspan=2), _cell()]),
+                TableRow(cells=[_cell(), _cell(colspan=2)]),
+            ],
+        )
+    ]
+)
+
+#: A link inside a link, as produced by parsing ``<a>x<a>y</a></a>``.
+#:
+#: Built here rather than parsed so the reproduction stays deterministic, but
+#: the shape is not synthetic: feeding that HTML to the HTML parser yields
+#: exactly this AST, which is why the ODF failure hits real documents.
+NESTED_LINK = Document(
+    children=[
+        Paragraph(
+            content=[
+                Link(
+                    url="https://a.example.com/",
+                    content=[
+                        Text(content="x"),
+                        Link(url="https://b.example.com/", content=[Text(content="y")]),
+                    ],
+                )
+            ]
+        )
+    ]
+)
+
+#: An empty list item nested one level down, alongside an empty sibling.
+NESTED_EMPTY_ITEM = Document(
+    children=[
+        Paragraph(content=[Text(content="0")]),
+        List(
+            ordered=False,
+            tight=False,
+            items=[
+                ListItem(children=[List(ordered=False, tight=False, items=[ListItem(children=[])])]),
+                ListItem(children=[]),
+            ],
+        ),
+    ]
+)
+
+#: The same shape, carrying a task status.
+NESTED_TASK_ITEM = Document(
+    children=[
+        List(
+            ordered=False,
+            tight=False,
+            items=[
+                ListItem(
+                    task_status="checked",
+                    children=[
+                        List(
+                            ordered=False,
+                            tight=False,
+                            items=[ListItem(children=[], task_status="checked")],
+                        )
+                    ],
+                )
+            ],
+        )
+    ]
+)
+
+
+@pytest.mark.unit
+@pytest.mark.fuzzing
+class TestKnownCrashRepros:
+    """Minimal reproductions for every :data:`KNOWN_CRASHES` entry.
+
+    Marked ``xfail(strict=True)`` rather than asserting the crash, because a test
+    that asserts broken behaviour defends the bug. Strict xfail does the
+    opposite: the day someone fixes the renderer the test XPASSes, CI fails, and
+    the contributor is told to delete the marker and the allowlist entry.
+    """
+
+    @pytest.mark.parametrize(
+        ("doc", "fmt"),
+        [
+            pytest.param(
+                NESTED_TASK_ITEM,
+                "asciidoc",
+                id="asciidoc-orphaned-nested-list-marker",
+                marks=pytest.mark.xfail(strict=True, reason="renderer writes '..' with no '.' parent"),
+            ),
+            pytest.param(
+                SPANNING_GRID_OVERFLOW,
+                "docx",
+                id="docx-span-past-grid-width",
+                marks=pytest.mark.xfail(strict=True, reason="merge target cell was never created"),
+            ),
+            pytest.param(
+                SPANNING_GRID_OVERFLOW,
+                "pptx",
+                id="pptx-remerge-merged-cells",
+                marks=pytest.mark.xfail(strict=True, reason="re-merges an already merged range"),
+            ),
+            pytest.param(
+                NESTED_EMPTY_ITEM,
+                "rtf",
+                id="rtf-nested-empty-list-item",
+                marks=pytest.mark.xfail(strict=True, reason="parser indexes past the end of a group"),
+            ),
+            pytest.param(
+                NESTED_TASK_ITEM,
+                "rtf",
+                id="rtf-nested-task-list-item",
+                marks=pytest.mark.xfail(strict=True, reason="raises an unwrapped KeyError"),
+            ),
+            pytest.param(
+                NESTED_LINK,
+                "odt",
+                id="odt-nested-link",
+                marks=pytest.mark.xfail(strict=True, reason="text:a nested inside text:a"),
+            ),
+            pytest.param(
+                NESTED_LINK,
+                "odp",
+                id="odp-nested-link",
+                marks=pytest.mark.xfail(strict=True, reason="text:a nested inside text:a"),
+            ),
+        ],
+    )
+    def test_known_crash_still_reproduces(self, doc: Document, fmt: str) -> None:
+        """Each known crash reproduces from a minimal document.
+
+        Every reproduction here was shrunk by Hypothesis from a generated
+        document, so it is the smallest shape that triggers the defect rather
+        than the first one found.
+        """
+        roundtrip_report(doc, via=fmt)
+
+
+# --------------------------------------------------------------------------- #
+# Gate 3: structural invariants
+# --------------------------------------------------------------------------- #
+
+
+def _round_trip(doc: Document, fmt: str) -> Document:
+    """Render ``doc`` to ``fmt`` and parse it straight back."""
+    rendered = from_ast(doc, fmt)
+    data = rendered.encode("utf-8") if isinstance(rendered, str) else rendered
+    return to_ast(io.BytesIO(data), source_format=fmt)
+
+
+def _collect(node: object, cls: type, found: list | None = None) -> list:
+    """Return every descendant of ``node`` that is an instance of ``cls``."""
+    found = [] if found is None else found
+    if isinstance(node, cls):
+        found.append(node)
+    for attr in ("children", "content", "items", "rows", "cells"):
+        for child in getattr(node, attr, None) or []:
+            _collect(child, cls, found)
+    header = getattr(node, "header", None)
+    if header is not None:
+        _collect(header, cls, found)
+    return found
+
+
+def _list_item_count(doc: Document) -> int:
+    return sum(len(node.items) for node in _collect(doc, List))
+
+
+def _list_starts(doc: Document) -> list[int]:
+    return [node.start for node in _collect(doc, List) if node.ordered]
+
+
+def _captions(doc: Document) -> list[str | None]:
+    return [node.caption for node in _collect(doc, Table)]
+
+
+def _header_widths(doc: Document) -> list[int]:
+    return [len(node.header.cells) for node in _collect(doc, Table) if node.header]
+
+
+def _heading_levels(doc: Document) -> list[int]:
+    return [node.level for node in _collect(doc, Heading)]
+
+
+def _code_languages(doc: Document) -> list[str | None]:
+    return [node.language for node in _collect(doc, CodeBlock)]
+
+
+#: One entry per invariant: a document, a probe, and the value the probe must
+#: return after a round trip. Each is drawn from a defect class this project has
+#: shipped a fix for, so the invariant is not hypothetical.
+INVARIANTS: dict[str, tuple[Document, object, object]] = {
+    # PRs #160 (bbcode), #159 (mediawiki), #119 (dokuwiki) all fixed a renderer
+    # that silently dropped an empty list item.
+    "empty-list-item-survives": (
+        Document(
+            children=[
+                List(
+                    ordered=False,
+                    items=[ListItem(children=[]), ListItem(children=[Paragraph(content=[Text(content="x")])])],
+                )
+            ]
+        ),
+        _list_item_count,
+        2,
+    ),
+    # PR #87 fixed HTML resetting `<ol start="N">` to 1.
+    "ordered-list-start-survives": (
+        Document(
+            children=[List(ordered=True, start=5, items=[ListItem(children=[Paragraph(content=[Text(content="a")])])])]
+        ),
+        _list_starts,
+        [5],
+    ),
+    # PRs #157, #129, #132 fixed mediawiki `|+` caption handling.
+    "table-caption-survives": (
+        Document(
+            children=[
+                Table(
+                    header=TableRow(is_header=True, cells=[_cell("a"), _cell("b")]),
+                    rows=[TableRow(cells=[_cell("1"), _cell("2")])],
+                    caption="cap",
+                )
+            ]
+        ),
+        _captions,
+        ["cap"],
+    ),
+    # PRs #153 (yaml) and #137 (json) fixed duplicate column values collapsing.
+    "duplicate-header-labels-survive": (
+        Document(
+            children=[
+                Table(
+                    header=TableRow(is_header=True, cells=[_cell("d"), _cell("d")]),
+                    rows=[TableRow(cells=[_cell("1"), _cell("2")])],
+                )
+            ]
+        ),
+        _header_widths,
+        [2],
+    ),
+    # PR #155 fixed org emitting heading levels above the AST maximum.
+    "heading-levels-survive": (
+        Document(children=[Heading(level=level, content=[Text(content=f"h{level}")]) for level in range(1, 7)]),
+        _heading_levels,
+        [1, 2, 3, 4, 5, 6],
+    ),
+    "code-block-language-survives": (
+        Document(children=[CodeBlock(content="x = 1", language="python")]),
+        _code_languages,
+        ["python"],
+    ),
+}
+
+#: Invariants that do not hold yet, as ``(format, invariant)`` with the reason.
+#:
+#: Everything here is a real asymmetry. Two of them are arguably by design and
+#: are called out as such; the rest are defects worth fixing. Entries are marked
+#: strict-xfail, so fixing one fails CI until the entry is deleted.
+KNOWN_INVARIANT_GAPS: dict[tuple[str, str], str] = {
+    # Markdown and reStructuredText have no table-caption syntax, so the caption
+    # has nowhere to go. Arguably by design, though both could round-trip it
+    # through a comment or a `.. table::` directive.
+    ("markdown", "table-caption-survives"): "markdown has no caption syntax",
+    ("rst", "table-caption-survives"): "rst renderer does not emit a table directive",
+    ("org", "table-caption-survives"): "org renderer does not emit #+CAPTION",
+    ("asciidoc", "table-caption-survives"): "asciidoc renderer does not emit a .caption line",
+    # rst derives heading level from the underline character, and the renderer
+    # reuses characters, so distinct levels collapse into each other.
+    ("rst", "heading-levels-survive"): "rst underline characters repeat, collapsing levels",
+    # asciidoc drops the first heading: the renderer treats a leading level-1 as
+    # the document title and the parser does not map it back.
+    ("asciidoc", "heading-levels-survive"): "leading h1 becomes the document title and is lost",
+    # asciidoc writes a trailing pipe after the last cell, which its parser reads
+    # as an extra empty column, so every table gains a phantom column.
+    ("asciidoc", "duplicate-header-labels-survive"): "trailing pipe parses as an extra empty cell",
+    # asciidoc and org both drop the ordered-list start attribute.
+    ("asciidoc", "ordered-list-start-survives"): "renderer does not emit the start attribute",
+    ("org", "ordered-list-start-survives"): "renderer does not emit [@N]",
+    # org loses an empty list item and the source-block language.
+    ("org", "empty-list-item-survives"): "renderer drops the empty item's bullet",
+    ("org", "code-block-language-survives"): "renderer does not emit the #+BEGIN_SRC language",
+}
+
+#: Formats the invariant gate covers. Text formats only: the invariants probe
+#: specific node attributes, and the container formats lose so much structure
+#: that every entry would need an allowlist line, which teaches nothing.
+INVARIANT_FORMATS = ("ast", "markdown", "html", "rst", "org", "asciidoc")
+
+
+def _invariant_params() -> list:
+    """Build one parametrization per (format, invariant), xfailing known gaps."""
+    params = []
+    for fmt in INVARIANT_FORMATS:
+        for name in INVARIANTS:
+            reason = KNOWN_INVARIANT_GAPS.get((fmt, name))
+            marks = [pytest.mark.xfail(strict=True, reason=reason)] if reason else []
+            params.append(pytest.param(fmt, name, id=f"{fmt}-{name}", marks=marks))
+    return params
+
+
+@pytest.mark.unit
+@pytest.mark.fuzzing
+class TestStructuralInvariants:
+    """Document shapes drawn from real shipped fixes must survive a round trip."""
+
+    @pytest.mark.parametrize(("fmt", "invariant"), _invariant_params())
+    def test_structural_invariant(self, fmt: str, invariant: str) -> None:
+        """Each invariant holds for each format, or is a documented gap.
+
+        These are the shapes this project has already had to fix once. Asserting
+        them per format is what turns 39 one-format bug fixes into a matrix: a
+        renderer that regresses "empty list items survive" fails here even if the
+        format that originally broke is untouched.
+        """
+        doc, probe, expected = INVARIANTS[invariant]
+        actual = probe(_round_trip(doc, fmt))  # type: ignore[operator]
+        assert actual == expected, f"{fmt}: {invariant} gave {actual!r}, expected {expected!r}"
+
+
+# --------------------------------------------------------------------------- #
+# Targeted generative properties
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.unit
+@pytest.mark.fuzzing
+class TestGeneratedTablesAndLists:
+    """Aim the generator at the two node classes that break most often."""
+
+    @settings(deadline=None, max_examples=25, suppress_health_check=[HealthCheck.too_slow])
+    @given(documents_of(tables()))
+    def test_table_documents_round_trip_through_html(self, doc: Document) -> None:
+        """Property: HTML preserves every table's declared dimensions.
+
+        HTML has explicit ``colspan``/``rowspan`` and a ``<caption>``, so it is
+        the one text format with no excuse for changing a table's shape. That
+        makes it the right place to assert dimensions rather than allowlist them.
+        """
+        source_widths = _header_widths(doc)
+        assert _header_widths(_round_trip(doc, "html")) == source_widths
+
+    @settings(deadline=None, max_examples=25, suppress_health_check=[HealthCheck.too_slow])
+    @given(documents_of(lists()))
+    def test_list_documents_keep_their_item_count_in_html(self, doc: Document) -> None:
+        """Property: HTML keeps every list item, including the empty ones.
+
+        ``<li></li>`` is legal and unambiguous, so an item that disappears here
+        was dropped by the renderer rather than squeezed out by the syntax.
+        """
+        assert _list_item_count(_round_trip(doc, "html")) == _list_item_count(doc)


### PR DESCRIPTION
The existing fuzz suites cover filenames, URLs, HTML sanitization and PDF edge cases, all security surfaces. Nothing generated documents and pushed them through the renderer/parser matrix, so "renderer emits output its own parser rejects" was only caught where somebody had written a fixture.

`tests/document_strategies.py` builds `Document` ASTs with Hypothesis. `tests/unit/test_roundtrip_fuzzing.py` feeds them to `roundtrip_report` across all 24 round-trippable formats, behind four gates: every format must be classified into a group so a new one cannot silently skip the fuzzer, `ast` must score exactly 100 as the control, no format may raise outside `KNOWN_CRASHES`, and shapes drawn from previously fixed defects must survive.

Both allowlists are `xfail(strict=True)`, so fixing an entry turns it into an XPASS and fails the run until the entry is deleted. The crash gates use a fixed seed so they fail on regressions rather than on an unlucky draw; `--hypothesis-seed=random` is documented in CONTRIBUTING for deliberate hunting.

No behaviour change. 31 passed, 18 xfailed. A 250-document randomized sweep over 19 formats found no crash class outside the six below.

Crash classes it found, each with a minimal shrunk reproduction in the file:

| Format | Failure | Shape |
|---|---|---|
| asciidoc | `Cannot nest to level 2 without a parent item at level 1` | ordered list inside an unordered item; the renderer numbers markers by absolute depth and writes `..` with no `.` parent |
| docx | `no 'tc' element at grid_offset=N` | spanning cells past the declared grid width |
| pptx | `range contains one or more merged cells` | same shape |
| rtf | `IndexError: list index out of range` | empty list item nested in a list |
| rtf | `KeyError: <class 'str'>` | same shape carrying a task status; a raw `str` reaches pyth's paragraph dispatch |
| odt / odp | `IllegalChild('<text:a> is not allowed in <text:a>')` | nested link; browsers accept nested `<a>` and the HTML parser keeps the nesting, so `all2md page.html -t odt` fails on real pages |

Two of these escape the documented exception contract rather than surfacing as `All2MdError`: `from_ast(doc, "pptx")` raises a bare `ValueError` and `from_ast(doc, "rtf")` a bare `KeyError`, so a caller catching `All2MdError` will not catch them. The docx and odt paths wrap correctly.
