### PR TITLE
fix(render): always raise All2MdError when a renderer fails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Rendering failures now always raise `All2MdError`, whatever the underlying library
+  raised.** `from_ast` documents that failures surface as `All2MdError` subclasses, but
+  renderers delegate to third-party libraries that raise their own types, and only some
+  renderers translated them — `from_ast(doc, "pptx")` raised a bare `ValueError` and
+  `from_ast(doc, "rtf")` a bare `KeyError`, so a caller writing the documented
+  `except All2MdError` crashed instead. Probing the whole matrix showed 15 of the 24
+  formats leaked, not just the two the fuzzer happened to expose, so the translation now
+  happens at the single point every render passes through; a renderer that already raises
+  `All2MdError` keeps its own message. The PPTX renderer, which guarded only its save
+  step, and the RTF renderer, whose `render_to_string` was unguarded while `render` was
+  not, are both brought in line with the DOCX renderer (#212).
 - **HTML parser: nested tables no longer duplicate their cells into the outer row.**
   Cells were collected with a recursive `find_all`, so a table inside a `<td>` had its
   own `td`/`th` pulled into the enclosing row as well — a one-cell inner table turned

--- a/src/all2md/renderers/pptx.py
+++ b/src/all2md/renderers/pptx.py
@@ -70,7 +70,7 @@ from all2md.constants import (
     DEFAULT_PPTX_MIN_TEXT_HEIGHT,
     DEPS_PPTX_RENDER,
 )
-from all2md.exceptions import RenderingError
+from all2md.exceptions import All2MdError, RenderingError
 from all2md.options.pptx import PptxRendererOptions
 from all2md.renderers._split_utils import (
     auto_split_ast,
@@ -159,30 +159,33 @@ class PptxRenderer(NodeVisitor, BaseRenderer):
         self._Inches = Inches
         self._Pt = Pt
 
-        # Create presentation
-        if self.options.template_path:
-            prs = Presentation(self.options.template_path)
-        else:
-            prs = Presentation()
-            # Set widescreen dimensions (default 16:9)
-            prs.slide_width = Inches(self.options.slide_width)  # type: ignore[misc,assignment]
-            prs.slide_height = Inches(self.options.slide_height)  # type: ignore[misc,assignment]
-
-        # Set creator metadata if configured
-        if self.options.creator:
-            prs.core_properties.last_modified_by = self.options.creator
-            # Set default author to creator if not overridden by document metadata
-            prs.core_properties.author = self.options.creator
-
-        # Split document into slides
-        slides_data = self._split_into_slides(doc)
-
-        # Create slides
-        for idx, (heading, content_nodes) in enumerate(slides_data, start=1):
-            self._create_slide(prs, heading, content_nodes, is_first=(idx == 1))
-
-        # Save presentation
+        # Only the save step used to be guarded, so python-pptx exceptions raised
+        # while building slides (merging table cells, in particular) escaped as
+        # bare ValueError. Guard the whole body, as the DOCX renderer does.
         try:
+            # Create presentation
+            if self.options.template_path:
+                prs = Presentation(self.options.template_path)
+            else:
+                prs = Presentation()
+                # Set widescreen dimensions (default 16:9)
+                prs.slide_width = Inches(self.options.slide_width)  # type: ignore[misc,assignment]
+                prs.slide_height = Inches(self.options.slide_height)  # type: ignore[misc,assignment]
+
+            # Set creator metadata if configured
+            if self.options.creator:
+                prs.core_properties.last_modified_by = self.options.creator
+                # Set default author to creator if not overridden by document metadata
+                prs.core_properties.author = self.options.creator
+
+            # Split document into slides
+            slides_data = self._split_into_slides(doc)
+
+            # Create slides
+            for idx, (heading, content_nodes) in enumerate(slides_data, start=1):
+                self._create_slide(prs, heading, content_nodes, is_first=(idx == 1))
+
+            # Save presentation
             if isinstance(output, (str, Path)):
                 prs.save(str(output))
             else:
@@ -191,10 +194,11 @@ class PptxRenderer(NodeVisitor, BaseRenderer):
                 prs.save(buffer)
                 buffer.seek(0)
                 output.write(buffer.read())
+        except All2MdError:
+            # Renderer-raised errors already carry a specific message; keep it.
+            raise
         except Exception as e:
-            raise RenderingError(
-                f"Failed to write PPTX file: {e!r}", rendering_stage="rendering", original_error=e
-            ) from e
+            raise RenderingError(f"Failed to render PPTX: {e!r}", rendering_stage="rendering", original_error=e) from e
         finally:
             # Clean up temporary files
             for temp_file in self._temp_files:

--- a/src/all2md/renderers/rtf.py
+++ b/src/all2md/renderers/rtf.py
@@ -193,6 +193,17 @@ class RtfRenderer(NodeVisitor, BaseRenderer):
     @requires_dependencies("rtf_render", DEPS_RTF_RENDER)
     def render(self, doc: Document, output: Union[str, Path, IO[bytes]]) -> None:
         """Render a document to an RTF stream or file."""
+        self.write_text_output(self.render_to_string(doc), output)
+
+    @requires_dependencies("rtf_render", DEPS_RTF_RENDER)
+    def render_to_string(self, doc: Document) -> str:
+        """Render a document to an in-memory RTF string.
+
+        Both entry points share this body so both get the error translation.
+        They used to duplicate the conversion with only ``render`` wrapping it,
+        which left ``render_to_string`` — the path the pipeline takes for a text
+        format — leaking pyth's own exceptions.
+        """
         self._ensure_dependencies()
         self._assert_dependencies_loaded()
         try:
@@ -201,25 +212,13 @@ class RtfRenderer(NodeVisitor, BaseRenderer):
             text = buffer.getvalue() if hasattr(buffer, "getvalue") else buffer
             if isinstance(text, bytes):
                 text = text.decode("utf-8")
-            self.write_text_output(text, output)
-        except Exception as exc:  # pragma: no cover - safety net
+            return cast(str, text)
+        except Exception as exc:
             raise RenderingError(
                 f"Failed to render RTF: {exc!r}",
                 rendering_stage="rendering",
                 original_error=exc,
             ) from exc
-
-    @requires_dependencies("rtf_render", DEPS_RTF_RENDER)
-    def render_to_string(self, doc: Document) -> str:
-        """Render a document to an in-memory RTF string."""
-        self._ensure_dependencies()
-        self._assert_dependencies_loaded()
-        pyth_doc = doc.accept(self)
-        buffer = cast(Any, self._writer_cls).write(pyth_doc, fontFamily=self.options.font_family)
-        text = buffer.getvalue() if hasattr(buffer, "getvalue") else buffer
-        if isinstance(text, bytes):
-            text = text.decode("utf-8")
-        return text
 
     def visit_document(self, node: Document) -> Any:
         """Convert the root document node to a pyth document."""

--- a/src/all2md/transforms/pipeline.py
+++ b/src/all2md/transforms/pipeline.py
@@ -55,6 +55,7 @@ from typing import Any, Optional, Union
 from all2md.ast.nodes import Document, Node
 from all2md.ast.transforms import NodeTransformer
 from all2md.converter_registry import registry
+from all2md.exceptions import All2MdError, RenderingError
 from all2md.options.markdown import MarkdownRendererOptions
 from all2md.progress import ProgressCallback, ProgressEvent
 from all2md.renderers import MarkdownRenderer
@@ -589,8 +590,29 @@ class Pipeline:
             # Don't let callback errors break the pipeline
             logger.warning(f"Progress callback failed: {e}", exc_info=True)
 
+    def _rendering_error(self, exc: Exception) -> RenderingError:
+        """Wrap a renderer's internal exception in the documented error type."""
+        name = self.renderer.__class__.__name__
+        return RenderingError(
+            f"{name} failed to render the document: {exc!r}",
+            rendering_stage="rendering",
+            original_error=exc,
+        )
+
     def _render(self, document: Document) -> Union[str, bytes]:
         """Render document using configured renderer.
+
+        Renderers reach third-party libraries (python-pptx, pyth, ...) that raise
+        their own exception types, and only some renderers translate those. This
+        is the single point every pipeline render passes through, so the
+        translation happens here: whatever a renderer raises, callers of the
+        public API see an ``All2MdError`` subclass, as ``from_ast`` documents.
+        Renderers that already raise ``All2MdError`` pass through untouched, so a
+        renderer keeping its own specific message loses nothing.
+
+        ``NotImplementedError`` and ``AttributeError`` keep their existing meaning
+        of "this renderer does not offer this output mode" and select the other
+        one rather than being wrapped.
 
         Parameters
         ----------
@@ -608,6 +630,8 @@ class Pipeline:
             If no renderer is configured (pipeline was created with renderer=False)
         NotImplementedError
             If renderer doesn't implement render_to_string or render_to_bytes
+        RenderingError
+            If the renderer raises anything else
 
         """
         if self.renderer is None:
@@ -624,12 +648,20 @@ class Pipeline:
             return self.renderer.render_to_string(document)
         except (NotImplementedError, AttributeError):
             pass
+        except All2MdError:
+            raise
+        except Exception as e:
+            raise self._rendering_error(e) from e
 
         # Fall back to render_to_bytes (for binary renderers)
         try:
             return self.renderer.render_to_bytes(document)
         except (NotImplementedError, AttributeError):
             pass
+        except All2MdError:
+            raise
+        except Exception as e:
+            raise self._rendering_error(e) from e
 
         # Neither method is implemented
         raise NotImplementedError(

--- a/tests/unit/test_render_error_contract.py
+++ b/tests/unit/test_render_error_contract.py
@@ -1,0 +1,164 @@
+#  Copyright (c) 2025 Tom Villani, Ph.D.
+#
+# tests/unit/test_render_error_contract.py
+"""``from_ast`` must fail with an ``All2MdError``, whatever the renderer raises.
+
+Renderers delegate to third-party libraries — python-pptx, pyth, odfpy — that
+raise their own exception types. Some renderers translated those and some did
+not, so ``from_ast(doc, "pptx")`` could raise a bare ``ValueError`` at a caller
+who had written the documented ``except All2MdError``. Issue #212.
+
+The gate here is the probe below rather than a list of documents known to break
+particular renderers. Those documents are the subject of #206-#211 and will stop
+raising as each is fixed, taking the coverage with them; the contract has to hold
+for *any* failure, including ones no current document produces.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from all2md import from_ast, roundtrippable_formats
+from all2md.ast.nodes import Document, List, ListItem, Paragraph, Table, TableCell, TableRow, Text
+from all2md.exceptions import All2MdError, DependencyError
+
+pytestmark = [pytest.mark.unit, pytest.mark.matrix_single]
+
+
+#: Formats whose renderers emit tabular data and legitimately ignore a prose
+#: node, so the probe never reaches them. Listing them explicitly means a *text*
+#: renderer that quietly stops walking the tree fails the test rather than
+#: passing it vacuously.
+NON_PROSE_FORMATS = frozenset({"csv", "ini", "json", "toml", "yaml"})
+
+
+class ProbeError(RuntimeError):
+    """Sentinel standing in for an arbitrary third-party library exception.
+
+    ``RuntimeError`` deliberately: it is not an ``All2MdError``, and it is not in
+    the ``(NotImplementedError, AttributeError)`` pair the pipeline treats as
+    "this renderer does not offer that output mode".
+    """
+
+
+class ProbeNode(Paragraph):
+    """A paragraph that raises when visited.
+
+    Raising from ``accept`` rather than from a specific ``visit_*`` method means
+    the probe fires wherever a renderer walks the tree, without depending on how
+    any one renderer dispatches.
+    """
+
+    def accept(self, visitor: object) -> object:  # type: ignore[override]
+        raise ProbeError("probe")
+
+
+def _probe_document() -> Document:
+    """A document with one ordinary block, then the probe."""
+    return Document(children=[Paragraph(content=[Text(content="before")]), ProbeNode(content=[])])
+
+
+@pytest.mark.parametrize("fmt", sorted(roundtrippable_formats()))
+def test_renderer_exceptions_surface_as_all2mderror(fmt: str) -> None:
+    """No renderer lets a foreign exception escape ``from_ast``.
+
+    Parametrised over the registry rather than a hand-written tuple, so a format
+    added later is covered without anyone remembering to add it here.
+    """
+    try:
+        from_ast(_probe_document(), fmt)
+    except DependencyError:
+        pytest.skip(f"{fmt} renderer's optional dependencies are not installed")
+    except ProbeError as exc:  # pragma: no cover - this is the regression
+        raise AssertionError(
+            f"{fmt}: renderer let a bare {type(exc).__name__} escape from_ast; "
+            f"a caller writing `except All2MdError` would crash"
+        ) from exc
+    except All2MdError:
+        pass
+    except Exception as exc:  # noqa: BLE001 - the assertion is about the class
+        raise AssertionError(f"{fmt}: from_ast raised {type(exc).__name__}, which is not an All2MdError") from exc
+    else:
+        # Nothing raised, so the renderer never visited the probe. That is only
+        # defensible for the data formats, which read tables and skip prose.
+        assert fmt in NON_PROSE_FORMATS, (
+            f"{fmt}: the probe never fired, so this format is not actually being "
+            f"tested. Either the renderer silently drops content, or it belongs "
+            f"in NON_PROSE_FORMATS with a reason."
+        )
+
+
+def test_renderer_specific_errors_are_not_reflattened() -> None:
+    """A renderer that already reports well keeps its own message.
+
+    The pipeline wraps what reaches it, so it must not replace the message of a
+    renderer that already raised an ``All2MdError``. DOCX is the reference
+    implementation: it wraps its own body and names the format.
+    """
+    doc = Document(
+        children=[
+            Table(
+                header=TableRow(is_header=True, cells=[TableCell(content=[Text(content="0")])] * 2),
+                rows=[
+                    TableRow(cells=[TableCell(content=[], colspan=2, rowspan=2), TableCell(content=[])]),
+                    TableRow(cells=[TableCell(content=[], colspan=1, rowspan=2), TableCell(content=[])]),
+                    TableRow(cells=[TableCell(content=[]), TableCell(content=[], colspan=2)]),
+                ],
+            )
+        ]
+    )
+    with pytest.raises(All2MdError) as excinfo:
+        from_ast(doc, "docx")
+    assert "Failed to render DOCX" in str(excinfo.value)
+
+
+def test_pptx_merged_cell_failure_is_wrapped() -> None:
+    """#208's document reaches the caller as an ``All2MdError``.
+
+    The merge itself is still wrong — that is #208, and this test does not assert
+    it succeeds. What it pins is that the failure is reportable.
+    """
+    doc = Document(
+        children=[
+            Table(
+                header=TableRow(is_header=True, cells=[TableCell(content=[Text(content="0")])] * 2),
+                rows=[
+                    TableRow(cells=[TableCell(content=[], colspan=2, rowspan=2), TableCell(content=[])]),
+                    TableRow(cells=[TableCell(content=[], colspan=1, rowspan=2), TableCell(content=[])]),
+                    TableRow(cells=[TableCell(content=[]), TableCell(content=[], colspan=2)]),
+                ],
+            )
+        ]
+    )
+    with pytest.raises(All2MdError):
+        from_ast(doc, "pptx")
+
+
+def test_rtf_nested_task_item_failure_is_wrapped() -> None:
+    """#210's document reaches the caller as an ``All2MdError``.
+
+    RTF is the case the split entry points hid: ``render`` wrapped its body but
+    ``render_to_string`` — the path a text format actually takes — did not.
+    """
+    doc = Document(
+        children=[
+            List(
+                ordered=False,
+                tight=False,
+                items=[
+                    ListItem(
+                        task_status="checked",
+                        children=[
+                            List(
+                                ordered=False,
+                                tight=False,
+                                items=[ListItem(children=[], task_status="checked")],
+                            )
+                        ],
+                    )
+                ],
+            )
+        ]
+    )
+    with pytest.raises(All2MdError):
+        from_ast(doc, "rtf")

--- a/tests/unit/test_roundtrip_fuzzing.py
+++ b/tests/unit/test_roundtrip_fuzzing.py
@@ -136,10 +136,11 @@ KNOWN_CRASHES: dict[tuple[str, str], str] = {
     # An empty list item nested inside another list leaves the RTF renderer
     # emitting a group the RTF parser walks off the end of.
     ("rtf", "IndexError"): "rtf round trip of a nested empty list item indexes out of range",
-    # Same shape carrying a task status takes a different path and raises a bare
-    # KeyError, which also means the error escapes without being wrapped in
-    # ParsingError or RenderingError the way the API contract implies.
-    ("rtf", "KeyError"): "rtf round trip of a nested task list item raises an unwrapped KeyError",
+    # Same shape carrying a task status takes a different path and raises a
+    # KeyError from pyth. It is now wrapped in RenderingError (#212), so the
+    # needle matches the original error inside the wrapper's message; the crash
+    # itself is still live.
+    ("rtf", "KeyError"): "rtf round trip of a nested task list item raises a KeyError",
     # Nested links reach odfpy as <text:a> inside <text:a>, which ODF forbids.
     # Not a generator artifact: browsers accept nested <a>, the HTML parser
     # keeps the nesting, so `all2md page.html -t odt` fails on real pages.
@@ -410,7 +411,7 @@ class TestKnownCrashRepros:
                 NESTED_TASK_ITEM,
                 "rtf",
                 id="rtf-nested-task-list-item",
-                marks=pytest.mark.xfail(strict=True, reason="raises an unwrapped KeyError"),
+                marks=pytest.mark.xfail(strict=True, reason="pyth raises KeyError on the task status"),
             ),
             pytest.param(
                 NESTED_LINK,


### PR DESCRIPTION
Closes #212.

## The issue was under-scoped

#212 reported that `from_ast(doc, "pptx")` raises a bare `ValueError` and
`from_ast(doc, "rtf")` a bare `KeyError`, escaping the documented
`All2MdError` contract, and suggested bringing those two renderers in line
with DOCX.

Before fixing two renderers I probed all of them, with a node that raises
`ProbeError` from `accept()` — standing in for any unanticipated library
exception, wherever a renderer happens to walk the tree:

| Behaviour | Formats | Count |
|---|---|---|
| **Leaked** the bare exception | asciidoc, ast, dokuwiki, epub, html, ipynb, latex, markdown, mediawiki, org, plaintext, pptx, rst, rtf, textile | **15** |
| Wrapped in `RenderingError` | csv, docx, odt, odp, pdf | 5 |
| Never visited the node | ini, json, toml, yaml | 4 |

The fuzzer had only reached pptx and rtf because those were the shapes it
happened to generate. Fixing renderers one at a time would leave the same
hole open for the 16th.

## The fix

**`Pipeline._render` translates.** It is the single point every render
passes through, so the guarantee is structural rather than per-file
diligence. Two behaviours are preserved deliberately:

- A renderer that already raises `All2MdError` is re-raised untouched, so
  DOCX keeps `Failed to render DOCX: ...` rather than being reflattened.
- `NotImplementedError` / `AttributeError` keep their existing meaning of
  "this renderer does not offer that output mode" and still select the
  other one.

**Two renderers had the guard half-applied**, and those are worth
correcting where they live rather than leaning on the net:

- **PPTX** guarded only its *save* step, so python-pptx exceptions raised
  while building slides escaped. It now guards the whole body, as DOCX does.
- **RTF** guarded `render` but not `render_to_string` — which is the path a
  text format actually takes, so the guard it had was on the unused path.
  Both entry points now share one body.

## Verification

The gate was checked against the broken code in both directions, not just
observed to pass:

| Reverted | Contract test result |
|---|---|
| Chokepoint only | **13 fail** (the 15 leakers minus pptx/rtf, which hold on their own wraps) |
| pptx + rtf renderer wraps only | **passes** — the net catches them |
| Nothing | passes |

That split confirms both halves are independently load-bearing rather than
one masking the other.

The regression test parametrises over `roundtrippable_formats()` rather
than a hand-written tuple, so a format added later is covered without
anyone remembering. It also asserts **the probe actually fired**: if
nothing raised, the format must be in `NON_PROSE_FORMATS`, so a renderer
that silently stops walking the tree fails rather than passing vacuously.

## Scope

The underlying crashes are unchanged and still on the fuzzer's allowlist —
those are #206–#211. Only the exception type callers see is fixed, so no
`xfail(strict=True)` entry is removed here. Two stale comments in
`test_roundtrip_fuzzing.py` that described the rtf `KeyError` as
"unwrapped" are updated.

Local: `75 passed, 18 xfailed`; renderer, transform, API, e2e and
integration suites green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
