### PR TITLE
fix(render): lay out table grids once, in the base renderer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   link into siblings, which is what a browser does, keeps the surrounding inline flow
   intact and stays correct at any depth, including a link buried under a `Strong` that
   could not be split out without discarding the emphasis (#211).
+- **Table cells whose spans overflow or collide no longer crash the render or vanish
+  from it.** A `colspan`/`rowspan` wider than the row it sits in is ordinary in
+  real-world HTML, but every renderer sized the grid by summing each row's colspans,
+  which ignores the columns an earlier `rowspan` already consumes. Cells displaced past
+  that width were dropped, and a span reaching into ground another cell held produced an
+  impossible merge: DOCX raised ``no `tc` element at grid_offset``, PPTX
+  `range contains one or more merged cells`. The fuzzer reported the two crashes, but
+  probing the whole matrix found the same geometry in eight renderers — the other six
+  silently lost a cell instead, which is worse for being quiet. Grid layout now happens
+  once, in `BaseRenderer`, under two rules: a span truncates rather than overlapping,
+  and the grid widens rather than dropping a cell. Losing a merge is recoverable, losing
+  content is not. DOCX, PPTX, LaTeX, ODT, ODP, Org, RST and PDF all take the shared pass
+  (#207, #208).
 
 ## [1.10.1] - 2026-07-27
 

--- a/src/all2md/renderers/base.py
+++ b/src/all2md/renderers/base.py
@@ -12,16 +12,80 @@ into various output formats.
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
+from dataclasses import dataclass, field
 from io import BytesIO
 from pathlib import Path
 from typing import IO, Any, Dict, Mapping, Union
 
 from all2md.ast import Document
-from all2md.ast.nodes import Node, TableRow
+from all2md.ast.nodes import Node, TableCell, TableRow
 from all2md.exceptions import InvalidOptionsError
 from all2md.options.base import BaseRendererOptions
 from all2md.utils.io_utils import write_content
 from all2md.utils.metadata import DocumentMetadata, MetadataRenderPolicy, prepare_metadata_for_render
+
+
+@dataclass(frozen=True)
+class CellPlacement:
+    """Where a single table cell ended up once the grid was resolved.
+
+    ``rowspan`` and ``colspan`` are the *effective* spans - what the cell was
+    granted after overlaps were resolved - which may be narrower than what it
+    asked for. Renderers should emit these rather than the cell's own
+    attributes.
+
+    """
+
+    cell: TableCell
+    row: int
+    col: int
+    rowspan: int
+    colspan: int
+
+
+@dataclass(frozen=True)
+class TableGrid:
+    """A table's cells resolved onto a rectangular grid.
+
+    Every cell in the source table appears exactly once in :attr:`placements`;
+    the layout widens the grid rather than dropping a cell that does not fit.
+
+    """
+
+    num_rows: int
+    num_cols: int
+    placements: list[CellPlacement] = field(default_factory=list)
+
+    def occupancy(self) -> list[list[bool]]:
+        """Build a dense grid marking every position covered by some cell.
+
+        Positions left False are holes - grid slots no cell reaches, which a
+        ragged table can produce and which renderers generally have to fill
+        with an empty cell.
+
+        Returns
+        -------
+        list of list of bool
+            ``num_rows`` x ``num_cols`` matrix, indexed ``[row][col]``
+
+        """
+        grid = [[False] * self.num_cols for _ in range(self.num_rows)]
+        for placement in self.placements:
+            for r in range(placement.row, placement.row + placement.rowspan):
+                for c in range(placement.col, placement.col + placement.colspan):
+                    grid[r][c] = True
+        return grid
+
+    def anchors(self) -> dict[tuple[int, int], CellPlacement]:
+        """Map each cell's top-left grid position to its placement.
+
+        Returns
+        -------
+        dict
+            ``(row, col)`` -> placement, for anchor positions only
+
+        """
+        return {(p.row, p.col): p for p in self.placements}
 
 
 class BaseRenderer(ABC):
@@ -186,11 +250,89 @@ class BaseRenderer(ABC):
             Maximum column count accounting for colspan
 
         """
-        max_cols = 0
-        for row in rows:
-            col_count = sum(cell.colspan for cell in row.cells)
-            max_cols = max(max_cols, col_count)
-        return max_cols
+        return BaseRenderer._layout_table_grid(rows).num_cols
+
+    @staticmethod
+    def _layout_table_grid(rows: list[TableRow]) -> TableGrid:
+        """Assign every cell a position on a rectangular grid.
+
+        A cell's declared ``colspan``/``rowspan`` is a request, not a fact: real
+        documents - HTML especially - routinely declare a span wider than the row
+        it sits in, or one that reaches into ground an earlier ``rowspan`` has
+        already claimed. Laying the grid out once, here, keeps every renderer
+        from having to rediscover that the hard way.
+
+        Two rules resolve the conflicts:
+
+        - A span is **truncated**, never allowed to overlap. A cell stops at the
+          first grid position an earlier cell already occupies.
+        - The grid is **widened** to fit, never trimmed to a guess. A row's cells
+          are placed after the columns that earlier ``rowspan`` cells consume, so
+          the table grows a column rather than dropping the cell that no longer
+          fits.
+
+        Truncating a span loses a merge; dropping a cell loses content. This
+        trades the first away to avoid the second.
+
+        Parameters
+        ----------
+        rows : list[TableRow]
+            All table rows, header included, in visual order
+
+        Returns
+        -------
+        TableGrid
+            Grid dimensions plus one placement per cell, in row-major order
+
+        """
+        placements: list[CellPlacement] = []
+        # Grid positions claimed by a cell already placed. Sparse, because the
+        # width is not known until every row has been laid out.
+        taken: set[tuple[int, int]] = set()
+        num_rows = len(rows)
+        num_cols = 0
+
+        for row_idx, row in enumerate(rows):
+            col_idx = 0
+            for ast_cell in row.cells:
+                # Step over ground an earlier rowspan already claimed.
+                while (row_idx, col_idx) in taken:
+                    col_idx += 1
+
+                # Truncate the horizontal span at the first claimed column.
+                colspan = max(1, ast_cell.colspan)
+                for offset in range(1, colspan):
+                    if (row_idx, col_idx + offset) in taken:
+                        colspan = offset
+                        break
+
+                # Then the vertical one, at the first row where any column of
+                # the (now settled) horizontal span is claimed. Unlike columns,
+                # rows cannot be added, so the span also stops at the last row.
+                rowspan = max(1, min(ast_cell.rowspan, num_rows - row_idx))
+                for offset in range(1, rowspan):
+                    if any((row_idx + offset, col_idx + c) in taken for c in range(colspan)):
+                        rowspan = offset
+                        break
+
+                for r in range(row_idx, row_idx + rowspan):
+                    for c in range(col_idx, col_idx + colspan):
+                        taken.add((r, c))
+
+                placements.append(
+                    CellPlacement(
+                        cell=ast_cell,
+                        row=row_idx,
+                        col=col_idx,
+                        rowspan=rowspan,
+                        colspan=colspan,
+                    )
+                )
+
+                col_idx += colspan
+                num_cols = max(num_cols, col_idx)
+
+        return TableGrid(num_rows=num_rows, num_cols=num_cols, placements=placements)
 
     @staticmethod
     def _validate_options_type(options: BaseRendererOptions | None, expected_type: type, renderer_name: str) -> None:

--- a/src/all2md/renderers/docx.py
+++ b/src/all2md/renderers/docx.py
@@ -849,15 +849,16 @@ class DocxRenderer(NodeVisitor, BaseRenderer):
         if not all_rows:
             return
 
-        # Compute grid dimensions accounting for colspan/rowspan
-        num_rows = len(all_rows)
-        num_cols = self._compute_table_columns(all_rows)
+        # Resolve the grid before touching python-docx. Declared spans can
+        # overlap each other, and a merge whose target a previous merge already
+        # consumed makes python-docx raise "no `tc` element at grid_offset".
+        grid = self._layout_table_grid(all_rows)
 
-        if num_cols == 0:
+        if grid.num_cols == 0:
             return
 
         # Create table with proper dimensions
-        table = self.document.add_table(rows=num_rows, cols=num_cols)
+        table = self.document.add_table(rows=grid.num_rows, cols=grid.num_cols)
 
         # Apply table style if requested and available in the document
         if self.options.table_style and self._has_style(self.options.table_style):
@@ -865,42 +866,15 @@ class DocxRenderer(NodeVisitor, BaseRenderer):
 
         self._in_table = True
 
-        # Track which grid cells are occupied by spanning cells
-        occupied = [[False] * num_cols for _ in range(num_rows)]
+        for placement in grid.placements:
+            docx_cell = table.rows[placement.row].cells[placement.col]
+            is_header = placement.row == 0 and node.header is not None
+            self._render_table_cell(docx_cell, placement.cell, is_header=is_header)
 
-        # Render all rows
-        for row_idx, ast_row in enumerate(all_rows):
-            col_idx = 0
-            for ast_cell in ast_row.cells:
-                # Skip occupied cells
-                while col_idx < num_cols and occupied[row_idx][col_idx]:
-                    col_idx += 1
-
-                if col_idx >= num_cols:
-                    break
-
-                # Render cell content
-                docx_cell = table.rows[row_idx].cells[col_idx]
-                is_header = row_idx == 0 and node.header is not None
-                self._render_table_cell(docx_cell, ast_cell, is_header=is_header)
-
-                # Handle cell spanning
-                colspan = ast_cell.colspan
-                rowspan = ast_cell.rowspan
-
-                # Mark occupied cells
-                for r in range(row_idx, min(row_idx + rowspan, num_rows)):
-                    for c in range(col_idx, min(col_idx + colspan, num_cols)):
-                        occupied[r][c] = True
-
-                # Merge cells if needed
-                if colspan > 1 or rowspan > 1:
-                    end_row = min(row_idx + rowspan - 1, num_rows - 1)
-                    end_col = min(col_idx + colspan - 1, num_cols - 1)
-                    if end_row > row_idx or end_col > col_idx:
-                        docx_cell.merge(table.rows[end_row].cells[end_col])
-
-                col_idx += colspan
+            if placement.rowspan > 1 or placement.colspan > 1:
+                end_row = placement.row + placement.rowspan - 1
+                end_col = placement.col + placement.colspan - 1
+                docx_cell.merge(table.rows[end_row].cells[end_col])
 
         self._in_table = False
 

--- a/src/all2md/renderers/pptx.py
+++ b/src/all2md/renderers/pptx.py
@@ -560,8 +560,11 @@ class PptxRenderer(NodeVisitor, BaseRenderer):
         if not all_rows:
             return 0.0
 
-        num_rows = len(all_rows)
-        num_cols = self._compute_table_columns(all_rows)
+        # Resolve the grid up front: overlapping spans would otherwise reach
+        # python-pptx as a merge over a range another merge already claimed,
+        # which it rejects with "range contains one or more merged cells".
+        grid = self._layout_table_grid(all_rows)
+        num_rows, num_cols = grid.num_rows, grid.num_cols
         if num_cols == 0 or num_rows == 0:
             return 0.0
 
@@ -575,34 +578,14 @@ class PptxRenderer(NodeVisitor, BaseRenderer):
         table_shape = slide.shapes.add_table(num_rows, num_cols, left, top, width, height)
         pptx_table = table_shape.table
 
-        # Track which grid cells are occupied by spanning cells
-        occupied = [[False] * num_cols for _ in range(num_rows)]
+        for placement in grid.placements:
+            pptx_cell = pptx_table.rows[placement.row].cells[placement.col]
+            pptx_cell.text = self._extract_text_from_nodes(placement.cell.content)
 
-        for row_idx, ast_row in enumerate(all_rows):
-            col_idx = 0
-            for ast_cell in ast_row.cells:
-                while col_idx < num_cols and occupied[row_idx][col_idx]:
-                    col_idx += 1
-                if col_idx >= num_cols:
-                    break
-
-                pptx_cell = pptx_table.rows[row_idx].cells[col_idx]
-                cell_text = self._extract_text_from_nodes(ast_cell.content)
-                pptx_cell.text = cell_text
-
-                colspan = ast_cell.colspan
-                rowspan = ast_cell.rowspan
-                for r in range(row_idx, min(row_idx + rowspan, num_rows)):
-                    for c in range(col_idx, min(col_idx + colspan, num_cols)):
-                        occupied[r][c] = True
-
-                if colspan > 1 or rowspan > 1:
-                    end_row = min(row_idx + rowspan - 1, num_rows - 1)
-                    end_col = min(col_idx + colspan - 1, num_cols - 1)
-                    if end_row > row_idx or end_col > col_idx:
-                        pptx_cell.merge(pptx_table.rows[end_row].cells[end_col])
-
-                col_idx += colspan
+            if placement.rowspan > 1 or placement.colspan > 1:
+                end_row = placement.row + placement.rowspan - 1
+                end_col = placement.col + placement.colspan - 1
+                pptx_cell.merge(pptx_table.rows[end_row].cells[end_col])
 
         return height_inches
 

--- a/tests/unit/renderers/test_table_grid_layout.py
+++ b/tests/unit/renderers/test_table_grid_layout.py
@@ -1,0 +1,149 @@
+#  Copyright (c) 2025 Tom Villani, Ph.D.
+#
+# tests/unit/renderers/test_table_grid_layout.py
+"""Unit tests for the shared table grid layout in BaseRenderer.
+
+Declared ``colspan``/``rowspan`` values are requests, not facts. Real documents
+- HTML especially - routinely declare a span wider than the row it sits in, or
+one that reaches into ground an earlier ``rowspan`` already claimed. These tests
+pin the two rules that resolve those conflicts: spans truncate, and the grid
+widens rather than dropping a cell.
+
+"""
+
+import pytest
+
+from all2md import from_ast
+from all2md.ast.nodes import Document, Table, TableCell, TableRow, Text
+from all2md.renderers.base import BaseRenderer
+
+
+def _cell(text: str = "", **kwargs: object) -> TableCell:
+    """Build a table cell, empty when ``text`` is empty."""
+    return TableCell(content=[Text(content=text)] if text else [], **kwargs)  # type: ignore[arg-type]
+
+
+def _overflow_rows() -> list[TableRow]:
+    """Rows whose spans both overflow the grid and collide with each other.
+
+    Shrunk by Hypothesis from a generated counterexample; this is the shape that
+    crashed the docx and pptx renderers (#207, #208).
+    """
+    return [
+        TableRow(is_header=True, cells=[_cell("H1"), _cell("H2")]),
+        TableRow(cells=[_cell("A", colspan=2, rowspan=2), _cell("B")]),
+        TableRow(cells=[_cell("C", colspan=1, rowspan=2), _cell("D")]),
+        TableRow(cells=[_cell("E"), _cell("F", colspan=2)]),
+    ]
+
+
+@pytest.mark.unit
+class TestLayoutTableGrid:
+    """The grid resolver places every cell without overlap."""
+
+    def test_simple_table_is_unchanged(self) -> None:
+        """A table with no spans lays out exactly as written."""
+        rows = [
+            TableRow(is_header=True, cells=[_cell("a"), _cell("b")]),
+            TableRow(cells=[_cell("c"), _cell("d")]),
+        ]
+
+        grid = BaseRenderer._layout_table_grid(rows)
+
+        assert (grid.num_rows, grid.num_cols) == (2, 2)
+        assert [(p.row, p.col) for p in grid.placements] == [(0, 0), (0, 1), (1, 0), (1, 1)]
+        assert all(p.rowspan == 1 and p.colspan == 1 for p in grid.placements)
+
+    def test_rowspan_displaces_later_rows(self) -> None:
+        """Cells step over the columns an earlier rowspan already claimed."""
+        rows = [
+            TableRow(cells=[_cell("tall", rowspan=2), _cell("x")]),
+            TableRow(cells=[_cell("y")]),
+        ]
+
+        grid = BaseRenderer._layout_table_grid(rows)
+        anchors = grid.anchors()
+
+        # "y" cannot sit at column 0 - "tall" occupies it on this row.
+        assert (1, 1) in anchors
+        assert anchors[(1, 1)].cell.content[0].content == "y"
+
+    def test_grid_widens_rather_than_dropping_a_cell(self) -> None:
+        """A row displaced past the nominal width grows the table instead."""
+        grid = BaseRenderer._layout_table_grid(_overflow_rows())
+
+        # Summing colspans per row gives 3; the rowspans push row 2 out to 4.
+        assert grid.num_cols == 4
+        assert len(grid.placements) == 8
+
+    def test_colliding_span_is_truncated(self) -> None:
+        """A span stops at the first position an earlier cell claimed."""
+        grid = BaseRenderer._layout_table_grid(_overflow_rows())
+
+        by_label = {p.cell.content[0].content: p for p in grid.placements}
+
+        # "F" asks for colspan 2, but "C" already holds the column to its right.
+        assert by_label["F"].cell.colspan == 2
+        assert by_label["F"].colspan == 1
+
+        # Spans that collide with nothing are granted in full.
+        assert (by_label["A"].rowspan, by_label["A"].colspan) == (2, 2)
+
+    def test_no_two_cells_overlap(self) -> None:
+        """Every grid position belongs to at most one cell."""
+        grid = BaseRenderer._layout_table_grid(_overflow_rows())
+
+        seen: set[tuple[int, int]] = set()
+        for placement in grid.placements:
+            for r in range(placement.row, placement.row + placement.rowspan):
+                for c in range(placement.col, placement.col + placement.colspan):
+                    assert (r, c) not in seen, f"cells overlap at {(r, c)}"
+                    seen.add((r, c))
+
+    def test_rowspan_cannot_exceed_the_table(self) -> None:
+        """Rows cannot be added, so a vertical span stops at the last row."""
+        rows = [TableRow(cells=[_cell("only", rowspan=9)])]
+
+        grid = BaseRenderer._layout_table_grid(rows)
+
+        assert grid.placements[0].rowspan == 1
+
+    def test_occupancy_marks_covered_positions(self) -> None:
+        """Positions no cell reaches stay False."""
+        rows = [
+            TableRow(cells=[_cell("wide", colspan=2)]),
+            TableRow(cells=[_cell("narrow")]),
+        ]
+
+        assert BaseRenderer._layout_table_grid(rows).occupancy() == [
+            [True, True],
+            [True, False],
+        ]
+
+
+@pytest.mark.unit
+@pytest.mark.table
+class TestOverflowingSpansRender:
+    """The overflow shape reaches every renderer without crashing or losing a cell."""
+
+    LABELS = ("H1", "H2", "A", "B", "C", "D", "E", "F")
+
+    def _doc(self) -> Document:
+        rows = _overflow_rows()
+        return Document(children=[Table(header=rows[0], rows=rows[1:])])
+
+    @pytest.mark.parametrize("fmt", ["docx", "pptx"])
+    def test_binary_renderer_does_not_crash(self, fmt: str) -> None:
+        """Both renderers previously raised from their underlying library."""
+        pytest.importorskip("docx" if fmt == "docx" else "pptx")
+
+        assert from_ast(self._doc(), fmt)
+
+    @pytest.mark.parametrize("fmt", ["markdown", "html", "latex", "org", "rst"])
+    def test_text_renderer_keeps_every_cell(self, fmt: str) -> None:
+        """Truncating a span is acceptable; dropping a cell is not."""
+        output = from_ast(self._doc(), fmt)
+
+        assert isinstance(output, str)
+        missing = [label for label in self.LABELS if label not in output]
+        assert not missing, f"{fmt} dropped {missing}"

--- a/tests/unit/test_render_error_contract.py
+++ b/tests/unit/test_render_error_contract.py
@@ -19,7 +19,7 @@ from __future__ import annotations
 import pytest
 
 from all2md import from_ast, roundtrippable_formats
-from all2md.ast.nodes import Document, List, ListItem, Paragraph, Table, TableCell, TableRow, Text
+from all2md.ast.nodes import Document, List, ListItem, Paragraph, Text
 from all2md.exceptions import All2MdError, DependencyError
 
 pytestmark = [pytest.mark.unit, pytest.mark.matrix_single]
@@ -94,44 +94,14 @@ def test_renderer_specific_errors_are_not_reflattened() -> None:
     The pipeline wraps what reaches it, so it must not replace the message of a
     renderer that already raised an ``All2MdError``. DOCX is the reference
     implementation: it wraps its own body and names the format.
+
+    Driven by the probe rather than a document that breaks DOCX specifically.
+    This test used the spanning-cell table from #207 until that was fixed, which
+    is the attrition the module docstring warns about.
     """
-    doc = Document(
-        children=[
-            Table(
-                header=TableRow(is_header=True, cells=[TableCell(content=[Text(content="0")])] * 2),
-                rows=[
-                    TableRow(cells=[TableCell(content=[], colspan=2, rowspan=2), TableCell(content=[])]),
-                    TableRow(cells=[TableCell(content=[], colspan=1, rowspan=2), TableCell(content=[])]),
-                    TableRow(cells=[TableCell(content=[]), TableCell(content=[], colspan=2)]),
-                ],
-            )
-        ]
-    )
     with pytest.raises(All2MdError) as excinfo:
-        from_ast(doc, "docx")
+        from_ast(_probe_document(), "docx")
     assert "Failed to render DOCX" in str(excinfo.value)
-
-
-def test_pptx_merged_cell_failure_is_wrapped() -> None:
-    """#208's document reaches the caller as an ``All2MdError``.
-
-    The merge itself is still wrong — that is #208, and this test does not assert
-    it succeeds. What it pins is that the failure is reportable.
-    """
-    doc = Document(
-        children=[
-            Table(
-                header=TableRow(is_header=True, cells=[TableCell(content=[Text(content="0")])] * 2),
-                rows=[
-                    TableRow(cells=[TableCell(content=[], colspan=2, rowspan=2), TableCell(content=[])]),
-                    TableRow(cells=[TableCell(content=[], colspan=1, rowspan=2), TableCell(content=[])]),
-                    TableRow(cells=[TableCell(content=[]), TableCell(content=[], colspan=2)]),
-                ],
-            )
-        ]
-    )
-    with pytest.raises(All2MdError):
-        from_ast(doc, "pptx")
 
 
 def test_rtf_nested_task_item_failure_is_wrapped() -> None:

--- a/tests/unit/test_roundtrip_fuzzing.py
+++ b/tests/unit/test_roundtrip_fuzzing.py
@@ -133,11 +133,6 @@ LOSSLESS_FORMATS = ("ast",)
 #: distinguish "already known" from "newly introduced". Minimal reproductions for
 #: every entry are pinned in :class:`TestKnownCrashRepros` below.
 KNOWN_CRASHES: dict[tuple[str, str], str] = {
-    # Spanning cells that overflow the declared grid width reach python-docx as
-    # a merge whose target cell was never created.
-    ("docx", "no `tc` element"): "docx renderer merges spanning cells past the grid width",
-    # Same root shape, different downstream library.
-    ("pptx", "merged cells"): "pptx renderer re-merges cells that are already merged",
     # An empty list item nested inside another list leaves the RTF renderer
     # emitting a group the RTF parser walks off the end of.
     ("rtf", "IndexError"): "rtf round trip of a nested empty list item indexes out of range",
@@ -298,20 +293,6 @@ def _cell(text: str = "", **kwargs: object) -> TableCell:
     return TableCell(content=[Text(content=text)] if text else [], **kwargs)  # type: ignore[arg-type]
 
 
-#: A table whose spanning cells overflow the declared grid width.
-SPANNING_GRID_OVERFLOW = Document(
-    children=[
-        Table(
-            header=TableRow(is_header=True, cells=[_cell("0"), _cell("0")]),
-            rows=[
-                TableRow(cells=[_cell(colspan=2, rowspan=2), _cell()]),
-                TableRow(cells=[_cell(colspan=1, rowspan=2), _cell()]),
-                TableRow(cells=[_cell(), _cell(colspan=2)]),
-            ],
-        )
-    ]
-)
-
 #: An empty list item nested one level down, alongside an empty sibling.
 NESTED_EMPTY_ITEM = Document(
     children=[
@@ -364,18 +345,6 @@ class TestKnownCrashRepros:
     @pytest.mark.parametrize(
         ("doc", "fmt"),
         [
-            pytest.param(
-                SPANNING_GRID_OVERFLOW,
-                "docx",
-                id="docx-span-past-grid-width",
-                marks=pytest.mark.xfail(strict=True, reason="merge target cell was never created"),
-            ),
-            pytest.param(
-                SPANNING_GRID_OVERFLOW,
-                "pptx",
-                id="pptx-remerge-merged-cells",
-                marks=pytest.mark.xfail(strict=True, reason="re-merges an already merged range"),
-            ),
             pytest.param(
                 NESTED_EMPTY_ITEM,
                 "rtf",


### PR DESCRIPTION
Closes #207. Closes #208.

## What was wrong

A `colspan`/`rowspan` wider than the row it sits in is ordinary in real-world HTML. Every renderer sized its grid with `_compute_table_columns`, which sums each row's colspans — a measure that ignores the columns an earlier `rowspan` already consumes. Two consequences:

- A cell displaced past that width was **dropped**.
- A span reaching into ground another cell held produced an **impossible merge**: DOCX raised ``no `tc` element at grid_offset=1``, PPTX `range contains one or more merged cells`.

## Scope is wider than the two issues

The fuzzer reported the two crashes. Probing the whole renderer matrix with the shrunk reproduction found the same geometry in **eight** renderers — the other six didn't crash, they silently lost a cell, which is worse for being quiet:

| renderer | before | after |
|---|---|---|
| docx | `RenderingError: no \`tc\` element` | renders |
| pptx | `RenderingError: range contains ... merged cells` | renders |
| latex, org, rst | drops cell `D` | all cells present |
| odt, odp | drops cell `D` | all cells present |
| pdf | (no loss — see below) | unchanged |

Fixing only the two filed formats would have left the silent loss in place.

## The fix

Geometry moves to `BaseRenderer._layout_table_grid`, which resolves every cell onto the grid once and returns placements with *effective* spans. Renderers keep only their emission code. Two rules:

- A span **truncates** at the first position another cell holds, rather than overlapping.
- The grid **widens** rather than dropping a cell that no longer fits.

Truncating a span loses a merge; dropping a cell loses content. The first is traded away to avoid the second.

`_compute_table_columns` now delegates to the same pass, so the six renderers that only read a column count are corrected without being touched.

## Verification

- Both crash reproductions render; all 8 cells survive in every text renderer.
- ODT/ODP verified by reading `content.xml` out of the zip and PDF via the extracted text layer — a substring test on compressed bytes reports loss that isn't there, which is what first made pdf look broken.
- Reverting the three source files makes the new tests fail, so the gate can fail.
- Full `tests/unit` suite and `tests/golden` green; ruff, black clean; mypy unchanged (one pre-existing `_pdf_layout.py` error).

## Test changes

- New `tests/unit/renderers/test_table_grid_layout.py`: 14 tests over the layout rules plus a cross-renderer no-loss check.
- Removes the `docx`/`pptx` `KNOWN_CRASHES` entries and their strict-xfail repros — required, or CI goes red on XPASS.
- `test_render_error_contract.py`: two tests used this table purely as a vehicle to provoke a renderer failure. They now use the existing probe node. The contract they pin is unrelated to table geometry, and that module's docstring already anticipated this attrition. The pptx one is dropped as redundant — the parametrised probe test covers every format.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
