### PR TITLE
test(roundtrip): give each format its own example budget, run the fuzzer on one leg

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,8 +99,18 @@ jobs:
           pip install -e ".[all,dev]"
 
       - name: Run tests with coverage
+        env:
+          PYTHON_VERSION: ${{ matrix.python-version }}
         run: |
-          pytest tests/ -v --cov=all2md --cov-report=xml --cov-report=term
+          # Tests marked matrix_single exercise parser/renderer logic, which does not
+          # vary by interpreter, so four of the five legs would redo identical work.
+          # They run on 3.12 — the same leg that uploads coverage, so the reported
+          # figure still includes them.
+          ARGS=(tests/ -v --cov=all2md --cov-report=xml --cov-report=term)
+          if [ "$PYTHON_VERSION" != "3.12" ]; then
+            ARGS+=(-m "not matrix_single")
+          fi
+          pytest "${ARGS[@]}"
 
       - name: Upload coverage to Codecov
         if: matrix.python-version == '3.12'

--- a/pytest.ini
+++ b/pytest.ini
@@ -38,6 +38,7 @@ markers =
     collation: Tests related to file collation features
     security: Security-focused tests (SSRF, file access, ZIP bombs)
     fuzzing: Property-based and fuzz tests using Hypothesis
+    matrix_single: Exercises library logic, not interpreter differences; CI runs it on one Python leg only
     golden: Golden/snapshot regression tests
     asciidoc: Tests related to AsciiDoc conversion
     plaintext: Tests related to PlainText rendering

--- a/tests/unit/test_roundtrip_fuzzing.py
+++ b/tests/unit/test_roundtrip_fuzzing.py
@@ -53,7 +53,6 @@ import io
 import pytest
 from document_strategies import documents, documents_of, lists, tables
 from hypothesis import HealthCheck, given, settings
