### PR TITLE
fix(ast): raise context-rich ValueError for invalid integer section range specs in parse_section_ranges

### DIFF
--- a/src/all2md/ast/sections.py
+++ b/src/all2md/ast/sections.py
@@ -292,16 +292,16 @@ def parse_section_ranges(section_spec: str, total_sections: int) -> list[int]:
             end_str = range_parts[1].strip()
 
             # Parse start (1-based to 0-based)
-            if start_str:
-                start = int(start_str) - 1
-            else:
-                start = 0
+            try:
+                start = int(start_str) - 1 if start_str else 0
+            except ValueError as e:
+                raise ValueError(f"Invalid section specification '{part}': '{start_str}' is not a valid integer") from e
 
             # Parse end (1-based to 0-based, or use total_sections if empty)
-            if end_str:
-                end = int(end_str) - 1
-            else:
-                end = total_sections - 1
+            try:
+                end = int(end_str) - 1 if end_str else total_sections - 1
+            except ValueError as e:
+                raise ValueError(f"Invalid section specification '{part}': '{end_str}' is not a valid integer") from e
 
             # Swap if reversed range (e.g., "10-5" becomes "5-10")
             if start > end:
@@ -313,7 +313,10 @@ def parse_section_ranges(section_spec: str, total_sections: int) -> list[int]:
                     sections.add(s)
         else:
             # Single section (1-based to 0-based)
-            section = int(part) - 1
+            try:
+                section = int(part) - 1
+            except ValueError as e:
+                raise ValueError(f"Invalid section specification '{part}': not a valid integer or range") from e
             if 0 <= section < total_sections:
                 sections.add(section)
 

--- a/tests/unit/ast/test_document_utils.py
+++ b/tests/unit/ast/test_document_utils.py
@@ -1103,3 +1103,21 @@ class TestFindHeading:
 
         assert result is not None
         assert result[0] == 0
+
+
+@pytest.mark.unit
+class TestParseSectionRanges:
+    """Tests for parse_section_ranges function."""
+
+    def test_parse_section_ranges_invalid_integer(self):
+        """Test parse_section_ranges with non-digit parts raises ValueError instead of unhandled ValueError."""
+        from all2md.ast.sections import parse_section_ranges
+
+        with pytest.raises(ValueError, match="Invalid section specification"):
+            parse_section_ranges("invalid", 5)
+
+        with pytest.raises(ValueError, match="Invalid section specification"):
+            parse_section_ranges("1-abc", 5)
+
+        with pytest.raises(ValueError, match="Invalid section specification"):
+            parse_section_ranges("abc-5", 5)


### PR DESCRIPTION
### Summary
Fix `parse_section_ranges` in `src/all2md/ast/sections.py` to catch raw `ValueError` from non-integer section range inputs and raise a helpful, descriptive error message.

### Root Cause
Passing malformed section range specifications (e.g. `"1-a"` or `"abc"`) caused uncaught `ValueError: invalid literal for int() with base 10` during range parsing.

### Fix
Wrapped integer conversion in `try...except ValueError` and raised `ValueError(f"Invalid section specification '{part}': not a valid integer or range")`.

### Verification
Added `TestParseSectionRanges` to `tests/unit/ast/test_document_utils.py`.
- Executed `uv run pytest tests/unit/ast/test_document_utils.py`: 100% passed.