### PR TITLE
test(roundtrip): move the generative gates off the per-PR run

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,8 +106,19 @@ jobs:
           # vary by interpreter, so four of the five legs would redo identical work.
           # They run on 3.12 — the same leg that uploads coverage, so the reported
           # figure still includes them.
-          ARGS=(tests/ -v --cov=all2md --cov-report=xml --cov-report=term)
-          if [ "$PYTHON_VERSION" != "3.12" ]; then
+          #
+          # The 3.12 leg additionally drops `generative`: the Hypothesis-drawn
+          # roundtrip gates are derandomized, so a per-PR run replays a fixed
+          # corpus for an answer that only moves when our code does. They run on
+          # a schedule instead (fuzz-corpus.yml). This is what took the leg from
+          # ~6 min to over 3 hours and made it the critical path for every PR.
+          #
+          # --durations is cheap and prints the 25 slowest tests, so the next
+          # time a leg blows up the log says which test rather than which file.
+          ARGS=(tests/ -v --durations=25 --cov=all2md --cov-report=xml --cov-report=term)
+          if [ "$PYTHON_VERSION" = "3.12" ]; then
+            ARGS+=(-m "not generative")
+          else
             ARGS+=(-m "not matrix_single")
           fi
           pytest "${ARGS[@]}"

--- a/.github/workflows/fuzz-corpus.yml
+++ b/.github/workflows/fuzz-corpus.yml
@@ -1,0 +1,65 @@
+name: Generative Roundtrip Gates
+
+# The Hypothesis-drawn roundtrip gates from tests/unit/test_roundtrip_fuzzing.py,
+# split off the per-PR run. See that file's header for which gates stay per-PR.
+#
+# Why they are not per-PR: every gate here is `derandomize=True`, so it draws the
+# same corpus every run. A PR replays a fixed set of documents to recompute an
+# answer that can only change when our code changes -- and the deterministic
+# half of the file (invariants, known-crash repros) already catches that in ~2s.
+# The discovery value is in a seeded sweep, which is a deliberate activity:
+#
+#     HYPOTHESIS_PROFILE=ci pytest -m fuzzing --hypothesis-seed=random
+#
+# What forced the split: on the 3.12 leg these took over 3 hours, against ~60s
+# for the same file locally. That ~160x gap is not explained by the example
+# count, by coverage instrumentation, or by the Hypothesis profile (CI does not
+# set HYPOTHESIS_PROFILE, so it runs `dev` exactly as a dev box does), and it
+# was making every PR wait hours. --durations below is here to name the tests
+# responsible; until that lands, treat the runtime here as unexplained rather
+# than as the cost of the gates.
+
+on:
+  schedule:
+    # 04:00 UTC daily. Nightly rather than weekly (unlike corpus-gate): this
+    # corpus is generated locally and costs no third-party downloads, and a
+    # one-day commit range is the cheapest thing to bisect when a crash class
+    # appears.
+    - cron: "0 4 * * *"
+  workflow_dispatch:
+
+concurrency:
+  group: fuzz-corpus-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  generative:
+    name: Generative Roundtrip Gates
+    runs-on: ubuntu-latest
+    # Deliberately above the ~3h these currently take, so a scheduled run still
+    # produces the --durations table instead of being killed just short of it.
+    # Tighten this once the runtime is understood.
+    timeout-minutes: 240
+
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v7
+
+      - name: Set up Python
+        uses: actions/setup-python@v7
+        with:
+          python-version: "3.12"
+
+      - name: Install
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e ".[all,dev]"
+
+      # --durations=0 prints every test rather than a top-N: the open question is
+      # the shape of the distribution (355 examples at ~25s each, or three tests
+      # hanging for 45 minutes), and a top-N cannot tell those apart.
+      - name: Run the generative gates
+        run: pytest tests/unit/test_roundtrip_fuzzing.py -m generative -v --durations=0

--- a/pytest.ini
+++ b/pytest.ini
@@ -39,6 +39,7 @@ markers =
     security: Security-focused tests (SSRF, file access, ZIP bombs)
     fuzzing: Property-based and fuzz tests using Hypothesis
     matrix_single: Exercises library logic, not interpreter differences; CI runs it on one Python leg only
+    generative: Draws its corpus with Hypothesis; fixed-seed and expensive, so CI runs it on a schedule rather than per PR
     golden: Golden/snapshot regression tests
     asciidoc: Tests related to AsciiDoc conversion
     plaintext: Tests related to PlainText rendering

