### PR TITLE
docs(changelog): credit santhreal's batch under Unreleased

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,57 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Tests: generative round-trip fuzzing across the format matrix.** `tests/document_strategies.py`
+  builds arbitrary `Document` trees with Hypothesis and feeds them to `roundtrip_report`
+  for all 24 round-trippable formats, behind four gates: every format must be classified
+  (so a newly registered one cannot silently skip the fuzzer), `ast` must score exactly
+  100 as the control, no format may raise outside a known-crashes allowlist, and shapes
+  drawn from previously fixed defects must survive the trip. Both allowlists are
+  `xfail(strict=True)`, so they can only shrink — fixing an entry turns it into an
+  XPASS and fails the build until it is removed. It found six crash classes and a set
+  of invariant gaps on existing formats, now filed as issues. Thanks
+  [@santhreal](https://github.com/santhreal) (#204).
+
+### Changed
+
+- **Type inference no longer reads `1` and `0` as booleans.** With `type_inference=True`,
+  the JSON, YAML and TOML renderers treated the table cells `1` and `0` as `true`/`false`,
+  so an `age` column of `1` serialized as a boolean. They are now integers; `true`/`yes`/`on`
+  and `false`/`no`/`off` still infer as booleans, matching YAML 1.1. Output changes for
+  anyone who relied on `1`/`0` inferring as booleans. Thanks
+  [@santhreal](https://github.com/santhreal) (#202).
+
+### Fixed
+
+- **HTML parser: nested tables no longer duplicate their cells into the outer row.**
+  Cells were collected with a recursive `find_all`, so a table inside a `<td>` had its
+  own `td`/`th` pulled into the enclosing row as well — a one-cell inner table turned
+  `| inner |` into `| inner | inner |`. Only direct children are collected now, matching
+  how the row walk already worked. Thanks [@santhreal](https://github.com/santhreal) (#199).
+- **DokuWiki parser: a whole-line `<del>`, `<sub>` or `<sup>` keeps its formatting.**
+  Those tags were taken as a plugin or HTML block when they were the entire line, so with
+  plugin parsing off the content was dropped outright. They now fall through to inline
+  parsing and produce strikethrough/subscript/superscript. Thanks
+  [@santhreal](https://github.com/santhreal) (#200).
+- **Org parser: a line that is only `+strikethrough+` is no longer an empty list.**
+  The list check matched `-`, `+` or `*` at the start of a line without requiring the
+  space that follows a real bullet, so `+gone+` on its own line parsed as an empty list
+  and lost the text. A space is now required after the marker. Thanks
+  [@santhreal](https://github.com/santhreal) (#201).
+- **AsciiDoc parser: `////` opens a block comment instead of commenting out one line.**
+  The lexer checked `//` before block delimiters, so `////` was read as a line comment
+  and the block's body was parsed as ordinary content — text meant to be hidden appeared
+  in the output as paragraphs, and the closing `////` was consumed as another comment.
+  `////` is now a delimiter pair whose body becomes a single `Comment` node, dropped
+  entirely under `strip_comments`. Thanks [@santhreal](https://github.com/santhreal) (#203).
+- **Textile renderer: an empty table no longer crashes the render.** A `Table` with no
+  header and no rows appends nothing, so the trailing-newline cleanup indexed an empty
+  buffer and raised `IndexError` whenever such a table was the first thing rendered.
+  The buffer is checked before indexing. Thanks
+  [@santhreal](https://github.com/santhreal) (#205).
+
 ## [1.10.1] - 2026-07-27
 
 A maintenance release. Almost all of it is infrastructure — the harnesses this


### PR DESCRIPTION
Records the seven contributions that landed as #199–#205 under `[Unreleased]`.

- `### Added` — the generative round-trip fuzzer (#204). It changes no conversion
  behaviour, so it isn't a fix, but it's why six crash classes and a set of invariant
  gaps are now filed as issues. This project already logs test/CI infrastructure
  (`Tests:`, `Benchmarks:`, `CI:` entries in 1.10.1), so the precedent holds.
- `### Changed` — type inference no longer reading `1`/`0` as booleans (#202), called
  out as output-changing for anyone who relied on the old behaviour.
- `### Fixed` — html nested-table cells (#199), dokuwiki whole-line `del`/`sub`/`sup`
  (#200), org list marker (#201), asciidoc `////` block comments (#203), textile
  empty-table crash (#205).

No entry for #213: it fixed a regression introduced by #200 inside this same unreleased
window, so there's no shipped behaviour to describe.

Each entry describes the user-visible symptom before the mechanism, and credits
[@santhreal](https://github.com/santhreal) with the PR number.

Verified the file still parses clean: `to_ast` finds **0** tables in `CHANGELOG.md`, so
the pipe characters quoted in the #199 entry (`| inner |`, `| inner | inner |`) don't
trip the prose-swallowed-into-a-table bug that 1.10.1 fixed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
