### PR TITLE
fix(asciidoc): round-trip nested lists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **AsciiDoc: nested lists survive a round trip.** The renderer emitted a `+` list
+  continuation before a nested list, which detaches it into a block of its own and
+  leaves the `**` marker with no `*` parent at the level below it — output the AsciiDoc
+  parser rejected with `Cannot nest to level 2 without a parent item at level 1`. Every
+  document with a nested list was affected, not only the task-list shape the fuzzer
+  first reported. Nesting is now carried by the marker alone; `+` is still emitted for
+  code blocks, tables, block quotes and additional paragraphs, which do need it.
+  Closing the round trip also required the parser to learn list continuations at all:
+  it treated a lone `+` as the end of the list, so the item after an attached block
+  started a fresh list with no parent to nest under, and valid hand-written AsciiDoc
+  such as `* a\n** b\n+\nc\n** d` was rejected. Continuation blocks now attach to the
+  open item and the list stays open (#206).
 - **Rendering failures now always raise `All2MdError`, whatever the underlying library
   raised.** `from_ast` documents that failures surface as `All2MdError` subclasses, but
   renderers delegate to third-party libraries that raise their own types, and only some

--- a/src/all2md/ast/builder.py
+++ b/src/all2md/ast/builder.py
@@ -194,6 +194,30 @@ class ListBuilder:
         item = ListItem(children=content, task_status=task_status)
         parent_list.items.append(item)
 
+    def add_content_to_last_item(self, content: list[Node]) -> None:
+        """Append block content to the most recently added item.
+
+        Formats with an explicit continuation marker - AsciiDoc's ``+`` line -
+        can attach a block to the open item without closing the list, so the
+        items that follow keep their nesting level.
+
+        Parameters
+        ----------
+        content : list of Node
+            Block nodes to append to the open item's children
+
+        Raises
+        ------
+        ValueError
+            If no item has been added yet, so there is nothing to attach to
+
+        """
+        current_list = self._list_stack[-1][0] if self._list_stack else None
+        if current_list is None or not current_list.items:
+            raise ValueError("Cannot attach content before the first list item")
+
+        current_list.items[-1].children.extend(content)
+
     def get_document(self) -> Document:
         """Get the constructed document.
 

--- a/src/all2md/parsers/asciidoc.py
+++ b/src/all2md/parsers/asciidoc.py
@@ -1451,6 +1451,21 @@ class AsciiDocParser(BaseParser):
             # Create and append the footnote definition
             children.append(FootnoteDefinition(identifier=identifier, content=cast(list[Node], content_nodes)))
 
+    def _is_list_continuation(self) -> bool:
+        """Report whether the cursor sits on a list continuation ("+") line.
+
+        The lexer has no dedicated token for it, so a continuation arrives as a
+        text line whose only content is a plus sign.
+
+        Returns
+        -------
+        bool
+            True if the current token is a lone "+" line
+
+        """
+        token = self._current_token()
+        return token.type == TokenType.TEXT_LINE and token.content.strip() == "+"
+
     def _parse_list(self) -> List | list[Node]:
         """Parse an ordered or unordered list with nesting support.
 
@@ -1497,6 +1512,34 @@ class AsciiDocParser(BaseParser):
             # Skip blank line after item if present
             if self._current_token().type == TokenType.BLANK_LINE:
                 self._advance()
+
+            # A "+" on a line of its own is a list continuation: the block that
+            # follows belongs to this item, and the list stays open. Consuming
+            # it here is what lets a later item keep its nesting level instead
+            # of starting a fresh list that has no parent to nest under.
+            while self._is_list_continuation():
+                self._advance()
+                if self._current_token().type == TokenType.BLANK_LINE:
+                    self._advance()
+
+                # A block attribute line such as "[source,python]" parses to
+                # None and only records pending state, so keep going until a
+                # real block materialises or the cursor stops moving.
+                attached: Node | list[Node] | None = None
+                while attached is None:
+                    before = self.current_token_index
+                    attached = self._parse_block()
+                    if self.current_token_index == before:
+                        break
+
+                if attached is None:
+                    # Nothing consumed - bail out rather than spin.
+                    break
+
+                list_builder.add_content_to_last_item(attached if isinstance(attached, list) else [attached])
+
+                if self._current_token().type == TokenType.BLANK_LINE:
+                    self._advance()
 
         # Get the built document and extract the lists
         built_doc = list_builder.get_document()

--- a/src/all2md/renderers/asciidoc.py
+++ b/src/all2md/renderers/asciidoc.py
@@ -364,25 +364,6 @@ class AsciiDocRenderer(NodeVisitor, InlineContentMixin, BaseRenderer):
             self._output.append("\n")
         self._output.append("____")
 
-    def _is_block_element(self, node: Node) -> bool:
-        """Check if a node is a block element requiring list continuation.
-
-        In AsciiDoc, block elements inside list items need a list continuation
-        line (+) to be properly associated with the list item.
-
-        Parameters
-        ----------
-        node : Node
-            Node to check
-
-        Returns
-        -------
-        bool
-            True if node is a block element
-
-        """
-        return isinstance(node, (CodeBlock, BlockQuote, List, Table))
-
     def _flatten_blocks_to_inline(self, nodes: list[Node]) -> str:
         """Flatten block-level nodes to inline text for use in inline contexts.
 
@@ -483,24 +464,21 @@ class AsciiDocRenderer(NodeVisitor, InlineContentMixin, BaseRenderer):
 
         # Render children
         for i, child in enumerate(node.children):
-            if i == 0:
-                # First child inline with marker
-                if isinstance(child, Paragraph):
-                    content = self._render_inline_content(child.content)
-                    self._output.append(content)
-                else:
-                    # First child is a block element - needs continuation
-                    self._output.append(f"\n{indent}+\n")
-                    child.accept(self)
+            if i == 0 and isinstance(child, Paragraph):
+                # First paragraph sits inline with the marker
+                self._output.append(self._render_inline_content(child.content))
+            elif isinstance(child, List):
+                # A nested list attaches to its parent item by marker depth
+                # alone. A "+" continuation would detach it into a block of its
+                # own, leaving the deeper marker with no parent at the level
+                # below it - output our own parser rejects as an orphaned
+                # nesting level.
+                self._output.append("\n")
+                child.accept(self)
             else:
-                # Subsequent children need continuation marker if they're blocks
-                if self._is_block_element(child):
-                    self._output.append(f"\n{indent}+\n")
-                    child.accept(self)
-                else:
-                    # Non-block subsequent children (e.g., additional Paragraphs)
-                    self._output.append(f"\n{indent}+\n")
-                    child.accept(self)
+                # Every other block attaches to the item via a continuation line
+                self._output.append(f"\n{indent}+\n")
+                child.accept(self)
 
     def visit_table(self, node: Table) -> None:
         """Render a Table node.

--- a/tests/unit/parsers/test_asciidoc_parser.py
+++ b/tests/unit/parsers/test_asciidoc_parser.py
@@ -568,6 +568,43 @@ class TestAsciiDocNestedLists:
         assert isinstance(nested_list, List)
         assert len(nested_list.items) == 2  # Two level-2 items
 
+    def test_continuation_keeps_the_list_open(self) -> None:
+        """A "+" attaches the next block to the item without closing the list.
+
+        Without continuation handling the list ends at the "+", so the item
+        after the attached block starts a fresh list at level 2 and has no
+        level-1 parent to nest under.
+        """
+        asciidoc = "* Outer\n** Inner\n+\nAttached\n** Sibling\n"
+        doc = AsciiDocParser().parse(asciidoc)
+
+        root_list = doc.children[0]
+        assert isinstance(root_list, List)
+        assert len(root_list.items) == 1
+
+        nested = root_list.items[0].children[1]
+        assert isinstance(nested, List)
+        assert len(nested.items) == 2
+
+        # The attached paragraph belongs to "Inner", not to the document
+        inner_paragraphs = [c for c in nested.items[0].children if isinstance(c, Paragraph)]
+        assert [p.content[0].content for p in inner_paragraphs] == ["Inner", "Attached"]
+        assert nested.items[1].children[0].content[0].content == "Sibling"
+
+    def test_continuation_attaches_a_code_block(self) -> None:
+        """A block attribute line before the attached block is not a list terminator."""
+        asciidoc = "* Outer\n** Inner\n+\n[source,python]\n----\nx = 1\n----\n** Sibling\n"
+        doc = AsciiDocParser().parse(asciidoc)
+
+        nested = doc.children[0].items[0].children[1]
+        assert isinstance(nested, List)
+        assert len(nested.items) == 2
+
+        code_blocks = [c for c in nested.items[0].children if isinstance(c, CodeBlock)]
+        assert len(code_blocks) == 1
+        assert code_blocks[0].content == "x = 1"
+        assert code_blocks[0].language == "python"
+
     def test_nested_ordered_list(self) -> None:
         """Test nested ordered lists."""
         asciidoc = """. First

--- a/tests/unit/renderers/test_asciidoc_renderer.py
+++ b/tests/unit/renderers/test_asciidoc_renderer.py
@@ -129,7 +129,12 @@ class TestListItemContinuation:
         assert "____" in result
 
     def test_list_item_with_nested_list(self):
-        """Test list item with nested list has continuation marker."""
+        """Test nested list attaches by marker depth, with no continuation marker.
+
+        A "+" before a nested list detaches it into a block of its own, leaving
+        the "**" marker with no "*" parent at the level below it - output the
+        AsciiDoc parser rejects outright.
+        """
         doc = Document(
             children=[
                 List(
@@ -151,11 +156,19 @@ class TestListItemContinuation:
         renderer = AsciiDocRenderer()
         result = renderer.render_to_string(doc)
 
-        # Should have continuation marker before nested list
-        assert "+\n" in result
-        # Should have both list levels
+        # Nesting is carried by the marker alone
+        assert "+" not in result
         assert "* Outer item" in result
         assert "** Inner item" in result
+
+        # ...and the result survives our own parser, which is what the
+        # continuation marker used to break.
+        reparsed = AsciiDocParser().parse(result)
+        outer = reparsed.children[0]
+        assert isinstance(outer, List)
+        inner = outer.items[0].children[1]
+        assert isinstance(inner, List)
+        assert inner.items[0].children[0].content[0].content == "Inner item"
 
     def test_list_item_with_table(self):
         """Test list item with table has continuation marker."""

--- a/tests/unit/test_roundtrip_fuzzing.py
+++ b/tests/unit/test_roundtrip_fuzzing.py
@@ -133,10 +133,6 @@ LOSSLESS_FORMATS = ("ast",)
 #: distinguish "already known" from "newly introduced". Minimal reproductions for
 #: every entry are pinned in :class:`TestKnownCrashRepros` below.
 KNOWN_CRASHES: dict[tuple[str, str], str] = {
-    # The AsciiDoc renderer numbers nested list markers by absolute depth, so an
-    # ordered list inside an unordered item is written `..` with no `.` parent.
-    # AsciiDoc counts depth per list type, so its own parser rejects the output.
-    ("asciidoc", "Cannot nest to level"): "asciidoc renderer emits an orphaned level-2 list marker",
     # Spanning cells that overflow the declared grid width reach python-docx as
     # a merge whose target cell was never created.
     ("docx", "no `tc` element"): "docx renderer merges spanning cells past the grid width",
@@ -368,12 +364,6 @@ class TestKnownCrashRepros:
     @pytest.mark.parametrize(
         ("doc", "fmt"),
         [
-            pytest.param(
-                NESTED_TASK_ITEM,
-                "asciidoc",
-                id="asciidoc-orphaned-nested-list-marker",
-                marks=pytest.mark.xfail(strict=True, reason="renderer writes '..' with no '.' parent"),
-            ),
             pytest.param(
                 SPANNING_GRID_OVERFLOW,
                 "docx",


### PR DESCRIPTION
Closes #206.

## What was wrong

The AsciiDoc renderer emitted a `+` list continuation before a nested list. In AsciiDoc a continuation detaches the block that follows into one of its own, so the `**` marker was left with no `*` parent at the level below it, and our own parser rejected the output:

```
ParsingError: AST conversion failed: ValueError('Cannot nest to level 2 without a
parent item at level 1. Either add an item at level 1 first, or enable allow_placeholders.')
```

## Two corrections to the issue's framing

**The marker depth was never the problem.** The issue attributed this to numbering nested markers by absolute depth, on the theory that AsciiDoc counts depth per list type. The parser in fact accepts absolute-depth markers in all four mixed-nesting forms:

| input | result |
|---|---|
| `* outer\n.. inner` (absolute depth) | OK |
| `* outer\n. inner` (per-family) | OK |
| `. outer\n** inner` (absolute depth) | OK |
| `. outer\n* inner` (per-family) | OK |

The `+` was the entire cause. Removing it, `* outer\n  ** inner` round-trips.

**It is not a task-list bug.** The issue's reproduction used a checked task item, but *every* document containing a nested list failed — `[Paragraph("outer"), List([...])]` fails identically.

## The second crash, previously masked

The allowlist entry keyed on the message substring `"Cannot nest to level"`, so it was also covering a distinct defect that surfaced the moment the entry came out. The parser had no notion of list continuations at all: it treated a lone `+` as the end of the list, so the item after an attached block started a fresh list with no parent to nest under. That also meant rejecting valid hand-written AsciiDoc:

```asciidoc
* a
** b
+
c
** d
```

`_parse_list` now consumes a continuation, attaches the block it introduces to the open item, and keeps the list open. A block attribute line like `[source,python]` parses to `None` while only recording pending state, so the attach loop keeps going until a real block materialises — otherwise `+` followed by a code block still escaped the item.

## Changes

- `renderers/asciidoc.py` — a nested `List` child attaches by marker depth, with no `+`. Code blocks, tables, block quotes and additional paragraphs still get one.
- `parsers/asciidoc.py` — `_is_list_continuation` plus continuation handling in `_parse_list`.
- `ast/builder.py` — `ListBuilder.add_content_to_last_item`, so the parser attaches content without reaching into `_list_stack`.
- Dropped `_is_block_element`: its sole caller's two branches were identical, so its answer never changed the output, and it classified `List` as continuation-requiring — the false premise above.

## Verification

- `test_list_item_with_nested_list` asserted `"+\n" in result`, i.e. it was defending the bug. It now asserts the absence and re-parses the result.
- Both halves verified load-bearing by reverting each alone: either one on its own fails `TestNoUnrecognisedCrash::test_text_formats_raise_nothing_new[asciidoc]`.
- Allowlist entry and `TestKnownCrashRepros` param removed; `tests/unit/test_roundtrip_fuzzing.py` is green (the strict xfail would otherwise XPASS).
- `tests/unit/parsers`, `tests/unit/renderers`, `tests/unit/ast`, `tests/golden` all pass; ruff and black clean; mypy unchanged (only the pre-existing `_pdf_layout.py:190`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)