### PR TITLE
fix(mediawiki): include pipe separator between table cell attributes and text content

### DIFF
--- a/src/all2md/renderers/mediawiki.py
+++ b/src/all2md/renderers/mediawiki.py
@@ -281,6 +281,8 @@ class MediaWikiRenderer(NodeVisitor, InlineContentMixin, BaseRenderer):
                     span_attrs += f' colspan="{cell.colspan}"'
                 if cell.rowspan > 1:
                     span_attrs += f' rowspan="{cell.rowspan}"'
+                if span_attrs:
+                    span_attrs += " |"
 
                 if first_cell:
                     self._output.append(f"!{span_attrs} ")
@@ -303,6 +305,8 @@ class MediaWikiRenderer(NodeVisitor, InlineContentMixin, BaseRenderer):
                     span_attrs += f' colspan="{cell.colspan}"'
                 if cell.rowspan > 1:
                     span_attrs += f' rowspan="{cell.rowspan}"'
+                if span_attrs:
+                    span_attrs += " |"
 
                 if first_cell:
                     self._output.append(f"|{span_attrs} ")

--- a/tests/unit/renderers/test_mediawiki_parser.py
+++ b/tests/unit/renderers/test_mediawiki_parser.py
@@ -557,3 +557,35 @@ class TestMediaWikiRenderer:
         output = renderer.render_to_string(doc)
 
         assert "<!-- [Comment by Jane Smith: needs review] -->" in output
+    def test_render_table_cell_attributes_use_pipe_separator(self) -> None:
+        """Test that table cell attributes (colspan/rowspan) use pipe separator in MediaWiki markup.
+
+        MediaWiki table syntax requires cell attributes to be separated from cell text content
+        by a pipe ('|'). Without the pipe separator, attributes like colspan or rowspan are
+        treated as literal cell text by MediaWiki rendering and parsing engines.
+        """
+        doc = Document(
+            children=[
+                Table(
+                    header=TableRow(
+                        cells=[
+                            TableCell(content=[Text(content="Header Spanning")], colspan=2),
+                            TableCell(content=[Text(content="Header 2")]),
+                        ]
+                    ),
+                    rows=[
+                        TableRow(
+                            cells=[
+                                TableCell(content=[Text(content="Cell Spanning")], colspan=2, rowspan=2),
+                                TableCell(content=[Text(content="Cell 2")]),
+                            ]
+                        )
+                    ],
+                )
+            ]
+        )
+        renderer = MediaWikiRenderer()
+        output = renderer.render_to_string(doc)
+
+        assert '! colspan="2" | Header Spanning' in output
+        assert '| colspan="2" rowspan="2" | Cell Spanning' in output

--- a/tests/unit/renderers/test_mediawiki_parser.py
+++ b/tests/unit/renderers/test_mediawiki_parser.py
@@ -557,6 +557,7 @@ class TestMediaWikiRenderer:
         output = renderer.render_to_string(doc)
 
         assert "<!-- [Comment by Jane Smith: needs review] -->" in output
+
     def test_render_table_cell_attributes_use_pipe_separator(self) -> None:
         """Test that table cell attributes (colspan/rowspan) use pipe separator in MediaWiki markup.
 


### PR DESCRIPTION
### Summary
Fix `MediaWikiRenderer` in `src/all2md/renderers/mediawiki.py` to include the required pipe `|` separator when rendering table cell attributes (such as `colspan` or `rowspan`).

### Root Cause
Table cell attributes were rendered directly preceding cell content without a pipe separator (`| colspan="2" Content`), causing MediaWiki wikitext parsers to treat `colspan="2" Content` as literal cell text instead of attribute formatting.

### Fix
Appended `" |"` to `span_attrs` when cell attributes are present.

### Verification
Added `test_render_table_cell_attributes_use_pipe_separator` to `tests/unit/renderers/test_mediawiki_parser.py`.
- Executed `uv run pytest tests/unit/renderers/test_mediawiki_parser.py`: 100% passed.