### PR TITLE
ci(fuzz): ask Hypothesis where the time goes

### DIFF
--- a/.github/workflows/fuzz-corpus.yml
+++ b/.github/workflows/fuzz-corpus.yml
@@ -12,12 +12,30 @@ name: Generative Roundtrip Gates
 #     HYPOTHESIS_PROFILE=ci pytest -m fuzzing --hypothesis-seed=random
 #
 # What forced the split: on the 3.12 leg these took over 3 hours, against ~60s
-# for the same file locally. That ~160x gap is not explained by the example
-# count, by coverage instrumentation, or by the Hypothesis profile (CI does not
-# set HYPOTHESIS_PROFILE, so it runs `dev` exactly as a dev box does), and it
-# was making every PR wait hours. --durations below is here to name the tests
-# responsible; until that lands, treat the runtime here as unexplained rather
-# than as the cost of the gates.
+# for the same file locally. That gap is still unexplained, and the list of
+# things it is NOT keeps growing -- each one measured, not argued:
+#
+#   - example count: #216's per-format budget is real, but it is 10x of ~6s
+#   - coverage: 61s plain vs 59s under --cov=all2md
+#   - Hypothesis profile: CI never sets HYPOTHESIS_PROFILE, so it loads `dev`
+#     exactly as a dev box does
+#   - Hypothesis version: CI installs 6.164.0 against 6.155.7 locally, but
+#     shadowing 6.164.0 onto a local run leaves dokuwiki at ~1s
+#   - corpus luck: dokuwiki is flat at ~1.5s across five different seeds
+#
+# The first --durations run ruled out a stall: the per-test durations sum to
+# 4938s against a 4993s job, so the time is real work spread over specific
+# tests. It is also wildly uneven -- dokuwiki 863s and asciidoc 557s in CI
+# against ~2s locally, while ipynb is only 6.5x. Locally those two are among
+# the *fastest* formats, so CI is not simply a slower machine: a constant
+# factor cannot invert the ordering.
+#
+# --hypothesis-show-statistics is the next instrument. Locally dokuwiki reports
+# 25 passing / 5 invalid examples with generation dominating (~74ms of an ~87ms
+# example). The CI numbers separate the live hypotheses: 25 examples at ~34s
+# each means execution is genuinely slow on this platform, while thousands of
+# invalid examples means Hypothesis is thrashing on generation and the finger
+# points away from our renderers entirely.
 
 on:
   schedule:
@@ -58,8 +76,25 @@ jobs:
           python -m pip install --upgrade pip
           pip install -e ".[all,dev]"
 
-      # --durations=0 prints every test rather than a top-N: the open question is
-      # the shape of the distribution (355 examples at ~25s each, or three tests
-      # hanging for 45 minutes), and a top-N cannot tell those apart.
+      # Record what the environment actually resolved to. `hypothesis` is pinned
+      # only as >=6.100.0, so the installed version drifts run to run, and
+      # ruling it in or out after the fact needs the number in the log.
+      - name: Record environment
+        run: |
+          python -VV
+          pip show hypothesis | head -2
+          python -c 'import sys; print("platform:", sys.platform)'
+
+      # --durations=0 prints every test rather than a top-N: the question is the
+      # shape of the distribution, and a top-N cannot show it.
+      #
+      # --hypothesis-show-statistics is the load-bearing flag here. It reports
+      # per test how many examples ran, how many were invalid, and how the time
+      # split between generating data and executing it -- which is what tells us
+      # whether 863s of dokuwiki is 25 slow round trips or a generator thrashing
+      # on rejected examples. Compare against the local baseline: 25 passing,
+      # 5 invalid, ~74ms of an ~87ms example spent in generation.
       - name: Run the generative gates
-        run: pytest tests/unit/test_roundtrip_fuzzing.py -m generative -v --durations=0
+        run: >
+          pytest tests/unit/test_roundtrip_fuzzing.py -m generative -v
+          --durations=0 --hypothesis-show-statistics


### PR DESCRIPTION
Follow-up to #230. One flag, plus an environment echo.

## What the durations table told us

It ruled out a stall — per-test durations sum to **4938s against a 4993s job**, so the 3h is real work spread across specific tests, not a hang. But it's wildly uneven:

| Format | Local | CI | Ratio |
|---|---|---|---|
| dokuwiki | 2.03s | 863.65s | **425x** |
| asciidoc | 1.69s | 557.26s | **330x** |
| markdown | 1.82s | 365.17s | 201x |
| latex | 2.40s | 435.00s | 181x |
| rst | 8.26s | 125.07s | 15x |
| pdf | 8.98s | 113.56s | 12.6x |
| ipynb | 0.52s | 3.36s | **6.5x** |

Locally `dokuwiki` and `asciidoc` are among the *fastest* formats; in CI they're the two slowest. A slower machine multiplies everything by roughly one constant — **it cannot invert the ordering**. So "clunky runner" doesn't cover this.

## Two more theories died

Both by measurement, not argument:

- **Hypothesis version drift** — looked strong, since `hypothesis` is pinned only as `>=6.100.0` and CI resolved **6.164.0** against **6.155.7** locally. But shadowing 6.164.0 onto a local run via `PYTHONPATH` leaves dokuwiki at ~1s. Refuted.
- **Corpus luck** — dokuwiki is flat at ~1.5s across five different `--hypothesis-seed` values, so there's no rare pathological shape CI happens to draw. Refuted.

Running list of what it is *not*: example count (#216's budget is 10x of ~6s), coverage (61s plain vs 59s under `--cov`), Hypothesis profile (CI never sets `HYPOTHESIS_PROFILE`), Hypothesis version, corpus luck, and network I/O (there is none in the parser/renderer path).

## Why this flag

`--hypothesis-show-statistics` reports, per test, how many examples ran, how many were invalid, and how time split between *generating* data and *executing* it. Local baseline for dokuwiki:

```
- during generate phase (0.88 seconds):
  - Typical runtimes: ~ 1-87 ms, of which ~ 0-74 ms in data generation
  - 25 passing examples, 0 failing examples, 5 invalid examples
- Stopped because settings.max_examples=25
```

Generation already dominates locally (~74ms of an ~87ms example). The CI numbers split the live hypotheses cleanly:

- **25 examples at ~34s each** → execution is genuinely slow on that platform, and the renderers are worth profiling.
- **Thousands of invalid examples** → Hypothesis is thrashing on generation, and our code isn't implicated at all.

Those want opposite fixes, so it's worth one run to find out.

Also echoes `python -VV` and the resolved `hypothesis` version — an unpinned dependency that drifts between runs can't be ruled in or out after the fact without the number in the log.

## Cost

No new job, no schedule change. The nightly already runs; this makes the run answer the question. Trigger it via `workflow_dispatch` once merged rather than waiting for 04:00 UTC.

🤖 Generated with [Claude Code](https://claude.com/claude-code)