-from hypothesis import strategies as st
 
 from all2md import from_ast, roundtrip_report, roundtrippable_formats, to_ast
 from all2md.ast.nodes import (
@@ -69,6 +68,15 @@ from all2md.ast.nodes import (
     TableRow,
     Text,
 )
+
+#: Every gate in this file exercises parser and renderer logic, which does not
+#: vary across interpreter versions, so CI runs the file on a single Python leg
+#: and deselects it on the rest with ``-m "not matrix_single"``. The marker is
+#: dedicated rather than reusing ``fuzzing``: four other suites carry that one
+#: (filename, URL, HTML-sanitizer and PDF edge-case fuzzing), they are all
+#: sub-second and security-relevant, and dropping them from four legs would save
+#: nothing while thinning the security coverage.
+pytestmark = pytest.mark.matrix_single
 
 # --------------------------------------------------------------------------- #
 # Format groups
@@ -217,16 +225,28 @@ class TestNoUnrecognisedCrash:
         HYPOTHESIS_PROFILE=ci python -m pytest -m fuzzing --hypothesis-seed=random
 
     Anything that finds belongs in :data:`KNOWN_CRASHES` with a reproduction.
+
+    The format comes from ``parametrize`` rather than from ``sampled_from``
+    inside the strategy, so ``max_examples`` is a budget *per format* instead of
+    a budget shared across all of them. Drawing the format made the gate much
+    less sensitive than it looks: 25 examples spread over 11 text formats is
+    about two documents per format, so a shape has to be common to be seen at
+    all. Measured, by breaking the mediawiki renderer for level-6 headings only
+    — a shape present in **12.8%** of generated documents (51/400): the
+    drawn-format gate passed green with the break live, this one fails on it.
+    Parametrizing also puts the format in the test id, so a failure names the
+    format without reading the Hypothesis output.
     """
 
+    @pytest.mark.parametrize("fmt", TEXT_FORMATS)
     @settings(
         deadline=None,
         max_examples=25,
         derandomize=True,
         suppress_health_check=[HealthCheck.too_slow],
     )
-    @given(documents(), st.sampled_from(TEXT_FORMATS))
-    def test_text_formats_raise_nothing_new(self, doc: Document, fmt: str) -> None:
+    @given(documents())
+    def test_text_formats_raise_nothing_new(self, fmt: str, doc: Document) -> None:
         """Property: a text-format round trip either works or fails a known way.
 
         Locks the current crash surface in place. A renderer change that makes
@@ -241,18 +261,22 @@ class TestNoUnrecognisedCrash:
                 pytest.fail(f"new crash class for {fmt!r}: {type(exc).__name__}: {exc}")
 
     @pytest.mark.slow
+    @pytest.mark.parametrize("fmt", BINARY_FORMATS)
     @settings(
         deadline=None,
         max_examples=10,
         derandomize=True,
         suppress_health_check=[HealthCheck.too_slow],
     )
-    @given(documents(max_blocks=3), st.sampled_from(BINARY_FORMATS))
-    def test_binary_formats_raise_nothing_new(self, doc: Document, fmt: str) -> None:
+    @given(documents(max_blocks=3))
+    def test_binary_formats_raise_nothing_new(self, fmt: str, doc: Document) -> None:
         """Property: the same guarantee for container and binary formats.
 
         Split out and marked ``slow`` because each example writes a real archive
         or PDF. Same gate, fewer examples, so a full run stays usable locally.
+
+        The shared-budget problem was worse here than for text: 10 examples over
+        8 formats meant most formats saw one document, and some saw none at all.
         """
         try:
             roundtrip_report(doc, via=fmt)


### PR DESCRIPTION
Follow-up to #204. Two changes to the round-trip fuzzer that pay for each other:
one makes it more sensitive, the other makes it cheaper, and together they're a
net saving.

## 1. Budget per format, not shared across formats

Both crash-ratchet gates drew the format *inside* the strategy:

```python
@given(documents(), st.sampled_from(TEXT_FORMATS))
```

so `max_examples=25` was a budget split across all 11 text formats — about two
documents each. The binary gate was worse: 10 examples over 8 formats, so some
formats saw one document and some saw none at all. The format now comes from
`parametrize`, which spends the full budget per format and puts the format in
the test id, so a failure names it without reading the Hypothesis output.
`TestLosslessFormatsAreLossless` already used this shape, so it's consistent
with the file.

**Measured, not argued.** I broke the mediawiki renderer so it raises on level-6
headings *only* — a shape present in **12.8%** of generated documents (51/400).
Against that same live break:

| gate | result |
|---|---|
| drawn format (`sampled_from`, on `main`) | **passes green** |
| parametrized (this PR) | **fails** on `[mediawiki]` |

I verified the injection was actually reached before trusting either result —
last time I probed this file I got a false read from an injection that sat in
dead code.

## 2. Run the file on one Python leg

Every gate here exercises parser and renderer logic, which doesn't vary by
interpreter, so four of the five matrix legs were redoing identical work. A new
`matrix_single` marker deselects the file on the other four. It runs on 3.12 —
the same leg that uploads coverage, so the reported figure is unchanged, and the
`if: matrix.python-version == '3.12'` on the Codecov step is the existing
precedent for singling out a leg.

**The marker is dedicated rather than reusing `fuzzing`,** which matters:

| selector | tests dropped |
|---|---|
| `-m "not fuzzing"` | 133 |
| `-m "not matrix_single"` | 66 — all in `test_roundtrip_fuzzing.py` |

The extra 67 are `test_filename_fuzzing`, `test_url_validation_fuzzing`,
`test_html_sanitizer_fuzzing` and `test_pdf_html_edge_case_fuzzing` — all
sub-second and security-relevant. Reusing `fuzzing` would have thinned security
coverage on four legs to save nothing.

## Net cost

The file goes 16.4s → 35.4s locally, but from five legs to one, so the matrix
does ~35s of this work where it used to do ~82s.

Not using the 2026-07-28 CI timings as a baseline for any of this — that runner
was degraded (`test_startup_gate.py` took ~25 min there and runs in under a
second on `main`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
