### PR TITLE
fix(odf): unwrap nested links instead of emitting invalid ODF

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   buffer and raised `IndexError` whenever such a table was the first thing rendered.
   The buffer is checked before indexing. Thanks
   [@santhreal](https://github.com/santhreal) (#205).
+- **ODT/ODP renderers: a nested link no longer fails the whole conversion.** ODF forbids
+  `<text:a>` inside `<text:a>` and odfpy enforces it, so a `Link` inside a `Link` raised
+  `IllegalChild` and aborted the render. This was reachable from ordinary input rather
+  than only from a hand-built AST: browsers accept nested `<a>` and the HTML parser
+  preserves the nesting, so `all2md page.html --out page.odt` failed outright on any page
+  containing one. The inner link is now unwrapped — its text is kept inside the enclosing
+  hyperlink and only its own target is dropped. Unwrapping rather than splitting the outer
+  link into siblings, which is what a browser does, keeps the surrounding inline flow
+  intact and stays correct at any depth, including a link buried under a `Strong` that
+  could not be split out without discarding the emphasis (#211).
 
 ## [1.10.1] - 2026-07-27
 

--- a/src/all2md/renderers/odp.py
+++ b/src/all2md/renderers/odp.py
@@ -123,6 +123,7 @@ class OdpRenderer(NodeVisitor, BaseRenderer):
         self._temp_files: list[str] = []  # Track temp files for cleanup
         self._network_rate_limiter: RateLimiter | None = None
         self._presentation: Any | None = None  # Current presentation object for image embedding
+        self._in_link: bool = False  # ODF forbids <text:a> inside <text:a>
 
     @requires_dependencies("odp_render", DEPS_ODF_RENDER)
     def render(self, doc: Document, output: Union[str, Path, IO[bytes]]) -> None:
@@ -964,20 +965,34 @@ class OdpRenderer(NodeVisitor, BaseRenderer):
         pass
 
     def visit_link(self, node: Link) -> None:
-        """Render link."""
+        """Render link.
+
+        A nested link is unwrapped rather than emitted, because ODF forbids
+        ``<text:a>`` inside ``<text:a>``. See :meth:`OdtRenderer.visit_link` for
+        why unwrapping is preferred over splitting the outer link.
+        """
         from odf.text import A
 
         if not self._current_paragraph:
             return
 
+        if self._in_link:
+            for child in node.content:
+                child.accept(self)
+            return
+
         link = A(href=node.url)
         saved_para = self._current_paragraph
         self._current_paragraph = link
+        self._in_link = True
 
-        for child in node.content:
-            child.accept(self)
+        try:
+            for child in node.content:
+                child.accept(self)
+        finally:
+            self._in_link = False
+            self._current_paragraph = saved_para
 
-        self._current_paragraph = saved_para
         saved_para.addElement(link)
 
     def visit_image(self, node: Image) -> None:

--- a/src/all2md/renderers/odt.py
+++ b/src/all2md/renderers/odt.py
@@ -115,6 +115,7 @@ class OdtRenderer(NodeVisitor, BaseRenderer):
         self._network_rate_limiter: RateLimiter | None = None
         self._list_ordered_stack: list[bool] = []  # Track ordered/unordered at each level
         self._blockquote_depth: int = 0  # Track blockquote nesting depth
+        self._in_link: bool = False  # ODF forbids <text:a> inside <text:a>
         self._in_table_header: bool = False  # Track if rendering table header cell
 
     @requires_dependencies("odt_render", DEPS_ODF_RENDER)
@@ -805,6 +806,20 @@ class OdtRenderer(NodeVisitor, BaseRenderer):
     def visit_link(self, node: Link) -> None:
         """Render a Link node.
 
+        A link nested inside another link is unwrapped: its text is rendered
+        into the enclosing hyperlink and its own target is dropped. ODF forbids
+        ``<text:a>`` inside ``<text:a>``, and odfpy enforces it, so emitting the
+        nested element raised ``IllegalChild`` and failed the whole render.
+
+        Nested links are invalid HTML too, but browsers accept them and the HTML
+        parser preserves the nesting, so this is reachable from an ordinary page
+        rather than only from a hand-built AST.
+
+        Unwrapping rather than splitting the outer link into siblings — what a
+        browser does — keeps the surrounding inline flow untouched and stays
+        correct at any depth, including a link buried under a ``Strong`` that
+        could not be split out without discarding the emphasis.
+
         Parameters
         ----------
         node : Link
@@ -816,15 +831,24 @@ class OdtRenderer(NodeVisitor, BaseRenderer):
         if not self._current_paragraph:
             return
 
+        if self._in_link:
+            for child in node.content:
+                child.accept(self)
+            return
+
         # Create hyperlink
         link = A(href=node.url)
         saved_para = self._current_paragraph
         self._current_paragraph = link
+        self._in_link = True
 
-        for child in node.content:
-            child.accept(self)
+        try:
+            for child in node.content:
+                child.accept(self)
+        finally:
+            self._in_link = False
+            self._current_paragraph = saved_para
 
-        self._current_paragraph = saved_para
         self._current_paragraph.addElement(link)
 
     def visit_image(self, node: Image) -> None:

--- a/tests/unit/renderers/test_odp_renderer.py
+++ b/tests/unit/renderers/test_odp_renderer.py
@@ -883,6 +883,47 @@ class TestLinkRendering:
 
         assert output_file.exists()
 
+    def test_nested_link_is_unwrapped(self, tmp_path):
+        """A link inside a link renders as one hyperlink, not two nested ones.
+
+        ODF forbids ``<text:a>`` inside ``<text:a>``, so this used to raise
+        ``IllegalChild`` and fail the whole render. Issue #211.
+        """
+        from odf.opendocument import load as odf_load
+        from odf.text import A
+
+        from all2md.ast import Link
+
+        doc = Document(
+            children=[
+                Paragraph(
+                    content=[
+                        Link(
+                            url="https://outer.example/",
+                            content=[
+                                Text(content="x"),
+                                Link(url="https://inner.example/", content=[Text(content="y")]),
+                            ],
+                        ),
+                        Text(content=" tail "),
+                        Link(url="https://after.example/", content=[Text(content="after")]),
+                    ]
+                ),
+            ]
+        )
+        renderer = OdpRenderer()
+        output_file = tmp_path / "nested_link.odp"
+        renderer.render(doc, output_file)
+
+        links = odf_load(str(output_file)).getElementsByType(A)
+        # The inner link is unwrapped, and the later sibling still gets its own
+        # href -- that second assertion is what pins the flag being cleared.
+        assert [link.getAttribute("href") for link in links] == [
+            "https://outer.example/",
+            "https://after.example/",
+        ]
+        assert str(links[0]) == "xy"
+
 
 @pytest.mark.unit
 class TestCommentRendering:

--- a/tests/unit/renderers/test_odt_renderer.py
+++ b/tests/unit/renderers/test_odt_renderer.py
@@ -265,6 +265,119 @@ class TestLinkRendering:
 
         assert output_file.exists()
 
+    def test_nested_link_is_unwrapped(self, tmp_path):
+        """A link inside a link renders as one hyperlink, not two nested ones.
+
+        ODF forbids ``<text:a>`` inside ``<text:a>`` and odfpy enforces it, so
+        this used to raise ``IllegalChild`` and fail the whole render. Reachable
+        from ordinary input: browsers accept nested ``<a>`` and the HTML parser
+        keeps the nesting. Issue #211.
+        """
+        doc = Document(
+            children=[
+                Paragraph(
+                    content=[
+                        Link(
+                            url="https://outer.example/",
+                            content=[
+                                Text(content="x"),
+                                Link(url="https://inner.example/", content=[Text(content="y")]),
+                            ],
+                        )
+                    ]
+                )
+            ]
+        )
+        renderer = OdtRenderer()
+        output_file = tmp_path / "nested_link.odt"
+        renderer.render(doc, output_file)
+
+        from odf.text import A
+
+        links = odf_load(str(output_file)).getElementsByType(A)
+        assert len(links) == 1, "the inner link must be unwrapped, not emitted"
+        assert links[0].getAttribute("href") == "https://outer.example/"
+        # Both pieces of text survive; only the inner target is dropped.
+        assert str(links[0]) == "xy"
+
+    def test_nested_link_does_not_leak_into_later_siblings(self, tmp_path):
+        """A link following a nested one still gets its own href.
+
+        The unwrapping is driven by a flag on the renderer, so this pins that the
+        flag is cleared: without that, every later link in the document would be
+        swallowed into the preceding one.
+        """
+        doc = Document(
+            children=[
+                Paragraph(
+                    content=[
+                        Link(
+                            url="https://outer.example/",
+                            content=[
+                                Text(content="x"),
+                                Link(url="https://inner.example/", content=[Text(content="y")]),
+                            ],
+                        ),
+                        Text(content=" tail "),
+                        Link(url="https://after.example/", content=[Text(content="after")]),
+                    ]
+                )
+            ]
+        )
+        renderer = OdtRenderer()
+        output_file = tmp_path / "nested_then_sibling.odt"
+        renderer.render(doc, output_file)
+
+        from odf.text import A
+
+        links = odf_load(str(output_file)).getElementsByType(A)
+        assert [link.getAttribute("href") for link in links] == [
+            "https://outer.example/",
+            "https://after.example/",
+        ]
+
+    def test_deeply_nested_links_are_unwrapped(self, tmp_path):
+        """Unwrapping holds at any depth, including through an inline wrapper.
+
+        A link buried under a ``Strong`` is why the renderer unwraps rather than
+        splitting the outer link into siblings the way a browser does: there is
+        no way to split it out without discarding the emphasis.
+        """
+        doc = Document(
+            children=[
+                Paragraph(
+                    content=[
+                        Link(
+                            url="https://outer.example/",
+                            content=[
+                                Text(content="a"),
+                                Strong(
+                                    content=[
+                                        Link(
+                                            url="https://mid.example/",
+                                            content=[
+                                                Link(url="https://deep.example/", content=[Text(content="b")]),
+                                            ],
+                                        )
+                                    ]
+                                ),
+                            ],
+                        )
+                    ]
+                )
+            ]
+        )
+        renderer = OdtRenderer()
+        output_file = tmp_path / "deep_nested_link.odt"
+        renderer.render(doc, output_file)
+
+        from odf.text import A
+
+        links = odf_load(str(output_file)).getElementsByType(A)
+        assert len(links) == 1
+        assert links[0].getAttribute("href") == "https://outer.example/"
+        assert str(links[0]) == "ab"
+
 
 @pytest.mark.unit
 class TestListRendering:

--- a/tests/unit/test_roundtrip_fuzzing.py
+++ b/tests/unit/test_roundtrip_fuzzing.py
@@ -135,20 +135,11 @@ KNOWN_CRASHES: dict[tuple[str, str], str] = {
     # An empty list item nested inside another list leaves the RTF renderer
     # emitting a group the RTF parser walks off the end of.
     ("rtf", "IndexError"): "rtf round trip of a nested empty list item indexes out of range",
-    # Same shape carrying a task status takes a different path and raises a bare
-    # KeyError, which also means the error escapes without being wrapped in
-    # ParsingError or RenderingError the way the API contract implies.
-    ("rtf", "KeyError"): "rtf round trip of a nested task list item raises an unwrapped KeyError",
     # Same shape carrying a task status takes a different path and raises a
     # KeyError from pyth. It is now wrapped in RenderingError (#212), so the
     # needle matches the original error inside the wrapper's message; the crash
     # itself is still live.
     ("rtf", "KeyError"): "rtf round trip of a nested task list item raises a KeyError",
-    # Nested links reach odfpy as <text:a> inside <text:a>, which ODF forbids.
-    # Not a generator artifact: browsers accept nested <a>, the HTML parser
-    # keeps the nesting, so `all2md page.html -t odt` fails on real pages.
-    ("odt", "IllegalChild"): "odt renderer emits nested text:a for a nested Link",
-    ("odp", "IllegalChild"): "odp renderer emits nested text:a for a nested Link",
 }
 
 

--- a/tests/unit/test_roundtrip_fuzzing.py
+++ b/tests/unit/test_roundtrip_fuzzing.py
@@ -59,7 +59,6 @@ from all2md.ast.nodes import (
     CodeBlock,
     Document,
     Heading,
-    Link,
     List,
     ListItem,
     Paragraph,
@@ -140,11 +139,6 @@ KNOWN_CRASHES: dict[tuple[str, str], str] = {
     # KeyError, which also means the error escapes without being wrapped in
     # ParsingError or RenderingError the way the API contract implies.
     ("rtf", "KeyError"): "rtf round trip of a nested task list item raises an unwrapped KeyError",
-    # Nested links reach odfpy as <text:a> inside <text:a>, which ODF forbids.
-    # Not a generator artifact: browsers accept nested <a>, the HTML parser
-    # keeps the nesting, so `all2md page.html -t odt` fails on real pages.
-    ("odt", "IllegalChild"): "odt renderer emits nested text:a for a nested Link",
-    ("odp", "IllegalChild"): "odp renderer emits nested text:a for a nested Link",
 }
 
 
@@ -309,27 +303,6 @@ SPANNING_GRID_OVERFLOW = Document(
     ]
 )
 
-#: A link inside a link, as produced by parsing ``<a>x<a>y</a></a>``.
-#:
-#: Built here rather than parsed so the reproduction stays deterministic, but
-#: the shape is not synthetic: feeding that HTML to the HTML parser yields
-#: exactly this AST, which is why the ODF failure hits real documents.
-NESTED_LINK = Document(
-    children=[
-        Paragraph(
-            content=[
-                Link(
-                    url="https://a.example.com/",
-                    content=[
-                        Text(content="x"),
-                        Link(url="https://b.example.com/", content=[Text(content="y")]),
-                    ],
-                )
-            ]
-        )
-    ]
-)
-
 #: An empty list item nested one level down, alongside an empty sibling.
 NESTED_EMPTY_ITEM = Document(
     children=[
@@ -411,18 +384,6 @@ class TestKnownCrashRepros:
                 "rtf",
                 id="rtf-nested-task-list-item",
                 marks=pytest.mark.xfail(strict=True, reason="raises an unwrapped KeyError"),
-            ),
-            pytest.param(
-                NESTED_LINK,
-                "odt",
-                id="odt-nested-link",
-                marks=pytest.mark.xfail(strict=True, reason="text:a nested inside text:a"),
-            ),
-            pytest.param(
-                NESTED_LINK,
-                "odp",
-                id="odp-nested-link",
-                marks=pytest.mark.xfail(strict=True, reason="text:a nested inside text:a"),
             ),
         ],
     )


### PR DESCRIPTION
Closes #211.

## The bug

ODF forbids `<text:a>` inside `<text:a>` and odfpy enforces it, so a `Link`
nested inside another `Link` raised `IllegalChild` and aborted the entire
render for both ODT and ODP.

## This one is reachable from real input

It is the only crash on the fuzzer's list that does not need a hand-built
AST, and I checked that rather than taking the issue's word for it:

```
$ cat nested.html
<html><body><p><a href="https://a.example/">x<a href="https://b.example/">y</a></a></p></body></html>

$ all2md nested.html --out out.odt
[ERROR] Failed to render ODT: IllegalChild('<text:a> is not allowed in <text:a>')
```

The HTML parser really does preserve the nesting — the outer `Link`'s
content comes back as `[Text, Link]` — so any page with a nested anchor
failed outright. After this change the same command writes the file.

## The fix

The inner link is unwrapped: its text renders into the enclosing hyperlink
and only its own target is dropped.

```xml
<!-- before: IllegalChild -->
<!-- after -->
<text:p><text:a xlink:href="https://a.example/">xy</text:a></text:p>
```

**Why unwrap rather than split into siblings** (which is what a browser
does, and would preserve the inner target): splitting reorders the inline
flow, and it cannot express a link buried under a `Strong` without
discarding the emphasis. Unwrapping is uniformly valid at any depth and
leaves surrounding formatting alone. Nested links are invalid HTML in the
first place, so the inner target is not reliably meaningful.

## Tests

Unwrapping is driven by a flag cleared in a `finally`, so there is a test
specifically for a link *following* a nested one — a leaked flag would
silently swallow every later link in the document, which is a worse bug
than the crash. Also covered: nesting through a `Strong`, triple nesting,
and the plain-link control.

Verified the tests can fail: with the renderer change reverted, all four
new tests fail (3 odt, 1 odp).

## Ratchet

Both entries are removed from `KNOWN_CRASHES` and `TestKnownCrashRepros`,
as strict-xfail requires — `48 passed, 16 xfailed`, down from 18.

The `NESTED_LINK` fixture goes with them. The invariant gate covers text
formats only (`INVARIANT_FORMATS`), so it could not host this shape; the
ODF renderer tests assert the emitted `text:a` elements directly, which is
stronger than a round-trip count. Generated documents still reach the shape
through the crash gate, so a regression fails there too.

## Parallel-work note

Branched off `main` and deliberately avoids the files in #217 — it touches
`odt.py`/`odp.py`, which that PR does not. The one shared file is
`test_roundtrip_fuzzing.py`, where #217 edits the rtf comment lines and this
edits the odt/odp entries below them; and `CHANGELOG.md`, where this entry
is appended at the end of `### Fixed` while #217 inserts at the top.

Local: `1292 passed, 16 xfailed` across the renderer suites and the fuzzer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
