### PR TITLE
fix(rtf): flatten nested lists before handing them to pyth

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -103,6 +103,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   and the grid widens rather than dropping a cell. Losing a merge is recoverable, losing
   content is not. DOCX, PPTX, LaTeX, ODT, ODP, Org, RST and PDF all take the shared pass
   (#207, #208).
+- **RTF: nested lists no longer crash the round trip, and stop losing their deepest
+  items.** The RTF renderer builds a pyth document, and pyth writes one `\ilvl` level
+  prefix per *paragraph* inside a list entry — so an entry whose content was a nested
+  list got the outer level's prefix and the inner level's prefix on the same output
+  paragraph. Reading that back, pyth charges both controls to the preceding paragraph
+  and sees a level decrease it never saw a matching increase for, at which point it pops
+  the document off its own stack (`IndexError`, #209). Carrying a task status took a
+  different path: `List` subclasses `Paragraph` in pyth, so the marker run was inserted
+  into the sub-list's content, where only entries belong, and the writer then dispatched
+  on the bare string it found there (`KeyError`, #210). Nested lists are now flattened
+  before being handed to pyth. That gives up nesting *depth*, which the RTF parser never
+  reconstructed anyway — a plain two-item list already read back as two paragraphs — and
+  in exchange it fixes a data-loss bug neither issue had noticed: a list three levels
+  deep silently dropped its deepest item, because pyth pushed a list for the level
+  increase and never re-attached it (#209, #210).
 
 ## [1.10.1] - 2026-07-27
 

--- a/src/all2md/renderers/rtf.py
+++ b/src/all2md/renderers/rtf.py
@@ -283,12 +283,56 @@ class RtfRenderer(NodeVisitor, BaseRenderer):
         List_cls = cast(Any, self._List)
         for entry in entries:
             if isinstance(entry, ListEntry_cls):
-                normalized_entries.append(entry)
+                normalized_entries.extend(self._flatten_entry(entry))
+            elif isinstance(entry, List_cls):
+                # Checked before Paragraph: pyth's List subclasses Paragraph.
+                normalized_entries.extend(self._flatten_entry(ListEntry_cls(content=[entry])))
             elif isinstance(entry, Paragraph_cls):
                 normalized_entries.append(ListEntry_cls(content=[entry]))
-            elif isinstance(entry, List_cls):
-                normalized_entries.append(ListEntry_cls(content=[entry]))
         return List_cls(content=normalized_entries)
+
+    def _flatten_entry(self, entry: Any) -> list[Any]:
+        r"""Split an entry that carries a sub-list into a run of sibling entries.
+
+        pyth writes one ``\ilvl`` prefix per *paragraph* inside an entry, so an
+        entry holding a nested list gets the outer level's prefix and the inner
+        level's prefix on the same output paragraph. Its reader then charges
+        those controls to the preceding paragraph and reads the result as a
+        level *decrease* it never saw a matching increase for - at which point it
+        pops the document off its own stack (#209), or, when a task marker made
+        us reach into the sub-list, dispatches on a bare string (#210).
+
+        Flattening keeps every paragraph and drops only the nesting depth, which
+        the RTF parser does not reconstruct in the first place: a plain two-item
+        list already round-trips back as two paragraphs.
+
+        Parameters
+        ----------
+        entry : Any
+            A pyth ``ListEntry``
+
+        Returns
+        -------
+        list of Any
+            One or more entries, none of which contains a nested list
+
+        """
+        ListEntry_cls = cast(Any, self._ListEntry)
+        List_cls = cast(Any, self._List)
+
+        own_paragraphs = [block for block in entry.content if not isinstance(block, List_cls)]
+        sub_lists = [block for block in entry.content if isinstance(block, List_cls)]
+
+        if not sub_lists:
+            return [entry]
+
+        flattened: list[Any] = []
+        if own_paragraphs:
+            flattened.append(ListEntry_cls(content=own_paragraphs))
+        for sub_list in sub_lists:
+            # Already flattened by the visit_list call that produced it.
+            flattened.extend(sub_list.content)
+        return flattened
 
     def visit_list_item(self, node: ListItem) -> Any:
         """Render a list item, preserving task status when present."""
@@ -296,14 +340,22 @@ class RtfRenderer(NodeVisitor, BaseRenderer):
         for child in node.children:
             paragraphs.extend(self._normalize_blocks(child.accept(self)))
         Paragraph_cls = cast(Any, self._Paragraph)
+        List_cls = cast(Any, self._List)
         if node.task_status in {"checked", "unchecked"}:
             marker = "[x] " if node.task_status == "checked" else "[ ] "
-            if paragraphs:
-                first = paragraphs[0]
-                if isinstance(first, Paragraph_cls):
-                    first.content.insert(0, self._create_text_run(marker))
+            # A List is a Paragraph in pyth, so the isinstance check has to
+            # exclude it explicitly. Without that, an item whose only child is a
+            # sub-list has the marker run inserted into the *list's* content,
+            # where only entries belong, and pyth's writer then dispatches on the
+            # bare string inside it (#210).
+            first = paragraphs[0] if paragraphs else None
+            if isinstance(first, Paragraph_cls) and not isinstance(first, List_cls):
+                first.content.insert(0, self._create_text_run(marker))
             else:
-                paragraphs.append(Paragraph_cls(content=[self._create_text_run(marker)]))
+                # No paragraph of the item's own to carry the marker, so give it
+                # one. Flattening turns it into the entry that precedes the
+                # sub-list's own entries.
+                paragraphs.insert(0, Paragraph_cls(content=[self._create_text_run(marker)]))
         if not paragraphs:
             paragraphs.append(Paragraph_cls(content=[self._create_text_run("")]))
         return cast(Any, self._ListEntry)(content=paragraphs)

--- a/tests/unit/renderers/test_rtf_nested_lists.py
+++ b/tests/unit/renderers/test_rtf_nested_lists.py
@@ -1,0 +1,159 @@
+#  Copyright (c) 2025 Tom Villani, Ph.D.
+#
+# tests/unit/renderers/test_rtf_nested_lists.py
+"""Unit tests for nested list handling in the RTF renderer.
+
+pyth writes one ``\\ilvl`` level prefix per paragraph inside a list entry, so an
+entry whose content is a nested list gets the outer level's prefix and the inner
+level's prefix on the same output paragraph. Its reader charges those controls to
+the preceding paragraph and reads the result as a level decrease with no matching
+increase, which either pops the document off its own stack (#209) or strands the
+content of a list it never re-attaches.
+
+The renderer therefore flattens nested lists before handing them to pyth. Nesting
+depth is the only thing given up, and the RTF parser does not reconstruct it in
+any case - a plain two-item list already round-trips back as two paragraphs.
+
+"""
+
+import io
+
+import pytest
+
+from all2md import from_ast
+from all2md.ast.nodes import Document, List, ListItem, Paragraph, Text
+from all2md.parsers.rtf import RtfToAstConverter
+
+pytestmark = [pytest.mark.unit, pytest.mark.formatting]
+
+
+def _p(text: str) -> Paragraph:
+    return Paragraph(content=[Text(content=text)])
+
+
+def _ul(*items: ListItem) -> List:
+    return List(ordered=False, tight=False, items=list(items))
+
+
+def _texts(node: object) -> list[str]:
+    """Collect every non-blank Text payload under a node."""
+    found: list[str] = []
+
+    def walk(current: object) -> None:
+        if isinstance(current, Text):
+            found.append(current.content)
+            return
+        for attr in ("children", "items", "content"):
+            for child in getattr(current, attr, None) or []:
+                walk(child)
+
+    walk(node)
+    return [text for text in found if text.strip()]
+
+
+def _round_trip(doc: Document) -> Document:
+    rtf = from_ast(doc, "rtf")
+    return RtfToAstConverter().parse(io.BytesIO(rtf.encode("utf-8")))
+
+
+#: An empty list item nested one level down, alongside an empty sibling. Shrunk
+#: by Hypothesis from a generated counterexample (#209).
+NESTED_EMPTY_ITEM = Document(
+    children=[
+        _p("0"),
+        _ul(ListItem(children=[_ul(ListItem(children=[]))]), ListItem(children=[])),
+    ]
+)
+
+#: The same shape carrying a task status, which took a different path (#210).
+NESTED_TASK_ITEM = Document(
+    children=[
+        _ul(
+            ListItem(
+                task_status="checked",
+                children=[_ul(ListItem(children=[], task_status="checked"))],
+            )
+        )
+    ]
+)
+
+
+class TestNestedListsDoNotCrash:
+    """The shapes the fuzzer shrank out must render and parse back."""
+
+    def test_nested_empty_item_round_trips(self) -> None:
+        """#209: the reader used to pop the document off its own list stack."""
+        assert _round_trip(NESTED_EMPTY_ITEM) is not None
+
+    def test_nested_task_item_renders(self) -> None:
+        """#210: a marker run reached pyth's paragraph dispatch as a bare str."""
+        assert from_ast(NESTED_TASK_ITEM, "rtf")
+
+
+class TestNestedListsKeepTheirContent:
+    """Flattening gives up depth, not text."""
+
+    def test_two_level_list_keeps_every_item(self) -> None:
+        doc = Document(
+            children=[_ul(ListItem(children=[_p("outer")]), ListItem(children=[_ul(ListItem(children=[_p("inner")]))]))]
+        )
+
+        assert _texts(_round_trip(doc)) == ["outer", "inner"]
+
+    def test_three_level_list_keeps_the_deepest_item(self) -> None:
+        """The depth that used to be dropped outright rather than flattened.
+
+        Before the fix this lost ``L3``: pyth's reader pushed a list for the
+        level increase and never popped it, so its content never reached the
+        document. That was a live data-loss bug the fuzzer had not reached.
+        """
+        doc = Document(
+            children=[
+                _ul(
+                    ListItem(children=[_p("L1")]),
+                    ListItem(
+                        children=[
+                            _ul(ListItem(children=[_p("L2")]), ListItem(children=[_ul(ListItem(children=[_p("L3")]))]))
+                        ]
+                    ),
+                )
+            ]
+        )
+
+        assert _texts(_round_trip(doc)) == ["L1", "L2", "L3"]
+
+    def test_item_with_text_and_a_sub_list_keeps_both(self) -> None:
+        doc = Document(children=[_ul(ListItem(children=[_p("head"), _ul(ListItem(children=[_p("sub")]))]))])
+
+        assert _texts(_round_trip(doc)) == ["head", "sub"]
+
+
+class TestTaskMarkers:
+    """A task marker survives whether or not the item has text of its own."""
+
+    def test_marker_is_written_for_a_plain_task_item(self) -> None:
+        doc = Document(children=[_ul(ListItem(children=[_p("todo")], task_status="unchecked"))])
+
+        assert "[ ] " in from_ast(doc, "rtf")
+
+    def test_marker_gets_its_own_paragraph_when_the_item_is_only_a_sub_list(self) -> None:
+        """The marker cannot be inserted into a List, so it needs a paragraph.
+
+        pyth's ``List`` subclasses ``Paragraph``, which is what let the run be
+        inserted into the sub-list's content in the first place.
+        """
+        assert "[x] " in from_ast(NESTED_TASK_ITEM, "rtf")
+
+
+class TestEmittedRtfIsWellFormed:
+    """The level prefixes pyth writes must stay balanced."""
+
+    def test_no_paragraph_declares_two_list_levels(self) -> None:
+        """Two ``\\ilvl`` controls on one paragraph is the shape that broke the reader."""
+        doc = Document(
+            children=[_ul(ListItem(children=[_p("outer")]), ListItem(children=[_ul(ListItem(children=[_p("inner")]))]))]
+        )
+
+        for line in from_ast(doc, "rtf").splitlines():
+            if "\\par" in line:
+                assert line.count("\\ilvl") <= 1, f"paragraph declares two list levels: {line}"

--- a/tests/unit/test_render_error_contract.py
+++ b/tests/unit/test_render_error_contract.py
@@ -19,8 +19,9 @@ from __future__ import annotations
 import pytest
 
 from all2md import from_ast, roundtrippable_formats
-from all2md.ast.nodes import Document, List, ListItem, Paragraph, Text
+from all2md.ast.nodes import Document, Paragraph, Text
 from all2md.exceptions import All2MdError, DependencyError
+from all2md.renderers.rtf import RtfRenderer
 
 pytestmark = [pytest.mark.unit, pytest.mark.matrix_single]
 
@@ -104,31 +105,17 @@ def test_renderer_specific_errors_are_not_reflattened() -> None:
     assert "Failed to render DOCX" in str(excinfo.value)
 
 
-def test_rtf_nested_task_item_failure_is_wrapped() -> None:
-    """#210's document reaches the caller as an ``All2MdError``.
+def test_rtf_render_to_string_wraps_its_body() -> None:
+    """RTF reports a failure on the path a text format actually takes.
 
     RTF is the case the split entry points hid: ``render`` wrapped its body but
-    ``render_to_string`` — the path a text format actually takes — did not.
+    ``render_to_string`` — the path the pipeline uses for a text format — did
+    not, so a failure escaped unwrapped.
+
+    Driven by the probe rather than #210's task-list document, which stopped
+    raising once that was fixed. This is the attrition the module docstring
+    warns about; the contract outlives any particular document that broke it.
     """
-    doc = Document(
-        children=[
-            List(
-                ordered=False,
-                tight=False,
-                items=[
-                    ListItem(
-                        task_status="checked",
-                        children=[
-                            List(
-                                ordered=False,
-                                tight=False,
-                                items=[ListItem(children=[], task_status="checked")],
-                            )
-                        ],
-                    )
-                ],
-            )
-        ]
-    )
+    renderer = RtfRenderer()
     with pytest.raises(All2MdError):
-        from_ast(doc, "rtf")
+        renderer.render_to_string(_probe_document())

--- a/tests/unit/test_roundtrip_fuzzing.py
+++ b/tests/unit/test_roundtrip_fuzzing.py
@@ -132,16 +132,7 @@ LOSSLESS_FORMATS = ("ast",)
 #: output its own parser rejects is always a bug. They are listed so the gate can
 #: distinguish "already known" from "newly introduced". Minimal reproductions for
 #: every entry are pinned in :class:`TestKnownCrashRepros` below.
-KNOWN_CRASHES: dict[tuple[str, str], str] = {
-    # An empty list item nested inside another list leaves the RTF renderer
-    # emitting a group the RTF parser walks off the end of.
-    ("rtf", "IndexError"): "rtf round trip of a nested empty list item indexes out of range",
-    # Same shape carrying a task status takes a different path and raises a
-    # KeyError from pyth. It is now wrapped in RenderingError (#212), so the
-    # needle matches the original error inside the wrapper's message; the crash
-    # itself is still live.
-    ("rtf", "KeyError"): "rtf round trip of a nested task list item raises a KeyError",
-}
+KNOWN_CRASHES: dict[tuple[str, str], str] = {}
 
 
 def is_known(fmt: str, exc: BaseException) -> bool:
@@ -293,22 +284,9 @@ def _cell(text: str = "", **kwargs: object) -> TableCell:
     return TableCell(content=[Text(content=text)] if text else [], **kwargs)  # type: ignore[arg-type]
 
 
-#: An empty list item nested one level down, alongside an empty sibling.
-NESTED_EMPTY_ITEM = Document(
-    children=[
-        Paragraph(content=[Text(content="0")]),
-        List(
-            ordered=False,
-            tight=False,
-            items=[
-                ListItem(children=[List(ordered=False, tight=False, items=[ListItem(children=[])])]),
-                ListItem(children=[]),
-            ],
-        ),
-    ]
-)
-
-#: The same shape, carrying a task status.
+#: An empty list item nested one level down, carrying a task status. The RTF
+#: repros that shared this shape moved to tests/unit/renderers/test_rtf_nested_lists.py
+#: when #209 and #210 were fixed.
 NESTED_TASK_ITEM = Document(
     children=[
         List(
@@ -344,20 +322,7 @@ class TestKnownCrashRepros:
 
     @pytest.mark.parametrize(
         ("doc", "fmt"),
-        [
-            pytest.param(
-                NESTED_EMPTY_ITEM,
-                "rtf",
-                id="rtf-nested-empty-list-item",
-                marks=pytest.mark.xfail(strict=True, reason="parser indexes past the end of a group"),
-            ),
-            pytest.param(
-                NESTED_TASK_ITEM,
-                "rtf",
-                id="rtf-nested-task-list-item",
-                marks=pytest.mark.xfail(strict=True, reason="pyth raises KeyError on the task status"),
-            ),
-        ],
+        [],
     )
     def test_known_crash_still_reproduces(self, doc: Document, fmt: str) -> None:
         """Each known crash reproduces from a minimal document.


### PR DESCRIPTION
Closes #209. Closes #210.

## What was wrong

Two crashes, one shape: **a list item whose only child is a nested list**.

pyth writes one `\ilvl` level prefix per *paragraph* inside a list entry, so such an entry gets the outer level's prefix **and** the inner level's prefix on the same output paragraph:

```
\ilvl0\ls0\li720\s1\ilvl1\ls0\li1440\s1\sa50{inner}\par\pard
```

Reading that back, pyth charges both controls to the *preceding* paragraph and sees a level decrease it never saw a matching increase for. A decrease with nothing pushed pops the document off its own list stack, and the next append raises `IndexError` (#209).

Carrying a task status reached the same shape by another route: pyth's `List` **subclasses `Paragraph`**, so the isinstance check guarding marker insertion accepted a nested list and put the marker run inside the *list's* content, where only entries belong. The writer's paragraph dispatch then hit the bare `str` it found there — `KeyError: <class 'str'>` (#210).

## The fix

Flatten nested lists into sibling entries before pyth sees them, and exclude `List` explicitly in the marker check. This makes both crashes structurally impossible rather than papered over.

Flattening gives up nesting **depth**. That costs nothing on the round trip, because the RTF parser never reconstructed it — a plain two-item list already reads back as two paragraphs.

## It also fixes a data-loss bug neither issue noticed

Measured across eight list shapes, before vs after:

| shape | before | after |
|---|---|---|
| flat-2, nested-text, item-then-sub, ordered, task-flat | ✓ | unchanged |
| **nested-3deep** | score 34, **lost `L3`** | score 43, nothing lost |
| empty-nested (#209) | `ParsingError` | round-trips |
| task-nested (#210) | `RenderingError` | renders |

A list three levels deep silently dropped its deepest item: pyth pushed a list for the level increase and, with no decrease before EOF, never re-attached it. Live in every release.

## An attempt that didn't work, and what it taught

I first gave such an item an empty paragraph of its own. That cleared both crashes — but regressed the ordinary nested-list case from 43 to 29 and **lost the inner item entirely**. Chasing that is what surfaced the EOF behaviour above. Worth recording because "both crashes are gone" looked like success until the fidelity comparison ran.

## Test changes

- New `tests/unit/renderers/test_rtf_nested_lists.py` (8 tests): the two shrunk reproductions, content-preservation at two and three levels, task markers, and a well-formedness check that no emitted paragraph declares two `\ilvl` levels. 5 of the 8 fail without the fix.
- Removes both `rtf` `KNOWN_CRASHES` entries and their strict-xfail repros — required, or CI goes red on XPASS.
- `test_rtf_nested_task_item_failure_is_wrapped` used #210's document only to *provoke* a failure. It moves to the probe node and keeps pinning what it was actually about — `render_to_string` wrapping its own body — as that module's docstring anticipates.

## Verification

Full `tests/unit` + `tests/golden` green; ruff, black, mypy clean on the touched files.

**Merge note:** this touches `tests/unit/test_render_error_contract.py` and `tests/unit/test_roundtrip_fuzzing.py`, both of which #231 also touches. Whichever lands second needs a local rebase — resolving in the web UI risks resurrecting deleted allowlist entries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
