### PR TITLE
fix(dokuwiki): tolerate a self-closing tag in the inline-markup check

### DIFF
--- a/src/all2md/parsers/dokuwiki.py
+++ b/src/all2md/parsers/dokuwiki.py
@@ -119,7 +119,12 @@ LINE_BREAK_PATTERN = re.compile(r"\\\\")
 FOOTNOTE_PATTERN = re.compile(r"\(\(([^\)]+)\)\)")
 
 # HTML tags (for html_passthrough_mode handling)
+# Note: the self-closing alternative has no capture group, so group(1) is None for e.g. <br/>
 HTML_TAG_PATTERN = re.compile(r"<([a-zA-Z][a-zA-Z0-9]*)\b[^>]*>.*?</\1>|<[a-zA-Z][a-zA-Z0-9]*\b[^>]*/>", re.DOTALL)
+
+# Tags DokuWiki spells as HTML but treats as inline markup, so a whole-line
+# occurrence must fall through to _process_inline rather than be taken as a block.
+INLINE_MARKUP_TAGS = ("del", "sub", "sup")
 
 
 class DokuWikiParser(BaseParser):
@@ -496,7 +501,7 @@ class DokuWikiParser(BaseParser):
         plugin_match = PLUGIN_PATTERN.match(line.strip())
         if plugin_match and plugin_match.group(0) == line.strip():
             # del/sub/sup are inline markup, not plugins — leave for _process_inline
-            if plugin_match.group(1).lower() in ("del", "sub", "sup"):
+            if (plugin_match.group(1) or "").lower() in INLINE_MARKUP_TAGS:
                 return False, 0
             self._flush_inline_buffer(inline_buffer, result)
             if self.options.parse_plugins:
@@ -526,8 +531,9 @@ class DokuWikiParser(BaseParser):
         """
         html_match = HTML_TAG_PATTERN.match(line.strip())
         if html_match and html_match.group(0) == line.strip():
-            # del/sub/sup are inline markup — leave for _process_inline
-            if html_match.group(1).lower() in ("del", "sub", "sup"):
+            # del/sub/sup are inline markup — leave for _process_inline.
+            # group(1) is None for a self-closing tag (<br/>), which is never inline markup.
+            if (html_match.group(1) or "").lower() in INLINE_MARKUP_TAGS:
                 return False, 0
             self._flush_inline_buffer(inline_buffer, result)
             html_content = html_match.group(0)

--- a/tests/unit/parsers/test_dokuwiki_parser.py
+++ b/tests/unit/parsers/test_dokuwiki_parser.py
@@ -241,6 +241,19 @@ class TestDokuWikiParserInlineFormatting:
         assert isinstance(sup_doc.children[0].content[0], Superscript)
         assert sup_doc.children[0].content[0].content[0].content == "y"
 
+    def test_whole_line_self_closing_tag_parses(self) -> None:
+        """A whole-line self-closing tag must still parse.
+
+        HTML_TAG_PATTERN's self-closing alternative has no capture group, so
+        group(1) is None for <br/>. The del/sub/sup inline-markup check has to
+        tolerate that rather than calling .lower() on None.
+        """
+        parser = DokuWikiParser()
+
+        for line in ("<br/>", "<br />", '<img src="a.png"/>', "<hr/>"):
+            doc = parser.parse(f"{line}\n")
+            assert doc.children, f"{line} produced no nodes"
+
     def test_parse_nested_formatting(self) -> None:
         """Test parsing nested inline formatting."""
         parser = DokuWikiParser()


### PR DESCRIPTION
Follow-up to #200, which landed a regression.

## What broke

#200 added a check that lets a whole-line `<del>`/`<sub>`/`<sup>` fall through to inline parsing. It reads the tag name from `HTML_TAG_PATTERN.group(1)` — but that pattern has two alternatives, and only the paired-tag one captures:

```python
r"<([a-zA-Z][a-zA-Z0-9]*)\b[^>]*>.*?</\1>|<[a-zA-Z][a-zA-Z0-9]*\b[^>]*/>"
#   ^^^^^^^^^^^^^^^^^^^^^^ captures                ^^^ self-closing: no group
```

So `group(1)` is `None` for a self-closing tag, and `.lower()` on it raises. Any line consisting only of `<br/>`, `<hr/>` or a self-closing `<img>` now fails to parse.

Confirmed live on `main` at a6e7372:

```
'<br/>'              -> ParsingError: 'NoneType' object has no attribute 'lower'
'<img src="a.png"/>' -> ParsingError: 'NoneType' object has no attribute 'lower'
```

Both parsed fine before #200.

## The fix

Guard the lookup with `(match.group(1) or "")` — a self-closing tag is never inline markup, so falling through to the block path is the right answer for it. The tag tuple moves to a named `INLINE_MARKUP_TAGS` constant so the plugin and HTML call sites read the same; the `PLUGIN_PATTERN` site was already safe (that pattern always captures) but now uses the same idiom.

## Verification

The new test fails without the fix and passes with it, rather than only passing with it:

```
FAILED tests/unit/parsers/test_dokuwiki_parser.py::...::test_whole_line_self_closing_tag_parses
E   ParsingError: Failed to parse DokuWiki markup: 'NoneType' object has no attribute 'lower'
```

All 46 dokuwiki tests pass with it applied; `black`, `ruff` and `mypy` clean.

## Note on the gap

CI was fully green on #200 because nothing covered a whole-line self-closing tag in DokuWiki. This is also a shape the #204 fuzzer would not have caught — it generates ASTs and round-trips them, so it never produces a hand-written DokuWiki source line.
