### PR TITLE
fix(yaml): handle non-string dictionary keys and sort key comparisons in YamlParser

### DIFF
--- a/src/all2md/parsers/yaml.py
+++ b/src/all2md/parsers/yaml.py
@@ -288,8 +288,8 @@ class YamlParser(BaseParser):
             nodes.append(Paragraph(content=[Text(content="{}")]))
             return nodes
 
-        # Get keys (optionally sorted)
-        keys = sorted(obj.keys()) if self.options.sort_keys else list(obj.keys())
+        # Get keys (optionally sorted, converting keys to str for sorting)
+        keys = sorted(obj.keys(), key=str) if self.options.sort_keys else list(obj.keys())
 
         # Check if we should flatten single-key objects
         if self.options.flatten_single_keys and len(keys) == 1:
@@ -299,7 +299,7 @@ class YamlParser(BaseParser):
             if isinstance(value, (dict, list)):
                 # Add heading for the single key and convert its value
                 heading_level = min(depth + 1, self.options.max_heading_depth)
-                nodes.append(Heading(level=heading_level, content=[Text(content=key)]))
+                nodes.append(Heading(level=heading_level, content=[Text(content=str(key))]))
                 nodes.extend(self._convert_value(value, depth + 1, key))
                 return nodes
 
@@ -319,7 +319,7 @@ class YamlParser(BaseParser):
                 # Create list item with bold key
                 paragraph = Paragraph(
                     content=[
-                        Strong(content=[Text(content=key)]),
+                        Strong(content=[Text(content=str(key))]),
                         Text(content=": "),
                     ]
                 )
@@ -343,14 +343,14 @@ class YamlParser(BaseParser):
             # Use heading if depth allows, otherwise use definition list style
             if depth < self.options.max_heading_depth:
                 heading_level = min(depth + 1, 6)
-                nodes.append(Heading(level=heading_level, content=[Text(content=key)]))
+                nodes.append(Heading(level=heading_level, content=[Text(content=str(key))]))
                 nodes.extend(self._convert_value(value, depth + 1, key))
             else:
                 # Too deep for headings - use bold key style in a list
                 value_nodes = self._convert_value(value, depth + 1, key)
                 paragraph = Paragraph(
                     content=[
-                        Strong(content=[Text(content=key)]),
+                        Strong(content=[Text(content=str(key))]),
                         Text(content=": "),
                     ]
                 )
@@ -461,7 +461,7 @@ class YamlParser(BaseParser):
         # Get column names from first item
         columns = list(arr[0].keys())
         if self.options.sort_keys:
-            columns = sorted(columns)
+            columns = sorted(columns, key=str)
 
         # Create header row
         header_cells = [TableCell(content=[Text(content=str(col))]) for col in columns]

--- a/tests/unit/parsers/test_yaml_parser.py
+++ b/tests/unit/parsers/test_yaml_parser.py
@@ -730,6 +730,7 @@ sections:
         headings = [child for child in doc.children if isinstance(child, Heading)]
         assert len(headings) > 0
 
+
 class TestYamlParserNonStringKeys:
     """Test YAML parser handling of non-string dictionary keys."""
 

--- a/tests/unit/parsers/test_yaml_parser.py
+++ b/tests/unit/parsers/test_yaml_parser.py
@@ -729,3 +729,52 @@ sections:
         # Should have headings for top-level keys
         headings = [child for child in doc.children if isinstance(child, Heading)]
         assert len(headings) > 0
+
+class TestYamlParserNonStringKeys:
+    """Test YAML parser handling of non-string dictionary keys."""
+
+    def test_non_string_keys_render_without_crash(self):
+        """YAML maps can contain non-string keys (integers, dates, booleans, floats).
+
+        Verify sorting and AST Text node creation handle non-string keys without TypeError crash.
+        """
+        from all2md.renderers.markdown import MarkdownRenderer
+
+        yaml_content = """
+2025-01-01: new_year
+100: century
+true: active
+3.14: pi
+"""
+        options = YamlParserOptions(literal_block=False, sort_keys=True)
+        parser = YamlParser(options)
+        doc = parser.parse(yaml_content)
+
+        renderer = MarkdownRenderer()
+        output = renderer.render_to_string(doc)
+
+        assert "**2025-01-01**: new_year" in output
+        assert "**100**: century" in output
+        assert "**True**: active" in output
+        assert "**3.14**: pi" in output
+
+    def test_non_string_table_keys(self):
+        """Verify YAML arrays of dicts with non-string keys render as tables without sorting errors."""
+        from all2md.renderers.markdown import MarkdownRenderer
+
+        yaml_content = """
+- 100: val1
+  200: val2
+- 100: val3
+  200: val4
+"""
+        options = YamlParserOptions(array_as_table_threshold=2, sort_keys=True)
+        parser = YamlParser(options)
+        doc = parser.parse(yaml_content)
+
+        renderer = MarkdownRenderer()
+        output = renderer.render_to_string(doc)
+
+        assert "100" in output
+        assert "200" in output
+        assert "val1" in output


### PR DESCRIPTION
### Summary
Fix `YamlParser` in `src/all2md/parsers/yaml.py` to handle YAML mappings containing non-string dictionary keys (integers, floats, dates, booleans) without raising `TypeError`.

### Root Cause
1. `sorted(obj.keys())` raised `TypeError: '<' not supported between instances of 'str' and 'int'` when a YAML map contained mixed key types.
2. Passing non-string keys directly to `Text(content=key)` raised `TypeError` in `Text.__init__`.

### Fix
- Used `sorted(obj.keys(), key=str)` for sorting dictionary keys.
- Wrapped keys with `str(key)` before instantiating `Text` nodes.

### Verification
Added `TestYamlParserNonStringKeys` to `tests/unit/parsers/test_yaml_parser.py`.
- Executed `uv run pytest tests/unit/parsers/test_yaml_parser.py`: 100% passed.