### PR TITLE
fix(fb2): handle raw XML string input directly in Fb2ToAstConverter.parse

### DIFF
--- a/src/all2md/parsers/fb2.py
+++ b/src/all2md/parsers/fb2.py
@@ -199,15 +199,26 @@ class Fb2ToAstConverter(BaseParser):
     # Parsing helpers
     # ------------------------------------------------------------------
     def _load_fb2_bytes(self, input_data: Union[str, Path, IO[bytes], bytes]) -> bytes:
-        if isinstance(input_data, (str, Path)):
-            path = Path(input_data)
-            if path.suffix.lower() == ".fb2":
-                return path.read_bytes()
-            if path.name.lower().endswith(".fb2.zip") or path.suffix.lower() == ".zip":
-                with self._validated_zip_input(path, suffix=".zip") as validated:
+        if isinstance(input_data, Path):
+            if input_data.name.lower().endswith(".fb2.zip") or input_data.suffix.lower() == ".zip":
+                with self._validated_zip_input(input_data, suffix=".zip") as validated:
                     return self._extract_fb2_from_zip(validated)
+            return input_data.read_bytes()
 
-            return path.read_bytes()
+        if isinstance(input_data, str):
+            if len(input_data) <= 260 and "\n" not in input_data:
+                try:
+                    path = Path(input_data)
+                    if path.is_file():
+                        if path.name.lower().endswith(".fb2.zip") or path.suffix.lower() == ".zip":
+                            with self._validated_zip_input(path, suffix=".zip") as validated:
+                                return self._extract_fb2_from_zip(validated)
+                        return path.read_bytes()
+                except OSError:
+                    # Ignore path resolution or file read errors; fall back to treating string as raw XML
+                    pass
+
+            return input_data.encode("utf-8")
 
         if isinstance(input_data, bytes):
             if input_data.startswith(b"PK\x03\x04"):

--- a/tests/unit/parsers/test_fb2_parser.py
+++ b/tests/unit/parsers/test_fb2_parser.py
@@ -234,3 +234,23 @@ def test_fb2_epigraph_still_blockquote() -> None:
     assert isinstance(document.children[0], BlockQuote)
     assert extract_text(document.children[0].children[0], joiner=" ").strip() == "epi"
     assert extract_text(document.children[0].children[1], joiner=" ").strip() == "auth"
+
+
+def test_fb2_parse_raw_xml_string_input() -> None:
+    """Parsing raw FB2 XML string content should return valid AST Document without FileNotFoundError."""
+    fb2_str = """<?xml version="1.0" encoding="utf-8"?>
+<FictionBook xmlns="http://www.gribuser.ru/xml/fictionbook/2.0">
+  <body>
+    <section>
+      <title><p>Raw String Chapter</p></title>
+      <p>Raw string content paragraph.</p>
+    </section>
+  </body>
+</FictionBook>"""
+    parser = Fb2ToAstConverter()
+    document = parser.parse(fb2_str)
+    assert len(document.children) == 2
+    assert isinstance(document.children[0], Heading)
+    assert extract_text(document.children[0], joiner=" ").strip() == "Raw String Chapter"
+    assert isinstance(document.children[1], Paragraph)
+    assert extract_text(document.children[1], joiner=" ").strip() == "Raw string content paragraph."


### PR DESCRIPTION
### Summary
Fix `Fb2ToAstConverter.parse` in `src/all2md/parsers/fb2.py` to handle raw FB2 XML string content directly without raising `FileNotFoundError`.

### Root Cause
Passing raw FB2 XML string content to `parse()` caused `_load_fb2_bytes` to treat every string as a file path, attempting `Path(input_data).read_bytes()` and raising `FileNotFoundError` (or `OSError`) on missing files.

### Fix
In `_load_fb2_bytes`, probe `Path(input_data).is_file()` for short strings (`len <= 260` without newlines) and handle `OSError`, falling back to encoding the string as UTF-8 XML content. Note: mistyped filenames now surface as FB2 XML parse syntax errors rather than missing-file errors, matching other text parsers.

### Verification
Added `test_fb2_parse_raw_xml_string_input` to `tests/unit/parsers/test_fb2_parser.py`.
- Executed `uv run pytest tests/unit/parsers/test_fb2_parser.py`: 100% passed.