### PR TITLE
fix(markdown): tolerate null or non-dictionary attrs in MarkdownToAstConverter token processing

### DIFF
--- a/src/all2md/parsers/markdown.py
+++ b/src/all2md/parsers/markdown.py
@@ -823,6 +823,8 @@ class MarkdownToAstConverter(BaseParser):
         """
         code_content = token.get("raw", "")
         attrs = token.get("attrs", {})
+        if not isinstance(attrs, dict):
+            attrs = {}
         info_string = attrs.get("info", None)
 
         # Initialize metadata for code block
@@ -961,6 +963,8 @@ class MarkdownToAstConverter(BaseParser):
         # Check for task list checkbox
         task_status: Literal["checked", "unchecked"] | None = None
         attrs = token.get("attrs", {})
+        if not isinstance(attrs, dict):
+            attrs = {}
         if "checked" in attrs:
             task_status = "checked" if attrs["checked"] else "unchecked"
 
@@ -1001,7 +1005,10 @@ class MarkdownToAstConverter(BaseParser):
                             content = self._process_inline_tokens(cell_children)
 
                             # Get alignment if specified
-                            align = cell_token.get("attrs", {}).get("align", None)
+                            cell_attrs = cell_token.get("attrs", {})
+                            if not isinstance(cell_attrs, dict):
+                                cell_attrs = {}
+                            align = cell_attrs.get("align", None)
                             alignments_list.append(align)
 
                             cells.append(TableCell(content=content, alignment=align))
@@ -1041,6 +1048,8 @@ class MarkdownToAstConverter(BaseParser):
 
             # Get alignment if specified
             attrs = cell_token.get("attrs", {})
+            if not isinstance(attrs, dict):
+                attrs = {}
             alignment = attrs.get("align", None)
 
             cells.append(TableCell(content=content, alignment=alignment))

--- a/tests/unit/parsers/test_markdown_parser_improvements.py
+++ b/tests/unit/parsers/test_markdown_parser_improvements.py
@@ -294,3 +294,49 @@ class TestMarkdownFootnotes:
         assert len(defs) == 1
         paragraphs = [c for c in defs[0].content if isinstance(c, Paragraph)]
         assert len(paragraphs) == 2
+
+class TestMarkdownNullAttrsHandling:
+    """Regression tests for tokens containing null or non-dict attrs attribute.
+
+    Mistune parser tokens or custom extension plugins may produce token dictionaries
+    where the ``attrs`` key is explicitly set to ``None`` or a non-dict value (such as
+    a string or list). The AST converter must safely handle non-dict ``attrs`` attributes
+    without raising ``AttributeError`` or ``TypeError``.
+    """
+
+    def test_null_or_nondict_attrs_handling(self) -> None:
+        """Verify that tokens with null or non-dict attrs do not raise exceptions during conversion.
+
+        When mistune tokens contain attrs=None or non-dict attrs (e.g., a string or list),
+        dictionary lookups like attrs.get() or 'key' in attrs raise AttributeError or TypeError.
+        The converter normalizes non-dict attrs to an empty dict.
+        """
+        converter = MarkdownToAstConverter()
+
+        # Token with attrs=None and attrs="invalid" for code block
+        for bad_attrs in (None, "invalid", [1, 2]):
+            code_token = {"type": "block_code", "raw": "print('hello')", "attrs": bad_attrs}
+            code_block = converter._process_code_block(code_token)
+            assert code_block.content == "print('hello')"
+
+        # Token with attrs=None and attrs="invalid" for list item
+        for bad_attrs in (None, "invalid", [1, 2]):
+            item_token = {"type": "list_item", "children": [], "attrs": bad_attrs}
+            list_item = converter._process_list_item(item_token)
+            assert list_item.task_status is None
+
+        # Token with attrs=None and attrs="invalid" for table_head cell in _process_table
+        for bad_attrs in (None, "invalid", [1, 2]):
+            head_cell = {"type": "table_cell", "children": [], "attrs": bad_attrs}
+            head_row = {"type": "table_head", "children": [head_cell]}
+            table = converter._process_table({"children": [head_row]})
+            assert table.header is not None
+            assert len(table.header.cells) == 1
+            assert table.header.cells[0].alignment is None
+
+        # Token with attrs=None and attrs="invalid" for table row cells in _process_table_row_cells
+        for bad_attrs in (None, "invalid", [1, 2]):
+            cell_token = {"type": "table_cell", "children": [], "attrs": bad_attrs}
+            cells = converter._process_table_row_cells({"children": [cell_token]})
+            assert len(cells) == 1
+            assert cells[0].alignment is None

--- a/tests/unit/parsers/test_markdown_parser_improvements.py
+++ b/tests/unit/parsers/test_markdown_parser_improvements.py
@@ -295,6 +295,7 @@ class TestMarkdownFootnotes:
         paragraphs = [c for c in defs[0].content if isinstance(c, Paragraph)]
         assert len(paragraphs) == 2
 
+
 class TestMarkdownNullAttrsHandling:
     """Regression tests for tokens containing null or non-dict attrs attribute.
 


### PR DESCRIPTION
### Summary
Fix `MarkdownToAstConverter` in `src/all2md/parsers/markdown.py` to handle tokens carrying `attrs=None` or non-dictionary `attrs` without raising `AttributeError` or `TypeError`.

### Root Cause
Tokens emitted by custom mistune extension plugins or token transformers may set `"attrs": None` or non-dict values. Calling `.get("align")` or `.get("language")` on `None` raised `AttributeError: 'NoneType' object has no attribute 'get'`.

### Fix
Guarded `attrs` extraction across code blocks, list items, and table cells with `if not isinstance(attrs, dict): attrs = {}`.

### Verification
Added `TestMarkdownNullAttrsHandling` to `tests/unit/parsers/test_markdown_parser_improvements.py`.
- Executed `uv run pytest tests/unit/parsers/test_markdown_parser_improvements.py`: 100% passed.