### PR TITLE
fix(rst): clamp heading level to 6 for deeply nested sections in RestructuredTextParser

### DIFF
--- a/src/all2md/parsers/rst.py
+++ b/src/all2md/parsers/rst.py
@@ -257,6 +257,7 @@ class RestructuredTextParser(BaseParser):
             if isinstance(parent, docutils_nodes.section):
                 level += 1
             parent = parent.parent
+        level = min(level, 6)
 
         # Process children
         for child in node.children:

--- a/tests/unit/parsers/test_rst_parser.py
+++ b/tests/unit/parsers/test_rst_parser.py
@@ -88,6 +88,29 @@ Level 3
         # Third heading is inside a section, so level may differ
         assert headings[2].level >= 1
 
+    def test_deeply_nested_headings(self) -> None:
+        """Test parsing deeply nested sections (> 6 levels) clamps heading level to 6."""
+        markers = ["=", "-", "~", "^", '"', "'", "+", "*", "#"]
+        lines = []
+        for i, m in enumerate(markers, start=1):
+            lines.extend([f"Section {i}", m * 10, ""])
+        rst = "\n".join(lines)
+
+        parser = RestructuredTextParser()
+        doc = parser.parse(rst)
+
+        def collect_headings(node):
+            res = []
+            if isinstance(node, Heading):
+                res.append(node)
+            for child in getattr(node, "children", []):
+                res.extend(collect_headings(child))
+            return res
+
+        headings = collect_headings(doc)
+        assert [h.level for h in headings] == [1, 2, 1, 2, 3, 4, 5, 6, 6]
+        assert headings[-1].level == 6
+
     def test_simple_paragraph(self) -> None:
         """Test parsing a simple paragraph."""
         rst = "This is a simple paragraph."


### PR DESCRIPTION
### Summary
Fix `RestructuredTextParser._process_section` in `src/all2md/parsers/rst.py` to clamp heading levels to 6 when parsing deeply nested reStructuredText sections (> 6 levels).

### Root Cause
reStructuredText documents with 7 or more nested section levels caused `Heading.__init__` to raise `ValueError: Heading level must be between 1 and 6, got 7`.

### Fix
Clamped section level using `level = min(level, 6)`.

### Verification
Added `test_deeply_nested_headings` to `tests/unit/parsers/test_rst_parser.py`.
- Executed `uv run pytest tests/unit/parsers/test_rst_parser.py`: 100% passed.