### PR TITLE
fix(transforms): reset heading index when reusing GenerateTocTransform with set_ids_if_missing=True

### DIFF
--- a/src/all2md/transforms/builtin.py
+++ b/src/all2md/transforms/builtin.py
@@ -1266,6 +1266,7 @@ class GenerateTocTransform(NodeTransformer):
         self._headings = []
         self._id_counts = {}
         self._heading_id_map = {}
+        self._current_heading_idx = 0
 
         # First pass: collect headings and track which need IDs injected
         self._collect_headings(node)

--- a/tests/unit/transforms/test_builtin_transforms.py
+++ b/tests/unit/transforms/test_builtin_transforms.py
@@ -1151,7 +1151,6 @@ class TestGenerateTocTransform:
         # Original heading should come after TOC
         assert result.children[1].content[0].content == "Section"
 
-
     def test_generate_toc_transform_reuse_resets_heading_idx(self):
         """Test that reusing GenerateTocTransform with set_ids_if_missing resets heading index for subsequent documents."""
         doc1 = Document(
@@ -1184,6 +1183,8 @@ class TestGenerateTocTransform:
 
         assert doc2_headings[0].metadata.get("id") == "heading-a"
         assert doc2_headings[1].metadata.get("id") == "heading-b"
+
+
 # TitlePromotionTransform tests
 
 

--- a/tests/unit/transforms/test_builtin_transforms.py
+++ b/tests/unit/transforms/test_builtin_transforms.py
@@ -1152,6 +1152,38 @@ class TestGenerateTocTransform:
         assert result.children[1].content[0].content == "Section"
 
 
+    def test_generate_toc_transform_reuse_resets_heading_idx(self):
+        """Test that reusing GenerateTocTransform with set_ids_if_missing resets heading index for subsequent documents."""
+        doc1 = Document(
+            children=[
+                Heading(level=1, content=[Text(content="Heading 1")]),
+                Heading(level=2, content=[Text(content="Heading 2")]),
+            ]
+        )
+        doc2 = Document(
+            children=[
+                Heading(level=1, content=[Text(content="Heading A")]),
+                Heading(level=2, content=[Text(content="Heading B")]),
+            ]
+        )
+
+        transform = GenerateTocTransform(set_ids_if_missing=True)
+
+        res1 = transform.transform(doc1)
+        res2 = transform.transform(doc2)
+
+        doc1_headings = [
+            c for c in res1.children if isinstance(c, Heading) and c.content[0].content != "Table of Contents"
+        ]
+        doc2_headings = [
+            c for c in res2.children if isinstance(c, Heading) and c.content[0].content != "Table of Contents"
+        ]
+
+        assert doc1_headings[0].metadata.get("id") == "heading-1"
+        assert doc1_headings[1].metadata.get("id") == "heading-2"
+
+        assert doc2_headings[0].metadata.get("id") == "heading-a"
+        assert doc2_headings[1].metadata.get("id") == "heading-b"
 # TitlePromotionTransform tests
 
 


### PR DESCRIPTION
### Summary
Reset `_current_heading_idx` to 0 on entry in `GenerateTocTransform.transform()` / `visit()` (`src/all2md/transforms/builtin.py`).

### Root Cause
When reusing a single `GenerateTocTransform` instance across multiple documents (standard in transform pipelines), `_current_heading_idx` persisted across invocations, generating offset/duplicate heading IDs for subsequent documents.

### Fix
Set `self._current_heading_idx = 0` at the start of TOC generation.

### Verification
Added `test_generate_toc_transform_reuse_resets_heading_idx` to `tests/unit/transforms/test_builtin_transforms.py`.
- Executed `uv run pytest tests/unit/transforms/test_builtin_transforms.py`: 100% passed.