### PR TITLE
fix(markdown): calculate table columns across all rows in MarkdownRenderer

### DIFF
--- a/src/all2md/renderers/markdown.py
+++ b/src/all2md/renderers/markdown.py
@@ -1148,7 +1148,7 @@ class MarkdownRenderer(NodeVisitor, InlineContentMixin, BaseRenderer):
         if not rows_to_render:
             return
 
-        num_cols = len(rows_to_render[0].cells) if rows_to_render else 0
+        num_cols = self._compute_table_columns(rows_to_render)
         rendered_rows = self._render_cells_to_strings(rows_to_render)
 
         if self.options.pad_table_cells:
@@ -1200,7 +1200,7 @@ class MarkdownRenderer(NodeVisitor, InlineContentMixin, BaseRenderer):
         if not rows_to_render:
             return
 
-        num_cols = len(rows_to_render[0].cells) if rows_to_render else 0
+        num_cols = self._compute_table_columns(rows_to_render)
 
         # Render all cells to determine column widths
         rendered_rows: list[list[str]] = []

--- a/tests/unit/renderers/test_markdown_renderer.py
+++ b/tests/unit/renderers/test_markdown_renderer.py
@@ -932,6 +932,28 @@ class TestTables:
         assert "<table>" in result
         assert "<th>Header</th>" in result
 
+    def test_table_body_rows_exceed_header_columns_padded(self):
+        """Test rendering table where body rows have more columns than the header row."""
+        header = TableRow(cells=[TableCell(content=[Text(content="H1")])], is_header=True)
+        row = TableRow(cells=[TableCell(content=[Text(content="C1")]), TableCell(content=[Text(content="C2")])])
+        table = Table(header=header, rows=[row])
+        options = MarkdownRendererOptions(pad_table_cells=True)
+        renderer = MarkdownRenderer(options)
+        result = renderer.render_to_string(table)
+        assert "C2" in result
+        assert "| C1 | C2 |" in result
+
+    def test_table_body_rows_exceed_header_columns_ascii(self):
+        """Test rendering ASCII table where body rows have more columns than the header row."""
+        header = TableRow(cells=[TableCell(content=[Text(content="H1")])], is_header=True)
+        row = TableRow(cells=[TableCell(content=[Text(content="C1")]), TableCell(content=[Text(content="C2")])])
+        table = Table(header=header, rows=[row])
+        options = MarkdownRendererOptions(flavor="commonmark", unsupported_table_mode="ascii")
+        renderer = MarkdownRenderer(options)
+        result = renderer.render_to_string(table)
+        assert "C2" in result
+        assert "| C1 | C2 |" in result
+
 
 @pytest.mark.unit
 class TestThematicBreak:


### PR DESCRIPTION
### Summary
Fix `MarkdownRenderer._render_table_grid` and `_render_table_as_ascii` in `src/all2md/renderers/markdown.py` to compute maximum column count across all table rows instead of relying solely on the header row.

### Root Cause
`num_cols` was calculated using `len(rows_to_render[0].cells)`, causing tables whose header row has fewer columns than body rows (or an empty header) to truncate and drop body cells beyond `num_cols - 1`.

### Fix
Switched to `self._compute_table_columns(rows_to_render)` in both grid and ASCII table rendering methods.

### Verification
Added `test_table_body_rows_exceed_header_columns_padded` to `tests/unit/renderers/test_markdown_renderer.py`.
- Executed `uv run pytest tests/unit/renderers/test_markdown_renderer.py`: 100% passed.