### PR TITLE
fix(pptx): clamp nesting_level to prevent list stack underflow in PptxRenderer

### DIFF
--- a/src/all2md/renderers/pptx.py
+++ b/src/all2md/renderers/pptx.py
@@ -1259,9 +1259,7 @@ class PptxRenderer(NodeVisitor, BaseRenderer):
         is_ordered = self._list_ordered_stack[-1] if self._list_ordered_stack else False
 
         # Calculate nesting level (depth in the stack)
-        nesting_level = len(self._list_ordered_stack) - 1
-        # Limit to reasonable depth for PowerPoint (0-8)
-        nesting_level = min(nesting_level, 8)
+        nesting_level = max(0, min(len(self._list_ordered_stack) - 1, 8))
 
         if is_ordered:
             # For ordered lists, manually add number prefix since python-pptx

--- a/tests/unit/renderers/test_pptx_renderer.py
+++ b/tests/unit/renderers/test_pptx_renderer.py
@@ -1775,6 +1775,7 @@ class TestFlowLayoutBackwardCompat:
         assert len(table_shapes) == 1
         assert abs(_shape_top_inches(table_shapes[0]) - 2.0) < 0.01
 
+
 @pytest.mark.unit
 @pytest.mark.pptx
 def test_standalone_list_item_rendering():

--- a/tests/unit/renderers/test_pptx_renderer.py
+++ b/tests/unit/renderers/test_pptx_renderer.py
@@ -1774,3 +1774,17 @@ class TestFlowLayoutBackwardCompat:
         table_shapes = [s for s in slide.shapes if s.has_table]
         assert len(table_shapes) == 1
         assert abs(_shape_top_inches(table_shapes[0]) - 2.0) < 0.01
+
+@pytest.mark.unit
+@pytest.mark.pptx
+def test_standalone_list_item_rendering():
+    """Verify standalone ListItem without parent List defaults level to 0 without stack underflow ValueError."""
+    renderer = PptxRenderer()
+    doc = Document(children=[ListItem(children=[Paragraph(content=[Text("Orphaned list item")])])])
+    out = BytesIO()
+    renderer.render(doc, out)
+    prs = Presentation(out)
+    assert len(prs.slides) == 1
+    text_shapes = [s for s in prs.slides[0].shapes if s.has_text_frame]
+    all_text = "\n".join(s.text_frame.text for s in text_shapes)
+    assert "Orphaned list item" in all_text


### PR DESCRIPTION
### Summary
Fix `PptxRenderer.visit_list_item` in `src/all2md/renderers/pptx.py` to prevent negative list nesting levels when rendering standalone `ListItem` AST nodes.

### Root Cause
Visiting a `ListItem` node outside a parent `List` resulted in `len(self._list_ordered_stack) - 1 == -1`, causing `python-pptx` paragraph `level` property to raise `ValueError: level must be between 0 and 8`.

### Fix
Clamped `nesting_level` via `max(0, min(len(self._list_ordered_stack) - 1, 8))`.

### Verification
Added `test_standalone_list_item_rendering` to `tests/unit/renderers/test_pptx_renderer.py`.
- Executed `uv run pytest tests/unit/renderers/test_pptx_renderer.py`: 100% passed.