### PR TITLE
fix(textile): handle rendering empty table without rows

### DIFF
--- a/src/all2md/renderers/textile.py
+++ b/src/all2md/renderers/textile.py
@@ -332,7 +332,7 @@ class TextileRenderer(NodeVisitor, InlineContentMixin, BaseRenderer):
             self._output.append("\n")
 
         # Remove trailing newline as it will be added by block spacing
-        if self._output[-1] == "\n":
+        if self._output and self._output[-1] == "\n":
             self._output.pop()
 
     def visit_table_row(self, node: TableRow) -> None:

--- a/tests/unit/renderers/test_textile_renderer.py
+++ b/tests/unit/renderers/test_textile_renderer.py
@@ -355,6 +355,13 @@ class TestTextileLists:
 @pytest.mark.unit
 class TestTextileTables:
     """Tests for Textile table rendering."""
+    def test_render_empty_table(self) -> None:
+        """Test rendering an empty table without header or rows."""
+        doc = Document(children=[Table(header=None, rows=[])])
+        renderer = TextileRenderer()
+        result = renderer.render_to_string(doc)
+        assert result == "\n"
+
 
     def test_render_simple_table(self) -> None:
         """Test rendering a simple table."""

--- a/tests/unit/renderers/test_textile_renderer.py
+++ b/tests/unit/renderers/test_textile_renderer.py
@@ -355,13 +355,13 @@ class TestTextileLists:
 @pytest.mark.unit
 class TestTextileTables:
     """Tests for Textile table rendering."""
+
     def test_render_empty_table(self) -> None:
         """Test rendering an empty table without header or rows."""
         doc = Document(children=[Table(header=None, rows=[])])
         renderer = TextileRenderer()
         result = renderer.render_to_string(doc)
         assert result == "\n"
-
 
     def test_render_simple_table(self) -> None:
         """Test rendering a simple table."""


### PR DESCRIPTION
When a Textile table contains no rows, TextileRenderer.visit_table raised IndexError when inspecting header row alignments.

Guard row indexing in visit_table when the table row collection is empty.