### PR TITLE
fix(parsers): decide str-is-path-or-content once, and fail loudly on a miss

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **A `str` that names a missing file now raises instead of becoming the document.**
+  Every text parser accepts a `str` that may be either a file path or the document
+  content, and nothing in the signature distinguishes them — so each parser guessed, and
+  the library guessed two different ways. Fifteen parsers fell through to "it must be
+  content", which meant a typo in a filename produced a one-line document containing the
+  filename: `MarkdownToAstConverter().parse("does_not_exist.md")` returned a `Paragraph`
+  reading `does_not_exist.md`, which downstream is a successful conversion of the wrong
+  thing. The other three (`csv`, `fb2`, `rtf`) read *every* `str` as a path, so raw
+  content was unusable. Both halves now go through one classifier in
+  `all2md.utils.inputs.resolve_str_input`, so all 18 agree: raw content parses, and a
+  string that looks like a path but does not resolve raises `FileNotFoundError` naming
+  the escape hatches. "Looks like a path" is deliberately narrow — no whitespace, no
+  `://`, and ends with an extension all2md knows — so prose such as `"read config.json"`
+  or `"Visit https://example.com"` is still content. Callers who pass content that fits
+  that shape should pass `bytes` or `io.StringIO`; `Path(...)` still always means a path.
+  `ini`, `json`, `toml` and `yaml` also stop re-wrapping typed all2md failures as
+  `ParsingError`, so the more specific exception survives (#233).
 - **Type inference no longer reads `1` and `0` as booleans.** With `type_inference=True`,
   the JSON, YAML and TOML renderers treated the table cells `1` and `0` as `true`/`false`,
   so an `age` column of `1` serialized as a boolean. They are now integers; `true`/`yes`/`on`

--- a/src/all2md/parsers/base.py
+++ b/src/all2md/parsers/base.py
@@ -21,6 +21,7 @@ from all2md.exceptions import InvalidOptionsError, ValidationError
 from all2md.options.base import BaseParserOptions
 from all2md.progress import ProgressCallback, ProgressEvent
 from all2md.utils.encoding import normalize_stream_to_bytes, normalize_stream_to_text, read_text_with_encoding_detection
+from all2md.utils.inputs import resolve_str_input
 from all2md.utils.metadata import DocumentMetadata
 from all2md.utils.parser_helpers import (
     append_attachment_footnotes as _append_attachment_footnotes_helper,
@@ -446,19 +447,13 @@ class BaseParser(ABC):
             with open(input_data, "rb") as f:
                 return read_text_with_encoding_detection(f.read())
         elif isinstance(input_data, str):
-            # Could be file path or content
-            # Check length first - Linux has 255 char limit for path components,
-            # and calling path.exists() on very long strings raises OSError
-            if len(input_data) <= 260 and "\n" not in input_data:
-                try:
-                    path = Path(input_data)
-                    if path.exists() and path.is_file():
-                        with open(path, "rb") as f:
-                            return read_text_with_encoding_detection(f.read())
-                except OSError:
-                    # Path too long or invalid - treat as content
-                    pass
-            # Assume it's content
+            # Ambiguous: could be a path or the content itself. resolve_str_input
+            # is the single place that decides, and raises rather than silently
+            # parsing a mistyped filename into a one-line document.
+            path = resolve_str_input(input_data)
+            if path is not None:
+                with open(path, "rb") as f:
+                    return read_text_with_encoding_detection(f.read())
             return input_data
         else:
             # File-like object (handles both binary and text mode)
@@ -482,9 +477,15 @@ class BaseParser(ABC):
         """
         if isinstance(input_data, bytes):
             return input_data
-        elif isinstance(input_data, (str, Path)):
-            path = Path(input_data)
-            return path.read_bytes()
+        elif isinstance(input_data, Path):
+            return input_data.read_bytes()
+        elif isinstance(input_data, str):
+            # Same path-or-content decision as _load_text_content; a string that
+            # is content becomes its UTF-8 encoding rather than a path error.
+            path = resolve_str_input(input_data)
+            if path is not None:
+                return path.read_bytes()
+            return input_data.encode("utf-8")
         elif hasattr(input_data, "read"):
             return normalize_stream_to_bytes(input_data)
         else:

--- a/src/all2md/parsers/csv.py
+++ b/src/all2md/parsers/csv.py
@@ -23,7 +23,7 @@ from all2md.options.csv import CsvOptions
 from all2md.parsers.base import BaseParser
 from all2md.progress import ProgressCallback
 from all2md.utils.encoding import read_text_with_encoding_detection
-from all2md.utils.inputs import validate_and_convert_input
+from all2md.utils.inputs import resolve_str_input, validate_and_convert_input
 from all2md.utils.metadata import DocumentMetadata
 from all2md.utils.spreadsheet import build_table_ast, sanitize_cell_text, transform_header_case
 
@@ -373,6 +373,12 @@ class CsvToAstConverter(BaseParser):
             AST document with table node
 
         """
+        # A str is a path or the CSV text itself. Resolve it here so this parser
+        # agrees with the text parsers instead of reading every str as a path.
+        if isinstance(input_data, str):
+            resolved = resolve_str_input(input_data)
+            input_data = resolved if resolved is not None else input_data.encode("utf-8")
+
         # Validate and load text
         try:
             doc_input, _ = validate_and_convert_input(input_data, supported_types=["path-like", "file-like", "bytes"])

--- a/src/all2md/parsers/fb2.py
+++ b/src/all2md/parsers/fb2.py
@@ -41,6 +41,7 @@ from all2md.parsers.base import BaseParser
 from all2md.progress import ProgressCallback
 from all2md.utils.attachments import process_attachment
 from all2md.utils.encoding import normalize_stream_to_bytes
+from all2md.utils.inputs import resolve_str_input
 from all2md.utils.metadata import DocumentMetadata
 from all2md.utils.parser_helpers import attachment_result_to_image_node
 
@@ -200,13 +201,19 @@ class Fb2ToAstConverter(BaseParser):
     # ------------------------------------------------------------------
     def _load_fb2_bytes(self, input_data: Union[str, Path, IO[bytes], bytes]) -> bytes:
         if isinstance(input_data, (str, Path)):
-            path = Path(input_data)
-            if path.suffix.lower() == ".fb2":
-                return path.read_bytes()
+            path: Optional[Path]
+            if isinstance(input_data, Path):
+                path = input_data
+            else:
+                # A str is a path or the FB2 XML itself; resolve_str_input decides
+                # once for every text parser and raises on a mistyped filename.
+                path = resolve_str_input(input_data)
+                if path is None:
+                    return input_data.encode("utf-8")
+
             if path.name.lower().endswith(".fb2.zip") or path.suffix.lower() == ".zip":
                 with self._validated_zip_input(path, suffix=".zip") as validated:
                     return self._extract_fb2_from_zip(validated)
-
             return path.read_bytes()
 
         if isinstance(input_data, bytes):

--- a/src/all2md/parsers/ini.py
+++ b/src/all2md/parsers/ini.py
@@ -71,7 +71,7 @@ from all2md.ast import (
     Text,
 )
 from all2md.converter_metadata import ConverterMetadata
-from all2md.exceptions import ParsingError
+from all2md.exceptions import All2MdError, ParsingError
 from all2md.options.ini import IniParserOptions
 from all2md.parsers.base import BaseParser
 from all2md.progress import ProgressCallback
@@ -241,6 +241,10 @@ class IniParser(BaseParser):
             return Document(children=children, metadata=metadata.to_dict())
 
         except ParsingError:
+            raise
+        except All2MdError:
+            # Already a typed all2md failure (e.g. the input was a mistyped path);
+            # re-wrapping it as ParsingError would hide the more specific type.
             raise
         except Exception as e:
             raise ParsingError(f"Failed to parse INI: {e}") from e

--- a/src/all2md/parsers/json.py
+++ b/src/all2md/parsers/json.py
@@ -80,7 +80,7 @@ from all2md.ast import (
     Text,
 )
 from all2md.converter_metadata import ConverterMetadata
-from all2md.exceptions import ParsingError
+from all2md.exceptions import All2MdError, ParsingError
 from all2md.options.json import JsonParserOptions
 from all2md.parsers.base import BaseParser
 from all2md.progress import ProgressCallback
@@ -194,6 +194,10 @@ class JsonParser(BaseParser):
             return Document(children=children, metadata=metadata.to_dict())
 
         except ParsingError:
+            raise
+        except All2MdError:
+            # Already a typed all2md failure (e.g. the input was a mistyped path);
+            # re-wrapping it as ParsingError would hide the more specific type.
             raise
         except Exception as e:
             raise ParsingError(f"Failed to parse JSON: {e}") from e

--- a/src/all2md/parsers/rtf.py
+++ b/src/all2md/parsers/rtf.py
@@ -38,7 +38,7 @@ from all2md.parsers.base import BaseParser
 from all2md.progress import ProgressCallback
 from all2md.utils.attachments import create_attachment_sequencer, process_attachment
 from all2md.utils.decorators import requires_dependencies
-from all2md.utils.inputs import validate_and_convert_input
+from all2md.utils.inputs import resolve_str_input, validate_and_convert_input
 from all2md.utils.metadata import DocumentMetadata
 from all2md.utils.parser_helpers import attachment_result_to_image_node
 
@@ -110,6 +110,12 @@ class RtfToAstConverter(BaseParser):
 
         """
         from pyth.plugins.rtf15.reader import Rtf15Reader
+
+        # RTF is a text format, so a str may be the document itself rather than a
+        # path. Resolve it the same way the text parsers do (#233).
+        if isinstance(input_data, str):
+            resolved = resolve_str_input(input_data)
+            input_data = resolved if resolved is not None else input_data.encode("utf-8")
 
         doc = None
         try:

--- a/src/all2md/parsers/toml.py
+++ b/src/all2md/parsers/toml.py
@@ -87,7 +87,7 @@ from all2md.ast import (
 )
 from all2md.constants import DEPS_TOML
 from all2md.converter_metadata import ConverterMetadata
-from all2md.exceptions import ParsingError
+from all2md.exceptions import All2MdError, ParsingError
 from all2md.options.toml import TomlParserOptions
 from all2md.parsers.base import BaseParser
 from all2md.progress import ProgressCallback
@@ -214,6 +214,10 @@ class TomlParser(BaseParser):
             return Document(children=children, metadata=metadata.to_dict())
 
         except ParsingError:
+            raise
+        except All2MdError:
+            # Already a typed all2md failure (e.g. the input was a mistyped path);
+            # re-wrapping it as ParsingError would hide the more specific type.
             raise
         except Exception as e:
             raise ParsingError(f"Failed to parse TOML: {e}") from e

--- a/src/all2md/parsers/yaml.py
+++ b/src/all2md/parsers/yaml.py
@@ -80,7 +80,7 @@ from all2md.ast import (
 )
 from all2md.constants import DEPS_YAML
 from all2md.converter_metadata import ConverterMetadata
-from all2md.exceptions import ParsingError
+from all2md.exceptions import All2MdError, ParsingError
 from all2md.options.yaml import YamlParserOptions
 from all2md.parsers.base import BaseParser
 from all2md.progress import ProgressCallback
@@ -203,6 +203,10 @@ class YamlParser(BaseParser):
             return Document(children=children, metadata=metadata.to_dict())
 
         except ParsingError:
+            raise
+        except All2MdError:
+            # Already a typed all2md failure (e.g. the input was a mistyped path);
+            # re-wrapping it as ParsingError would hide the more specific type.
             raise
         except Exception as e:
             raise ParsingError(f"Failed to parse YAML: {e}") from e

--- a/src/all2md/utils/inputs.py
+++ b/src/all2md/utils/inputs.py
@@ -88,6 +88,123 @@ def is_file_like(obj: Any) -> bool:
     return hasattr(obj, "read") and callable(obj.read)
 
 
+#: Longest ``str`` that is probed against the filesystem. Most platforms cap a
+#: single path component at 255 bytes, and on some of them ``Path.is_file()``
+#: raises ``OSError`` rather than returning ``False`` for an over-long name.
+MAX_PROBEABLE_PATH_LENGTH = 260
+
+
+def looks_like_path_attempt(value: str) -> bool:
+    """Return whether a ``str`` was plausibly meant as a file path.
+
+    Text parsers accept a ``str`` that may be either a path or the document
+    content itself, and nothing in the signature distinguishes them. When the
+    filesystem probe misses, this decides between two failure modes: raising
+    (the caller meant a path and mistyped it) or parsing the string as content
+    (the caller meant content all along).
+
+    The predicate is deliberately narrow, because a false positive breaks
+    working code that parses short strings while a false negative only leaves
+    today's behaviour in place. All four conditions must hold:
+
+    - short enough and single-line to be a plausible filename,
+    - no whitespace, so prose such as ``"read config.json"`` stays content,
+    - no ``://``, so a bare URL such as ``"https://example.com/a.md"`` stays
+      content,
+    - ends with a file extension all2md actually knows.
+
+    Parameters
+    ----------
+    value : str
+        The ambiguous string.
+
+    Returns
+    -------
+    bool
+        True if the string should be read as a mistyped path rather than as
+        document content.
+
+    Examples
+    --------
+    >>> looks_like_path_attempt("does_not_exist.md")
+    True
+    >>> looks_like_path_attempt("read config.json")
+    False
+    >>> looks_like_path_attempt("Visit https://example.com")
+    False
+
+    """
+    if not value or len(value) > MAX_PROBEABLE_PATH_LENGTH:
+        return False
+    if any(character.isspace() for character in value):
+        return False
+    if "://" in value:
+        return False
+
+    # Imported here rather than at module scope: the registry imports this
+    # module's siblings, and startup cost is a tracked budget.
+    from all2md.converter_registry import registry
+
+    lowered = value.lower()
+    return any(lowered.endswith(extension) for extension in registry.get_all_extensions())
+
+
+def resolve_str_input(value: str) -> Path | None:
+    """Classify an ambiguous ``str`` as a filesystem path or as document content.
+
+    Every text parser takes a ``str`` that may be either. This is the single
+    place that decides, so the 18 parsers agree and the rule can be changed
+    once.
+
+    Parameters
+    ----------
+    value : str
+        The ambiguous string.
+
+    Returns
+    -------
+    Path or None
+        The resolved path when the string names an existing file, otherwise
+        ``None``, meaning treat ``value`` itself as the document content.
+
+    Raises
+    ------
+    all2md.exceptions.FileNotFoundError
+        If the string looks like a path (see :func:`looks_like_path_attempt`)
+        but no such file exists. Without this a mistyped filename parsed into a
+        one-line document containing the filename, which reads downstream as a
+        successful conversion of the wrong thing.
+
+    Examples
+    --------
+    >>> resolve_str_input("# A heading") is None
+    True
+
+    """
+    if len(value) <= MAX_PROBEABLE_PATH_LENGTH and "\n" not in value:
+        try:
+            path = Path(value)
+            if path.is_file():
+                return path
+        except OSError:
+            # Over-long, or illegal characters for this platform. Not a path we
+            # can read either way, so fall through to the content decision.
+            pass
+
+    if looks_like_path_attempt(value):
+        raise All2MdFileNotFoundError(
+            file_path=value,
+            message=(
+                f"File not found: {value}\n"
+                "This string was read as a file path because it has no whitespace and ends "
+                "with a known all2md extension. If it is document content rather than a "
+                "path, pass it as bytes (value.encode()) or wrap it in io.StringIO to say "
+                "so explicitly; pass Path(...) to always mean a path."
+            ),
+        )
+    return None
+
+
 def validate_page_range(pages: list[int] | str | None, max_pages: int | None = None) -> list[int] | None:
     """Validate and normalize a page range specification.
 

--- a/tests/unit/parsers/test_str_input_disambiguation.py
+++ b/tests/unit/parsers/test_str_input_disambiguation.py
@@ -1,0 +1,165 @@
+#  Copyright (c) 2025 Tom Villani, Ph.D.
+#
+# tests/unit/parsers/test_str_input_disambiguation.py
+"""Every text parser must read a ``str`` the same way (#233).
+
+A ``str`` passed to a text parser may be either a file path or the document
+content, and nothing in the signature says which. Before #233 the library
+guessed two different ways: three parsers read every ``str`` as a path, so raw
+content was unusable, and fifteen fell through to "it must be content", so a
+mistyped filename silently became a one-line document containing the filename
+— a successful conversion of the wrong thing.
+
+These tests pin both halves across the whole set, so the two groups cannot
+drift apart again.
+"""
+
+from __future__ import annotations
+
+import importlib
+from pathlib import Path
+
+import pytest
+
+from all2md.exceptions import FileNotFoundError as All2MdFileNotFoundError
+from all2md.utils.inputs import looks_like_path_attempt, resolve_str_input
+
+#: ``(format, module, class, sample content, extension)`` for every text parser
+#: that accepts an ambiguous ``str``.
+TEXT_PARSERS = [
+    ("asciidoc", "all2md.parsers.asciidoc", "AsciiDocParser", "Hello world", ".adoc"),
+    ("bbcode", "all2md.parsers.bbcode", "BBCodeParser", "Hello world", ".bbcode"),
+    ("csv", "all2md.parsers.csv", "CsvToAstConverter", "a,b\nc,d", ".csv"),
+    ("dokuwiki", "all2md.parsers.dokuwiki", "DokuWikiParser", "Hello world", ".dokuwiki"),
+    ("html", "all2md.parsers.html", "HtmlToAstConverter", "<p>Hello</p>", ".html"),
+    ("ini", "all2md.parsers.ini", "IniParser", "[s]\nk = v", ".ini"),
+    ("json", "all2md.parsers.json", "JsonParser", '{"a": 1}', ".json"),
+    ("latex", "all2md.parsers.latex", "LatexParser", "Hello world", ".tex"),
+    ("markdown", "all2md.parsers.markdown", "MarkdownToAstConverter", "Hello world", ".md"),
+    ("mediawiki", "all2md.parsers.mediawiki", "MediaWikiParser", "Hello world", ".wiki"),
+    ("org", "all2md.parsers.org", "OrgParser", "Hello world", ".org"),
+    ("plaintext", "all2md.parsers.plaintext", "PlainTextToAstConverter", "Hello world", ".txt"),
+    ("rst", "all2md.parsers.rst", "RestructuredTextParser", "Hello world", ".rst"),
+    ("rtf", "all2md.parsers.rtf", "RtfToAstConverter", r"{\rtf1\ansi Hello}", ".rtf"),
+    ("textile", "all2md.parsers.textile", "TextileParser", "Hello world", ".textile"),
+    ("toml", "all2md.parsers.toml", "TomlParser", "a = 1", ".toml"),
+    ("yaml", "all2md.parsers.yaml", "YamlParser", "a: 1", ".yaml"),
+    # fb2 has no one-line content form, so it appears only in the missing-path test.
+    ("fb2", "all2md.parsers.fb2", "Fb2ToAstConverter", None, ".fb2"),
+]
+
+IDS = [entry[0] for entry in TEXT_PARSERS]
+
+
+def _parser(module_name: str, class_name: str):
+    """Import and instantiate a parser by name."""
+    return getattr(importlib.import_module(module_name), class_name)()
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(("fmt", "module", "cls", "content", "extension"), TEXT_PARSERS, ids=IDS)
+def test_raw_content_str_parses(fmt, module, cls, content, extension) -> None:
+    """A ``str`` holding document content parses instead of being read as a path."""
+    if content is None:
+        pytest.skip(f"{fmt} has no single-line content form")
+
+    document = _parser(module, cls).parse(content)
+
+    assert document.children, f"{fmt} produced an empty document from raw content"
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(("fmt", "module", "cls", "content", "extension"), TEXT_PARSERS, ids=IDS)
+def test_missing_path_str_raises_instead_of_becoming_a_document(fmt, module, cls, content, extension) -> None:
+    """A mistyped filename raises rather than parsing into a one-line document."""
+    with pytest.raises(All2MdFileNotFoundError):
+        _parser(module, cls).parse(f"does_not_exist_{fmt}{extension}")
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(("fmt", "module", "cls", "content", "extension"), TEXT_PARSERS, ids=IDS)
+def test_existing_path_str_is_read(fmt, module, cls, content, extension, tmp_path) -> None:
+    """A ``str`` naming a real file is still read from disk."""
+    if content is None:
+        pytest.skip(f"{fmt} has no single-line content form")
+
+    source = tmp_path / f"sample{extension}"
+    source.write_text(content, encoding="utf-8")
+
+    document = _parser(module, cls).parse(str(source))
+
+    assert document.children, f"{fmt} produced an empty document from a real file"
+
+
+@pytest.mark.unit
+class TestLooksLikePathAttempt:
+    """The predicate is deliberately narrow: prose must never be read as a path."""
+
+    @pytest.mark.parametrize(
+        "value",
+        [
+            "does_not_exist.md",
+            "docs/guide.rst",
+            "REPORT.DOCX",  # extension match is case-insensitive
+        ],
+    )
+    def test_path_shaped_strings(self, value: str) -> None:
+        assert looks_like_path_attempt(value) is True
+
+    @pytest.mark.parametrize(
+        "value",
+        [
+            "read config.json",  # whitespace: prose mentioning a file
+            "Visit https://example.com",  # a URL, and prose
+            "https://example.com/page.html",  # bare URL ending in a known extension
+            "Hello world",  # no extension at all
+            "yes/no",  # a separator, but no known extension
+            "notes.unknownext",  # extension all2md does not know
+            "",
+        ],
+    )
+    def test_content_shaped_strings(self, value: str) -> None:
+        assert looks_like_path_attempt(value) is False
+
+    def test_over_long_strings_are_never_probed(self) -> None:
+        """A string past the path-length cap is content, whatever it ends with."""
+        assert looks_like_path_attempt("x" * 300 + ".md") is False
+
+
+@pytest.mark.unit
+class TestResolveStrInput:
+    """The shared classifier used by every text parser."""
+
+    def test_content_resolves_to_none(self) -> None:
+        assert resolve_str_input("# A heading") is None
+
+    def test_existing_file_resolves_to_its_path(self, tmp_path) -> None:
+        source = tmp_path / "real.md"
+        source.write_text("# Hi", encoding="utf-8")
+
+        assert resolve_str_input(str(source)) == Path(str(source))
+
+    def test_missing_path_error_explains_how_to_force_content(self) -> None:
+        with pytest.raises(All2MdFileNotFoundError) as excinfo:
+            resolve_str_input("does_not_exist.md")
+
+        message = str(excinfo.value)
+        assert "does_not_exist.md" in message
+        # The escape hatches must be named, or the raise is just a new dead end.
+        assert "encode()" in message
+        assert "StringIO" in message
+        assert "Path(" in message
+
+
+@pytest.mark.unit
+def test_prose_ending_in_a_dotted_word_still_parses() -> None:
+    """Regression: ``.com`` is not an all2md extension, so this stays content.
+
+    The asciidoc suite has parsed this exact string since long before #233; it
+    is the shape most at risk from a looser "looks like a path" rule.
+    """
+    from all2md.parsers.asciidoc import AsciiDocParser
+
+    document = AsciiDocParser().parse("Visit https://example.com")
+
+    assert document.children


### PR DESCRIPTION
Closes #233.

## The problem

Every text parser accepts a `str` for `input_data` that may be either a **file path** or the **document content**. Nothing in the API distinguishes them, so each parser guessed — and the codebase guessed two different ways.

**Group B (15 parsers, via `BaseParser._load_text_content`)** falls through to "assume it's content" when the filesystem probe misses. A typo in a filename became the document:

```python
>>> MarkdownToAstConverter().parse("does_not_exist.md")
Document(children=[Paragraph(content=[Text(content='does_not_exist.md')])])
```

No exception. Downstream that is a successful conversion of the wrong thing — the failure mode most likely to reach a user's output unnoticed.

**Group A (`csv`, `fb2`, `rtf`)** read every `str` as a path. They failed loudly, but raw content was simply unusable.

## The fix

One classifier, `all2md.utils.inputs.resolve_str_input`, used by both groups. All 18 parsers now agree:

| | before (group A) | before (group B) | after |
|---|---|---|---|
| raw content | ❌ path error | ✅ parses | ✅ parses |
| existing path | ✅ read | ✅ read | ✅ read |
| **missing path** | ✅ raises | ❌ **silently becomes a document** | ✅ raises |

Verified across all 18 — every cell is `parses` / `raises FileNotFound`, with zero silent documents.

## On the "looks like a path" predicate

The decision only bites when the filesystem probe misses, and there it picks between raising and parsing as content. It is deliberately **narrow**, because a false positive breaks working code while a false negative only leaves today's behaviour in place. All must hold:

- short enough and single-line to be a plausible filename,
- **no whitespace**, so `"read config.json"` stays content,
- **no `://`**, so `"https://example.com/page.html"` stays content,
- ends with an extension all2md actually knows (160 of them; `.com` is not one).

The asciidoc suite has parsed `"Visit https://example.com"` since long before this change — it is the shape most at risk from a looser rule, and it is pinned as a regression test.

The raise names the escape hatches (`bytes`, `io.StringIO`, `Path`), since a raise with no way out is just a new dead end.

## Also

`ini`, `json`, `toml` and `yaml` had a bare `except Exception` that re-wrapped typed all2md failures as `ParsingError`, so `except FileNotFoundError` would not catch a missing file. They now re-raise `All2MdError` untouched — consistent with the contract #212 established.

## Relationship to #228

#228 fixes the `fb2` half of this by copying the `len <= 260 and "\n" not in ...` heuristic verbatim out of `base.py`, which gives two copies that can drift, and moves `fb2` from "fails loudly on a typo" to "silently parses the filename" — the trade this issue was filed about. This supersedes it: `fb2` gets raw-string input *and* keeps its loud failure. **Recommend closing #228 in favour of this**, with thanks — it surfaced the split.

## Verification

- Full `tests/unit` suite: green (exit 0)
- `tests/golden`: green
- `ruff check`, `black --check`, `mypy src/`: clean (the one remaining mypy error, `_pdf_layout.py:190`, is pre-existing on `main` and outside CI's typed extras)
- New `tests/unit/parsers/test_str_input_disambiguation.py`: 72 tests parametrized across all 18 parsers, plus predicate unit tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)