--- a/tests/unit/test_roundtrip_fuzzing.py
+++ b/tests/unit/test_roundtrip_fuzzing.py
@@ -75,6 +75,16 @@ from all2md.ast.nodes import (
 #: (filename, URL, HTML-sanitizer and PDF edge-case fuzzing), they are all
 #: sub-second and security-relevant, and dropping them from four legs would save
 #: nothing while thinning the security coverage.
+#:
+#: The gates that draw their corpus with Hypothesis carry a second marker,
+#: ``generative``, and per-PR CI deselects it: those run on a schedule instead
+#: (see .github/workflows/fuzz-corpus.yml). They are ``derandomize=True``, so a
+#: PR run recomputes a fixed answer over a fixed corpus and can only change when
+#: our code does -- the discovery value is in a seeded sweep, not in the 300th
+#: identical replay. What stays per-PR is everything deterministic and cheap:
+#: the classification check, the structural invariants, and the known-crash
+#: repros, whose strict xfails are what fail the moment someone fixes a bug and
+#: leaves the allowlist entry behind.
 pytestmark = pytest.mark.matrix_single
 
 # --------------------------------------------------------------------------- #
@@ -179,6 +189,7 @@ class TestMatrixCoverage:
 
 @pytest.mark.unit
 @pytest.mark.fuzzing
+@pytest.mark.generative
 class TestLosslessFormatsAreLossless:
     """The formats that claim exactness are the harness's control."""
 
@@ -204,6 +215,7 @@ class TestLosslessFormatsAreLossless:
 
 @pytest.mark.unit
 @pytest.mark.fuzzing
+@pytest.mark.generative
 class TestNoUnrecognisedCrash:
     """No format may fail in a way that is not already documented.
 
@@ -587,6 +599,7 @@ class TestStructuralInvariants:
 
 @pytest.mark.unit
 @pytest.mark.fuzzing
+@pytest.mark.generative
 class TestGeneratedTablesAndLists:
     """Aim the generator at the two node classes that break most often."""
 


### PR DESCRIPTION
## Why

The 3.12 leg has been taking **over three hours**, making it the critical path for every PR. It is the only leg that runs `test_roundtrip_fuzzing.py`, and the CI log localises the time to that file — one progress line spanning `08:45:19 -> 11:02:37`.

The before/after control points at #216, which moved the file onto one leg:

| Run | Commit | 3.12 leg | Other 4 legs |
|---|---|---|---|
| 30594648555 | `a023291` (before #216) | 29 min | 29–55 min |
| 30597594319 | `52cd401` (#216) | **3h 17m** | 4–6 min |

#216 was right about the other four legs. The problem is that it also made 3.12 the sole critical path.

## The example count is not the cost

Measured before blaming it:

| | Time |
|---|---|
| Whole file, local | **61s** |
| Same, under `--cov=all2md` | **59s** (coverage is free here) |
| `TestStructuralInvariants` (deterministic half) | ~2s |
| Same file, CI 3.12 leg | **2h 39m** |

CI does not set `HYPOTHESIS_PROFILE`, so it runs the same `dev` profile a dev box does. That leaves a **~160x CI-to-local gap** that the per-format budget does not explain — #216's increase is real, but it is 10x of about six seconds.

So `max_examples` stays put. Cutting it would give back exactly the sensitivity #216 measured (the 12.8%-frequency mediawiki shape the shared-budget gate could not see) and buy back nothing.

## What this does instead

Splits the file by what a per-PR run can actually learn. Every gate that draws from Hypothesis is `derandomize=True` — a PR replays a fixed corpus to recompute an answer that only moves when our code moves. Those get a `generative` marker and run nightly in `fuzz-corpus.yml`.

What stays per-PR is the deterministic half: the classification check, the structural invariants, and the known-crash repros whose strict xfails fire the moment someone fixes a bug and leaves the allowlist entry behind. **42 of the file's 64 tests, 9s against 61s for the whole file.**

The marker is dedicated rather than reusing `slow` or `fuzzing`, for the reason #216 gave: both are carried by suites that should keep running per PR.

## The open question

Adds `--durations` to the matrix legs and `--durations=0` to the scheduled run. The 160x is still unexplained, and the shape of the distribution decides the fix — 355 examples at ~25s each is a different bug from three tests hanging for 45 minutes apiece. A top-N cannot tell those apart, hence `=0` on the scheduled run.

Until that reports, the runtime in `fuzz-corpus.yml` is unexplained rather than the cost of the gates, and its `timeout-minutes` is deliberately set above the observed ~3h so the durations table survives instead of being killed just short of it.

I'd suggest kicking off `Generative Roundtrip Gates` via `workflow_dispatch` once this lands rather than waiting for 04:00 UTC.

## Verified locally

- `not generative` → 42 tests, 9s; `generative` → 22 tests
- marker registers cleanly (no `PytestUnknownMarkWarning`)
- ruff, black, YAML parse, pre-commit all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)