### PR TITLE
ci(omnidocbench): gate PDF fidelity against external ground truth

### DIFF
--- a/.github/workflows/omnidocbench-gate.yml
+++ b/.github/workflows/omnidocbench-gate.yml
@@ -1,0 +1,83 @@
+name: OmniDocBench PDF Fidelity Gate
+
+# Runs independent 981-page PDF fidelity scoring against pinned external ground
+# truth. This is intentionally separate from per-PR and release workflows.
+#
+# Unlike the other workflows, this one installs through `uv sync --frozen` rather than pip, and
+# pins the runner image instead of using `ubuntu-latest`. The ratchet baseline records parser
+# runtime identity, including the PyMuPDF, pymupdf-layout, pytesseract, Pillow, and Tesseract
+# versions and the digest of each language-data file. A resolver that is free to move those
+# versions, or a runner image that changes the system Tesseract, reports identity drift instead
+# of a fidelity result, so the lockfile and the image are part of the measurement.
+
+on:
+  schedule:
+    # 06:00 UTC on the first day of each month. OCR makes a full run expensive,
+    # while the immutable corpus keeps the signal stable between runs.
+    - cron: "0 6 1 * *"
+  workflow_dispatch:
+    inputs:
+      record_baseline:
+        description: "Upload a reviewable baseline candidate instead of gating (use for the first run)"
+        required: false
+        default: false
+        type: boolean
+
+concurrency:
+  group: omnidocbench-gate-${{ github.ref }}-${{ github.event_name }}-${{ inputs.record_baseline || false }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  fidelity:
+    name: OmniDocBench PDF Fidelity Gate
+    runs-on: ubuntu-24.04
+    timeout-minutes: 240
+
+    steps:
+      - name: Check out all2md
+        uses: actions/checkout@v7
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          python-version: "3.12"
+          enable-cache: true
+
+      - name: Install OCR language data
+        run: |
+          sudo apt-get update
+          sudo apt-get install --yes tesseract-ocr tesseract-ocr-eng tesseract-ocr-chi-sim
+
+      - name: Install all2md from the lockfile
+        run: uv sync --frozen --extra pdf_layout --extra ocr
+
+      - name: Run fidelity gate
+        if: ${{ !inputs.record_baseline }}
+        run: |
+          uv run --frozen --extra pdf_layout --extra ocr python -m benchmarks.omnidocbench \
+            --output benchmarks/omnidocbench/.cache/results/current.json
+
+      - name: Produce baseline candidate
+        if: ${{ inputs.record_baseline }}
+        run: |
+          uv run --frozen --extra pdf_layout --extra ocr python -m benchmarks.omnidocbench \
+            --output benchmarks/omnidocbench/.cache/results/current.json \
+            --write-baseline benchmarks/omnidocbench/.cache/results/baseline-candidate.json \
+            --default-tolerance 0.005
+
+      - name: Upload derived scores
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: omnidocbench-scores-${{ github.run_number }}
+          # The results live under the gitignored `.cache/` directory, and this action skips
+          # anything inside a dot-directory unless hidden files are opted in. Without this the
+          # upload silently produces an empty artifact and the baseline bootstrap has nothing to
+          # review. Only derived score JSON is matched; corpus PDFs sit in the revision directory.
+          include-hidden-files: true
+          path: benchmarks/omnidocbench/.cache/results/*.json
+          if-no-files-found: error
+          retention-days: 14

--- a/.gitignore
+++ b/.gitignore
@@ -102,6 +102,9 @@ benchmarks/corpus/results/
 benchmarks/corpus/inspect/
 benchmarks/corpus/.test/
 
+# External-ground-truth benchmark
+benchmarks/omnidocbench/.cache/
+
 .claude/
 broken/
 design/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   XPASS and fails the build until it is removed. It found six crash classes and a set
   of invariant gaps on existing formats, now filed as issues. Thanks
   [@santhreal](https://github.com/santhreal) (#204).
+- **Tests: external PDF fidelity against pinned OmniDocBench ground truth.**
+  `benchmarks/omnidocbench` downloads the immutable 981-page v1.0 corpus, calls
+  `all2md.to_ast` once for each page, and compares AST text, tables, formulae, and reading
+  order directly with annotation fields. Dimensions the parser cannot yet express are reported
+  as unsupported instead of scored, so absent capabilities cannot earn credit. A fail-closed
+  ratchet records score denominators, variance, and exact page scores, rejects
+  corpus, oracle, parser-policy, parser-runtime, or conversion drift, and requires review for
+  both regressions and improvements. The full lane runs only on a monthly schedule or manual
+  dispatch. Pull request and release CI keep using synthetic, network-free tests. The first
+  scheduled baseline is recorded by dispatching the workflow with `record_baseline` enabled;
+  until that candidate is reviewed and committed the gate reports `ABSENT_BASELINE` red.
+  Every metric is monotone on the pinned corpus: exact reproduction of the annotation scores
+  1.0 and no degradation of it scores higher, checked across eleven degraded variants and all
+  six dimensions on all 981 pages. Thanks [@santhreal](https://github.com/santhreal).
 
 ### Changed
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -207,15 +207,19 @@ People star us because "it just converted my gnarly PDF perfectly." Protect and 
   hole (#212), and the first **enumerated** — rather than suspected — list of round-trip gaps
   in the org and asciidoc renderers (table captions, ordered-list `start`, the `#+BEGIN_SRC`
   language, and an asciidoc trailing pipe its own parser reads as a phantom column).
-- 🚀 **External ground truth** — *the headline metric, once the ratchet exists.*
-  `roundtrip_report` (🚢) is **self-referential**: it proves we invert our own parsers, not
-  that we read the document correctly. A garbled table round-trips perfectly. So the open
-  work is (a) running fidelity corpus-wide via the ratchet, and (b) scoring against a real
-  external ground truth — which, once the ratchet is in place, is just another oracle plugged
-  into a socket that already works. Corpora, split by job:
+- 🚀 **External ground truth** (lane landed in `benchmarks/omnidocbench`; the first baseline is
+  still to be recorded, so the gate reads `ABSENT_BASELINE` until then) is the headline
+  metric. `roundtrip_report` (🚢) is **self-referential**: it proves we invert our own
+  parsers, not that we read the document correctly. A garbled table can round-trip perfectly.
+  The scheduled OmniDocBench lane now downloads an immutable 981-page corpus, calls
+  `all2md.to_ast` once per page, and compares supported AST facts directly with annotation
+  fields for text, formulae, tables, and reading order. Its committed ratchet fails on corpus
+  drift, parser-policy drift, denominator drift, vacuous metrics, regressions, and unreviewed
+  improvements.
+  Corpora remain split by job:
   - **Structure ground-truth (headline metric):** [**OmniDocBench**](https://github.com/opendatalab/OmniDocBench)
-    (CVPR 2025) — 981 pages, 9 doc types, with table (Markdown/HTML/LaTeX), formula, and
-    reading-order metrics that map directly onto our output. Anchor the public score here.
+    (CVPR 2025), 981 pages and 9 document types with table, formula, text, and reading-order
+    metrics. The scheduled external fidelity lane anchors the public score here.
     Supplement with [**DocLayNet**](https://github.com/DS4SD/DocLayNet) (80k diverse
     annotated pages, good for reading order) and **M6Doc** (scanned + CJK coverage).
     *Avoid relying on PubLayNet/DocBank alone — academic-only, low layout variability.*
@@ -552,27 +556,24 @@ round-trip asymmetries #70/#71/#72 🚢, and the Markdown round-trip losses 🚢
    so an action that could version-drift from the library would silently redefine every
    consumer's threshold. A Marketplace listing is a separate, public call and is **not** done.
 
-**Remaining, ordered by leverage-per-effort.** With (1) shipped, (5) is now the cheap next
-step it was always predicted to be — and is the **chosen next batch**:
+**Remaining, ordered by leverage-per-effort.** The external-ground-truth lane selected for
+the next batch is now implemented:
 
-5. **External ground truth** (Theme 2) — OmniDocBench as the headline score. Cheap *now that*
-   the ratchet exists, because it is just another oracle in a working socket. Heed the
-   caveat the optimizer taught us: pick the metric by measuring that it *varies* across the
-   corpus, not by assuming it does. Be prepared for it to say something we don't want to hear
-   — finding that out before sinking a batch into Theme 8 is the entire point.
-6. **Theme 8 — positional fidelity** (OCR geometry → provenance → layout). The big bet. It
-   was unevaluable, which is why it sat behind (1); (1) is now done, so (5) is the only thing
-   still standing between here and a defensible go/no-go on it.
+5. **External ground truth** (Theme 2) uses OmniDocBench as the headline score. The normalized
+   result records each aggregate, denominator, and sample variance. The gate rejects zero
+   variance, so the metric cannot pass merely because an evaluator path stayed constant.
+6. **Theme 8: positional fidelity** (OCR geometry → provenance → layout). The external
+   baseline makes this bet measurable. Use score and denominator changes from the pinned lane
+   to decide whether positional provenance improves real pages before expanding the design.
 7. **Async facade + async I/O edge** — unblocks the server/MCP story (see the Async
    Architecture Decision); the deferred-asset-resolution phase is the user-visible win. Also
    a prerequisite for clean multi-worker training-corpus loading (Theme 1).
 8. **Math support** (Theme 2) — deepens the fidelity moat; pairs with the arXiv source↔PDF
    ground-truth corpus.
 
-**The next batch: (5), plus the fuzzer's backlog as its visible half.** External ground truth
-is the headline and the go/no-go on Theme 8 — it is what turns (6) into a decision rather than
-a guess, and the whole reason (1) was sequenced first. Alongside it, the defects the #204
-fuzzer surfaced (#206–#212) are the batch's user-visible half: real fidelity fixes that arrive
+**This batch delivers (5), plus the fuzzer's backlog as its visible half.** External ground
+truth is the headline and the measuring instrument for Theme 8. Alongside it, the defects the
+#204 fuzzer surfaced (#206–#212) are the batch's user-visible half: real fidelity fixes
 with shrunk reproductions already attached, which beats the RAG-framework loader adapters as
 filler because they deepen the moat instead of shipping commodity glue.
 

--- a/benchmarks/omnidocbench/README.md
+++ b/benchmarks/omnidocbench/README.md
@@ -1,0 +1,106 @@
+# OmniDocBench PDF fidelity gate
+
+This benchmark compares one `all2md` PDF AST with independent OmniDocBench annotations. It does not render the AST to Markdown, parse a prediction, or call `roundtrip_report`. A parser and renderer therefore cannot agree on the same wrong structure and receive a perfect score.
+
+The scheduled workflow runs the full 981-page corpus. Pull request and release workflows do not run it. The corpus includes about 410 MB of page-level PDFs, and OCR makes a complete run too expensive for per-commit CI.
+
+## Pinned inputs
+
+The benchmark fixes each external input by immutable identity:
+
+- OmniDocBench v1.0 dataset: `f5f559bddf50e36f7f9899d842d0006f13ce8afc`
+- `OmniDocBench.json` SHA-256: `2fafe9329dc92fc426b30036aee51c716b3fcdcc1d20cb964dc7670579533817`
+- Expected annotations and page PDFs: 981
+- Local oracle schema: 3
+- Normalized result schema: 2
+
+The OmniDocBench evaluator source is Apache-2.0, but this lane does not execute it. The dataset is different. Its card states that collected PDFs are for research purposes only and must not be used commercially. The adapter downloads corpus bytes into `benchmarks/omnidocbench/.cache/`, which Git ignores. Do not commit the cache, annotation JSON, page PDFs, or images. CI artifacts contain only derived scores.
+
+## Install the tools
+
+Reproduce the CI runtime with the locked environment the scheduled workflow uses. The full corpus includes English and simplified Chinese pages:
+
+```bash
+uv sync --frozen --extra pdf_layout --extra ocr
+sudo apt-get install tesseract-ocr tesseract-ocr-eng tesseract-ocr-chi-sim
+```
+
+Any other environment, including a plain `python -m pip install -e ".[pdf_layout,ocr]"` on another distribution, resolves different parser-runtime identity and cannot match a CI-recorded baseline. Run full runs from such an environment with `--skip-gate`.
+
+The pinned parser policy uses enabled layout analysis and automatic Tesseract OCR at 200 DPI.
+It requests `eng+chi_sim` by default. The ratchet treats parser-policy and parser-runtime changes as identity drift. Runtime identity records the PyMuPDF, pymupdf-layout, pytesseract, Pillow, Tesseract, and Tesseract language-data versions.
+
+A complete local run downloads and validates the corpus, calls `all2md.to_ast` once for each page, projects supported AST facts, and compares the result with `baseline.json`. Page conversion is serial because PyMuPDF is not thread-safe; `--download-workers` controls only corpus download and first-pass cache validation parallelism, and revalidating an already-indexed warm cache is serial:
+
+```bash
+python -m benchmarks.omnidocbench
+```
+
+Use a deterministic subset only for integration smoke tests. A limited run must skip the gate because it does not have the full denominator. Fifty pages include text, tables, and formula ground truth:
+
+```bash
+python -m benchmarks.omnidocbench \
+  --limit 50 --download-workers 1 --skip-gate
+```
+
+## Score contract
+
+The local oracle loads annotation fields directly and projects these AST nodes:
+
+- `Heading`, `Paragraph`, and `CodeBlock` for text content, against every text-bearing annotation category: `text_block`, `title`, `code_txt`, `header`, `footer`, `page_number`, `figure_caption`, `table_caption`, `equation_caption`, `figure_footnote`, `table_footnote`, `page_footnote`, and `reference`. Scoring a filtered subset would compare part of the page with the whole AST, so dropping captions or references would raise the score. Table cell text joins the text stream on both sides, so failing to build a `Table` node is not scored worse than deleting the table outright.
+- The ordered `Heading`, `Paragraph`, `CodeBlock`, `Table`, and `MathBlock` sequence for reading order. Every `header`, `footer`, `page_number`, and `page_footnote` annotation carries `order: null`, so those are placed by the vertical centre of their polygon relative to the page height. Sorting them last would rank a running head after the body, which made deleting the header outscore emitting it.
+- `Table`, `TableRow`, and `TableCell` for table rows, columns, spans, and cell text.
+- `MathBlock` against top-level `equation_isolated` annotations and `MathInline` against `equation_inline` annotations, both top-level detections and non-ignored nested spans. Spans nested inside `code_txt` are skipped, because a `CodeBlock` holds a plain string and cannot expose them.
+
+The normalized result can record six higher-is-better metrics:
+
+| Dimension | Eligible pages |
+| --- | --- |
+| Text content similarity | Every page |
+| Reading-order similarity | Every page |
+| Formula presence accuracy | Pages with annotated or emitted inline or isolated formulae |
+| Table structure similarity | Pages with annotated or emitted tables |
+| Table content similarity | Pages with annotated or emitted tables |
+| Formula content similarity | Pages with annotated or emitted inline or isolated formulae |
+
+Each dimension records the aggregate, eligible-page denominator, population variance, and exact page scores. Text comparison uses exact normalized Levenshtein similarity after Unicode normalization and case folding. Whitespace is deleted only where it touches ideographic text, because OCR inserts spurious spaces between CJK glyphs; every other whitespace run collapses to a single space, so losing Latin word boundaries costs score. The deletion runs on both sides of NFKC, since NFKC folds fullwidth punctuation to ASCII and would otherwise leave the spurious spaces beside those glyphs in place: of the 743 pinned pages whose text contains such a glyph, padding it with spaces cost score on 588 before the class was widened and on none after. Table structure compares row, column, and expanded cell-slot counts; table structure and content share one exact best order-preserving alignment. Formulae use the same alignment rule, with unmatched items scored as zero. Inline and isolated formulae align only with the same kind; their LaTeX comparison preserves case and semantic whitespace.
+
+Reading order measures block segmentation and ordering. It is an edit similarity over the block-category sequence, scaled by the order agreement of the emitted blocks matched to their most similar annotated block. The coverage term alone is not an order metric: eleven text categories collapse to one `text_block` token, so fully reversed output scored exactly 1.0 on 153 of the 981 pinned pages, and any permutation was free on the 113 pages whose kinds are a single repeated token. Reversal still scores 1.0 on the 15 pages that carry fewer than two text blocks, where there is no order to disagree about. On the pinned corpus a projection that reproduces the annotation exactly scores 1.0 on both dimensions; merging every text block into one paragraph scores 0.129 on order and still 1.0 on text; reversing the blocks scores 0.020 on order and 0.331 on text. Recovering a table's cells as a paragraph costs exactly one kind substitution and nothing else, so it strictly beats deleting the table on all 317 pages that have table ground truth. Every degraded variant scores at or below exact reproduction on all six dimensions across all 981 pages.
+
+A dimension that the PDF parser cannot expose is reported in `unsupported_dimensions`. Scoring is union-scoped, so a page with neither an annotated nor an emitted item of that kind is never scored: when all2md emits no math nodes at all, the alternative to reporting `formula_fidelity` unsupported is a dimension that is uniformly zero across every eligible page, which the ratchet reds as a vacuous aggregate. Each message names both how many pages converted and how many pages carry that kind of ground truth, so the erased eligibility stays measurable; it is also visible in `unscored_annotation_categories` and the page counts. If the parser later starts emitting that AST capability, the new dimensions are a ratchet change that requires baseline review.
+
+A page whose conversion degrades, for example an OCR fallback recorded in `confidence.degraded_events`, is recorded as a conversion failure and scores zero in every dimension it is eligible for. A `table_rejected` event is the exception: refusing a non-tabular grid is a correct parser decision, and its cost still lands on text content and reading order because the cell text stays in the annotation's text stream. Every degraded-event kind observed in a run is counted in `degraded_events`, so an exempted degradation still leaves evidence in the payload.
+
+The ratchet fails closed for missing or duplicate pages, corpus, oracle, parser-policy, or parser-runtime drift, malformed or non-finite scores, missing or stale dimensions, changed denominators, new conversion failures, fixed recorded failures, regressions, and improvements that have not been accepted in the baseline. The recorded `worktree_dirty` flag is compared like every other identity field, so a measurement taken from an unclean tree can never match a baseline recorded from a clean one. A dimension that loses all page-to-page spread is red unless the baseline records that unanimity, which keeps a genuinely 0/1-per-page metric such as formula presence reviewable instead of permanently red.
+
+Its sensitivity is the recorded per-metric tolerance, which `--default-tolerance` sets to 0.005. Measured on the full-corpus result: sliding every dimension down by exactly 0.005 stays green, and 0.007 is red on both dimensions. A regression smaller than the tolerance is therefore invisible by construction, which is the price of not going red on measurement noise. Tighten the tolerance in the baseline for a metric whose page scores are stable enough to justify it. A tolerance of 1 or more is rejected outright, because every score lives in `[0, 1]` and such a band could never be breached by any run.
+
+The same reasoning bounds the aggregate itself. A recorded value within its own tolerance of the metric's worst possible score is refused as vacuous, not only a value exactly at that score: no later decline can exceed the tolerance from there, so one degenerate bootstrap run would otherwise mint a permanently green baseline and then report the first working run as an unrecorded improvement. A single page scoring one part in a billion is enough to lift the variance off zero, so the exact-floor test alone did not close this.
+
+A dimension may also not declare more eligible items than the corpus holds pages, since each dimension scores a page at most once. That check is suppressed while the page counts themselves disagree with the baseline, where the deficit is already reported once against `pages`.
+
+## Review a baseline change
+
+Generate a candidate only from a complete run:
+
+```bash
+python -m benchmarks.omnidocbench \
+  --write-baseline /tmp/omnidocbench-baseline.json \
+  --default-tolerance 0.005
+```
+
+Review the candidate's metric values, `eligible_items`, `variance`, and `tolerance`, and the run's `unsupported_dimensions`, `unscored_annotation_categories`, page counts, and every expected conversion failure before replacing `baseline.json`. The candidate records only the identity, page, dimension, and expected-failure fields; the unsupported and unscored evidence lives in the result JSON the same run writes. A tolerance is an absolute score delta in the metric's native `[0, 1]` range.
+
+`baseline.json` is not committed yet, so the gate reports `ABSENT_BASELINE` red until a candidate is accepted. Bootstrap it by dispatching the `OmniDocBench PDF Fidelity Gate` workflow with `record_baseline` enabled, reviewing the uploaded candidate, and committing it as `benchmarks/omnidocbench/baseline.json`. Recording the baseline from CI is required: a local run resolves different parser-runtime identity and every later CI run would report `IDENTITY_DRIFT`.
+
+Synthetic adapter, oracle, and ratchet tests run without the corpus:
+
+```bash
+pytest -q \
+  tests/unit/test_omnidocbench_corpus.py \
+  tests/unit/test_omnidocbench_oracles.py \
+  tests/unit/test_omnidocbench_benchmark.py \
+  tests/unit/test_omnidocbench_pipeline.py \
+  tests/unit/test_omnidocbench_gate.py \
+  tests/unit/test_omnidocbench_run.py
+```

--- a/benchmarks/omnidocbench/__init__.py
+++ b/benchmarks/omnidocbench/__init__.py
@@ -1,0 +1,5 @@
+"""External-ground-truth PDF fidelity benchmark for OmniDocBench."""
+
+from .benchmark import ORACLE_SCHEMA_VERSION, SCHEMA_VERSION
+
+__all__ = ["ORACLE_SCHEMA_VERSION", "SCHEMA_VERSION"]

--- a/benchmarks/omnidocbench/__main__.py
+++ b/benchmarks/omnidocbench/__main__.py
@@ -1,0 +1,8 @@
+"""CLI entry point for ``python -m benchmarks.omnidocbench``."""
+
+import sys
+
+from .run import main
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/benchmarks/omnidocbench/benchmark.py
+++ b/benchmarks/omnidocbench/benchmark.py
@@ -1,0 +1,293 @@
+"""Run all2md AST projections against pinned OmniDocBench annotations."""
+
+from __future__ import annotations
+
+import json
+import math
+import statistics
+import sys
+import time
+from collections import Counter
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import TYPE_CHECKING, Any, Mapping
+
+from .corpus import ANNOTATION_SHA256, CorpusPage, CorpusSnapshot
+from .oracles import GroundTruthPage, PageProjection, project_annotation, project_ast, score_page
+
+if TYPE_CHECKING:
+    from all2md.options.pdf import PdfOptions
+
+SCHEMA_VERSION = 2
+ORACLE_SCHEMA_VERSION = 3
+
+
+class DegradedConversionError(RuntimeError):
+    """Requested PDF processing degraded to a fallback path."""
+
+
+@dataclass(frozen=True, slots=True)
+class PageEvaluation:
+    """Direct external-ground-truth scores for one page."""
+
+    page_id: str
+    scores: Mapping[str, float]
+    predicted_tables: int
+    predicted_formulas: int
+    duration_seconds: float
+    degraded_events: tuple[str, ...] = ()
+    error_type: str | None = None
+    error: str | None = None
+
+
+def _pdf_options(ocr_languages: str) -> PdfOptions:
+    """Build the fixed PDF parser policy used by the external benchmark."""
+    from all2md.options.common import OCROptions
+    from all2md.options.pdf import PdfOptions
+
+    return PdfOptions(
+        layout_analysis_mode="enabled",
+        ocr=OCROptions(
+            enabled=True,
+            mode="auto",
+            engine="tesseract",
+            languages=ocr_languages,
+            dpi=200,
+        ),
+    )
+
+
+def load_ground_truth(snapshot: CorpusSnapshot) -> dict[str, GroundTruthPage]:
+    """Load supported annotation facts directly from the pinned JSON file."""
+    try:
+        records = json.loads(snapshot.annotation_path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise ValueError(f"cannot read pinned annotation JSON: {exc}") from exc
+    if not isinstance(records, list):
+        raise ValueError("OmniDocBench annotation root must be an array")
+
+    projected: dict[str, GroundTruthPage] = {}
+    for raw in records:
+        if not isinstance(raw, dict):
+            raise ValueError("OmniDocBench annotation contains a non-object page")
+        page = project_annotation(raw)
+        if page.page_id in projected:
+            raise ValueError(f"duplicate annotation page ID: {page.page_id}")
+        projected[page.page_id] = page
+
+    selected_ids = {page.page_id for page in snapshot.pages}
+    missing = sorted(selected_ids - projected.keys())
+    if missing:
+        raise ValueError(f"selected PDFs have no annotations: {missing[:5]}")
+    return {page_id: projected[page_id] for page_id in sorted(selected_ids)}
+
+
+# A deliberate non-tabular rejection is a correct parser decision, and the table and
+# reading-order metrics already score its outcome. Zeroing every dimension on the page would
+# turn correct behavior into a whole-page fidelity failure.
+_MEASURABLE_DEGRADED_KINDS = frozenset({"table_rejected"})
+
+
+def _degraded_conversion(document: Any) -> str | None:
+    metadata = document.metadata if isinstance(document.metadata, Mapping) else {}
+    confidence = metadata.get("confidence")
+    events = confidence.get("degraded_events") if isinstance(confidence, Mapping) else None
+    if not isinstance(events, list):
+        return None
+    blocking = [
+        event
+        for event in events
+        if not (isinstance(event, Mapping) and event.get("kind") in _MEASURABLE_DEGRADED_KINDS)
+    ]
+    if not blocking:
+        return None
+    return json.dumps(blocking, sort_keys=True, ensure_ascii=False, default=str)
+
+
+def _degraded_kinds(document: Any) -> tuple[str, ...]:
+    """Return every degraded-event kind so an exempted degradation still leaves evidence."""
+    metadata = document.metadata if isinstance(document.metadata, Mapping) else {}
+    confidence = metadata.get("confidence")
+    events = confidence.get("degraded_events") if isinstance(confidence, Mapping) else None
+    if not isinstance(events, list):
+        return ()
+    return tuple(sorted(str(event["kind"]) for event in events if isinstance(event, Mapping) and "kind" in event))
+
+
+def _evaluate_page(
+    page: CorpusPage,
+    truth: GroundTruthPage,
+    ocr_languages: str,
+) -> PageEvaluation:
+    from all2md import to_ast
+
+    started = time.perf_counter()
+    try:
+        document = to_ast(
+            page.pdf_path,
+            source_format="pdf",
+            parser_options=_pdf_options(ocr_languages),
+        )
+        degraded = _degraded_conversion(document)
+        if degraded is not None:
+            raise DegradedConversionError(degraded)
+        actual = project_ast(document)
+        return PageEvaluation(
+            page_id=page.page_id,
+            scores=score_page(truth.projection, actual),
+            predicted_tables=len(actual.tables),
+            predicted_formulas=len(actual.formulas),
+            duration_seconds=time.perf_counter() - started,
+            degraded_events=_degraded_kinds(document),
+        )
+    except Exception as exc:  # noqa: BLE001 - failed pages stay in every applicable denominator
+        empty = PageProjection((), (), (), ())
+        failure_scores = dict.fromkeys(score_page(truth.projection, empty), 0.0)
+        return PageEvaluation(
+            page_id=page.page_id,
+            scores=failure_scores,
+            predicted_tables=0,
+            predicted_formulas=0,
+            duration_seconds=time.perf_counter() - started,
+            error_type=type(exc).__name__,
+            error=str(exc),
+        )
+
+
+def evaluate_corpus(
+    snapshot: CorpusSnapshot,
+    ground_truth: Mapping[str, GroundTruthPage],
+    *,
+    ocr_languages: str = "eng+chi_sim",
+) -> list[PageEvaluation]:
+    """Call ``to_ast`` once per page and score its projection independently."""
+    results = [_evaluate_page(page, ground_truth[page.page_id], ocr_languages) for page in snapshot.pages]
+    results.sort(key=lambda result: result.page_id)
+    if len({result.page_id for result in results}) != len(snapshot.pages):
+        raise RuntimeError("evaluation did not produce one unique result per selected PDF")
+    return results
+
+
+def _dimension(
+    evaluations: list[PageEvaluation],
+    name: str,
+) -> dict[str, Any] | None:
+    samples = {result.page_id: float(result.scores[name]) for result in evaluations if name in result.scores}
+    if not samples:
+        return None
+    if any(not math.isfinite(value) or not 0 <= value <= 1 for value in samples.values()):
+        raise ValueError(f"oracle emitted an invalid score for {name}")
+    values = list(samples.values())
+    return {
+        "value": statistics.fmean(values),
+        "direction": "higher",
+        "eligible_items": len(values),
+        "variance": statistics.pvariance(values) if len(values) > 1 else 0.0,
+        "sample_scores": dict(sorted(samples.items())),
+    }
+
+
+def normalize_results(
+    *,
+    snapshot: CorpusSnapshot,
+    ground_truth: Mapping[str, GroundTruthPage],
+    evaluations: list[PageEvaluation],
+    all2md_commit: str,
+    worktree_dirty: bool = False,
+    parser_runtime: Mapping[str, str],
+    ocr_languages: str = "eng+chi_sim",
+) -> dict[str, Any]:
+    """Build the deterministic fail-closed ratchet input."""
+    metric_names = {name for evaluation in evaluations for name in evaluation.scores}
+    predicted_tables = sum(result.predicted_tables for result in evaluations)
+    predicted_formulas = sum(result.predicted_formulas for result in evaluations)
+    converted = sum(1 for result in evaluations if result.error_type is None)
+    unsupported: dict[str, str] = {}
+    # Union-scoped scoring never awards a perfect score here: without the erasure these
+    # dimensions would be uniformly 0.0 across every eligible page, which the ratchet reds as a
+    # vacuous aggregate. The message names both sides, so the payload still shows how many pages
+    # needed the erased dimension instead of only how many pages converted.
+    eligible_tables = sum(1 for page in ground_truth.values() if page.projection.tables)
+    eligible_formulas = sum(1 for page in ground_truth.values() if page.projection.formulas)
+    if predicted_tables == 0:
+        metric_names -= {"table_structure_similarity", "table_content_similarity"}
+        unsupported["table_fidelity"] = (
+            f"all2md emitted no Table nodes on {converted} converted page(s); "
+            f"{eligible_tables} pages have table ground truth"
+        )
+    if predicted_formulas == 0:
+        metric_names -= {"formula_presence_accuracy", "formula_content_similarity"}
+        unsupported["formula_fidelity"] = (
+            f"all2md emitted no MathBlock or MathInline nodes on {converted} converted page(s); "
+            f"{eligible_formulas} pages have formula ground truth"
+        )
+
+    dimensions: dict[str, dict[str, Any]] = {}
+    for name in sorted(metric_names):
+        dimension = _dimension(evaluations, name)
+        if dimension is not None:
+            dimensions[name] = dimension
+
+    failures = {
+        result.page_id: f"{result.error_type}: {result.error}"
+        for result in evaluations
+        if result.error_type is not None
+    }
+    unscored: Counter[str] = Counter()
+    explicitly_ignored = 0
+    for page in ground_truth.values():
+        unscored.update(page.unscored_categories)
+        explicitly_ignored += page.explicitly_ignored
+
+    successful = sum(result.error_type is None for result in evaluations)
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "provenance": {
+            "dataset_revision": snapshot.revision,
+            "annotation_sha256": ANNOTATION_SHA256,
+            "oracle_schema_version": ORACLE_SCHEMA_VERSION,
+            "all2md_commit": all2md_commit,
+            "worktree_dirty": worktree_dirty,
+            "created_at": datetime.now(timezone.utc).isoformat(),
+            "python": sys.version,
+            "platform": sys.platform,
+            "parser_runtime": dict(sorted(parser_runtime.items())),
+            "parser_config": {
+                "layout_analysis_mode": "enabled",
+                "ocr": {
+                    "enabled": True,
+                    "engine": "tesseract",
+                    "mode": "auto",
+                    "languages": ocr_languages,
+                    "dpi": 200,
+                },
+            },
+        },
+        "pages": {
+            "expected": snapshot.expected_pages,
+            "annotations": len(ground_truth),
+            "pdfs": len(snapshot.pages),
+            "converted": successful,
+            "scored": len(evaluations),
+            "unique_ids": len({result.page_id for result in evaluations}),
+        },
+        "dimensions": dimensions,
+        "conversion_failures": failures,
+        "unsupported_dimensions": unsupported,
+        "unscored_annotation_categories": dict(sorted(unscored.items())),
+        "degraded_events": dict(
+            sorted(Counter(kind for result in evaluations for kind in result.degraded_events).items())
+        ),
+        "explicitly_ignored_annotations": explicitly_ignored,
+    }
+
+
+def write_result(payload: Mapping[str, Any], path: Path) -> Path:
+    """Write normalized benchmark evidence as strict JSON."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(payload, indent=2, ensure_ascii=False, allow_nan=False),
+        encoding="utf-8",
+    )
+    return path

--- a/benchmarks/omnidocbench/corpus.py
+++ b/benchmarks/omnidocbench/corpus.py
@@ -1,0 +1,750 @@
+"""Pinned OmniDocBench v1.0 corpus download and cache validation.
+
+The benchmark data is fetched only at runtime into a caller-supplied cache.  The
+annotation and every page PDF are tied to the immutable Hugging Face revision;
+no OmniDocBench corpus content belongs in the source tree.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import re
+from concurrent.futures import ThreadPoolExecutor
+from contextlib import contextmanager
+from dataclasses import asdict, dataclass
+from pathlib import Path, PurePosixPath
+from typing import Any, Iterator
+from urllib.parse import quote
+from uuid import uuid4
+
+from benchmarks.corpus import download as corpus_download
+
+DATASET_ID = "opendatalab/OmniDocBench"
+REVISION = "f5f559bddf50e36f7f9899d842d0006f13ce8afc"
+ANNOTATION_SHA256 = "2fafe9329dc92fc426b30036aee51c716b3fcdcc1d20cb964dc7670579533817"
+EXPECTED_PAGES = 981
+ANNOTATION_FILENAME = "OmniDocBench.json"
+INDEX_SCHEMA_VERSION = 1
+MANIFEST_SCHEMA_VERSION = 1
+MANIFEST_FILENAME = f"_artifacts-{REVISION}.json"
+_RESOLVE_BASE = f"https://huggingface.co/datasets/{DATASET_ID}/resolve/{REVISION}"
+_SHA256_RE = re.compile(r"[0-9a-f]{64}\Z")
+
+
+class CorpusError(RuntimeError):
+    """Base error for an unusable OmniDocBench corpus cache."""
+
+
+class CorpusDownloadError(CorpusError):
+    """A pinned corpus artifact could not be downloaded atomically."""
+
+
+class CorpusIntegrityError(CorpusError):
+    """A corpus artifact did not match its required content contract."""
+
+
+class CorpusCacheError(CorpusError):
+    """A warm corpus cache failed revision or artifact validation."""
+
+
+@dataclass(frozen=True, slots=True)
+class CorpusPage:
+    """One immutable page PDF in the pinned OmniDocBench snapshot.
+
+    Attributes
+    ----------
+    page_id : str
+        Stable page identifier derived from the annotation image basename.
+    image_path : str
+        Image path recorded verbatim in ``page_info.image_path``.
+    pdf_path : pathlib.Path
+        Local path to the downloaded single-page PDF.
+    sha256 : str
+        Lowercase SHA-256 digest of the cached PDF bytes.
+    size_bytes : int
+        Exact size of the cached PDF in bytes.
+
+    """
+
+    page_id: str
+    image_path: str
+    pdf_path: Path
+    sha256: str
+    size_bytes: int
+
+
+@dataclass(frozen=True, slots=True)
+class CorpusSnapshot:
+    """Validated view of a pinned OmniDocBench cache.
+
+    Attributes
+    ----------
+    revision : str
+        Immutable Hugging Face dataset revision used by this snapshot.
+    annotation_path : pathlib.Path
+        Local path to the hash-validated v1.0 annotation JSON.
+    pages : tuple[CorpusPage, ...]
+        Validated page PDFs selected for this invocation.
+    expected_pages : int
+        Required size of the complete pinned snapshot, always ``981``.
+    complete : bool
+        ``True`` only when the caller requested full-corpus mode.  Supplying a
+        ``limit`` always produces ``False``, even when the limit is 981.
+
+    """
+
+    revision: str
+    annotation_path: Path
+    pages: tuple[CorpusPage, ...]
+    expected_pages: int = EXPECTED_PAGES
+    complete: bool = True
+
+
+@dataclass(frozen=True, slots=True)
+class _AnnotatedPage:
+    page_id: str
+    image_path: str
+    pdf_relative_path: str
+
+
+@dataclass(frozen=True, slots=True)
+class _ManifestPage:
+    page_id: str
+    image_path: str
+    pdf_relative_path: str
+    sha256: str
+    size_bytes: int
+
+
+def load_corpus(
+    cache_dir: Path,
+    *,
+    limit: int | None = None,
+    workers: int = 8,
+) -> CorpusSnapshot:
+    """Load or download the pinned OmniDocBench v1.0 page corpus.
+
+    A warm cache is accepted only after the annotation, selected page set, file
+    sizes, and every PDF digest have been revalidated.  A revision-wide artifact
+    manifest prevents a page cached by one mode from being re-blessed by another.
+    A non-``None`` ``limit`` selects the first annotated pages deterministically
+    and is always represented as an incomplete snapshot.
+
+    Parameters
+    ----------
+    cache_dir : pathlib.Path
+        Directory under which all downloaded annotation and PDF bytes are kept.
+    limit : int or None, optional
+        Positive number of pages to select for an explicitly incomplete smoke
+        run.  ``None`` requires and selects all 981 pages.
+    workers : int, optional
+        Positive number of concurrent PDF download workers.
+
+    Returns
+    -------
+    CorpusSnapshot
+        Fully validated full or explicitly incomplete corpus view.
+
+    Raises
+    ------
+    ValueError
+        If ``limit`` or ``workers`` is outside its supported range.
+    CorpusDownloadError
+        If a required artifact cannot be downloaded.
+    CorpusIntegrityError
+        If the pinned annotation or newly downloaded PDF is invalid.
+    CorpusCacheError
+        If an existing revision-qualified index or cached artifact is invalid.
+
+    """
+    _validate_options(limit=limit, workers=workers)
+    revision_dir = _prepare_revision_dir(Path(cache_dir))
+    annotation_path = revision_dir / ANNOTATION_FILENAME
+    index_path = _index_path(revision_dir, limit)
+    manifest_path = _manifest_path(revision_dir)
+
+    with _cache_lock(revision_dir):
+        _ensure_annotation(annotation_path)
+        annotated_pages = _read_annotation(annotation_path)
+        selected = annotated_pages if limit is None else annotated_pages[:limit]
+        manifest = _read_manifest(manifest_path)
+        _validate_manifest_page_set(manifest, annotated_pages)
+
+        if index_path.exists():
+            rows = _validated_index_rows(index_path, selected=selected, limit=limit)
+            _validate_index_manifest_agreement(rows, manifest)
+            if all(page.page_id in manifest for page in selected):
+                return _load_warm_cache(
+                    revision_dir=revision_dir,
+                    annotation_path=annotation_path,
+                    rows=rows,
+                    selected=selected,
+                    manifest=manifest,
+                    limit=limit,
+                )
+
+        pages, discovered = _materialize_pages(
+            selected,
+            revision_dir,
+            manifest=manifest,
+            workers=workers,
+        )
+        for page_id, entry in discovered.items():
+            existing = manifest.get(page_id)
+            if existing is not None and existing != entry:
+                raise CorpusCacheError(f"artifact manifest digest changed for {page_id!r}")
+            manifest[page_id] = entry
+        if discovered or not manifest_path.exists():
+            _write_manifest(manifest_path, manifest)
+
+        snapshot = CorpusSnapshot(
+            revision=REVISION,
+            annotation_path=annotation_path,
+            pages=pages,
+            expected_pages=EXPECTED_PAGES,
+            complete=limit is None,
+        )
+        _write_index(index_path, snapshot, revision_dir=revision_dir, limit=limit)
+        return snapshot
+
+
+def _validate_options(*, limit: int | None, workers: int) -> None:
+    if isinstance(limit, bool) or (limit is not None and not isinstance(limit, int)):
+        raise ValueError("limit must be an integer or None")
+    if limit is not None and not 1 <= limit <= EXPECTED_PAGES:
+        raise ValueError(f"limit must be between 1 and {EXPECTED_PAGES}")
+    if isinstance(workers, bool) or not isinstance(workers, int) or workers < 1:
+        raise ValueError("workers must be a positive integer")
+
+
+def _prepare_revision_dir(cache_dir: Path) -> Path:
+    if cache_dir.exists() and (cache_dir.is_symlink() or not cache_dir.is_dir()):
+        raise CorpusCacheError(f"cache directory is not a real directory: {cache_dir}")
+    cache_dir.mkdir(parents=True, exist_ok=True)
+    revision_dir = cache_dir / REVISION
+    if revision_dir.exists() and revision_dir.is_symlink():
+        raise CorpusCacheError(f"revision cache must not be a symlink: {revision_dir}")
+    revision_dir.mkdir(parents=True, exist_ok=True)
+    _require_contained(revision_dir, cache_dir)
+    pdf_dir = revision_dir / "pdfs"
+    if pdf_dir.exists() and pdf_dir.is_symlink():
+        raise CorpusCacheError(f"PDF cache must not be a symlink: {pdf_dir}")
+    pdf_dir.mkdir(parents=True, exist_ok=True)
+    _require_contained(pdf_dir, cache_dir)
+    return revision_dir
+
+
+@contextmanager
+def _cache_lock(revision_dir: Path) -> Iterator[None]:
+    # Imported here rather than at module scope so the adapter and its tests stay importable on
+    # platforms without `fcntl`. The lock guards cache integrity, so an unlockable platform is
+    # refused rather than silently run without exclusion.
+    if os.name != "posix":
+        raise CorpusCacheError(f"corpus cache locking requires a POSIX platform, got {os.name}")
+    import fcntl
+
+    lock_path = revision_dir / f".lock-{REVISION}"
+    flags = os.O_RDWR | os.O_CREAT
+    if hasattr(os, "O_NOFOLLOW"):
+        flags |= os.O_NOFOLLOW
+    try:
+        descriptor = os.open(lock_path, flags, 0o600)
+    except OSError as exc:
+        raise CorpusCacheError(f"cannot open corpus cache lock: {exc}") from exc
+    with os.fdopen(descriptor, "a+b") as lock_file:
+        fcntl.flock(lock_file.fileno(), fcntl.LOCK_EX)
+        try:
+            yield
+        finally:
+            fcntl.flock(lock_file.fileno(), fcntl.LOCK_UN)
+
+
+def _require_contained(path: Path, cache_dir: Path) -> None:
+    try:
+        path.resolve().relative_to(cache_dir.resolve())
+    except ValueError as exc:
+        raise CorpusCacheError(f"cache artifact escapes supplied directory: {path}") from exc
+
+
+def _index_path(revision_dir: Path, limit: int | None) -> Path:
+    mode = "full" if limit is None else f"limit-{limit}"
+    return revision_dir / f"_index-{REVISION}-{mode}.json"
+
+
+def _manifest_path(revision_dir: Path) -> Path:
+    return revision_dir / MANIFEST_FILENAME
+
+
+def _ensure_annotation(annotation_path: Path) -> None:
+    if annotation_path.exists():
+        _require_regular_file(annotation_path, label="annotation")
+        actual = _sha256(annotation_path)
+        if actual != ANNOTATION_SHA256:
+            raise CorpusIntegrityError(f"annotation SHA-256 mismatch: expected {ANNOTATION_SHA256}, got {actual}")
+        return
+
+    _download_artifact(_artifact_url(ANNOTATION_FILENAME), annotation_path, label="annotation")
+    actual = _sha256(annotation_path)
+    if actual != ANNOTATION_SHA256:
+        annotation_path.unlink(missing_ok=True)
+        raise CorpusIntegrityError(f"annotation SHA-256 mismatch: expected {ANNOTATION_SHA256}, got {actual}")
+
+
+def _read_annotation(annotation_path: Path) -> tuple[_AnnotatedPage, ...]:
+    try:
+        raw = json.loads(annotation_path.read_bytes())
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise CorpusIntegrityError(f"annotation is not valid JSON: {exc}") from exc
+
+    if not isinstance(raw, list):
+        raise CorpusIntegrityError("annotation root must be a JSON array")
+    if len(raw) != EXPECTED_PAGES:
+        raise CorpusIntegrityError(f"annotation page count mismatch: expected {EXPECTED_PAGES}, got {len(raw)}")
+
+    pages: list[_AnnotatedPage] = []
+    seen: set[str] = set()
+    for position, record in enumerate(raw):
+        page = _parse_annotation_record(record, position=position)
+        if page.page_id in seen:
+            raise CorpusIntegrityError(f"duplicate page_id {page.page_id!r} at annotation record {position}")
+        seen.add(page.page_id)
+        pages.append(page)
+    return tuple(pages)
+
+
+def _parse_annotation_record(record: Any, *, position: int) -> _AnnotatedPage:
+    if not isinstance(record, dict):
+        raise CorpusIntegrityError(f"annotation record {position} must be an object")
+    missing_record_fields = {"layout_dets", "page_info"} - record.keys()
+    if missing_record_fields:
+        fields = ", ".join(sorted(missing_record_fields))
+        raise CorpusIntegrityError(f"annotation record {position} is missing fields: {fields}")
+    if not isinstance(record["layout_dets"], list):
+        raise CorpusIntegrityError(f"annotation record {position} layout_dets must be an array")
+    if "extra" in record and not isinstance(record["extra"], dict):
+        raise CorpusIntegrityError(f"annotation record {position} extra must be an object")
+
+    page_info = record["page_info"]
+    if not isinstance(page_info, dict):
+        raise CorpusIntegrityError(f"annotation record {position} page_info must be an object")
+    required_page_fields = {"page_attribute", "page_no", "height", "width", "image_path"}
+    missing_page_fields = required_page_fields - page_info.keys()
+    if missing_page_fields:
+        fields = ", ".join(sorted(missing_page_fields))
+        raise CorpusIntegrityError(f"annotation record {position} page_info is missing fields: {fields}")
+    if not isinstance(page_info["page_attribute"], dict):
+        raise CorpusIntegrityError(f"annotation record {position} page_info.page_attribute must be an object")
+    if isinstance(page_info["page_no"], bool) or not isinstance(page_info["page_no"], int):
+        raise CorpusIntegrityError(f"annotation record {position} page_info.page_no must be an integer")
+    for dimension in ("height", "width"):
+        value = page_info[dimension]
+        if isinstance(value, bool) or not isinstance(value, (int, float)) or value <= 0:
+            raise CorpusIntegrityError(f"annotation record {position} page_info.{dimension} must be positive")
+
+    image_path = page_info["image_path"]
+    if not isinstance(image_path, str) or not image_path.strip():
+        raise CorpusIntegrityError(f"annotation record {position} page_info.image_path must be a non-empty string")
+    normalized_image = PurePosixPath(image_path.replace("\\", "/"))
+    if normalized_image.is_absolute() or ".." in normalized_image.parts:
+        raise CorpusIntegrityError(f"annotation record {position} page_info.image_path must be relative")
+    image_name = normalized_image.name
+    page_id = PurePosixPath(image_name).stem
+    if not page_id or page_id in {".", ".."}:
+        raise CorpusIntegrityError(f"annotation record {position} page_info.image_path has no page identifier")
+    pdf_relative_path = str(PurePosixPath("pdfs") / f"{page_id}.pdf")
+    return _AnnotatedPage(
+        page_id=page_id,
+        image_path=image_path,
+        pdf_relative_path=pdf_relative_path,
+    )
+
+
+def _materialize_pages(
+    selected: tuple[_AnnotatedPage, ...],
+    revision_dir: Path,
+    *,
+    manifest: dict[str, _ManifestPage],
+    workers: int,
+) -> tuple[tuple[CorpusPage, ...], dict[str, _ManifestPage]]:
+    def materialize(
+        page: _AnnotatedPage,
+    ) -> tuple[CorpusPage, _ManifestPage | None]:
+        pdf_path = revision_dir / page.pdf_relative_path
+        _require_contained(pdf_path, revision_dir)
+        trusted = manifest.get(page.page_id)
+        if pdf_path.exists() and trusted is not None:
+            return _cached_page_from_manifest(page, trusted, revision_dir), None
+        if pdf_path.exists():
+            _require_regular_file(pdf_path, label=f"PDF {page.page_id}")
+            pdf_path.unlink()
+
+        remote_path = quote(page.pdf_relative_path, safe="/")
+        _download_artifact(
+            _artifact_url(remote_path),
+            pdf_path,
+            label=f"PDF {page.page_id}",
+        )
+        size_bytes = pdf_path.stat().st_size
+        if size_bytes <= 0 or not corpus_download._is_pdf(pdf_path):
+            pdf_path.unlink(missing_ok=True)
+            raise CorpusIntegrityError(f"downloaded PDF {page.page_id!r} is not a non-empty PDF")
+        digest = _sha256(pdf_path)
+        downloaded = _ManifestPage(
+            page_id=page.page_id,
+            image_path=page.image_path,
+            pdf_relative_path=page.pdf_relative_path,
+            sha256=digest,
+            size_bytes=size_bytes,
+        )
+        if trusted is not None and downloaded != trusted:
+            pdf_path.unlink(missing_ok=True)
+            raise CorpusCacheError(f"downloaded PDF digest disagrees with artifact manifest for {page.page_id!r}")
+        return (
+            CorpusPage(
+                page_id=page.page_id,
+                image_path=page.image_path,
+                pdf_path=pdf_path,
+                sha256=digest,
+                size_bytes=size_bytes,
+            ),
+            downloaded if trusted is None else None,
+        )
+
+    results: tuple[tuple[CorpusPage, _ManifestPage | None], ...]
+    if len(selected) == 1:
+        results = (materialize(selected[0]),)
+    else:
+        with ThreadPoolExecutor(max_workers=min(workers, len(selected))) as executor:
+            results = tuple(executor.map(materialize, selected))
+    pages = tuple(result[0] for result in results)
+    discovered = {entry.page_id: entry for _, entry in results if entry is not None}
+    return pages, discovered
+
+
+def _cached_page_from_manifest(
+    page: _AnnotatedPage,
+    trusted: _ManifestPage,
+    revision_dir: Path,
+) -> CorpusPage:
+    pdf_path = revision_dir / page.pdf_relative_path
+    _require_contained(pdf_path, revision_dir)
+    if not pdf_path.exists():
+        raise CorpusCacheError(f"cached PDF is missing for {page.page_id!r}")
+    _require_regular_file(pdf_path, label=f"PDF {page.page_id}")
+    actual_size = pdf_path.stat().st_size
+    if actual_size != trusted.size_bytes:
+        raise CorpusCacheError(
+            f"cached PDF size mismatch for {page.page_id!r}: " f"expected {trusted.size_bytes}, got {actual_size}"
+        )
+    if not corpus_download._is_pdf(pdf_path):
+        raise CorpusCacheError(f"cached PDF is invalid for {page.page_id!r}")
+    actual_digest = _sha256(pdf_path)
+    if actual_digest != trusted.sha256:
+        raise CorpusCacheError(
+            f"cached PDF SHA-256 mismatch for {page.page_id!r}: " f"expected {trusted.sha256}, got {actual_digest}"
+        )
+    return CorpusPage(
+        page_id=page.page_id,
+        image_path=page.image_path,
+        pdf_path=pdf_path,
+        sha256=trusted.sha256,
+        size_bytes=trusted.size_bytes,
+    )
+
+
+def _artifact_url(relative_path: str) -> str:
+    return f"{_RESOLVE_BASE}/{relative_path}?download=true"
+
+
+def _download_artifact(url: str, destination: Path, *, label: str) -> None:
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    unique = f".{destination.name}.{os.getpid()}.{uuid4().hex}.download"
+    staging_path = destination.parent / unique
+    transport_part = staging_path.with_suffix(staging_path.suffix + ".part")
+    try:
+        # A 981-page cold run is fatal on the first throttle without a bounded retry.
+        if corpus_download._try_download(url, staging_path, label=label, retries=2) is None:
+            raise CorpusDownloadError(f"failed to download {label}")
+        if not staging_path.is_file() or staging_path.is_symlink():
+            raise CorpusDownloadError(f"failed to download {label}: no regular file was produced")
+        staging_path.replace(destination)
+    except CorpusDownloadError:
+        raise
+    except Exception as exc:
+        raise CorpusDownloadError(f"failed to download {label}: {exc}") from exc
+    finally:
+        staging_path.unlink(missing_ok=True)
+        transport_part.unlink(missing_ok=True)
+
+
+def _validated_index_rows(
+    index_path: Path,
+    *,
+    selected: tuple[_AnnotatedPage, ...],
+    limit: int | None,
+) -> list[dict[str, Any]]:
+    _require_regular_file(index_path, label="index")
+    index = _read_index(index_path)
+    _validate_index_header(index, limit=limit)
+    rows = index["pages"]
+    if not isinstance(rows, list):
+        raise CorpusCacheError("cache index pages must be an array")
+    expected_identity = [(page.page_id, page.image_path, page.pdf_relative_path) for page in selected]
+    indexed_identity: list[tuple[Any, Any, Any]] = []
+    required_fields = {"page_id", "image_path", "pdf_path", "sha256", "size_bytes"}
+    for row in rows:
+        if not isinstance(row, dict):
+            raise CorpusCacheError("cache index page rows must be objects")
+        indexed_identity.append((row.get("page_id"), row.get("image_path"), row.get("pdf_path")))
+        if set(row) != required_fields:
+            raise CorpusCacheError(f"cache index row schema mismatch for {row.get('page_id')!r}")
+        page_id = row["page_id"]
+        digest = row["sha256"]
+        size_bytes = row["size_bytes"]
+        if not isinstance(digest, str) or _SHA256_RE.fullmatch(digest) is None:
+            raise CorpusCacheError(f"cache index SHA-256 is invalid for {page_id!r}")
+        if isinstance(size_bytes, bool) or not isinstance(size_bytes, int) or size_bytes <= 0:
+            raise CorpusCacheError(f"cache index size is invalid for {page_id!r}")
+    if indexed_identity != expected_identity:
+        raise CorpusCacheError("cache index page set does not match pinned annotation")
+    return rows
+
+
+def _validate_index_manifest_agreement(
+    rows: list[dict[str, Any]],
+    manifest: dict[str, _ManifestPage],
+) -> None:
+    for row in rows:
+        page_id = row["page_id"]
+        trusted = manifest.get(page_id)
+        if trusted is None:
+            continue
+        if row["sha256"] != trusted.sha256:
+            raise CorpusCacheError(f"cache index digest disagrees with artifact manifest for {page_id!r}")
+        if row["size_bytes"] != trusted.size_bytes:
+            raise CorpusCacheError(f"cache index size disagrees with artifact manifest for {page_id!r}")
+
+
+def _load_warm_cache(
+    *,
+    revision_dir: Path,
+    annotation_path: Path,
+    rows: list[dict[str, Any]],
+    selected: tuple[_AnnotatedPage, ...],
+    manifest: dict[str, _ManifestPage],
+    limit: int | None,
+) -> CorpusSnapshot:
+    pages: list[CorpusPage] = []
+    for _row, page in zip(rows, selected, strict=True):
+        trusted = manifest.get(page.page_id)
+        if trusted is None:
+            raise CorpusCacheError(f"artifact manifest has no digest for {page.page_id!r}")
+        pages.append(_cached_page_from_manifest(page, trusted, revision_dir))
+
+    return CorpusSnapshot(
+        revision=REVISION,
+        annotation_path=annotation_path,
+        pages=tuple(pages),
+        expected_pages=EXPECTED_PAGES,
+        complete=limit is None,
+    )
+
+
+def _read_manifest(manifest_path: Path) -> dict[str, _ManifestPage]:
+    if not manifest_path.exists():
+        return {}
+    _require_regular_file(manifest_path, label="artifact manifest")
+    try:
+        payload = json.loads(manifest_path.read_bytes())
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise CorpusCacheError(f"artifact manifest is not valid JSON: {exc}") from exc
+    if not isinstance(payload, dict):
+        raise CorpusCacheError("artifact manifest root must be an object")
+    required_fields = {
+        "schema_version",
+        "dataset",
+        "revision",
+        "annotation_sha256",
+        "expected_pages",
+        "pages",
+    }
+    if set(payload) != required_fields:
+        raise CorpusCacheError("artifact manifest schema does not match this adapter")
+    if payload["schema_version"] != MANIFEST_SCHEMA_VERSION:
+        raise CorpusCacheError(
+            "artifact manifest schema version mismatch: "
+            f"expected {MANIFEST_SCHEMA_VERSION}, got {payload['schema_version']!r}"
+        )
+    if payload["dataset"] != DATASET_ID:
+        raise CorpusCacheError("artifact manifest dataset mismatch")
+    if payload["revision"] != REVISION:
+        raise CorpusCacheError(
+            f"artifact manifest revision mismatch: expected {REVISION}, " f"got {payload['revision']!r}"
+        )
+    if payload["annotation_sha256"] != ANNOTATION_SHA256:
+        raise CorpusCacheError("artifact manifest annotation SHA-256 mismatch")
+    if payload["expected_pages"] != EXPECTED_PAGES:
+        raise CorpusCacheError("artifact manifest expected page count mismatch")
+    raw_pages = payload["pages"]
+    if not isinstance(raw_pages, dict):
+        raise CorpusCacheError("artifact manifest pages must be an object")
+
+    manifest: dict[str, _ManifestPage] = {}
+    required_page_fields = {"image_path", "pdf_path", "sha256", "size_bytes"}
+    for page_id, row in raw_pages.items():
+        if not isinstance(page_id, str) or not isinstance(row, dict):
+            raise CorpusCacheError("artifact manifest page entries must be objects")
+        if set(row) != required_page_fields:
+            raise CorpusCacheError(f"artifact manifest row schema mismatch for {page_id!r}")
+        digest = row["sha256"]
+        size_bytes = row["size_bytes"]
+        if not isinstance(digest, str) or _SHA256_RE.fullmatch(digest) is None:
+            raise CorpusCacheError(f"artifact manifest SHA-256 is invalid for {page_id!r}")
+        if isinstance(size_bytes, bool) or not isinstance(size_bytes, int) or size_bytes <= 0:
+            raise CorpusCacheError(f"artifact manifest size is invalid for {page_id!r}")
+        if not isinstance(row["image_path"], str) or not isinstance(row["pdf_path"], str):
+            raise CorpusCacheError(f"artifact manifest paths are invalid for {page_id!r}")
+        manifest[page_id] = _ManifestPage(
+            page_id=page_id,
+            image_path=row["image_path"],
+            pdf_relative_path=row["pdf_path"],
+            sha256=digest,
+            size_bytes=size_bytes,
+        )
+    return manifest
+
+
+def _validate_manifest_page_set(
+    manifest: dict[str, _ManifestPage],
+    annotated_pages: tuple[_AnnotatedPage, ...],
+) -> None:
+    annotation_by_id = {page.page_id: page for page in annotated_pages}
+    for page_id, entry in manifest.items():
+        annotated = annotation_by_id.get(page_id)
+        if annotated is None:
+            raise CorpusCacheError(f"artifact manifest contains unknown page {page_id!r}")
+        if entry.image_path != annotated.image_path or entry.pdf_relative_path != annotated.pdf_relative_path:
+            raise CorpusCacheError(f"artifact manifest identity disagrees with annotation for {page_id!r}")
+
+
+def _write_manifest(
+    manifest_path: Path,
+    manifest: dict[str, _ManifestPage],
+) -> None:
+    pages = {
+        page_id: {
+            "image_path": entry.image_path,
+            "pdf_path": entry.pdf_relative_path,
+            "sha256": entry.sha256,
+            "size_bytes": entry.size_bytes,
+        }
+        for page_id, entry in manifest.items()
+    }
+    payload = {
+        "schema_version": MANIFEST_SCHEMA_VERSION,
+        "dataset": DATASET_ID,
+        "revision": REVISION,
+        "annotation_sha256": ANNOTATION_SHA256,
+        "expected_pages": EXPECTED_PAGES,
+        "pages": pages,
+    }
+    _atomic_write_json(manifest_path, payload)
+
+
+def _read_index(index_path: Path) -> dict[str, Any]:
+    try:
+        index = json.loads(index_path.read_bytes())
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise CorpusCacheError(f"cache index is not valid JSON: {exc}") from exc
+    if not isinstance(index, dict):
+        raise CorpusCacheError("cache index root must be an object")
+    return index
+
+
+def _validate_index_header(index: dict[str, Any], *, limit: int | None) -> None:
+    required_fields = {
+        "schema_version",
+        "dataset",
+        "revision",
+        "annotation_path",
+        "annotation_sha256",
+        "expected_pages",
+        "requested_limit",
+        "complete",
+        "pages",
+    }
+    if set(index) != required_fields:
+        raise CorpusCacheError("cache index schema does not match this adapter")
+    if index["schema_version"] != INDEX_SCHEMA_VERSION:
+        raise CorpusCacheError(
+            f"cache index schema version mismatch: expected {INDEX_SCHEMA_VERSION}, " f"got {index['schema_version']!r}"
+        )
+    if index["dataset"] != DATASET_ID:
+        raise CorpusCacheError(f"cache index dataset mismatch: expected {DATASET_ID!r}, got {index['dataset']!r}")
+    if index["revision"] != REVISION:
+        raise CorpusCacheError(f"cache index revision mismatch: expected {REVISION}, got {index['revision']!r}")
+    if index["annotation_path"] != ANNOTATION_FILENAME:
+        raise CorpusCacheError("cache index annotation path mismatch")
+    if index["annotation_sha256"] != ANNOTATION_SHA256:
+        raise CorpusCacheError("cache index annotation SHA-256 mismatch")
+    if index["expected_pages"] != EXPECTED_PAGES:
+        raise CorpusCacheError("cache index expected page count mismatch")
+    if index["requested_limit"] != limit:
+        raise CorpusCacheError("cache index requested limit mismatch")
+    if index["complete"] is not (limit is None):
+        raise CorpusCacheError("cache index completeness marker mismatch")
+
+
+def _write_index(
+    index_path: Path,
+    snapshot: CorpusSnapshot,
+    *,
+    revision_dir: Path,
+    limit: int | None,
+) -> None:
+    rows = []
+    for page in snapshot.pages:
+        row = asdict(page)
+        row["pdf_path"] = page.pdf_path.relative_to(revision_dir).as_posix()
+        rows.append(row)
+    payload = {
+        "schema_version": INDEX_SCHEMA_VERSION,
+        "dataset": DATASET_ID,
+        "revision": REVISION,
+        "annotation_path": ANNOTATION_FILENAME,
+        "annotation_sha256": ANNOTATION_SHA256,
+        "expected_pages": EXPECTED_PAGES,
+        "requested_limit": limit,
+        "complete": snapshot.complete,
+        "pages": rows,
+    }
+    _atomic_write_json(index_path, payload)
+
+
+def _atomic_write_json(path: Path, payload: dict[str, Any]) -> None:
+    unique = f".{path.name}.{os.getpid()}.{uuid4().hex}.tmp"
+    staging_path = path.parent / unique
+    try:
+        with staging_path.open("w", encoding="utf-8") as output:
+            json.dump(payload, output, indent=2, sort_keys=True)
+            output.write("\n")
+            output.flush()
+            os.fsync(output.fileno())
+        staging_path.replace(path)
+    finally:
+        staging_path.unlink(missing_ok=True)
+
+
+def _require_regular_file(path: Path, *, label: str) -> None:
+    if path.is_symlink() or not path.is_file():
+        raise CorpusCacheError(f"cached {label} is not a regular file: {path}")
+
+
+def _sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as input_file:
+        for block in iter(lambda: input_file.read(1 << 20), b""):
+            digest.update(block)
+    return digest.hexdigest()

--- a/benchmarks/omnidocbench/gate.py
+++ b/benchmarks/omnidocbench/gate.py
@@ -1,0 +1,857 @@
+"""Fail-closed ratchet for normalized OmniDocBench fidelity results."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import re
+import statistics
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Mapping, cast
+
+HERE = Path(__file__).resolve().parent
+DEFAULT_BASELINE = HERE / "baseline.json"
+_DATASET_REVISION_RE = re.compile(r"[0-9a-f]{40}\Z")
+_SHA256_RE = re.compile(r"[0-9a-f]{64}\Z")
+_SUPPORTED_SCHEMA_VERSION = 2
+_SUPPORTED_ORACLE_SCHEMA_VERSION = 3
+
+_IDENTITY_FIELDS = (
+    "schema_version",
+    "provenance.dataset_revision",
+    "provenance.annotation_sha256",
+    "provenance.oracle_schema_version",
+    "provenance.parser_config",
+    "provenance.parser_runtime",
+    "provenance.worktree_dirty",
+)
+_PAGE_FIELDS = ("expected", "annotations", "pdfs", "converted", "scored", "unique_ids")
+_DIMENSION_FIELDS = ("value", "direction", "eligible_items", "variance")
+_RESULT_DIMENSION_FIELDS = (*_DIMENSION_FIELDS, "sample_scores")
+
+
+@dataclass(frozen=True)
+class Finding:
+    """One fail-closed result from comparing a run with its baseline."""
+
+    status: str
+    subject: str
+    detail: str
+
+
+@dataclass
+class Verdict:
+    """The complete, deterministically ordered gate verdict."""
+
+    findings: list[Finding] = field(default_factory=list)
+
+    @property
+    def failed(self) -> bool:
+        """Return whether any finding was recorded.
+
+        Every status this module emits is red, so membership in a status allow-list would
+        only create a way for a newly added status to pass silently.
+        """
+        return bool(self.findings)
+
+
+def _nested(payload: Mapping[str, Any], dotted_path: str) -> tuple[bool, Any]:
+    value: Any = payload
+    for part in dotted_path.split("."):
+        if not isinstance(value, Mapping) or part not in value:
+            return False, None
+        value = value[part]
+    return True, value
+
+
+def _number(value: Any) -> bool:
+    return isinstance(value, (int, float)) and not isinstance(value, bool)
+
+
+def _finite(value: Any) -> bool:
+    if not _number(value):
+        return False
+    try:
+        return math.isfinite(value)
+    except OverflowError:
+        # A JSON integer literal too large for a float must become a finding, not a traceback.
+        return False
+
+
+def _page_count(value: Any) -> bool:
+    return isinstance(value, int) and not isinstance(value, bool) and value >= 0
+
+
+def _repr(value: Any) -> str:
+    return json.dumps(value, sort_keys=True, ensure_ascii=False)
+
+
+def _add(verdict: Verdict, status: str, subject: str, detail: str) -> None:
+    verdict.findings.append(Finding(status, subject, detail))
+
+
+def _identity_error(path: str, value: Any) -> str | None:
+    if path == "schema_version":
+        if not isinstance(value, int) or isinstance(value, bool) or value != _SUPPORTED_SCHEMA_VERSION:
+            return f"must be integer {_SUPPORTED_SCHEMA_VERSION}"
+    elif path == "provenance.dataset_revision":
+        if not isinstance(value, str) or _DATASET_REVISION_RE.fullmatch(value) is None:
+            return "must be a 40-character lowercase hexadecimal revision"
+    elif path == "provenance.annotation_sha256":
+        if not isinstance(value, str) or _SHA256_RE.fullmatch(value) is None:
+            return "must be a 64-character lowercase hexadecimal digest"
+    elif path == "provenance.oracle_schema_version":
+        if not isinstance(value, int) or isinstance(value, bool) or value != _SUPPORTED_ORACLE_SCHEMA_VERSION:
+            return f"must be integer {_SUPPORTED_ORACLE_SCHEMA_VERSION}"
+    elif path == "provenance.parser_config":
+        if not isinstance(value, Mapping):
+            return "must be a mapping"
+        if set(value) != {"layout_analysis_mode", "ocr"}:
+            return "must contain exactly layout_analysis_mode and ocr"
+        if not isinstance(value["layout_analysis_mode"], str) or not value["layout_analysis_mode"]:
+            return "layout_analysis_mode must be a non-empty string"
+        ocr = value["ocr"]
+        if not isinstance(ocr, Mapping):
+            return "ocr must be a mapping"
+        if set(ocr) != {"enabled", "engine", "mode", "languages", "dpi"}:
+            return "ocr must contain exactly enabled, engine, mode, languages, and dpi"
+        if not isinstance(ocr["enabled"], bool):
+            return "ocr.enabled must be a boolean"
+        for field in ("engine", "mode", "languages"):
+            if not isinstance(ocr[field], str) or not ocr[field]:
+                return f"ocr.{field} must be a non-empty string"
+        if not isinstance(ocr["dpi"], int) or isinstance(ocr["dpi"], bool) or ocr["dpi"] <= 0:
+            return "ocr.dpi must be a positive integer"
+    elif path == "provenance.parser_runtime":
+        if not isinstance(value, Mapping) or not value:
+            return "must be a non-empty mapping"
+        if any(
+            not isinstance(name, str) or not name or not isinstance(version, str) or not version
+            for name, version in value.items()
+        ):
+            return "names and versions must be non-empty strings"
+    elif path == "provenance.worktree_dirty":
+        # Recorded on both sides and compared for equality like every other identity field, so a
+        # measurement taken from an unclean tree can never match a baseline recorded from a clean
+        # one. Requiring False outright would make the field unusable in a baseline candidate.
+        if not isinstance(value, bool):
+            return "must be a boolean"
+    return None
+
+
+def _baseline_page_values(
+    baseline: Mapping[str, Any],
+    expected_failure_count: int | None,
+    verdict: Verdict,
+) -> dict[str, int]:
+    pages = baseline.get("pages")
+    if not isinstance(pages, Mapping):
+        _add(verdict, "INVALID_BASELINE", "pages", "required pages mapping is missing")
+        return {}
+
+    values: dict[str, int] = {}
+    for name in _PAGE_FIELDS:
+        if name not in pages:
+            _add(
+                verdict,
+                "INVALID_BASELINE",
+                f"pages.{name}",
+                "required page count is missing from baseline",
+            )
+        elif not _page_count(pages[name]):
+            _add(
+                verdict,
+                "INVALID_BASELINE",
+                f"pages.{name}",
+                f"expected a non-negative integer, got {_repr(pages[name])}",
+            )
+        else:
+            values[name] = pages[name]
+
+    expected = values.get("expected")
+    if expected is None:
+        return values
+    if expected == 0:
+        _add(
+            verdict,
+            "INVALID_BASELINE",
+            "pages.expected",
+            "baseline must record a positive expected page count",
+        )
+        return values
+    for name in ("annotations", "pdfs", "scored", "unique_ids"):
+        value = values.get(name)
+        if value is not None and value != expected:
+            _add(
+                verdict,
+                "INVALID_BASELINE",
+                f"pages.{name}",
+                f"must equal pages.expected {expected}, got {value}",
+            )
+    converted = values.get("converted")
+    if converted is not None and expected_failure_count is not None:
+        accounted = converted + expected_failure_count
+        if accounted != expected:
+            _add(
+                verdict,
+                "INVALID_BASELINE",
+                "pages.converted",
+                f"{converted} converted + {expected_failure_count} expected failures "
+                f"accounts for {accounted} of {expected} pages",
+            )
+    return values
+
+
+def _check_identity(results: Mapping[str, Any], baseline: Mapping[str, Any], verdict: Verdict) -> None:
+    for path in _IDENTITY_FIELDS:
+        result_present, actual = _nested(results, path)
+        baseline_present, expected = _nested(baseline, path)
+        if not baseline_present:
+            _add(verdict, "INVALID_BASELINE", path, "required identity field is missing from baseline")
+            continue
+        baseline_error = _identity_error(path, expected)
+        if baseline_error is not None:
+            _add(verdict, "INVALID_BASELINE", path, baseline_error)
+            continue
+        if not result_present:
+            _add(verdict, "IDENTITY_DRIFT", path, "required identity field is missing from result")
+            continue
+        result_error = _identity_error(path, actual)
+        if result_error is not None:
+            _add(verdict, "IDENTITY_DRIFT", path, result_error)
+        elif actual != expected:
+            _add(
+                verdict,
+                "IDENTITY_DRIFT",
+                path,
+                f"expected {_repr(expected)}, got {_repr(actual)}",
+            )
+
+
+def _check_pages(
+    results: Mapping[str, Any],
+    baseline: Mapping[str, Any],
+    failure_count: int | None,
+    expected_failure_count: int | None,
+    verdict: Verdict,
+) -> None:
+    baseline_values = _baseline_page_values(baseline, expected_failure_count, verdict)
+    pages = results.get("pages")
+    if not isinstance(pages, Mapping):
+        _add(verdict, "MISSING_PAGES", "pages", "required pages mapping is missing")
+        return
+
+    values: dict[str, int] = {}
+    for name in _PAGE_FIELDS:
+        if name not in pages:
+            _add(verdict, "MISSING_PAGES", f"pages.{name}", "required page count is missing")
+        elif not _page_count(pages[name]):
+            _add(
+                verdict,
+                "INVALID_PAGE_COUNT",
+                f"pages.{name}",
+                f"expected a non-negative integer, got {_repr(pages[name])}",
+            )
+        else:
+            values[name] = pages[name]
+
+    expected = values.get("expected")
+    if expected == 0:
+        _add(verdict, "ZERO_PAGES", "pages.expected", "a zero-page run cannot establish fidelity")
+        return
+
+    baseline_expected = baseline_values.get("expected")
+    if expected is not None and baseline_expected is not None:
+        if expected < baseline_expected:
+            _add(
+                verdict,
+                "TRUNCATED_PAGES",
+                "pages.expected",
+                f"expected {baseline_expected} pages from baseline, got {expected}",
+            )
+        elif expected > baseline_expected:
+            _add(
+                verdict,
+                "IDENTITY_DRIFT",
+                "pages.expected",
+                f"expected {baseline_expected}, got {expected}",
+            )
+
+    if expected is None:
+        return
+
+    for name in ("annotations", "pdfs"):
+        actual = values.get(name)
+        if actual == 0:
+            _add(verdict, "ZERO_PAGES", f"pages.{name}", f"no {name} were available")
+        elif actual is not None and actual < expected:
+            _add(
+                verdict,
+                "MISSING_PAGES",
+                f"pages.{name}",
+                f"expected {expected}, got {actual}",
+            )
+        elif actual is not None and actual > expected:
+            _add(
+                verdict,
+                "INVALID_PAGE_COUNT",
+                f"pages.{name}",
+                f"count {actual} exceeds pages.expected {expected}",
+            )
+
+    converted = values.get("converted")
+    if converted == 0:
+        _add(verdict, "ZERO_PAGES", "pages.converted", "no pages converted successfully")
+    elif converted is not None and failure_count is not None:
+        accounted = converted + failure_count
+        if accounted < expected:
+            _add(
+                verdict,
+                "MISSING_PAGES",
+                "pages.converted",
+                f"{converted} converted + {failure_count} failures accounts for {accounted} of {expected} pages",
+            )
+        elif accounted > expected:
+            _add(
+                verdict,
+                "INVALID_PAGE_COUNT",
+                "pages.converted",
+                f"{converted} converted + {failure_count} failures exceeds {expected} pages",
+            )
+
+    scored = values.get("scored")
+    if scored == 0:
+        _add(verdict, "ZERO_PAGES", "pages.scored", "no page projections were scored")
+    elif scored is not None:
+        if scored < expected:
+            _add(
+                verdict,
+                "MISSING_PAGES",
+                "pages.scored",
+                f"expected {expected} scored pages (including conversion failures), got {scored}",
+            )
+        elif scored > expected:
+            _add(
+                verdict,
+                "INVALID_PAGE_COUNT",
+                "pages.scored",
+                f"scored pages {scored} exceeds pages.expected {expected}",
+            )
+
+    unique_ids = values.get("unique_ids")
+    if unique_ids == 0:
+        _add(verdict, "ZERO_PAGES", "pages.unique_ids", "no unique scored page IDs were recorded")
+    elif unique_ids is not None and scored is not None:
+        if unique_ids < scored:
+            _add(
+                verdict,
+                "DUPLICATE_PAGES",
+                "pages.unique_ids",
+                f"{scored} scored pages contain only {unique_ids} unique page IDs",
+            )
+        elif unique_ids > scored:
+            _add(
+                verdict,
+                "INVALID_PAGE_COUNT",
+                "pages.unique_ids",
+                f"unique IDs {unique_ids} exceeds scored pages {scored}",
+            )
+
+
+def _valid_baseline_dimension(name: str, dimension: Any, verdict: Verdict) -> bool:
+    subject = f"dimensions.{name}"
+    if not isinstance(dimension, Mapping):
+        _add(verdict, "INVALID_BASELINE", subject, "baseline metric must be a mapping")
+        return False
+    missing = [field for field in (*_DIMENSION_FIELDS, "tolerance") if field not in dimension]
+    if missing:
+        _add(
+            verdict,
+            "INVALID_BASELINE",
+            subject,
+            f"missing required fields: {', '.join(missing)}",
+        )
+        return False
+    direction = dimension["direction"]
+    if not isinstance(direction, str) or direction not in {"higher", "lower"}:
+        _add(verdict, "INVALID_BASELINE", f"{subject}.direction", "direction must be 'higher' or 'lower'")
+        return False
+    if not _finite(dimension["value"]) or not 0 <= dimension["value"] <= 1:
+        _add(verdict, "INVALID_BASELINE", f"{subject}.value", "value must be finite and in [0, 1]")
+        return False
+    tolerance = dimension["tolerance"]
+    if not _finite(tolerance) or not 0 <= tolerance < 1:
+        # A tolerance of 1 or more is vacuous for the same reason a zero-variance aggregate is: no
+        # score in [0, 1] can ever breach it, so the dimension stops being able to fail.
+        _add(verdict, "INVALID_BASELINE", f"{subject}.tolerance", "tolerance must be finite and in [0, 1)")
+        return False
+    if (
+        not isinstance(dimension["eligible_items"], int)
+        or isinstance(dimension["eligible_items"], bool)
+        or dimension["eligible_items"] <= 0
+    ):
+        _add(verdict, "INVALID_BASELINE", f"{subject}.eligible_items", "eligible_items must be a positive integer")
+        return False
+    # A metric may legitimately be unanimous (formula presence is 0/1 per page). Accepting
+    # that requires recording it, so drifting into unanimity is still red.
+    if not _finite(dimension["variance"]) or dimension["variance"] < 0:
+        _add(verdict, "INVALID_BASELINE", f"{subject}.variance", "variance must be finite and non-negative")
+        return False
+    return True
+
+
+def _check_dimension_direction(
+    actual: Mapping[str, Any],
+    expected: Mapping[str, Any],
+    subject: str,
+    verdict: Verdict,
+) -> tuple[Any, bool]:
+    direction = actual["direction"]
+    valid = isinstance(direction, str) and direction in {"higher", "lower"}
+    if not valid:
+        _add(verdict, "INVALID_DIRECTION", f"{subject}.direction", "direction must be 'higher' or 'lower'")
+    elif direction != expected["direction"]:
+        _add(
+            verdict,
+            "IDENTITY_DRIFT",
+            f"{subject}.direction",
+            f"expected {_repr(expected['direction'])}, got {_repr(direction)}",
+        )
+    return direction, valid
+
+
+def _check_dimension_eligible_items(
+    actual: Mapping[str, Any],
+    expected: Mapping[str, Any],
+    subject: str,
+    verdict: Verdict,
+) -> tuple[Any, bool]:
+    eligible = actual["eligible_items"]
+    valid = isinstance(eligible, int) and not isinstance(eligible, bool) and eligible >= 0
+    if not valid:
+        _add(
+            verdict,
+            "OUT_OF_RANGE_VALUE",
+            f"{subject}.eligible_items",
+            f"expected a non-negative integer, got {_repr(eligible)}",
+        )
+    elif eligible == 0:
+        _add(verdict, "ZERO_ELIGIBLE_ITEMS", f"{subject}.eligible_items", "metric has no eligible items")
+    elif eligible != expected["eligible_items"]:
+        _add(
+            verdict,
+            "IDENTITY_DRIFT",
+            f"{subject}.eligible_items",
+            f"expected {expected['eligible_items']}, got {eligible}",
+        )
+    return eligible, valid
+
+
+def _dimension_sample_values(
+    actual: Mapping[str, Any],
+    subject: str,
+    verdict: Verdict,
+) -> list[float] | None:
+    samples = actual["sample_scores"]
+    if not isinstance(samples, Mapping):
+        _add(verdict, "MISSING_METRIC", f"{subject}.sample_scores", "sample_scores must be a mapping")
+        return None
+    if not samples:
+        _add(verdict, "ZERO_ELIGIBLE_ITEMS", f"{subject}.sample_scores", "metric has no sample scores")
+        return None
+    invalid_samples = sorted(
+        str(page_id)
+        for page_id, sample in samples.items()
+        if not isinstance(page_id, str) or not page_id or not _finite(sample) or not 0 <= sample <= 1
+    )
+    if invalid_samples:
+        _add(
+            verdict,
+            "OUT_OF_RANGE_VALUE",
+            f"{subject}.sample_scores",
+            f"page IDs must be non-empty strings and scores finite in [0, 1]: {', '.join(invalid_samples)}",
+        )
+        return None
+    return [float(samples[page_id]) for page_id in sorted(samples)]
+
+
+def _check_dimension_summary(
+    actual: Mapping[str, Any],
+    expected: Mapping[str, Any],
+    subject: str,
+    direction: Any,
+    direction_valid: bool,
+    computed_value: float,
+    computed_variance: float,
+    verdict: Verdict,
+) -> None:
+    variance = actual["variance"]
+    variance_valid = _finite(variance) and variance >= 0
+    if not _finite(variance):
+        _add(verdict, "NONFINITE_VALUE", f"{subject}.variance", f"got {_repr(variance)}")
+    elif variance < 0:
+        _add(verdict, "OUT_OF_RANGE_VALUE", f"{subject}.variance", f"expected a non-negative value, got {variance}")
+    elif not math.isclose(variance, computed_variance, rel_tol=1e-12, abs_tol=1e-15):
+        _add(
+            verdict,
+            "IDENTITY_DRIFT",
+            f"{subject}.variance",
+            f"declared {variance}, recomputed {computed_variance} from sample_scores",
+        )
+    # A metric whose recorded aggregate sits within its own tolerance of its worst possible score
+    # is vacuous by construction: recording it cannot make it discriminating, because no further
+    # decline can exceed the tolerance. Accepting that would let one degenerate bootstrap run mint
+    # a permanently green baseline and then report the first working run as an improvement. The
+    # test is against the tolerance rather than exact equality with the floor, because a single
+    # page scoring one part in a billion is enough to make the variance non-zero.
+    worst = 0.0 if direction == "higher" else 1.0
+    floor_bound = expected.get("tolerance")
+    at_the_floor = _finite(floor_bound) and abs(computed_value - worst) <= float(cast(float, floor_bound))
+    if computed_variance == 0 and (expected.get("variance") != 0 or computed_value == worst):
+        _add(verdict, "ZERO_VARIANCE", f"{subject}.variance", "zero variance makes the aggregate vacuous")
+    elif at_the_floor:
+        _add(
+            verdict,
+            "ZERO_VARIANCE",
+            f"{subject}.value",
+            f"aggregate {computed_value} is within the recorded tolerance of the worst score {worst}",
+        )
+
+    value = actual["value"]
+    value_valid = _finite(value) and 0 <= value <= 1
+    value_matches_samples = value_valid and math.isclose(
+        value,
+        computed_value,
+        rel_tol=1e-12,
+        abs_tol=1e-15,
+    )
+    if not _finite(value):
+        _add(verdict, "NONFINITE_VALUE", f"{subject}.value", f"got {_repr(value)}")
+    elif not 0 <= value <= 1:
+        _add(verdict, "OUT_OF_RANGE_VALUE", f"{subject}.value", f"expected a value in [0, 1], got {value}")
+    elif not value_matches_samples:
+        _add(
+            verdict,
+            "IDENTITY_DRIFT",
+            f"{subject}.value",
+            f"declared {value}, recomputed {computed_value} from sample_scores",
+        )
+
+    if not direction_valid or not value_valid or not variance_valid:
+        return
+    baseline_value = expected["value"]
+    tolerance = expected["tolerance"]
+    signed_change = computed_value - baseline_value
+    displayed_value = value if value_matches_samples else computed_value
+    quality_change = signed_change if direction == "higher" else -signed_change
+    if quality_change < -tolerance and not math.isclose(
+        quality_change,
+        -tolerance,
+        rel_tol=1e-12,
+        abs_tol=1e-15,
+    ):
+        _add(
+            verdict,
+            "REGRESSION",
+            subject,
+            f"{direction} is better: baseline {baseline_value}, result {displayed_value}, tolerance {tolerance}",
+        )
+    elif quality_change > tolerance and not math.isclose(
+        quality_change,
+        tolerance,
+        rel_tol=1e-12,
+        abs_tol=1e-15,
+    ):
+        _add(
+            verdict,
+            "UNRECORDED_IMPROVEMENT",
+            subject,
+            f"{direction} is better: baseline {baseline_value}, result {displayed_value}, tolerance {tolerance}",
+        )
+
+
+def _check_result_dimension(
+    name: str,
+    actual: Any,
+    expected: Mapping[str, Any],
+    verdict: Verdict,
+    page_bound: int | None,
+) -> None:
+    subject = f"dimensions.{name}"
+    if not isinstance(actual, Mapping):
+        _add(verdict, "MISSING_METRIC", subject, "metric must be a mapping")
+        return
+    missing = [field for field in _RESULT_DIMENSION_FIELDS if field not in actual]
+    if missing:
+        _add(verdict, "MISSING_METRIC", subject, f"missing required fields: {', '.join(missing)}")
+        return
+
+    direction, direction_valid = _check_dimension_direction(actual, expected, subject, verdict)
+    eligible, eligible_valid = _check_dimension_eligible_items(actual, expected, subject, verdict)
+    sample_values = _dimension_sample_values(actual, subject, verdict)
+    if sample_values is None:
+        return
+    if eligible_valid and eligible > 0 and eligible != len(sample_values):
+        _add(
+            verdict,
+            "IDENTITY_DRIFT",
+            f"{subject}.eligible_items",
+            f"declared {eligible}, but sample_scores contains {len(sample_values)} items",
+        )
+    if eligible_valid and page_bound is not None and eligible > page_bound:
+        # Each dimension scores a page at most once, so more eligible items than pages in the
+        # manifest means the aggregate was padded with entries no page could have produced.
+        _add(
+            verdict,
+            "INVALID_PAGE_COUNT",
+            f"{subject}.eligible_items",
+            f"declared {eligible} eligible items but the manifest holds only {page_bound} pages",
+        )
+
+    computed_value = statistics.fmean(sample_values)
+    computed_variance = statistics.pvariance(sample_values) if len(sample_values) > 1 else 0.0
+    _check_dimension_summary(
+        actual,
+        expected,
+        subject,
+        direction,
+        direction_valid,
+        computed_value,
+        computed_variance,
+        verdict,
+    )
+
+
+def _check_dimensions(
+    results: Mapping[str, Any],
+    baseline: Mapping[str, Any],
+    verdict: Verdict,
+    *,
+    pages_coherent: bool = True,
+) -> None:
+    actual_dimensions = results.get("dimensions")
+    baseline_dimensions = baseline.get("dimensions")
+    pages = results.get("pages")
+    # Bound eligibility against the manifest size, which is the largest number of pages any single
+    # dimension could have scored.
+    page_bound = pages.get("expected") if isinstance(pages, Mapping) else None
+    if not pages_coherent or not _page_count(page_bound):
+        page_bound = None
+    if not isinstance(baseline_dimensions, Mapping):
+        _add(verdict, "INVALID_BASELINE", "dimensions", "required dimensions mapping is missing")
+        return
+    if not isinstance(actual_dimensions, Mapping):
+        _add(verdict, "MISSING_METRIC", "dimensions", "required dimensions mapping is missing")
+        return
+    if not baseline_dimensions and not actual_dimensions:
+        _add(verdict, "ZERO_METRICS", "dimensions", "a run with no metrics cannot establish fidelity")
+        return
+
+    baseline_names = set(baseline_dimensions)
+    actual_names = set(actual_dimensions)
+    for name in sorted(baseline_names - actual_names):
+        _add(verdict, "MISSING_METRIC", f"dimensions.{name}", "baseline metric is missing from result")
+    for name in sorted(actual_names - baseline_names):
+        _add(verdict, "STALE_METRIC", f"dimensions.{name}", "result metric is not recorded in baseline")
+    for name in sorted(baseline_names & actual_names):
+        expected = baseline_dimensions[name]
+        if _valid_baseline_dimension(name, expected, verdict):
+            _check_result_dimension(name, actual_dimensions[name], expected, verdict, page_bound)
+
+
+def _failure_mapping(
+    payload: Mapping[str, Any], field: str, verdict: Verdict, baseline: bool = False
+) -> Mapping[str, str] | None:
+    value = payload.get(field)
+    status = "INVALID_BASELINE" if baseline else "MISSING_PAGES"
+    if not isinstance(value, Mapping):
+        _add(verdict, status, field, "required page-ID-to-error mapping is missing")
+        return None
+    bad = sorted(
+        str(page_id)
+        for page_id, error in value.items()
+        if not isinstance(page_id, str) or not page_id or not isinstance(error, str) or not error
+    )
+    if bad:
+        _add(verdict, status, field, f"page IDs and errors must be non-empty strings: {', '.join(bad)}")
+        return None
+    return value
+
+
+def _check_failures(
+    actual: Mapping[str, str] | None,
+    expected: Mapping[str, str] | None,
+    verdict: Verdict,
+) -> None:
+    if actual is None or expected is None:
+        return
+    actual_ids = set(actual)
+    expected_ids = set(expected)
+    for page_id in sorted(actual_ids - expected_ids):
+        _add(
+            verdict,
+            "UNEXPECTED_CONVERSION_FAILURE",
+            page_id,
+            actual[page_id],
+        )
+    for page_id in sorted(expected_ids - actual_ids):
+        _add(
+            verdict,
+            "FIXED_CONVERSION_FAILURE",
+            page_id,
+            f"expected {expected[page_id]!r}, but page now converts",
+        )
+    for page_id in sorted(actual_ids & expected_ids):
+        if actual[page_id] != expected[page_id]:
+            _add(
+                verdict,
+                "STALE_CONVERSION_FAILURE",
+                page_id,
+                f"expected {expected[page_id]!r}, got {actual[page_id]!r}",
+            )
+
+
+def compare(results: Any, baseline: Any) -> Verdict:
+    """Compare normalized results with a baseline, returning every red finding."""
+    verdict = Verdict()
+    if not baseline:
+        _add(verdict, "ABSENT_BASELINE", "baseline", "a committed baseline is required")
+        return verdict
+    if not isinstance(baseline, Mapping):
+        _add(verdict, "INVALID_BASELINE", "baseline", "baseline must be a mapping")
+        return verdict
+    if not isinstance(results, Mapping):
+        _add(verdict, "IDENTITY_DRIFT", "result", "normalized result must be a mapping")
+        return verdict
+
+    _check_identity(results, baseline, verdict)
+    actual_failures = _failure_mapping(results, "conversion_failures", verdict)
+    expected_failures = _failure_mapping(baseline, "expected_conversion_failures", verdict, baseline=True)
+    pages_before = len(verdict.findings)
+    _check_pages(
+        results,
+        baseline,
+        len(actual_failures) if actual_failures is not None else None,
+        len(expected_failures) if expected_failures is not None else None,
+        verdict,
+    )
+    # The per-dimension eligibility bound is only meaningful once the page counts agree with the
+    # baseline. When they do not, the deficit is already reported against `pages` and repeating it
+    # for every dimension would bury that finding.
+    _check_dimensions(results, baseline, verdict, pages_coherent=len(verdict.findings) == pages_before)
+    _check_failures(actual_failures, expected_failures, verdict)
+    return verdict
+
+
+def emit_baseline(
+    results: Mapping[str, Any],
+    tolerances: Mapping[str, float] | None = None,
+    *,
+    default_tolerance: float = 0.0,
+) -> dict[str, Any]:
+    """Create a reviewable baseline which makes an unchanged valid run green."""
+    if not _finite(default_tolerance) or not 0 <= default_tolerance < 1:
+        raise ValueError("default tolerance must be finite and in [0, 1)")
+    tolerances = tolerances or {}
+    if not isinstance(results, Mapping):
+        raise TypeError("benchmark results must be a JSON object")
+    result_dimensions = results.get("dimensions", {})
+    if not isinstance(result_dimensions, Mapping):
+        raise TypeError("benchmark results dimensions must be a JSON object")
+    unknown = set(tolerances) - set(result_dimensions)
+    if unknown:
+        raise ValueError(f"tolerances provided for unknown metrics: {', '.join(sorted(unknown))}")
+
+    dimensions: dict[str, dict[str, Any]] = {}
+    for name, metric in sorted(result_dimensions.items()):
+        tolerance = tolerances.get(name, default_tolerance)
+        if not _finite(tolerance) or not 0 <= tolerance < 1:
+            raise ValueError(f"tolerance for {name} must be finite and in [0, 1)")
+        dimensions[name] = {
+            "value": metric["value"],
+            "direction": metric["direction"],
+            "eligible_items": metric["eligible_items"],
+            "variance": metric["variance"],
+            "tolerance": tolerance,
+        }
+
+    candidate = {
+        "schema_version": results["schema_version"],
+        "provenance": dict(results["provenance"]),
+        "pages": dict(results["pages"]),
+        "dimensions": dimensions,
+        "expected_conversion_failures": dict(sorted(results["conversion_failures"].items())),
+    }
+    verdict = compare(results, candidate)
+    if verdict.failed:
+        raise ValueError("refusing to emit an invalid baseline:\n" + format_verdict(verdict))
+    return candidate
+
+
+def format_verdict(verdict: Verdict) -> str:
+    """Render a concise one-line-per-finding CLI verdict."""
+    if not verdict.findings:
+        return "OMNIDOCBENCH GATE PASS"
+    lines = [f"OMNIDOCBENCH GATE FAIL ({len(verdict.findings)} finding(s))"]
+    lines.extend(f"{finding.status} {finding.subject}: {finding.detail}" for finding in verdict.findings)
+    return "\n".join(lines)
+
+
+def _reject_duplicate_keys(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    payload: dict[str, Any] = {}
+    for key, value in pairs:
+        if key in payload:
+            raise ValueError(f"duplicate JSON key {key!r}")
+        payload[key] = value
+    return payload
+
+
+def _reject_nonfinite_json(value: str) -> None:
+    raise ValueError(f"non-finite JSON number {value}")
+
+
+def _load_json(path: Path) -> Any:
+    try:
+        return json.loads(
+            path.read_text(encoding="utf-8"),
+            object_pairs_hook=_reject_duplicate_keys,
+            parse_constant=_reject_nonfinite_json,
+        )
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError, ValueError) as exc:
+        raise ValueError(f"cannot read strict JSON from {path}: {exc}") from exc
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(prog="benchmarks.omnidocbench.gate", description=__doc__)
+    parser.add_argument("results", type=Path, help="normalized result JSON")
+    parser.add_argument("--baseline", type=Path, default=DEFAULT_BASELINE, help="committed ratchet baseline")
+    parser.add_argument("--emit-baseline", action="store_true", help="emit a baseline instead of comparing")
+    parser.add_argument("--tolerance", type=float, default=0.0, help="default tolerance for emitted metrics")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Run the command-line gate."""
+    args = _build_parser().parse_args(argv)
+    try:
+        results = _load_json(args.results)
+        if args.emit_baseline:
+            emitted = emit_baseline(results, default_tolerance=args.tolerance)
+            print(json.dumps(emitted, indent=2, sort_keys=True))
+            return 0
+        # A missing baseline is the documented pre-bootstrap state: a red verdict, not a broken
+        # environment. compare() reports ABSENT_BASELINE for a falsy baseline.
+        baseline = _load_json(args.baseline) if args.baseline.is_file() else {}
+    except (AttributeError, KeyError, TypeError, ValueError) as exc:
+        print(f"OMNIDOCBENCH GATE ERROR: {exc}", file=sys.stderr)
+        return 2
+    verdict = compare(results, baseline)
+    print(format_verdict(verdict))
+    return 1 if verdict.failed else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/benchmarks/omnidocbench/oracles.py
+++ b/benchmarks/omnidocbench/oracles.py
@@ -1,0 +1,605 @@
+"""Independent OmniDocBench annotation and all2md AST projections."""
+
+from __future__ import annotations
+
+import re
+import unicodedata
+from collections import Counter
+from dataclasses import dataclass
+from html.parser import HTMLParser
+from typing import Any, Callable, Iterable, Literal, Mapping, TypeVar
+
+from all2md.ast.nodes import (
+    Code,
+    CodeBlock,
+    Document,
+    Heading,
+    MathBlock,
+    MathInline,
+    Node,
+    Paragraph,
+    Table,
+    Text,
+    get_node_children,
+)
+
+# Every text-bearing category the dataset annotates. Scoring a filtered subset of the page
+# inverts the metric: a parser that drops captions, headers, footers, page numbers,
+# references, or footnotes would match a shorter ground truth and score higher for losing
+# content. 63 pinned pages score 0.0 for perfect fidelity under a filtered projection.
+TEXT_CATEGORIES = frozenset(
+    {
+        "code_txt",
+        "equation_caption",
+        "figure_caption",
+        "figure_footnote",
+        "footer",
+        "header",
+        "page_footnote",
+        "page_number",
+        "reference",
+        "table_caption",
+        "table_footnote",
+        "text_block",
+        "title",
+    }
+)
+SUPPORTED_CATEGORIES = TEXT_CATEGORIES | frozenset({"table", "equation_isolated", "equation_inline"})
+_WHITESPACE = re.compile(r"\s+")
+# Deleting whitespace only next to ideographic text: CJK OCR inserts spurious inter-glyph
+# spaces, but deleting Latin spaces makes total word-boundary loss score a perfect 1.0. The
+# fullwidth block is included because NFKC folds those glyphs to ASCII, which would otherwise
+# leave the spurious spaces beside fullwidth punctuation in place. Of the 743 pinned pages whose
+# text contains such a glyph, padding it with spaces cost score on 588 before this widening and
+# on none after it.
+_IDEOGRAPHIC = "\u2e80-\u9fff\uac00-\ud7af\uf900-\ufaff\uff01-\uff60\uffe0-\uffe6"
+_CJK_ADJACENT_WHITESPACE = re.compile(rf"(?<=[{_IDEOGRAPHIC}])\s+|\s+(?=[{_IDEOGRAPHIC}])")
+_ProjectionT = TypeVar("_ProjectionT")
+
+
+@dataclass(frozen=True, slots=True)
+class TableProjection:
+    """Comparable table structure and content."""
+
+    rows: int
+    columns: int
+    cell_slots: int
+    text: str
+
+
+@dataclass(frozen=True, slots=True)
+class FormulaProjection:
+    """Comparable formula content with its AST-level semantic kind."""
+
+    kind: Literal["inline", "block"]
+    content: str
+
+
+@dataclass(frozen=True, slots=True)
+class PageProjection:
+    """Comparable document facts for one page."""
+
+    text_blocks: tuple[str, ...]
+    block_kinds: tuple[str, ...]
+    tables: tuple[TableProjection, ...]
+    formulas: tuple[FormulaProjection, ...]
+
+
+@dataclass(frozen=True, slots=True)
+class GroundTruthPage:
+    """Validated supported facts projected directly from one annotation record."""
+
+    page_id: str
+    projection: PageProjection
+    unscored_categories: Mapping[str, int]
+    explicitly_ignored: int
+
+
+class _TableHTMLParser(HTMLParser):
+    """Extract table dimensions and cell text without accepting active markup."""
+
+    def __init__(self) -> None:
+        super().__init__(convert_charrefs=True)
+        self.rows = 0
+        self.columns = 0
+        self.cell_slots = 0
+        self._row_columns = 0
+        self._in_row = False
+        self._in_cell = False
+        self._cell_text: list[str] = []
+        self.text_cells: list[str] = []
+
+    def handle_starttag(self, tag: str, attrs: list[tuple[str, str | None]]) -> None:
+        attributes = dict(attrs)
+        if tag == "tr":
+            self._in_row = True
+            self._row_columns = 0
+            self.rows += 1
+        elif tag in {"td", "th"} and self._in_row:
+            colspan = _positive_span(attributes.get("colspan"))
+            rowspan = _positive_span(attributes.get("rowspan"))
+            self._row_columns += colspan
+            self.cell_slots += colspan * rowspan
+            self._in_cell = True
+            self._cell_text = []
+
+    def handle_endtag(self, tag: str) -> None:
+        if tag in {"td", "th"} and self._in_cell:
+            self.text_cells.append("".join(self._cell_text))
+            self._cell_text = []
+            self._in_cell = False
+        elif tag == "tr" and self._in_row:
+            self.columns = max(self.columns, self._row_columns)
+            self._row_columns = 0
+            self._in_row = False
+
+    def handle_data(self, data: str) -> None:
+        if self._in_cell:
+            self._cell_text.append(data)
+
+
+def _positive_span(value: str | None) -> int:
+    try:
+        span = int(value) if value is not None else 1
+    except ValueError:
+        return 1
+    return max(1, span)
+
+
+def normalize_text(value: str) -> str:
+    """Normalize text for content comparison while ignoring layout whitespace."""
+    # Run the substitution on both sides of NFKC: before it, fullwidth punctuation is still in
+    # the ideographic class; after it, halfwidth forms have composed into it.
+    collapsed = _CJK_ADJACENT_WHITESPACE.sub("", value)
+    normalized = unicodedata.normalize("NFKC", collapsed).casefold()
+    normalized = _CJK_ADJACENT_WHITESPACE.sub("", normalized)
+    return _WHITESPACE.sub(" ", normalized).strip()
+
+
+def normalize_formula(value: str) -> str:
+    """Remove outer display delimiters without changing LaTeX semantics."""
+    normalized = value.strip()
+    for prefix, suffix in (("$$", "$$"), ("\\[", "\\]"), ("$", "$")):
+        if normalized.startswith(prefix) and normalized.endswith(suffix):
+            return normalized[len(prefix) : -len(suffix)].strip()
+    return normalized
+
+
+def _node_text(node: Node) -> str:
+    if isinstance(node, (Text, Code)):
+        return node.content
+    children = get_node_children(node)
+    if children:
+        return " ".join(part for child in children if (part := _node_text(child)))
+    content = getattr(node, "content", None)
+    return content if isinstance(content, str) else ""
+
+
+def _semantic_blocks(node: Node) -> Iterable[Node]:
+    if isinstance(node, (Heading, Paragraph, CodeBlock, Table, MathBlock)):
+        yield node
+        return
+    for child in get_node_children(node):
+        yield from _semantic_blocks(child)
+
+
+def _all_nodes(node: Node) -> Iterable[Node]:
+    yield node
+    for child in get_node_children(node):
+        yield from _all_nodes(child)
+
+
+def _ast_table(table: Table) -> TableProjection:
+    rows = ([table.header] if table.header is not None else []) + list(table.rows)
+    columns = max(
+        (sum(max(1, cell.colspan) for cell in row.cells) for row in rows),
+        default=0,
+    )
+    cell_slots = sum(max(1, cell.colspan) * max(1, cell.rowspan) for row in rows for cell in row.cells)
+    text = " ".join(_node_text(cell) for row in rows for cell in row.cells)
+    return TableProjection(len(rows), columns, cell_slots, text)
+
+
+def project_ast(document: Document) -> PageProjection:
+    """Project one all2md AST without routing through a renderer or second parser."""
+    text_blocks: list[str] = []
+    block_kinds: list[str] = []
+    tables: list[TableProjection] = []
+    formulas: list[FormulaProjection] = []
+
+    for block in _semantic_blocks(document):
+        if isinstance(block, Heading):
+            block_kinds.append("title")
+            text_blocks.append(_node_text(block))
+        elif isinstance(block, (Paragraph, CodeBlock)):
+            block_kinds.append("text_block")
+            text_blocks.append(_node_text(block))
+        elif isinstance(block, Table):
+            block_kinds.append("table")
+            tables.append(_ast_table(block))
+            # Cell text belongs in the text stream on both sides. Otherwise a parser that fails
+            # to build a Table node and emits the cells as a paragraph is punished harder than
+            # one that deletes the table outright, on 317 of the 981 pinned pages.
+            text_blocks.append(tables[-1].text)
+        elif isinstance(block, MathBlock):
+            block_kinds.append("equation_isolated")
+            content, _ = block.get_preferred_representation("latex")
+            formulas.append(FormulaProjection("block", content))
+
+        if not isinstance(block, MathBlock):
+            formulas.extend(
+                FormulaProjection("inline", node.get_preferred_representation("latex")[0])
+                for node in _all_nodes(block)
+                if isinstance(node, MathInline)
+            )
+
+    return PageProjection(
+        text_blocks=tuple(text_blocks),
+        block_kinds=tuple(block_kinds),
+        tables=tuple(tables),
+        formulas=tuple(formulas),
+    )
+
+
+def _html_table(value: str) -> TableProjection:
+    parser = _TableHTMLParser()
+    parser.feed(value)
+    parser.close()
+    return TableProjection(
+        rows=parser.rows,
+        columns=parser.columns,
+        cell_slots=parser.cell_slots,
+        text=" ".join(parser.text_cells),
+    )
+
+
+def _annotation_page_id(record: Mapping[str, Any]) -> str:
+    page_info = record.get("page_info")
+    image_path = page_info.get("image_path") if isinstance(page_info, Mapping) else None
+    if not isinstance(image_path, str) or not image_path:
+        raise ValueError("annotation record has no page_info.image_path")
+    filename = image_path.replace("\\", "/").rsplit("/", 1)[-1]
+    return filename.rsplit(".", 1)[0]
+
+
+def _annotation_inline_formulas(
+    detection: Mapping[str, Any],
+    *,
+    page_id: str,
+) -> tuple[list[FormulaProjection], int]:
+    spans = detection.get("line_with_spans")
+    if spans is None:
+        return [], 0
+    if not isinstance(spans, list):
+        raise ValueError(f"annotation page {page_id!r} line_with_spans must be an array")
+
+    formulas: list[FormulaProjection] = []
+    ignored = 0
+    for span in spans:
+        if not isinstance(span, Mapping):
+            raise ValueError(f"annotation page {page_id!r} contains a non-object line span")
+        if span.get("ignore") is True:
+            ignored += 1
+            continue
+        if span.get("category_type") != "equation_inline":
+            continue
+        latex = span.get("latex")
+        if not isinstance(latex, str):
+            raise ValueError(f"annotation page {page_id!r} inline formula has no LaTeX ground truth")
+        formulas.append(FormulaProjection("inline", latex))
+    return formulas, ignored
+
+
+def _reading_rank(detection: Mapping[str, Any], record: Mapping[str, Any]) -> tuple[int, float]:
+    """Rank one detection in reading order, placing unordered running content by geometry.
+
+    Every ``header``, ``footer``, ``page_number``, and ``page_footnote`` detection in the pinned
+    dataset carries ``order: null``. Sorting those last put running content after the body, which
+    made dropping a header score higher than emitting it in its true position. A category-only
+    rank is not enough: about one page number in seven sits at the top of the page.
+    """
+    order = detection.get("order")
+    if isinstance(order, int) and not isinstance(order, bool):
+        return (1, float(order))
+    page_info = record.get("page_info")
+    raw_height = page_info.get("height") if isinstance(page_info, Mapping) else None
+    height = float(raw_height) if isinstance(raw_height, (int, float)) and raw_height else 1.0
+    poly = detection.get("poly")
+    vertical = [float(value) for value in poly[1::2]] if isinstance(poly, list) and poly else [0.0]
+    centre = (min(vertical) + max(vertical)) / 2 / height
+    return (0 if centre < 0.5 else 2, centre)
+
+
+def project_annotation(record: Mapping[str, Any]) -> GroundTruthPage:
+    """Project supported facts directly from one OmniDocBench annotation record."""
+    page_id = _annotation_page_id(record)
+    detections = record.get("layout_dets")
+    if not isinstance(detections, list):
+        raise ValueError(f"annotation page {page_id!r} has no layout_dets array")
+
+    ordered: list[tuple[tuple[int, float], int, Mapping[str, Any]]] = []
+    unscored: Counter[str] = Counter()
+    explicitly_ignored = 0
+    for position, raw in enumerate(detections):
+        if not isinstance(raw, Mapping):
+            raise ValueError(f"annotation page {page_id!r} contains a non-object layout item")
+        if raw.get("ignore") is True:
+            explicitly_ignored += 1
+            continue
+        category = raw.get("category_type")
+        if not isinstance(category, str):
+            raise ValueError(f"annotation page {page_id!r} has a layout item without category_type")
+        if category not in SUPPORTED_CATEGORIES:
+            unscored[category] += 1
+        ordered.append((_reading_rank(raw, record), position, raw))
+
+    text_blocks: list[str] = []
+    block_kinds: list[str] = []
+    tables: list[TableProjection] = []
+    formulas: list[FormulaProjection] = []
+    for _, _, detection in sorted(ordered):
+        category = detection["category_type"]
+        if category in TEXT_CATEGORIES:
+            text = detection.get("text")
+            if not isinstance(text, str):
+                raise ValueError(f"annotation page {page_id!r} {category} has no text")
+            text_blocks.append(text)
+            block_kinds.append("title" if category == "title" else "text_block")
+        elif category == "table":
+            html = detection.get("html")
+            if not isinstance(html, str) or not html:
+                raise ValueError(f"annotation page {page_id!r} table has no HTML ground truth")
+            tables.append(_html_table(html))
+            block_kinds.append("table")
+            text_blocks.append(tables[-1].text)
+        elif category == "equation_isolated":
+            latex = detection.get("latex")
+            if not isinstance(latex, str):
+                raise ValueError(f"annotation page {page_id!r} formula has no LaTeX ground truth")
+            formulas.append(FormulaProjection("block", latex))
+            block_kinds.append("equation_isolated")
+        elif category == "equation_inline":
+            latex = detection.get("latex")
+            if not isinstance(latex, str):
+                raise ValueError(f"annotation page {page_id!r} inline formula has no LaTeX ground truth")
+            formulas.append(FormulaProjection("inline", latex))
+
+        # A CodeBlock holds a plain string, so an inline equation inside code cannot be
+        # represented in any AST; harvesting it would create ground truth nothing can match.
+        if category == "code_txt":
+            continue
+        inline_formulas, ignored_spans = _annotation_inline_formulas(detection, page_id=page_id)
+        formulas.extend(inline_formulas)
+        explicitly_ignored += ignored_spans
+
+    return GroundTruthPage(
+        page_id=page_id,
+        projection=PageProjection(
+            text_blocks=tuple(text_blocks),
+            block_kinds=tuple(block_kinds),
+            tables=tuple(tables),
+            formulas=tuple(formulas),
+        ),
+        unscored_categories=dict(sorted(unscored.items())),
+        explicitly_ignored=explicitly_ignored,
+    )
+
+
+def _edit_distance(left: str, right: str) -> int:
+    """Return exact Levenshtein distance with a bit-parallel Unicode pattern."""
+    if len(left) > len(right):
+        left, right = right, left
+    if not left:
+        return len(right)
+
+    character_masks: dict[str, int] = {}
+    for index, character in enumerate(left):
+        character_masks[character] = character_masks.get(character, 0) | (1 << index)
+
+    positive = ~0
+    negative = 0
+    score = len(left)
+    highest = 1 << (len(left) - 1)
+    for character in right:
+        matching = character_masks.get(character, 0)
+        vertical = matching | negative
+        horizontal = (((matching & positive) + positive) ^ positive) | matching
+        positive_horizontal = negative | ~(horizontal | positive)
+        negative_horizontal = positive & horizontal
+        if positive_horizontal & highest:
+            score += 1
+        elif negative_horizontal & highest:
+            score -= 1
+        positive_horizontal = (positive_horizontal << 1) | 1
+        negative_horizontal <<= 1
+        positive = negative_horizontal | ~(vertical | positive_horizontal)
+        negative = positive_horizontal & vertical
+    return score
+
+
+def _string_similarity(left: str, right: str) -> float:
+    if not left and not right:
+        return 1.0
+    if not left or not right:
+        return 0.0
+    return 1.0 - _edit_distance(left, right) / max(len(left), len(right))
+
+
+def content_similarity(expected: str, actual: str) -> float:
+    """Return normalized character-sequence similarity in ``[0, 1]``."""
+    return _string_similarity(normalize_text(expected), normalize_text(actual))
+
+
+def _sequence_similarity(expected: tuple[str, ...], actual: tuple[str, ...]) -> float:
+    if not expected and not actual:
+        return 1.0
+    if not expected or not actual:
+        return 0.0
+    previous = list(range(len(actual) + 1))
+    for expected_item in expected:
+        current = [previous[0] + 1]
+        for index, actual_item in enumerate(actual, 1):
+            current.append(
+                min(
+                    current[-1] + 1,
+                    previous[index] + 1,
+                    previous[index - 1] + (expected_item != actual_item),
+                )
+            )
+        previous = current
+    distance = previous[-1]
+    return 1.0 - distance / max(len(expected), len(actual))
+
+
+def _count_similarity(expected: int, actual: int) -> float:
+    if expected == actual == 0:
+        return 1.0
+    return 1.0 - abs(expected - actual) / max(expected, actual)
+
+
+def _table_shape_similarity(expected: TableProjection, actual: TableProjection) -> float:
+    return (
+        _count_similarity(expected.rows, actual.rows)
+        + _count_similarity(expected.columns, actual.columns)
+        + _count_similarity(expected.cell_slots, actual.cell_slots)
+    ) / 3
+
+
+def _aligned_average(
+    expected: tuple[_ProjectionT, ...],
+    actual: tuple[_ProjectionT, ...],
+    scorer: Callable[[_ProjectionT, _ProjectionT], float],
+) -> float:
+    denominator = max(len(expected), len(actual))
+    if denominator == 0:
+        return 1.0
+
+    previous = [0.0] * (len(actual) + 1)
+    for expected_item in expected:
+        current = [0.0]
+        for index, actual_item in enumerate(actual, 1):
+            current.append(
+                max(
+                    previous[index],
+                    current[-1],
+                    previous[index - 1] + scorer(expected_item, actual_item),
+                )
+            )
+        previous = current
+    return previous[-1] / denominator
+
+
+def _formula_similarity(expected: FormulaProjection, actual: FormulaProjection) -> float:
+    if expected.kind != actual.kind:
+        return 0.0
+    return _string_similarity(
+        normalize_formula(expected.content),
+        normalize_formula(actual.content),
+    )
+
+
+def _align_pairs(
+    expected: tuple[_ProjectionT, ...],
+    actual: tuple[_ProjectionT, ...],
+    weight: Callable[[_ProjectionT, _ProjectionT], float],
+) -> list[tuple[int, int]]:
+    """Return the order-preserving pairing that maximizes total match weight."""
+    best = [[0.0] * (len(actual) + 1) for _ in range(len(expected) + 1)]
+    for expected_index, expected_item in enumerate(expected, 1):
+        for actual_index, actual_item in enumerate(actual, 1):
+            best[expected_index][actual_index] = max(
+                best[expected_index - 1][actual_index],
+                best[expected_index][actual_index - 1],
+                best[expected_index - 1][actual_index - 1] + weight(expected_item, actual_item),
+            )
+
+    pairs: list[tuple[int, int]] = []
+    expected_index, actual_index = len(expected), len(actual)
+    while expected_index and actual_index:
+        current = best[expected_index][actual_index]
+        if current == best[expected_index - 1][actual_index]:
+            expected_index -= 1
+        elif current == best[expected_index][actual_index - 1]:
+            actual_index -= 1
+        else:
+            pairs.append((expected_index - 1, actual_index - 1))
+            expected_index -= 1
+            actual_index -= 1
+    pairs.reverse()
+    return pairs
+
+
+def _table_similarities(
+    expected: tuple[TableProjection, ...],
+    actual: tuple[TableProjection, ...],
+) -> tuple[float, float]:
+    """Score table structure and content through one shared table alignment."""
+    denominator = max(len(expected), len(actual))
+    if denominator == 0:
+        return 1.0, 1.0
+
+    def composite(left: TableProjection, right: TableProjection) -> float:
+        return (_table_shape_similarity(left, right) + content_similarity(left.text, right.text)) / 2
+
+    structure = 0.0
+    content = 0.0
+    for expected_index, actual_index in _align_pairs(expected, actual, composite):
+        expected_table = expected[expected_index]
+        actual_table = actual[actual_index]
+        structure += _table_shape_similarity(expected_table, actual_table)
+        content += content_similarity(expected_table.text, actual_table.text)
+    return structure / denominator, content / denominator
+
+
+def _reading_order_similarity(expected: PageProjection, actual: PageProjection) -> float:
+    """Score block-sequence coverage, scaled by the order agreement of the matched blocks.
+
+    The category sequence alone is not an order metric: eleven text categories collapse to
+    ``text_block``, so fully reversed output scored exactly 1.0 on 153 of the 981 pinned pages
+    and any permutation was free on the 113 pages with a single repeated kind. Matching each
+    emitted block to its most similar ground-truth block with an unconstrained argmax exposes
+    inversions, which an order-preserving alignment is blind to by construction.
+
+    Equally similar candidates are resolved towards the block's own position, so a page that
+    repeats one string cannot invert against itself: identical output must score exactly 1.0.
+    """
+    coverage = _sequence_similarity(expected.block_kinds, actual.block_kinds)
+    count = len(actual.text_blocks)
+    if len(expected.text_blocks) < 2 or count < 2:
+        return coverage
+    scale = (len(expected.text_blocks) - 1) / (count - 1)
+    matched = []
+    for position, block in enumerate(actual.text_blocks):
+        preferred = position * scale
+        matched.append(
+            max(
+                range(len(expected.text_blocks)),
+                key=lambda index: (content_similarity(expected.text_blocks[index], block), -abs(index - preferred)),
+            )
+        )
+    pairs = count * (count - 1) // 2
+    inversions = sum(1 for left in range(count) for right in range(left + 1, count) if matched[left] > matched[right])
+    return coverage * (1.0 - inversions / pairs)
+
+
+def score_page(expected: PageProjection, actual: PageProjection) -> dict[str, float]:
+    """Score one AST projection directly against external annotation facts."""
+    scores = {
+        "text_content_similarity": content_similarity(
+            " ".join(expected.text_blocks),
+            " ".join(actual.text_blocks),
+        ),
+        "reading_order_similarity": _reading_order_similarity(expected, actual),
+    }
+    if expected.tables or actual.tables:
+        structure, content = _table_similarities(expected.tables, actual.tables)
+        scores["table_structure_similarity"] = structure
+        scores["table_content_similarity"] = content
+    if expected.formulas or actual.formulas:
+        scores["formula_presence_accuracy"] = float(bool(expected.formulas) == bool(actual.formulas))
+        scores["formula_content_similarity"] = _aligned_average(
+            expected.formulas,
+            actual.formulas,
+            _formula_similarity,
+        )
+    return scores

--- a/benchmarks/omnidocbench/run.py
+++ b/benchmarks/omnidocbench/run.py
@@ -1,0 +1,244 @@
+"""Run the pinned OmniDocBench AST fidelity benchmark end to end."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import re
+import subprocess
+import sys
+from importlib import metadata
+from pathlib import Path
+from typing import Any
+
+from .benchmark import evaluate_corpus, load_ground_truth, normalize_results, write_result
+from .corpus import load_corpus
+from .gate import compare, emit_baseline, format_verdict
+
+HERE = Path(__file__).resolve().parent
+DEFAULT_CACHE = HERE / ".cache"
+DEFAULT_BASELINE = HERE / "baseline.json"
+DEFAULT_RESULT = DEFAULT_CACHE / "results" / "current.json"
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(prog="benchmarks.omnidocbench.run", description=__doc__)
+    parser.add_argument("--cache-dir", type=Path, default=DEFAULT_CACHE, help="revision-qualified corpus cache")
+    parser.add_argument("--output", type=Path, default=DEFAULT_RESULT, help="where to write the normalized result")
+    parser.add_argument("--baseline", type=Path, default=DEFAULT_BASELINE, help="committed ratchet baseline")
+    parser.add_argument(
+        "--download-workers",
+        type=int,
+        default=8,
+        help="corpus download and first-pass validation parallelism; page conversion is always serial",
+    )
+    parser.add_argument("--limit", type=int, help="run a deterministic incomplete smoke subset")
+    parser.add_argument("--ocr-languages", default="eng+chi_sim", help="Tesseract languages the pinned policy requests")
+    parser.add_argument(
+        "--skip-gate",
+        action="store_true",
+        help="measure without comparing the committed baseline",
+    )
+    parser.add_argument(
+        "--allow-conversion-failures",
+        action="store_true",
+        help="allow a --skip-gate measurement to succeed with recorded conversion failures",
+    )
+    parser.add_argument("--write-baseline", type=Path, help="write a baseline from a complete run")
+    parser.add_argument(
+        "--default-tolerance",
+        type=float,
+        default=0.005,
+        help="per-metric tolerance recorded in an emitted baseline",
+    )
+    parser.add_argument("--download-only", action="store_true", help="populate and validate the cache, then stop")
+    return parser
+
+
+def _git_identity() -> tuple[str, bool]:
+    """Record the source commit and whether the worktree differs from it."""
+    try:
+        commit_result = subprocess.run(
+            ["git", "rev-parse", "HEAD"],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+        status_result = subprocess.run(
+            ["git", "status", "--porcelain=v1", "--untracked-files=normal"],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+    except (OSError, subprocess.CalledProcessError) as exc:
+        raise RuntimeError(f"cannot record the all2md source identity: {exc}") from exc
+    commit = commit_result.stdout.strip()
+    if len(commit) != 40:
+        raise RuntimeError(f"git returned an invalid all2md commit: {commit!r}")
+    return commit, bool(status_result.stdout.strip())
+
+
+def _tessdata_dir() -> Path:
+    """Resolve the Tesseract language-data directory the OCR engine will actually load."""
+    try:
+        completed = subprocess.run(
+            ["tesseract", "--list-langs"],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+    except (OSError, subprocess.CalledProcessError) as exc:
+        raise RuntimeError(f"cannot list the installed Tesseract languages: {exc}") from exc
+    listing = completed.stdout + completed.stderr
+    match = re.search(r'available languages in "?([^"\n]+?)"? \(', listing)
+    if match is None:
+        raise RuntimeError(f"cannot resolve the Tesseract language-data directory from: {listing!r}")
+    return Path(match.group(1))
+
+
+def _language_digests(languages: str) -> dict[str, str]:
+    """Digest every requested traineddata file so OCR model drift changes ratchet identity."""
+    tessdata = _tessdata_dir()
+    digests: dict[str, str] = {}
+    for language in sorted({name for name in languages.split("+") if name}):
+        path = tessdata / f"{language}.traineddata"
+        try:
+            payload = path.read_bytes()
+        except OSError as exc:
+            raise RuntimeError(f"cannot read pinned OCR language data {path}: {exc}") from exc
+        digests[f"tessdata_{language}_sha256"] = hashlib.sha256(payload).hexdigest()
+    if not digests:
+        raise RuntimeError("no OCR languages were requested")
+    return digests
+
+
+def _parser_runtime(ocr_languages: str) -> dict[str, str]:
+    """Record the parser binaries, locked packages, and OCR models that affect the AST."""
+    distributions = {
+        "pymupdf": "PyMuPDF",
+        "pymupdf_layout": "pymupdf-layout",
+        "pytesseract": "pytesseract",
+        "pillow": "Pillow",
+    }
+    try:
+        versions = {name: metadata.version(distribution) for name, distribution in distributions.items()}
+        completed = subprocess.run(
+            ["tesseract", "--version"],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+    except (metadata.PackageNotFoundError, OSError, subprocess.CalledProcessError) as exc:
+        raise RuntimeError(
+            "cannot identify the pinned PDF/OCR runtime; install the pdf_layout and ocr extras " f"and Tesseract: {exc}"
+        ) from exc
+    first_line = completed.stdout.splitlines()
+    if not first_line or not first_line[0].strip():
+        raise RuntimeError("tesseract --version returned no version")
+    versions["tesseract"] = first_line[0].strip()
+    versions.update(_language_digests(ocr_languages))
+    return versions
+
+
+def _read_json(path: Path) -> dict[str, Any]:
+    """Read the baseline through the ratchet's strict loader, not permissive json.loads.
+
+    The production entrypoint is the only path CI runs, so rejecting duplicate keys and non-finite
+    literals has to happen here or it never happens where the baseline is trusted.
+    """
+    from .gate import _load_json
+
+    try:
+        payload = _load_json(path)
+    except (OSError, ValueError) as exc:
+        raise RuntimeError(f"cannot read JSON from {path}: {exc}") from exc
+    if not isinstance(payload, dict):
+        raise RuntimeError(f"expected a JSON object in {path}")
+    return payload
+
+
+def run(args: argparse.Namespace) -> int:
+    """Execute the requested benchmark operation."""
+    if args.download_workers < 1:
+        raise ValueError("--download-workers must be a positive integer")
+    if args.limit is not None and not args.skip_gate:
+        raise ValueError("--limit requires --skip-gate because an incomplete corpus cannot pass the ratchet")
+    if args.limit is not None and args.write_baseline:
+        raise ValueError("--write-baseline requires the complete 981-page corpus")
+
+    git_commit = ""
+    worktree_dirty = False
+    if not args.download_only:
+        git_commit, worktree_dirty = _git_identity()
+        if args.write_baseline and worktree_dirty:
+            raise RuntimeError("cannot write a baseline from a dirty worktree")
+
+    baseline = None
+    if not args.skip_gate and not args.write_baseline and not args.download_only:
+        # Before the first accepted baseline the gate must report ABSENT_BASELINE
+        # red, not an unreadable-file error: bootstrap runs record one instead.
+        baseline = _read_json(args.baseline) if args.baseline.is_file() else {}
+
+    snapshot = load_corpus(args.cache_dir, limit=args.limit, workers=args.download_workers)
+    print(
+        f"OmniDocBench {snapshot.revision}: validated {len(snapshot.pages)}/{snapshot.expected_pages} PDFs",
+        flush=True,
+    )
+    if args.download_only:
+        return 0
+    parser_runtime = _parser_runtime(args.ocr_languages)
+
+    ground_truth = load_ground_truth(snapshot)
+    evaluations = evaluate_corpus(
+        snapshot,
+        ground_truth,
+        ocr_languages=args.ocr_languages,
+    )
+    failures = sum(result.error_type is not None for result in evaluations)
+    print(
+        f"Projected and scored {len(evaluations) - failures}/{len(evaluations)} pages; failures={failures}",
+        flush=True,
+    )
+    normalized = normalize_results(
+        snapshot=snapshot,
+        ground_truth=ground_truth,
+        evaluations=evaluations,
+        all2md_commit=git_commit,
+        worktree_dirty=worktree_dirty,
+        parser_runtime=parser_runtime,
+        ocr_languages=args.ocr_languages,
+    )
+    write_result(normalized, args.output)
+    print(f"Wrote {args.output}", flush=True)
+
+    if args.write_baseline:
+        if not snapshot.complete:
+            raise RuntimeError("cannot write a baseline from an incomplete corpus")
+        candidate = emit_baseline(normalized, default_tolerance=args.default_tolerance)
+        candidate_verdict = compare(normalized, candidate)
+        if candidate_verdict.failed:
+            raise RuntimeError("refusing to write an invalid baseline:\n" + format_verdict(candidate_verdict))
+        write_result(candidate, args.write_baseline)
+        print(f"Wrote reviewable baseline {args.write_baseline}", flush=True)
+        return 0
+    if args.skip_gate:
+        return 1 if failures and not args.allow_conversion_failures else 0
+
+    verdict = compare(normalized, baseline)
+    print(format_verdict(verdict))
+    return 1 if verdict.failed else 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Parse CLI arguments and execute the benchmark."""
+    parser = _build_parser()
+    args = parser.parse_args(argv)
+    try:
+        return run(args)
+    except (OSError, RuntimeError, ValueError) as exc:
+        print(f"OMNIDOCBENCH ERROR: {exc}", file=sys.stderr)
+        return 2
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/unit/test_omnidocbench_benchmark.py
+++ b/tests/unit/test_omnidocbench_benchmark.py
@@ -1,0 +1,301 @@
+"""Behavioral tests for the direct OmniDocBench AST benchmark."""
+
+from __future__ import annotations
+
+import json
+import threading
+from pathlib import Path
+
+import pytest
+
+from all2md.ast.nodes import Document, Paragraph, Text
+from benchmarks.omnidocbench import benchmark
+from benchmarks.omnidocbench.corpus import CorpusPage, CorpusSnapshot
+from benchmarks.omnidocbench.oracles import GroundTruthPage, PageProjection
+
+pytestmark = pytest.mark.unit
+
+
+def _page(tmp_path: Path, page_id: str) -> CorpusPage:
+    return CorpusPage(
+        page_id=page_id,
+        image_path=f"images/{page_id}.jpg",
+        pdf_path=tmp_path / f"{page_id}.pdf",
+        sha256="a" * 64,
+        size_bytes=100,
+    )
+
+
+def _snapshot(tmp_path: Path, page_ids: tuple[str, ...] = ("page-a", "page-b")) -> CorpusSnapshot:
+    return CorpusSnapshot(
+        revision="dataset-revision",
+        annotation_path=tmp_path / "OmniDocBench.json",
+        pages=tuple(_page(tmp_path, page_id) for page_id in page_ids),
+        expected_pages=len(page_ids),
+        complete=True,
+    )
+
+
+def _annotation(page_id: str, text: str = "Body") -> dict[str, object]:
+    return {
+        "page_info": {"image_path": f"images/{page_id}.jpg"},
+        "layout_dets": [
+            {
+                "category_type": "text_block",
+                "order": 1,
+                "text": text,
+                "ignore": False,
+            }
+        ],
+    }
+
+
+def _truth(page_id: str) -> GroundTruthPage:
+    return GroundTruthPage(
+        page_id=page_id,
+        projection=PageProjection(("Body",), ("text_block",), (), ()),
+        unscored_categories={"figure": 1},
+        explicitly_ignored=1,
+    )
+
+
+def test_ground_truth_loader_selects_exact_pdf_page_ids(tmp_path: Path) -> None:
+    """A limited run must load its exact annotation rows without scoring absent pages."""
+    snapshot = _snapshot(tmp_path, ("page-b",))
+    snapshot.annotation_path.write_text(
+        json.dumps([_annotation("page-a", "A"), _annotation("page-b", "B")]),
+        encoding="utf-8",
+    )
+
+    truth = benchmark.load_ground_truth(snapshot)
+
+    assert list(truth) == ["page-b"]
+    assert truth["page-b"].projection.text_blocks == ("B",)
+
+
+def test_ground_truth_loader_rejects_missing_selected_page(tmp_path: Path) -> None:
+    """A PDF without external truth must fail instead of shrinking the denominator."""
+    snapshot = _snapshot(tmp_path, ("page-b",))
+    snapshot.annotation_path.write_text(json.dumps([_annotation("page-a")]), encoding="utf-8")
+
+    with pytest.raises(ValueError, match=r"selected PDFs have no annotations: \['page-b'\]"):
+        benchmark.load_ground_truth(snapshot)
+
+
+def test_evaluation_calls_to_ast_once_and_scores_the_returned_document(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """One page must have exactly one parser observation and no renderer or reparsing step."""
+    snapshot = _snapshot(tmp_path, ("page-a",))
+    calls: list[tuple[Path, str, object]] = []
+
+    def fake_to_ast(source: Path, *, source_format: str, parser_options: object):
+        calls.append((source, source_format, parser_options))
+        return Document(children=[Paragraph(content=[Text(content="Body")])])
+
+    monkeypatch.setattr("all2md.to_ast", fake_to_ast)
+    results = benchmark.evaluate_corpus(
+        snapshot,
+        {"page-a": _truth("page-a")},
+        ocr_languages="eng",
+    )
+
+    assert len(calls) == 1
+    assert calls[0][0] == snapshot.pages[0].pdf_path
+    assert calls[0][1] == "pdf"
+    assert calls[0][2].ocr.languages == "eng"
+    assert results == [
+        benchmark.PageEvaluation(
+            page_id="page-a",
+            scores={
+                "text_content_similarity": 1.0,
+                "reading_order_similarity": 1.0,
+            },
+            predicted_tables=0,
+            predicted_formulas=0,
+            duration_seconds=results[0].duration_seconds,
+        )
+    ]
+
+
+def test_evaluation_serializes_multiple_pymupdf_pages_on_the_caller_thread(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """PyMuPDF pages must never be parsed concurrently because its API is not thread-safe."""
+    snapshot = _snapshot(tmp_path, ("page-a", "page-b"))
+    caller_thread = threading.get_ident()
+    calls: list[tuple[Path, int]] = []
+
+    def fake_to_ast(source: Path, **_kwargs):
+        calls.append((source, threading.get_ident()))
+        return Document(children=[Paragraph(content=[Text(content="Body")])])
+
+    monkeypatch.setattr("all2md.to_ast", fake_to_ast)
+    results = benchmark.evaluate_corpus(
+        snapshot,
+        {"page-a": _truth("page-a"), "page-b": _truth("page-b")},
+    )
+
+    assert [result.page_id for result in results] == ["page-a", "page-b"]
+    assert calls == [
+        (snapshot.pages[0].pdf_path, caller_thread),
+        (snapshot.pages[1].pdf_path, caller_thread),
+    ]
+
+
+def test_failed_ast_conversion_contributes_zero_scores(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """A parser exception must remain visible and must not earn absence-match credit."""
+    snapshot = _snapshot(tmp_path, ("page-a",))
+
+    def fail_to_ast(*_args, **_kwargs):
+        raise RuntimeError("broken PDF")
+
+    monkeypatch.setattr("all2md.to_ast", fail_to_ast)
+    result = benchmark.evaluate_corpus(
+        snapshot,
+        {"page-a": _truth("page-a")},
+    )[0]
+
+    assert result.scores == {
+        "text_content_similarity": 0.0,
+        "reading_order_similarity": 0.0,
+    }
+    assert result.error_type == "RuntimeError"
+    assert result.error == "broken PDF"
+
+
+def test_degraded_pdf_fallback_contributes_zero_scores(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """An OCR fallback must become ratcheted failure evidence, not a silent success."""
+    snapshot = _snapshot(tmp_path, ("page-a",))
+
+    def degraded_to_ast(*_args, **_kwargs):
+        return Document(
+            children=[Paragraph(content=[Text(content="Body")])],
+            metadata={"confidence": {"degraded_events": [{"kind": "ocr_fallback"}]}},
+        )
+
+    monkeypatch.setattr("all2md.to_ast", degraded_to_ast)
+    result = benchmark.evaluate_corpus(
+        snapshot,
+        {"page-a": _truth("page-a")},
+    )[0]
+
+    assert result.scores == {
+        "text_content_similarity": 0.0,
+        "reading_order_similarity": 0.0,
+    }
+    assert result.error_type == "DegradedConversionError"
+    assert result.error == '[{"kind": "ocr_fallback"}]'
+
+
+def test_a_deliberate_table_rejection_is_scored_not_failed(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Correctly refusing a non-tabular grid must not zero every dimension on the page.
+
+    ``table_rejected`` is the only degraded event the PDF parser records, and it fires on
+    deliberate decisions (dot-leader TOC, degenerate grid, layout region not tabular). Treating
+    it as a conversion failure made a byte-perfect page score 0.0 in every dimension while its
+    own confidence card read high, and the table and reading-order metrics already score that
+    outcome. Any other degradation still fails the page.
+    """
+    snapshot = _snapshot(tmp_path, ("page-a",))
+
+    def rejected_table_to_ast(*_args, **_kwargs):
+        return Document(
+            children=[Paragraph(content=[Text(content="Body")])],
+            metadata={"confidence": {"degraded_events": [{"kind": "table_rejected", "detail": "dot_leader_toc"}]}},
+        )
+
+    monkeypatch.setattr("all2md.to_ast", rejected_table_to_ast)
+    result = benchmark.evaluate_corpus(snapshot, {"page-a": _truth("page-a")})[0]
+
+    assert result.error_type is None
+    assert result.scores["text_content_similarity"] > 0.0
+
+
+def test_normalization_records_variance_failures_and_unsupported_dimensions(tmp_path: Path) -> None:
+    """The ratchet input must expose exact samples and capabilities, not only averages."""
+    snapshot = _snapshot(tmp_path)
+    truth = {"page-a": _truth("page-a"), "page-b": _truth("page-b")}
+    evaluations = [
+        benchmark.PageEvaluation(
+            page_id="page-a",
+            scores={
+                "text_content_similarity": 0.2,
+                "reading_order_similarity": 0.5,
+                "formula_presence_accuracy": 1.0,
+                "table_structure_similarity": 0.3,
+                "table_content_similarity": 0.4,
+            },
+            predicted_tables=1,
+            predicted_formulas=0,
+            duration_seconds=0.5,
+        ),
+        benchmark.PageEvaluation(
+            page_id="page-b",
+            scores={
+                "text_content_similarity": 0.6,
+                "reading_order_similarity": 0.5,
+                "formula_presence_accuracy": 0.0,
+                "table_structure_similarity": 0.7,
+                "table_content_similarity": 0.8,
+                "formula_content_similarity": 0.0,
+            },
+            predicted_tables=0,
+            predicted_formulas=0,
+            duration_seconds=0.6,
+            error_type="RuntimeError",
+            error="broken PDF",
+        ),
+    ]
+
+    payload = benchmark.normalize_results(
+        snapshot=snapshot,
+        ground_truth=truth,
+        evaluations=evaluations,
+        all2md_commit="all2md-commit",
+        parser_runtime={"pymupdf": "1.28.0", "tesseract": "tesseract 5.3.0"},
+    )
+
+    assert payload["schema_version"] == 2
+    assert payload["pages"] == {
+        "expected": 2,
+        "annotations": 2,
+        "pdfs": 2,
+        "converted": 1,
+        "scored": 2,
+        "unique_ids": 2,
+    }
+    assert payload["dimensions"]["text_content_similarity"] == {
+        "value": pytest.approx(0.4),
+        "direction": "higher",
+        "eligible_items": 2,
+        "variance": pytest.approx(0.04),
+        "sample_scores": {"page-a": 0.2, "page-b": 0.6},
+    }
+    assert payload["dimensions"]["table_structure_similarity"]["value"] == pytest.approx(0.5)
+    assert "formula_content_similarity" not in payload["dimensions"]
+    assert payload["unsupported_dimensions"] == {
+        "formula_fidelity": (
+            "all2md emitted no MathBlock or MathInline nodes on 1 converted page(s); "
+            "0 pages have formula ground truth"
+        )
+    }
+    assert payload["conversion_failures"] == {"page-b": "RuntimeError: broken PDF"}
+    assert payload["unscored_annotation_categories"] == {"figure": 2}
+    assert payload["explicitly_ignored_annotations"] == 2
+    assert payload["provenance"]["oracle_schema_version"] == 3
+    assert payload["provenance"]["parser_config"]["layout_analysis_mode"] == "enabled"
+    assert payload["provenance"]["parser_runtime"] == {
+        "pymupdf": "1.28.0",
+        "tesseract": "tesseract 5.3.0",
+    }
+    assert payload["provenance"]["parser_config"]["ocr"]["languages"] == "eng+chi_sim"
+
+
+def test_strict_result_json_rejects_non_finite_scores(tmp_path: Path) -> None:
+    """NaN cannot enter a baseline because JSON readers disagree on its meaning."""
+    with pytest.raises(ValueError, match="Out of range float values"):
+        benchmark.write_result({"score": float("nan")}, tmp_path / "result.json")

--- a/tests/unit/test_omnidocbench_corpus.py
+++ b/tests/unit/test_omnidocbench_corpus.py
@@ -1,0 +1,681 @@
+"""Regression tests for the pinned OmniDocBench runtime corpus cache."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import subprocess
+import sys
+from pathlib import Path
+from typing import Callable
+from urllib.parse import unquote, urlsplit
+
+import pytest
+
+from benchmarks.omnidocbench import corpus
+
+pytestmark = pytest.mark.unit
+
+
+def _record(position: int, *, image_path: str | None = None) -> dict[str, object]:
+    return {
+        "layout_dets": [],
+        "page_info": {
+            "page_attribute": {},
+            "page_no": position,
+            "height": 1200,
+            "width": 900,
+            "image_path": image_path or f"page-{position:04d}.jpg",
+        },
+    }
+
+
+def _annotation_bytes(
+    count: int = corpus.EXPECTED_PAGES,
+    *,
+    records: list[dict[str, object]] | None = None,
+) -> bytes:
+    payload = records if records is not None else [_record(i) for i in range(count)]
+    return json.dumps(payload, separators=(",", ":"), ensure_ascii=False).encode()
+
+
+def _pdf_bytes(page_id: str) -> bytes:
+    return f"%PDF-1.7\nsynthetic {page_id}\n%%EOF\n".encode()
+
+
+def _install_downloader(
+    monkeypatch: pytest.MonkeyPatch,
+    annotation: bytes,
+) -> list[str]:
+    calls: list[str] = []
+    monkeypatch.setattr(corpus, "ANNOTATION_SHA256", hashlib.sha256(annotation).hexdigest())
+
+    def download(url: str, destination: Path, **_: object) -> int:
+        calls.append(url)
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        name = unquote(Path(urlsplit(url).path).name)
+        content = annotation if name == corpus.ANNOTATION_FILENAME else _pdf_bytes(Path(name).stem)
+        destination.write_bytes(content)
+        return len(content)
+
+    monkeypatch.setattr(corpus.corpus_download, "_download", download)
+    return calls
+
+
+def _prime_cache(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    limit: int,
+) -> tuple[corpus.CorpusSnapshot, bytes, list[str]]:
+    annotation = _annotation_bytes()
+    calls = _install_downloader(monkeypatch, annotation)
+    snapshot = corpus.load_corpus(tmp_path, limit=limit, workers=1)
+    return snapshot, annotation, calls
+
+
+def _forbid_download(monkeypatch: pytest.MonkeyPatch) -> None:
+    def fail_download(*_: object, **__: object) -> int:
+        raise AssertionError("warm cache unexpectedly attempted network transport")
+
+    monkeypatch.setattr(corpus.corpus_download, "_download", fail_download)
+
+
+def _rewrite_index(index_path: Path, mutate: Callable[[dict[str, object]], None]) -> None:
+    payload = json.loads(index_path.read_text(encoding="utf-8"))
+    mutate(payload)
+    index_path.write_text(json.dumps(payload), encoding="utf-8")
+
+
+def test_valid_cold_cache_downloads_and_indexes_all_pinned_pages(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A cold full run must hash exactly 981 PDFs and write pinned provenance."""
+    annotation = _annotation_bytes()
+    calls = _install_downloader(monkeypatch, annotation)
+
+    snapshot = corpus.load_corpus(tmp_path, workers=1)
+
+    revision_dir = tmp_path / corpus.REVISION
+    index_path = corpus._index_path(revision_dir, None)
+    first_pdf = _pdf_bytes("page-0000")
+    last_pdf = _pdf_bytes("page-0980")
+    assert snapshot.revision == corpus.REVISION
+    assert snapshot.annotation_path == revision_dir / corpus.ANNOTATION_FILENAME
+    assert snapshot.annotation_path.read_bytes() == annotation
+    assert snapshot.expected_pages == 981
+    assert snapshot.complete is True
+    assert len(snapshot.pages) == 981
+    assert snapshot.pages[0] == corpus.CorpusPage(
+        page_id="page-0000",
+        image_path="page-0000.jpg",
+        pdf_path=revision_dir / "pdfs/page-0000.pdf",
+        sha256=hashlib.sha256(first_pdf).hexdigest(),
+        size_bytes=len(first_pdf),
+    )
+    assert snapshot.pages[-1] == corpus.CorpusPage(
+        page_id="page-0980",
+        image_path="page-0980.jpg",
+        pdf_path=revision_dir / "pdfs/page-0980.pdf",
+        sha256=hashlib.sha256(last_pdf).hexdigest(),
+        size_bytes=len(last_pdf),
+    )
+    assert len(calls) == 982
+    assert calls[0] == (
+        f"https://huggingface.co/datasets/{corpus.DATASET_ID}/resolve/"
+        f"{corpus.REVISION}/{corpus.ANNOTATION_FILENAME}?download=true"
+    )
+    assert calls[-1].endswith(f"/{corpus.REVISION}/pdfs/page-0980.pdf?download=true")
+    assert index_path.is_file() is True
+    assert corpus.REVISION in index_path.name
+    index = json.loads(index_path.read_text(encoding="utf-8"))
+    assert index["revision"] == corpus.REVISION
+    assert index["annotation_sha256"] == hashlib.sha256(annotation).hexdigest()
+    assert index["expected_pages"] == 981
+    assert index["requested_limit"] is None
+    assert index["complete"] is True
+    assert len(index["pages"]) == 981
+
+
+def test_valid_warm_cache_revalidates_without_downloading(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A warm hit must reproduce exact page metadata without invoking transport."""
+    cold, _, cold_calls = _prime_cache(tmp_path, monkeypatch, limit=2)
+    assert len(cold_calls) == 3
+    _forbid_download(monkeypatch)
+
+    warm = corpus.load_corpus(tmp_path, limit=2, workers=1)
+
+    assert warm == cold
+    assert warm.complete is False
+    assert warm.expected_pages == 981
+    assert tuple(page.page_id for page in warm.pages) == ("page-0000", "page-0001")
+
+
+def test_annotation_sha256_mismatch_is_rejected_before_page_downloads(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Unpinned annotation bytes must leave no annotation, PDFs, or cache index."""
+    annotation = _annotation_bytes()
+    calls = _install_downloader(monkeypatch, annotation)
+    monkeypatch.setattr(corpus, "ANNOTATION_SHA256", "0" * 64)
+    actual = hashlib.sha256(annotation).hexdigest()
+
+    with pytest.raises(corpus.CorpusIntegrityError) as raised:
+        corpus.load_corpus(tmp_path, limit=1, workers=1)
+
+    revision_dir = tmp_path / corpus.REVISION
+    assert str(raised.value) == f"annotation SHA-256 mismatch: expected {'0' * 64}, got {actual}"
+    assert len(calls) == 1
+    assert (revision_dir / corpus.ANNOTATION_FILENAME).exists() is False
+    assert (revision_dir / f"{corpus.ANNOTATION_FILENAME}.part").exists() is False
+    assert corpus._index_path(revision_dir, 1).exists() is False
+    assert list((revision_dir / "pdfs").iterdir()) == []
+
+
+@pytest.mark.parametrize(
+    ("count", "expected_message"),
+    [
+        (0, "annotation page count mismatch: expected 981, got 0"),
+        (980, "annotation page count mismatch: expected 981, got 980"),
+    ],
+    ids=["zero-records", "truncated-record-set"],
+)
+def test_annotation_requires_the_exact_record_count(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    count: int,
+    expected_message: str,
+) -> None:
+    """Zero and truncated annotation arrays must never become benchmark corpora."""
+    annotation = _annotation_bytes(count)
+    calls = _install_downloader(monkeypatch, annotation)
+
+    with pytest.raises(corpus.CorpusIntegrityError) as raised:
+        corpus.load_corpus(tmp_path, limit=1, workers=1)
+
+    assert str(raised.value) == expected_message
+    assert len(calls) == 1
+    assert corpus._index_path(tmp_path / corpus.REVISION, 1).exists() is False
+
+
+def test_annotation_rejects_duplicate_derived_page_ids(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Two image paths deriving the same page ID must fail before any PDF fetch."""
+    records = [_record(i) for i in range(corpus.EXPECTED_PAGES)]
+    records[-1] = _record(corpus.EXPECTED_PAGES - 1, image_path="nested/page-0000.png")
+    annotation = _annotation_bytes(records=records)
+    calls = _install_downloader(monkeypatch, annotation)
+
+    with pytest.raises(corpus.CorpusIntegrityError) as raised:
+        corpus.load_corpus(tmp_path, limit=1, workers=1)
+
+    assert str(raised.value) == "duplicate page_id 'page-0000' at annotation record 980"
+    assert len(calls) == 1
+    assert list((tmp_path / corpus.REVISION / "pdfs").iterdir()) == []
+
+
+def test_annotation_rejects_a_truncated_page_schema(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A record missing one required page_info field must fail exact schema validation."""
+    records = [_record(i) for i in range(corpus.EXPECTED_PAGES)]
+    page_info = records[17]["page_info"]
+    assert isinstance(page_info, dict)
+    del page_info["height"]
+    annotation = _annotation_bytes(records=records)
+    calls = _install_downloader(monkeypatch, annotation)
+
+    with pytest.raises(corpus.CorpusIntegrityError) as raised:
+        corpus.load_corpus(tmp_path, limit=1, workers=1)
+
+    assert str(raised.value) == "annotation record 17 page_info is missing fields: height"
+    assert len(calls) == 1
+    assert corpus._index_path(tmp_path / corpus.REVISION, 1).exists() is False
+
+
+def test_warm_cache_rejects_an_index_for_the_wrong_revision(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A warm index with any other dataset revision must not authorize cached bytes."""
+    _, _, _ = _prime_cache(tmp_path, monkeypatch, limit=1)
+    index_path = corpus._index_path(tmp_path / corpus.REVISION, 1)
+    _rewrite_index(index_path, lambda index: index.__setitem__("revision", "wrong-revision"))
+    _forbid_download(monkeypatch)
+
+    with pytest.raises(corpus.CorpusCacheError) as raised:
+        corpus.load_corpus(tmp_path, limit=1, workers=1)
+
+    assert str(raised.value) == (f"cache index revision mismatch: expected {corpus.REVISION}, got 'wrong-revision'")
+    assert index_path.exists() is True
+
+
+def test_warm_cache_rejects_a_nonexact_index_page_set(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Dropping one selected page from an index must invalidate the entire warm hit."""
+    _, _, _ = _prime_cache(tmp_path, monkeypatch, limit=2)
+    index_path = corpus._index_path(tmp_path / corpus.REVISION, 2)
+
+    def drop_last(index: dict[str, object]) -> None:
+        pages = index["pages"]
+        assert isinstance(pages, list)
+        pages.pop()
+
+    _rewrite_index(index_path, drop_last)
+    _forbid_download(monkeypatch)
+
+    with pytest.raises(corpus.CorpusCacheError) as raised:
+        corpus.load_corpus(tmp_path, limit=2, workers=1)
+
+    assert str(raised.value) == "cache index page set does not match pinned annotation"
+    index = json.loads(index_path.read_text(encoding="utf-8"))
+    assert len(index["pages"]) == 1
+
+
+def test_warm_cache_rejects_a_missing_pdf(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A deleted indexed PDF must be reported rather than treated as a cache hit."""
+    snapshot, _, _ = _prime_cache(tmp_path, monkeypatch, limit=1)
+    pdf_path = snapshot.pages[0].pdf_path
+    pdf_path.unlink()
+    _forbid_download(monkeypatch)
+
+    with pytest.raises(corpus.CorpusCacheError) as raised:
+        corpus.load_corpus(tmp_path, limit=1, workers=1)
+
+    assert str(raised.value) == "cached PDF is missing for 'page-0000'"
+    assert pdf_path.exists() is False
+
+
+def test_warm_cache_rejects_a_truncated_pdf_size(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A truncated PDF must fail the indexed exact-size contract before hashing."""
+    snapshot, _, _ = _prime_cache(tmp_path, monkeypatch, limit=1)
+    page = snapshot.pages[0]
+    original = page.pdf_path.read_bytes()
+    page.pdf_path.write_bytes(original[:-1])
+    _forbid_download(monkeypatch)
+
+    with pytest.raises(corpus.CorpusCacheError) as raised:
+        corpus.load_corpus(tmp_path, limit=1, workers=1)
+
+    assert str(raised.value) == (
+        f"cached PDF size mismatch for 'page-0000': expected {len(original)}, got {len(original) - 1}"
+    )
+    assert page.pdf_path.stat().st_size == len(original) - 1
+
+
+def test_warm_cache_rejects_same_size_pdf_corruption_by_hash(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Same-size PDF corruption must be detected by full SHA-256 revalidation."""
+    snapshot, _, _ = _prime_cache(tmp_path, monkeypatch, limit=1)
+    page = snapshot.pages[0]
+    original = page.pdf_path.read_bytes()
+    corrupted = original[:-2] + b"X\n"
+    assert len(corrupted) == len(original)
+    page.pdf_path.write_bytes(corrupted)
+    actual = hashlib.sha256(corrupted).hexdigest()
+    _forbid_download(monkeypatch)
+
+    with pytest.raises(corpus.CorpusCacheError) as raised:
+        corpus.load_corpus(tmp_path, limit=1, workers=1)
+
+    assert str(raised.value) == (f"cached PDF SHA-256 mismatch for 'page-0000': expected {page.sha256}, got {actual}")
+    assert page.pdf_path.stat().st_size == page.size_bytes
+
+
+@pytest.mark.parametrize(
+    ("invalid_pdf", "expected_size"),
+    [(b"", 0), (b"%PD", 3)],
+    ids=["zero-byte-pdf", "truncated-pdf"],
+)
+def test_cold_cache_rejects_zero_or_truncated_pdf_bytes(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    invalid_pdf: bytes,
+    expected_size: int,
+) -> None:
+    """Zero and truncated PDF downloads must be removed and never indexed."""
+    annotation = _annotation_bytes()
+    monkeypatch.setattr(corpus, "ANNOTATION_SHA256", hashlib.sha256(annotation).hexdigest())
+    calls: list[str] = []
+
+    def invalid_download(url: str, destination: Path, **_: object) -> int:
+        calls.append(url)
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        name = unquote(Path(urlsplit(url).path).name)
+        content = annotation if name == corpus.ANNOTATION_FILENAME else invalid_pdf
+        destination.write_bytes(content)
+        return len(content)
+
+    monkeypatch.setattr(corpus.corpus_download, "_download", invalid_download)
+
+    with pytest.raises(corpus.CorpusIntegrityError) as raised:
+        corpus.load_corpus(tmp_path, limit=1, workers=1)
+
+    revision_dir = tmp_path / corpus.REVISION
+    pdf_path = revision_dir / "pdfs/page-0000.pdf"
+    assert str(raised.value) == "downloaded PDF 'page-0000' is not a non-empty PDF"
+    assert len(calls) == 2
+    assert len(invalid_pdf) == expected_size
+    assert pdf_path.exists() is False
+    assert corpus._index_path(revision_dir, 1).exists() is False
+
+
+def test_failed_download_is_atomic_and_never_writes_an_index(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A transport failure must remove both partial and prematurely final PDF bytes."""
+    annotation = _annotation_bytes()
+    monkeypatch.setattr(corpus, "ANNOTATION_SHA256", hashlib.sha256(annotation).hexdigest())
+    calls: list[str] = []
+    monkeypatch.setattr(corpus.corpus_download, "RETRY_BACKOFF_SECONDS", 0)
+
+    def failing_download(url: str, destination: Path, **_: object) -> int:
+        calls.append(url)
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        name = unquote(Path(urlsplit(url).path).name)
+        if name == corpus.ANNOTATION_FILENAME:
+            destination.write_bytes(annotation)
+            return len(annotation)
+        destination.with_suffix(destination.suffix + ".part").write_bytes(b"partial")
+        destination.write_bytes(b"premature-final")
+        raise OSError("synthetic connection reset")
+
+    monkeypatch.setattr(corpus.corpus_download, "_download", failing_download)
+
+    with pytest.raises(corpus.CorpusDownloadError) as raised:
+        corpus.load_corpus(tmp_path, limit=1, workers=1)
+
+    revision_dir = tmp_path / corpus.REVISION
+    pdf_path = revision_dir / "pdfs/page-0000.pdf"
+    assert str(raised.value) == "failed to download PDF page-0000"
+    assert len(calls) == 4
+    assert (revision_dir / corpus.ANNOTATION_FILENAME).read_bytes() == annotation
+    assert pdf_path.exists() is False
+    assert pdf_path.with_suffix(".pdf.part").exists() is False
+    assert corpus._index_path(revision_dir, 1).exists() is False
+
+
+def test_limited_mode_is_explicitly_incomplete_even_at_the_full_page_limit(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Supplying any limit must preserve expected_pages=981 while marking incomplete."""
+    annotation = _annotation_bytes()
+    calls = _install_downloader(monkeypatch, annotation)
+
+    smoke = corpus.load_corpus(tmp_path, limit=2, workers=1)
+    all_but_limited = corpus.load_corpus(tmp_path, limit=981, workers=1)
+
+    revision_dir = tmp_path / corpus.REVISION
+    smoke_index = json.loads(corpus._index_path(revision_dir, 2).read_text(encoding="utf-8"))
+    all_limited_index = json.loads(corpus._index_path(revision_dir, 981).read_text(encoding="utf-8"))
+    assert smoke.complete is False
+    assert smoke.expected_pages == 981
+    assert len(smoke.pages) == 2
+    assert smoke_index["complete"] is False
+    assert smoke_index["requested_limit"] == 2
+    assert len(smoke_index["pages"]) == 2
+    assert all_but_limited.complete is False
+    assert all_but_limited.expected_pages == 981
+    assert len(all_but_limited.pages) == 981
+    assert all_limited_index["complete"] is False
+    assert all_limited_index["requested_limit"] == 981
+    assert len(all_limited_index["pages"]) == 981
+    assert corpus._index_path(revision_dir, None).exists() is False
+    assert len(calls) == 982
+
+
+def test_cross_mode_load_rejects_corruption_using_the_shared_manifest(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A new mode must reject a %PDF-prefixed page corrupted after another mode."""
+    snapshot, _, _ = _prime_cache(tmp_path, monkeypatch, limit=2)
+    page = snapshot.pages[0]
+    original = page.pdf_path.read_bytes()
+    corrupted = original[:-2] + b"X\n"
+    assert len(corrupted) == len(original)
+    assert corrupted.startswith(b"%PDF") is True
+    page.pdf_path.write_bytes(corrupted)
+    actual = hashlib.sha256(corrupted).hexdigest()
+    _forbid_download(monkeypatch)
+
+    with pytest.raises(corpus.CorpusCacheError) as raised:
+        corpus.load_corpus(tmp_path, limit=1, workers=1)
+
+    revision_dir = tmp_path / corpus.REVISION
+    manifest = json.loads(corpus._manifest_path(revision_dir).read_text(encoding="utf-8"))
+    assert str(raised.value) == (
+        f"cached PDF SHA-256 mismatch for 'page-0000': " f"expected {page.sha256}, got {actual}"
+    )
+    assert manifest["pages"]["page-0000"]["sha256"] == page.sha256
+    assert corpus._index_path(revision_dir, 1).exists() is False
+
+
+def test_mode_index_digest_disagreement_with_manifest_is_rejected(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A mode index cannot replace a revision-wide immutable page digest."""
+    snapshot, _, _ = _prime_cache(tmp_path, monkeypatch, limit=1)
+    index_path = corpus._index_path(tmp_path / corpus.REVISION, 1)
+
+    def replace_digest(index: dict[str, object]) -> None:
+        pages = index["pages"]
+        assert isinstance(pages, list)
+        row = pages[0]
+        assert isinstance(row, dict)
+        row["sha256"] = "0" * 64
+
+    _rewrite_index(index_path, replace_digest)
+    _forbid_download(monkeypatch)
+
+    with pytest.raises(corpus.CorpusCacheError) as raised:
+        corpus.load_corpus(tmp_path, limit=1, workers=1)
+
+    assert str(raised.value) == ("cache index digest disagrees with artifact manifest for 'page-0000'")
+    assert snapshot.pages[0].pdf_path.read_bytes() == _pdf_bytes("page-0000")
+    assert snapshot.pages[0].sha256 != "0" * 64
+
+
+def test_untrusted_existing_pdf_is_redownloaded_before_manifest_publication(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An orphan PDF with no manifest digest must be replaced, not rehashed and blessed."""
+    annotation = _annotation_bytes()
+    calls = _install_downloader(monkeypatch, annotation)
+    revision_dir = tmp_path / corpus.REVISION
+    pdf_path = revision_dir / "pdfs/page-0000.pdf"
+    pdf_path.parent.mkdir(parents=True)
+    (revision_dir / corpus.ANNOTATION_FILENAME).write_bytes(annotation)
+    orphan = b"%PDF-1.7\nuntrusted but plausible\n%%EOF\n"
+    pdf_path.write_bytes(orphan)
+
+    snapshot = corpus.load_corpus(tmp_path, limit=1, workers=1)
+
+    trusted = _pdf_bytes("page-0000")
+    manifest = json.loads(corpus._manifest_path(revision_dir).read_text(encoding="utf-8"))
+    assert len(calls) == 1
+    assert calls[0].endswith(f"/{corpus.REVISION}/pdfs/page-0000.pdf?download=true")
+    assert pdf_path.read_bytes() == trusted
+    assert pdf_path.read_bytes() != orphan
+    assert snapshot.pages[0].sha256 == hashlib.sha256(trusted).hexdigest()
+    assert manifest["pages"]["page-0000"]["sha256"] == snapshot.pages[0].sha256
+
+
+def test_concurrent_processes_publish_one_complete_materialization(
+    tmp_path: Path,
+) -> None:
+    """Two processes must serialize publication and leave no shared or partial temp."""
+    annotation = _annotation_bytes()
+    source_path = tmp_path / "_synthetic_annotation.json"
+    source_path.write_bytes(annotation)
+    log_path = tmp_path / "_download_log.txt"
+    start_path = tmp_path / "_start"
+    script = """
+import hashlib
+import importlib.util
+import json
+import os
+import sys
+import time
+from pathlib import Path
+from urllib.parse import unquote, urlsplit
+
+
+cache_dir = Path(sys.argv[1])
+source_path = Path(sys.argv[2])
+log_path = Path(sys.argv[3])
+start_path = Path(sys.argv[4])
+corpus_path = Path(sys.argv[5])
+spec = importlib.util.spec_from_file_location("omnidocbench_corpus_child", corpus_path)
+if spec is None or spec.loader is None:
+    raise RuntimeError("cannot load corpus adapter")
+corpus = importlib.util.module_from_spec(spec)
+sys.modules[spec.name] = corpus
+spec.loader.exec_module(corpus)
+annotation = source_path.read_bytes()
+corpus.ANNOTATION_SHA256 = hashlib.sha256(annotation).hexdigest()
+
+def record(message):
+    with log_path.open("a", encoding="utf-8") as output:
+        output.write(message + "\\n")
+        output.flush()
+        os.fsync(output.fileno())
+
+def download(url, destination, **_):
+    name = unquote(Path(urlsplit(url).path).name)
+    record("start " + name)
+    time.sleep(0.05)
+    content = (
+        annotation
+        if name == corpus.ANNOTATION_FILENAME
+        else f"%PDF-1.7\\nsynthetic {Path(name).stem}\\n%%EOF\\n".encode()
+    )
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    destination.write_bytes(content)
+    record("end " + name)
+    return len(content)
+
+corpus.corpus_download._download = download
+deadline = time.monotonic() + 5
+while not start_path.exists():
+    if time.monotonic() >= deadline:
+        raise TimeoutError("start barrier was not released")
+    time.sleep(0.01)
+snapshot = corpus.load_corpus(cache_dir, limit=1, workers=1)
+print(json.dumps({
+    "complete": snapshot.complete,
+    "page_id": snapshot.pages[0].page_id,
+    "sha256": snapshot.pages[0].sha256,
+}))
+"""
+    processes = [
+        subprocess.Popen(
+            [
+                sys.executable,
+                "-c",
+                script,
+                str(tmp_path),
+                str(source_path),
+                str(log_path),
+                str(start_path),
+                str(Path(corpus.__file__).resolve()),
+            ],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+        )
+        for _ in range(2)
+    ]
+    start_path.write_text("start", encoding="utf-8")
+    completed = [process.communicate(timeout=15) for process in processes]
+    assert [process.returncode for process in processes] == [0, 0], [stderr for _, stderr in completed]
+    assert [stderr for _, stderr in completed] == ["", ""]
+
+    expected_digest = hashlib.sha256(_pdf_bytes("page-0000")).hexdigest()
+    observed = [json.loads(stdout) for stdout, _ in completed]
+    revision_dir = tmp_path / corpus.REVISION
+    leftovers = sorted(
+        path.name
+        for path in revision_dir.rglob("*")
+        if ".download" in path.name or path.name.endswith(".part") or path.name.endswith(".tmp")
+    )
+    assert observed == [
+        {
+            "complete": False,
+            "page_id": "page-0000",
+            "sha256": expected_digest,
+        },
+        {
+            "complete": False,
+            "page_id": "page-0000",
+            "sha256": expected_digest,
+        },
+    ]
+    assert log_path.read_text(encoding="utf-8").splitlines() == [
+        f"start {corpus.ANNOTATION_FILENAME}",
+        f"end {corpus.ANNOTATION_FILENAME}",
+        "start page-0000.pdf",
+        "end page-0000.pdf",
+    ]
+    assert leftovers == []
+    assert corpus._manifest_path(revision_dir).is_file() is True
+    assert corpus._index_path(revision_dir, 1).is_file() is True
+
+
+def test_transient_transport_failure_is_retried_before_the_run_fails(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """One throttled response out of 981 downloads must not abort a monthly cold run.
+
+    ``_download_artifact`` used to call ``corpus_download._download`` directly, so the very
+    first transient network error raised ``CorpusDownloadError`` and discarded every page
+    already fetched. It now goes through ``_try_download`` with a bounded retry budget: the
+    bound matters in both directions, because retrying forever would stop the gate from ever
+    reporting that the network is broken.
+    """
+    annotation = _annotation_bytes()
+    monkeypatch.setattr(corpus, "ANNOTATION_SHA256", hashlib.sha256(annotation).hexdigest())
+    monkeypatch.setattr(corpus.corpus_download, "RETRY_BACKOFF_SECONDS", 0)
+    attempts: list[str] = []
+
+    def flaky(url: str, destination: Path, **_: object) -> int:
+        attempts.append(url)
+        name = unquote(Path(urlsplit(url).path).name)
+        if name != corpus.ANNOTATION_FILENAME and len([u for u in attempts if u == url]) == 1:
+            raise TimeoutError("connection timed out")
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        content = annotation if name == corpus.ANNOTATION_FILENAME else _pdf_bytes(Path(name).stem)
+        destination.write_bytes(content)
+        return len(content)
+
+    monkeypatch.setattr(corpus.corpus_download, "_download", flaky)
+
+    snapshot = corpus.load_corpus(tmp_path, limit=1, workers=1)
+
+    assert len(snapshot.pages) == 1
+    pdf_urls = [url for url in attempts if url.endswith(".pdf?download=true")]
+    assert len(pdf_urls) == 2 and pdf_urls[0] == pdf_urls[1]
+    assert snapshot.pages[0].pdf_path.read_bytes().startswith(b"%PDF")

--- a/tests/unit/test_omnidocbench_gate.py
+++ b/tests/unit/test_omnidocbench_gate.py
@@ -1,0 +1,983 @@
+#  Copyright (c) 2025 Tom Villani, Ph.D.
+"""Synthetic contract tests for the external-fidelity OmniDocBench gate."""
+
+from __future__ import annotations
+
+import copy
+import json
+
+import pytest
+
+from benchmarks.omnidocbench import gate
+
+pytestmark = pytest.mark.unit
+
+
+RESULTS = {
+    "schema_version": 2,
+    "provenance": {
+        "dataset_revision": "f5f559bddf50e36f7f9899d842d0006f13ce8afc",
+        "annotation_sha256": "2fafe9329dc92fc426b30036aee51c716b3fcdcc1d20cb964dc7670579533817",
+        "oracle_schema_version": 3,
+        "parser_config": {
+            "layout_analysis_mode": "auto",
+            "ocr": {
+                "enabled": True,
+                "engine": "tesseract",
+                "mode": "auto",
+                "languages": "eng+chi_sim",
+                "dpi": 200,
+            },
+        },
+        "parser_runtime": {
+            "pymupdf": "1.26.3",
+            "tesseract": "5.3.0",
+        },
+        "worktree_dirty": False,
+    },
+    "pages": {
+        "expected": 3,
+        "annotations": 3,
+        "pdfs": 3,
+        "converted": 2,
+        "scored": 3,
+        "unique_ids": 3,
+    },
+    "dimensions": {
+        "edit_distance": {
+            "value": 0.2,
+            "direction": "lower",
+            "eligible_items": 3,
+            "variance": 0.006666666666666666,
+            "sample_scores": {
+                "page-001": 0.1,
+                "page-002": 0.2,
+                "page-003": 0.3,
+            },
+        },
+        "text_similarity": {
+            "value": 0.8,
+            "direction": "higher",
+            "eligible_items": 3,
+            "variance": 0.006666666666666668,
+            "sample_scores": {
+                "page-001": 0.7,
+                "page-002": 0.8,
+                "page-003": 0.9,
+            },
+        },
+    },
+    "conversion_failures": {"page-003": "Encrypted PDF"},
+}
+BASELINE = gate.emit_baseline(
+    RESULTS,
+    {"edit_distance": 0.01, "text_similarity": 0.01},
+)
+
+
+def _results() -> dict:
+    return copy.deepcopy(RESULTS)
+
+
+def _baseline() -> dict:
+    return copy.deepcopy(BASELINE)
+
+
+def _set_metric_value(results: dict, metric: str, value: float) -> None:
+    dimension = results["dimensions"][metric]
+    delta = value - dimension["value"]
+    dimension["value"] = value
+    dimension["sample_scores"] = {page_id: score + delta for page_id, score in dimension["sample_scores"].items()}
+
+
+def _finding(status: str, subject: str, detail: str) -> list[gate.Finding]:
+    return [gate.Finding(status, subject, detail)]
+
+
+def test_an_exact_normalized_run_is_green() -> None:
+    """An unchanged, fully accounted run must be the gate's exact green path."""
+    verdict = gate.compare(_results(), _baseline())
+    assert verdict.findings == []
+    assert verdict.failed is False
+    assert gate.format_verdict(verdict) == "OMNIDOCBENCH GATE PASS"
+
+
+def test_failed_conversion_stays_in_the_scored_denominator() -> None:
+    """One failed AST conversion must still contribute a zero-score page."""
+    results = _results()
+    results["pages"] = {
+        "expected": 2,
+        "annotations": 2,
+        "pdfs": 2,
+        "converted": 1,
+        "scored": 2,
+        "unique_ids": 2,
+    }
+    # The sample scores have to shrink with the manifest: page-003 is the failed conversion that
+    # still scores, and a third page would claim a score no manifest entry could have produced.
+    for metric, scores in (
+        ("edit_distance", {"page-001": 0.1, "page-003": 0.3}),
+        ("text_similarity", {"page-001": 0.7, "page-003": 0.9}),
+    ):
+        dimension = results["dimensions"][metric]
+        dimension["sample_scores"] = scores
+        dimension["eligible_items"] = 2
+        dimension["variance"] = 0.01
+    baseline = gate.emit_baseline(
+        results,
+        {"edit_distance": 0.01, "text_similarity": 0.01},
+    )
+    verdict = gate.compare(results, baseline)
+    assert verdict.findings == []
+    assert verdict.failed is False
+
+
+@pytest.mark.parametrize(
+    ("metric", "value", "status", "detail"),
+    [
+        (
+            "text_similarity",
+            0.78,
+            "REGRESSION",
+            "higher is better: baseline 0.8, result 0.78, tolerance 0.01",
+        ),
+        (
+            "text_similarity",
+            0.82,
+            "UNRECORDED_IMPROVEMENT",
+            "higher is better: baseline 0.8, result 0.82, tolerance 0.01",
+        ),
+        (
+            "edit_distance",
+            0.22,
+            "REGRESSION",
+            "lower is better: baseline 0.2, result 0.22, tolerance 0.01",
+        ),
+        (
+            "edit_distance",
+            0.18,
+            "UNRECORDED_IMPROVEMENT",
+            "lower is better: baseline 0.2, result 0.18, tolerance 0.01",
+        ),
+    ],
+)
+def test_metric_mutations_are_red_in_both_directions(
+    metric: str,
+    value: float,
+    status: str,
+    detail: str,
+) -> None:
+    """Both metric directions must reject regressions and unrecorded improvements."""
+    results = _results()
+    _set_metric_value(results, metric, value)
+    verdict = gate.compare(results, _baseline())
+    assert verdict.findings == _finding(status, f"dimensions.{metric}", detail)
+    assert verdict.failed is True
+
+
+def test_a_change_inside_the_recorded_tolerance_is_green() -> None:
+    """The inclusive per-metric tolerance must absorb only deliberately recorded noise."""
+    results = _results()
+    _set_metric_value(results, "text_similarity", 0.81)
+    _set_metric_value(results, "edit_distance", 0.19)
+    verdict = gate.compare(results, _baseline())
+    assert verdict.findings == []
+    assert verdict.failed is False
+
+
+def test_a_missing_metric_is_red() -> None:
+    """Dropping a baseline dimension must not shrink coverage into a vacuous pass."""
+    results = _results()
+    del results["dimensions"]["text_similarity"]
+    verdict = gate.compare(results, _baseline())
+    assert verdict.findings == _finding(
+        "MISSING_METRIC",
+        "dimensions.text_similarity",
+        "baseline metric is missing from result",
+    )
+    assert verdict.failed is True
+
+
+def test_an_untracked_stale_metric_is_red() -> None:
+    """A result dimension absent from the baseline must force an explicit baseline decision."""
+    baseline = _baseline()
+    del baseline["dimensions"]["text_similarity"]
+    verdict = gate.compare(_results(), baseline)
+    assert verdict.findings == _finding(
+        "STALE_METRIC",
+        "dimensions.text_similarity",
+        "result metric is not recorded in baseline",
+    )
+    assert verdict.failed is True
+
+
+def test_identity_drift_is_red() -> None:
+    """Changing pinned corpus identity must never compare scores from different truth sets."""
+    results = _results()
+    results["provenance"]["annotation_sha256"] = "0" * 64
+    verdict = gate.compare(results, _baseline())
+    assert verdict.findings == _finding(
+        "IDENTITY_DRIFT",
+        "provenance.annotation_sha256",
+        'expected "2fafe9329dc92fc426b30036aee51c716b3fcdcc1d20cb964dc7670579533817", ' f'got "{"0" * 64}"',
+    )
+    assert verdict.failed is True
+
+
+def test_parser_policy_drift_is_red() -> None:
+    """A changed OCR policy must not compare scores produced by different parsers."""
+    results = _results()
+    results["provenance"]["parser_config"]["ocr"]["dpi"] = 300
+    verdict = gate.compare(results, _baseline())
+    assert verdict.findings == _finding(
+        "IDENTITY_DRIFT",
+        "provenance.parser_config",
+        'expected {"layout_analysis_mode": "auto", "ocr": {"dpi": 200, "enabled": true, '
+        '"engine": "tesseract", "languages": "eng+chi_sim", "mode": "auto"}}, got '
+        '{"layout_analysis_mode": "auto", "ocr": {"dpi": 300, "enabled": true, '
+        '"engine": "tesseract", "languages": "eng+chi_sim", "mode": "auto"}}',
+    )
+    assert verdict.failed is True
+
+
+def test_a_missing_required_identity_field_is_red() -> None:
+    """A missing schema version must fail closed rather than bypass identity comparison."""
+    results = _results()
+    del results["schema_version"]
+    verdict = gate.compare(results, _baseline())
+    assert verdict.findings == _finding(
+        "IDENTITY_DRIFT",
+        "schema_version",
+        "required identity field is missing from result",
+    )
+    assert verdict.failed is True
+
+
+def test_a_missing_page_count_is_red() -> None:
+    """Every pipeline-stage count is required so omitted pages cannot disappear silently."""
+    results = _results()
+    del results["pages"]["pdfs"]
+    verdict = gate.compare(results, _baseline())
+    assert verdict.findings == _finding(
+        "MISSING_PAGES",
+        "pages.pdfs",
+        "required page count is missing",
+    )
+    assert verdict.failed is True
+
+
+def test_missing_scored_pages_are_red() -> None:
+    """Fewer scored pages than expected must expose a truncated denominator."""
+    results = _results()
+    results["pages"]["scored"] = 2
+    results["pages"]["unique_ids"] = 2
+    verdict = gate.compare(results, _baseline())
+    assert verdict.findings == _finding(
+        "MISSING_PAGES",
+        "pages.scored",
+        "expected 3 scored pages (including conversion failures), got 2",
+    )
+    assert verdict.failed is True
+
+
+def test_duplicate_page_ids_are_red() -> None:
+    """Repeated scored page IDs must not satisfy the total by raw row count."""
+    results = _results()
+    results["pages"]["unique_ids"] = 2
+    verdict = gate.compare(results, _baseline())
+    assert verdict.findings == _finding(
+        "DUPLICATE_PAGES",
+        "pages.unique_ids",
+        "3 scored pages contain only 2 unique page IDs",
+    )
+    assert verdict.failed is True
+
+
+def test_a_zero_page_run_is_red() -> None:
+    """A zero-page result has no evidence and must never be reported as fidelity success."""
+    results = _results()
+    results["pages"] = dict.fromkeys(results["pages"], 0)
+    verdict = gate.compare(results, _baseline())
+    assert verdict.findings == _finding(
+        "ZERO_PAGES",
+        "pages.expected",
+        "a zero-page run cannot establish fidelity",
+    )
+    assert verdict.failed is True
+
+
+def test_a_truncated_page_selection_is_red() -> None:
+    """Lowering the run's declared expected count must expose a truncated corpus run."""
+    results = _results()
+    results["pages"] = {
+        "expected": 2,
+        "annotations": 2,
+        "pdfs": 2,
+        "converted": 1,
+        "scored": 2,
+        "unique_ids": 2,
+    }
+    verdict = gate.compare(results, _baseline())
+    assert verdict.findings == _finding(
+        "TRUNCATED_PAGES",
+        "pages.expected",
+        "expected 3 pages from baseline, got 2",
+    )
+    assert verdict.failed is True
+
+
+@pytest.mark.parametrize(
+    ("value", "status", "detail"),
+    [
+        (float("nan"), "NONFINITE_VALUE", "got NaN"),
+        (1.2, "OUT_OF_RANGE_VALUE", "expected a value in [0, 1], got 1.2"),
+    ],
+)
+def test_nonfinite_and_out_of_range_metric_values_are_red(
+    value: float,
+    status: str,
+    detail: str,
+) -> None:
+    """Invalid bounded metric values must fail instead of poisoning or flattering comparison."""
+    results = _results()
+    results["dimensions"]["text_similarity"]["value"] = value
+    verdict = gate.compare(results, _baseline())
+    assert verdict.findings == _finding(status, "dimensions.text_similarity.value", detail)
+    assert verdict.failed is True
+
+
+def test_a_missing_metric_member_is_red() -> None:
+    """Omitting a required dimension member must fail before score comparison."""
+    results = _results()
+    del results["dimensions"]["text_similarity"]["variance"]
+    verdict = gate.compare(results, _baseline())
+    assert verdict.findings == _finding(
+        "MISSING_METRIC",
+        "dimensions.text_similarity",
+        "missing required fields: variance",
+    )
+    assert verdict.failed is True
+
+
+def test_an_invalid_metric_direction_is_red() -> None:
+    """A direction outside the normalized higher/lower vocabulary must fail closed."""
+    results = _results()
+    results["dimensions"]["text_similarity"]["direction"] = "sideways"
+    verdict = gate.compare(results, _baseline())
+    assert verdict.findings == _finding(
+        "INVALID_DIRECTION",
+        "dimensions.text_similarity.direction",
+        "direction must be 'higher' or 'lower'",
+    )
+    assert verdict.failed is True
+
+
+def test_zero_eligible_items_are_red() -> None:
+    """A metric with no scored items must not retain a reassuring aggregate value."""
+    results = _results()
+    results["dimensions"]["text_similarity"]["eligible_items"] = 0
+    verdict = gate.compare(results, _baseline())
+    assert verdict.findings == _finding(
+        "ZERO_ELIGIBLE_ITEMS",
+        "dimensions.text_similarity.eligible_items",
+        "metric has no eligible items",
+    )
+    assert verdict.failed is True
+
+
+def test_zero_variance_is_red() -> None:
+    """A zero-variance aggregate must be treated as vacuous oracle output."""
+    results = _results()
+    results["dimensions"]["text_similarity"]["sample_scores"] = dict.fromkeys(
+        results["dimensions"]["text_similarity"]["sample_scores"],
+        0.8,
+    )
+    results["dimensions"]["text_similarity"]["variance"] = 0.0
+    verdict = gate.compare(results, _baseline())
+    assert verdict.findings == _finding(
+        "ZERO_VARIANCE",
+        "dimensions.text_similarity.variance",
+        "zero variance makes the aggregate vacuous",
+    )
+    assert verdict.failed is True
+
+
+def test_unreviewed_drift_into_unanimity_stays_red() -> None:
+    """Losing all spread against a baseline that recorded spread must still fail.
+
+    Unanimity is the classic vacuous pass: an oracle that stops discriminating reports a
+    stable aggregate. Accepting it is a reviewer decision recorded in the baseline, never
+    something a run may award itself.
+    """
+    results = _results()
+    scores = results["dimensions"]["text_similarity"]["sample_scores"]
+    results["dimensions"]["text_similarity"]["sample_scores"] = dict.fromkeys(scores, 0.8)
+    results["dimensions"]["text_similarity"]["value"] = 0.8
+    results["dimensions"]["text_similarity"]["variance"] = 0.0
+    baseline = _baseline()
+    baseline["dimensions"]["text_similarity"]["value"] = 0.8
+
+    statuses = [finding.status for finding in gate.compare(results, baseline).findings]
+    assert "ZERO_VARIANCE" in statuses
+
+
+def test_reviewed_unanimity_recorded_in_the_baseline_is_green() -> None:
+    """A genuinely 0/1-per-page metric must have a path through baseline review.
+
+    ``formula_presence_accuracy`` scores one bit per eligible page, so unanimous agreement is
+    a real outcome. Firing ZERO_VARIANCE unconditionally made that outcome permanently red
+    with no way to accept it, which turns a working gate into one maintainers must disable.
+    """
+    results = _results()
+    scores = results["dimensions"]["text_similarity"]["sample_scores"]
+    results["dimensions"]["text_similarity"]["sample_scores"] = dict.fromkeys(scores, 1.0)
+    results["dimensions"]["text_similarity"]["value"] = 1.0
+    results["dimensions"]["text_similarity"]["variance"] = 0.0
+    baseline = _baseline()
+    baseline["dimensions"]["text_similarity"]["value"] = 1.0
+    baseline["dimensions"]["text_similarity"]["variance"] = 0.0
+
+    verdict = gate.compare(results, baseline)
+    assert verdict.findings == []
+    assert verdict.failed is False
+
+
+def test_unanimity_at_the_worst_score_can_never_be_accepted() -> None:
+    """A metric that is unanimous at its floor must stay red even if a baseline records it.
+
+    ``baseline.json`` is bootstrapped from a single dispatched run. If that run is degenerate --
+    missing OCR models, an empty-text parser path -- every page scores 0.0 with zero variance.
+    Letting the baseline accept that unanimity mints a permanently green gate over a broken
+    parser and then reports the first working run as ``UNRECORDED_IMPROVEMENT``: the ratchet
+    installed upside down. Recording unanimity cannot make a floor score discriminating,
+    because nothing can move it further down.
+    """
+    results = _results()
+    scores = results["dimensions"]["text_similarity"]["sample_scores"]
+    results["dimensions"]["text_similarity"]["sample_scores"] = dict.fromkeys(scores, 0.0)
+    results["dimensions"]["text_similarity"]["value"] = 0.0
+    results["dimensions"]["text_similarity"]["variance"] = 0.0
+    baseline = _baseline()
+    baseline["dimensions"]["text_similarity"]["value"] = 0.0
+    baseline["dimensions"]["text_similarity"]["variance"] = 0.0
+
+    verdict = gate.compare(results, baseline)
+    assert [finding.status for finding in verdict.findings] == ["ZERO_VARIANCE"]
+
+    with pytest.raises(ValueError, match="ZERO_VARIANCE"):
+        gate.emit_baseline(results, default_tolerance=0.005)
+
+
+def test_zero_metrics_are_red() -> None:
+    """Mutually empty dimension mappings must not pass merely because they match."""
+    results = _results()
+    baseline = _baseline()
+    results["dimensions"] = {}
+    baseline["dimensions"] = {}
+    verdict = gate.compare(results, baseline)
+    assert verdict.findings == _finding(
+        "ZERO_METRICS",
+        "dimensions",
+        "a run with no metrics cannot establish fidelity",
+    )
+    assert verdict.failed is True
+
+
+def test_an_unexpected_conversion_failure_is_red() -> None:
+    """A new failed page must be ratcheted even when total page accounting remains valid."""
+    results = _results()
+    results["conversion_failures"]["page-002"] = "Parser crashed"
+    results["pages"]["converted"] = 1
+    results["pages"]["scored"] = 3
+    results["pages"]["unique_ids"] = 3
+    verdict = gate.compare(results, _baseline())
+    assert verdict.findings == _finding(
+        "UNEXPECTED_CONVERSION_FAILURE",
+        "page-002",
+        "Parser crashed",
+    )
+    assert verdict.failed is True
+
+
+def test_a_fixed_conversion_failure_is_red() -> None:
+    """A formerly failing page that converts must require removing its stale allowance."""
+    results = _results()
+    results["conversion_failures"] = {}
+    results["pages"]["converted"] = 3
+    results["pages"]["scored"] = 3
+    results["pages"]["unique_ids"] = 3
+    verdict = gate.compare(results, _baseline())
+    assert verdict.findings == _finding(
+        "FIXED_CONVERSION_FAILURE",
+        "page-003",
+        "expected 'Encrypted PDF', but page now converts",
+    )
+    assert verdict.failed is True
+
+
+def test_a_stale_conversion_failure_reason_is_red() -> None:
+    """A changed failure mode must not hide behind an allowance for a different error."""
+    results = _results()
+    results["conversion_failures"]["page-003"] = "Timeout"
+    verdict = gate.compare(results, _baseline())
+    assert verdict.findings == _finding(
+        "STALE_CONVERSION_FAILURE",
+        "page-003",
+        "expected 'Encrypted PDF', got 'Timeout'",
+    )
+    assert verdict.failed is True
+
+
+def test_an_absent_baseline_is_red() -> None:
+    """The first run without a reviewed comparison point must fail rather than self-bless."""
+    verdict = gate.compare(_results(), None)
+    assert verdict.findings == _finding(
+        "ABSENT_BASELINE",
+        "baseline",
+        "a committed baseline is required",
+    )
+    assert verdict.failed is True
+
+
+def test_baseline_emission_copies_identity_metrics_tolerances_and_failures() -> None:
+    """Emission must preserve the complete ratchet identity and produce its own green baseline."""
+    emitted = gate.emit_baseline(_results(), {"text_similarity": 0.02}, default_tolerance=0.005)
+    assert emitted == {
+        "schema_version": 2,
+        "provenance": RESULTS["provenance"],
+        "pages": RESULTS["pages"],
+        "dimensions": {
+            "edit_distance": {
+                "value": 0.2,
+                "direction": "lower",
+                "eligible_items": 3,
+                "variance": 0.006666666666666666,
+                "tolerance": 0.005,
+            },
+            "text_similarity": {
+                "value": 0.8,
+                "direction": "higher",
+                "eligible_items": 3,
+                "variance": 0.006666666666666668,
+                "tolerance": 0.02,
+            },
+        },
+        "expected_conversion_failures": {"page-003": "Encrypted PDF"},
+    }
+    assert gate.compare(_results(), emitted).findings == []
+
+
+def test_cli_formats_findings_concisely_and_returns_failure(tmp_path, capsys) -> None:
+    """The CLI must expose an exact one-line red finding and a failing exit status."""
+    results = _results()
+    _set_metric_value(results, "text_similarity", 0.78)
+    results_path = tmp_path / "results.json"
+    baseline_path = tmp_path / "baseline.json"
+    results_path.write_text(json.dumps(results), encoding="utf-8")
+    baseline_path.write_text(json.dumps(_baseline()), encoding="utf-8")
+    rc = gate.main([str(results_path), "--baseline", str(baseline_path)])
+    assert rc == 1
+    assert capsys.readouterr().out == (
+        "OMNIDOCBENCH GATE FAIL (1 finding(s))\n"
+        "REGRESSION dimensions.text_similarity: higher is better: baseline 0.8, result 0.78, tolerance 0.01\n"
+    )
+
+
+def test_cli_reports_a_missing_baseline_as_a_red_verdict(tmp_path, capsys) -> None:
+    """A missing baseline is the documented pre-bootstrap state: red (1), not an error (2).
+
+    Exit 1 means a fidelity verdict and exit 2 means a broken environment. The CLI used to
+    print the ABSENT_BASELINE verdict and then return 2, contradicting both the production
+    entrypoint and its own behavior for a baseline file containing ``{}``.
+    """
+    results_path = tmp_path / "results.json"
+    results_path.write_text(json.dumps(_results()), encoding="utf-8")
+    rc = gate.main([str(results_path), "--baseline", str(tmp_path / "absent.json")])
+    assert rc == 1
+    assert capsys.readouterr().out == (
+        "OMNIDOCBENCH GATE FAIL (1 finding(s))\n" "ABSENT_BASELINE baseline: a committed baseline is required\n"
+    )
+
+
+@pytest.mark.parametrize(
+    ("path", "value"),
+    [
+        (("schema_version",), None),
+        (("provenance", "dataset_revision"), ""),
+        (("provenance", "annotation_sha256"), "bad"),
+        (("provenance", "oracle_schema_version"), None),
+        (("provenance", "parser_config"), []),
+        (("provenance", "parser_runtime"), {}),
+    ],
+)
+def test_matching_malformed_baseline_identity_is_red(path: tuple[str, ...], value: object) -> None:
+    """Matching malformed identities must not let a result self-authorize."""
+    results = _results()
+    baseline = _baseline()
+    result_target = results
+    baseline_target = baseline
+    for part in path[:-1]:
+        result_target = result_target[part]
+        baseline_target = baseline_target[part]
+    result_target[path[-1]] = value
+    baseline_target[path[-1]] = value
+
+    verdict = gate.compare(results, baseline)
+
+    assert verdict.findings == [
+        gate.Finding(
+            "INVALID_BASELINE",
+            ".".join(path),
+            {
+                ("schema_version",): "must be integer 2",
+                ("provenance", "dataset_revision"): "must be a 40-character lowercase hexadecimal revision",
+                ("provenance", "annotation_sha256"): "must be a 64-character lowercase hexadecimal digest",
+                ("provenance", "oracle_schema_version"): "must be integer 3",
+                ("provenance", "parser_config"): "must be a mapping",
+                ("provenance", "parser_runtime"): "must be a non-empty mapping",
+            }[path],
+        )
+    ]
+
+
+def test_missing_parser_runtime_is_red() -> None:
+    """Parser runtime identity is required independently of parser options."""
+    results = _results()
+    del results["provenance"]["parser_runtime"]
+
+    assert gate.compare(results, _baseline()).findings == _finding(
+        "IDENTITY_DRIFT",
+        "provenance.parser_runtime",
+        "required identity field is missing from result",
+    )
+
+
+def test_malformed_parser_runtime_is_red() -> None:
+    """Runtime names and versions must both be non-empty strings."""
+    results = _results()
+    results["provenance"]["parser_runtime"] = {"tesseract": ""}
+
+    assert gate.compare(results, _baseline()).findings == _finding(
+        "IDENTITY_DRIFT",
+        "provenance.parser_runtime",
+        "names and versions must be non-empty strings",
+    )
+
+
+def test_parser_runtime_drift_is_red() -> None:
+    """A parser dependency version change requires a baseline decision."""
+    results = _results()
+    results["provenance"]["parser_runtime"]["tesseract"] = "5.4.0"
+
+    assert gate.compare(results, _baseline()).findings == _finding(
+        "IDENTITY_DRIFT",
+        "provenance.parser_runtime",
+        'expected {"pymupdf": "1.26.3", "tesseract": "5.3.0"}, ' 'got {"pymupdf": "1.26.3", "tesseract": "5.4.0"}',
+    )
+
+
+@pytest.mark.parametrize("field", ("annotations", "pdfs", "converted", "scored", "unique_ids"))
+def test_a_missing_baseline_page_count_is_red(field: str) -> None:
+    """Every baseline page-stage count is independently required."""
+    baseline = _baseline()
+    del baseline["pages"][field]
+
+    assert gate.compare(_results(), baseline).findings == _finding(
+        "INVALID_BASELINE",
+        f"pages.{field}",
+        "required page count is missing from baseline",
+    )
+
+
+@pytest.mark.parametrize("field", ("expected", "annotations", "pdfs", "converted", "scored", "unique_ids"))
+def test_a_malformed_baseline_page_count_is_red(field: str) -> None:
+    """Baseline counts must remain non-negative integers."""
+    baseline = _baseline()
+    baseline["pages"][field] = "three"
+
+    assert gate.compare(_results(), baseline).findings == _finding(
+        "INVALID_BASELINE",
+        f"pages.{field}",
+        'expected a non-negative integer, got "three"',
+    )
+
+
+def test_internally_inconsistent_baseline_pages_are_red() -> None:
+    """Baseline conversion accounting must include every expected failure."""
+    baseline = _baseline()
+    baseline["pages"]["converted"] = 1
+
+    assert gate.compare(_results(), baseline).findings == _finding(
+        "INVALID_BASELINE",
+        "pages.converted",
+        "1 converted + 1 expected failures accounts for 2 of 3 pages",
+    )
+
+
+@pytest.mark.parametrize("direction", ([], {}))
+def test_unhashable_result_direction_is_red(direction: object) -> None:
+    """JSON arrays and objects must become findings rather than TypeError."""
+    results = _results()
+    results["dimensions"]["text_similarity"]["direction"] = direction
+
+    assert gate.compare(results, _baseline()).findings == _finding(
+        "INVALID_DIRECTION",
+        "dimensions.text_similarity.direction",
+        "direction must be 'higher' or 'lower'",
+    )
+
+
+@pytest.mark.parametrize("direction", ([], {}))
+def test_unhashable_baseline_direction_is_red(direction: object) -> None:
+    """Malformed baseline directions must return deterministic findings."""
+    baseline = _baseline()
+    baseline["dimensions"]["text_similarity"]["direction"] = direction
+
+    assert gate.compare(_results(), baseline).findings == _finding(
+        "INVALID_BASELINE",
+        "dimensions.text_similarity.direction",
+        "direction must be 'higher' or 'lower'",
+    )
+
+
+def test_missing_sample_scores_are_red() -> None:
+    """An aggregate without exact page evidence must not pass."""
+    results = _results()
+    del results["dimensions"]["text_similarity"]["sample_scores"]
+
+    assert gate.compare(results, _baseline()).findings == _finding(
+        "MISSING_METRIC",
+        "dimensions.text_similarity",
+        "missing required fields: sample_scores",
+    )
+
+
+def test_declared_aggregate_and_variance_must_match_samples() -> None:
+    """Declared metric summaries must be recomputed from exact page scores."""
+    results = _results()
+    results["dimensions"]["text_similarity"]["sample_scores"] = {
+        "page-001": 0.5,
+        "page-002": 0.5,
+        "page-003": 0.5,
+    }
+    results["dimensions"]["text_similarity"]["value"] = 0.8
+    results["dimensions"]["text_similarity"]["variance"] = 0.1
+
+    assert gate.compare(results, _baseline()).findings == [
+        gate.Finding(
+            "IDENTITY_DRIFT",
+            "dimensions.text_similarity.variance",
+            "declared 0.1, recomputed 0.0 from sample_scores",
+        ),
+        gate.Finding(
+            "ZERO_VARIANCE",
+            "dimensions.text_similarity.variance",
+            "zero variance makes the aggregate vacuous",
+        ),
+        gate.Finding(
+            "IDENTITY_DRIFT",
+            "dimensions.text_similarity.value",
+            "declared 0.8, recomputed 0.5 from sample_scores",
+        ),
+        gate.Finding(
+            "REGRESSION",
+            "dimensions.text_similarity",
+            "higher is better: baseline 0.8, result 0.5, tolerance 0.01",
+        ),
+    ]
+
+
+@pytest.mark.parametrize(
+    ("metric", "value"),
+    [
+        ("text_similarity", 0.79),
+        ("edit_distance", 0.21),
+    ],
+)
+def test_regression_at_the_tolerance_boundary_is_green(metric: str, value: float) -> None:
+    """The recorded tolerance is inclusive on the regression side."""
+    results = _results()
+    _set_metric_value(results, metric, value)
+
+    assert gate.compare(results, _baseline()).findings == []
+
+
+def test_cli_rejects_duplicate_json_keys(tmp_path, capsys) -> None:
+    """Ambiguous JSON objects must fail before comparison."""
+    results_path = tmp_path / "results.json"
+    results_path.write_text('{"schema_version": null, "schema_version": 2}', encoding="utf-8")
+
+    assert gate.main([str(results_path), "--emit-baseline"]) == 2
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    assert captured.err == (
+        f"OMNIDOCBENCH GATE ERROR: cannot read strict JSON from {results_path}: "
+        "duplicate JSON key 'schema_version'\n"
+    )
+
+
+def test_cli_rejects_nonfinite_json_numbers(tmp_path, capsys) -> None:
+    """Non-standard NaN tokens must fail strict result loading."""
+    results_path = tmp_path / "results.json"
+    results_path.write_text('{"score": NaN}', encoding="utf-8")
+
+    assert gate.main([str(results_path), "--emit-baseline"]) == 2
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    assert captured.err == (
+        f"OMNIDOCBENCH GATE ERROR: cannot read strict JSON from {results_path}: " "non-finite JSON number NaN\n"
+    )
+
+
+def test_emit_baseline_rejects_invalid_identity() -> None:
+    """Baseline emission must not self-bless malformed identity."""
+    results = _results()
+    results["schema_version"] = None
+
+    with pytest.raises(ValueError, match="INVALID_BASELINE schema_version: must be integer 2"):
+        gate.emit_baseline(results)
+
+
+def test_a_tolerance_of_one_is_rejected_because_no_score_could_ever_breach_it() -> None:
+    """Guards the vacuous-tolerance escape.
+
+    Scores live in [0, 1], so a tolerance of 1 or more makes a dimension unable to fail: the worst
+    imaginable run still lands inside the band and the gate reports a clean pass. That is the same
+    defect ZERO_VARIANCE exists to catch, so the bound must be enforced when the baseline is read,
+    not just when it is emitted.
+    """
+    baseline = _baseline()
+    baseline["dimensions"]["text_similarity"]["tolerance"] = 1.0
+    results = _results()
+    _set_metric_value(results, "text_similarity", 0.0)
+
+    verdict = gate.compare(results, baseline)
+
+    assert verdict.failed
+    assert (
+        gate.Finding(
+            "INVALID_BASELINE",
+            "dimensions.text_similarity.tolerance",
+            "tolerance must be finite and in [0, 1)",
+        )
+        in verdict.findings
+    )
+
+
+def test_emit_baseline_refuses_a_tolerance_of_one() -> None:
+    """The emitter must reject the same vacuous band the comparator rejects.
+
+    Otherwise `--emit-baseline --default-tolerance 1` would mint a baseline that `compare` then
+    refuses, splitting the two halves of the contract.
+    """
+    with pytest.raises(ValueError, match=r"default tolerance must be finite and in \[0, 1\)"):
+        gate.emit_baseline(_results(), default_tolerance=1.0)
+    with pytest.raises(ValueError, match=r"tolerance for text_similarity must be finite and in \[0, 1\)"):
+        gate.emit_baseline(_results(), {"text_similarity": 1.5})
+
+
+def test_an_aggregate_within_tolerance_of_the_worst_score_is_vacuous() -> None:
+    """Guards the near-floor unanimity escape.
+
+    Exact-floor unanimity was already refused, but a single page scoring one part in a billion made
+    the variance non-zero and slipped past. Such a baseline is still permanently green, because no
+    later decline can exceed the tolerance from a value already at the floor. The rule therefore
+    has to measure distance to the floor against the recorded tolerance.
+    """
+    results = _results()
+    dimension = results["dimensions"]["text_similarity"]
+    dimension["sample_scores"] = {"page-001": 0.0, "page-002": 0.0, "page-003": 1e-9}
+    dimension["value"] = 1e-9 / 3
+    dimension["variance"] = 2.2222222222222224e-19
+
+    verdict = gate.compare(results, _baseline())
+
+    assert verdict.failed
+    assert [finding for finding in verdict.findings if finding.status == "ZERO_VARIANCE"] == [
+        gate.Finding(
+            "ZERO_VARIANCE",
+            "dimensions.text_similarity.value",
+            f"aggregate {1e-9 / 3} is within the recorded tolerance of the worst score 0.0",
+        )
+    ]
+
+
+def test_more_eligible_items_than_manifest_pages_is_a_finding() -> None:
+    """Each dimension scores a page at most once, so eligible items cannot exceed the manifest.
+
+    Without this sibling invariant a producer could inflate a weak aggregate by padding
+    `sample_scores` with page IDs no manifest entry could have produced, and every other declared
+    number would still be self-consistent.
+    """
+    results = _results()
+    baseline = _baseline()
+    for payload in (results, baseline):
+        payload["dimensions"]["text_similarity"]["eligible_items"] = 4
+    results["dimensions"]["text_similarity"]["sample_scores"]["page-004"] = 0.8
+
+    verdict = gate.compare(results, baseline)
+
+    assert verdict.failed
+    assert (
+        gate.Finding(
+            "INVALID_PAGE_COUNT",
+            "dimensions.text_similarity.eligible_items",
+            "declared 4 eligible items but the manifest holds only 3 pages",
+        )
+        in verdict.findings
+    )
+
+
+def test_an_integer_too_large_for_a_float_is_a_finding_not_a_traceback() -> None:
+    """`math.isfinite` raises OverflowError on a huge int, which JSON permits without notation.
+
+    A hostile or corrupt result file must yield an ordinary finding and exit 1, never an uncaught
+    traceback that leaves the run with no verdict at all.
+    """
+    results = _results()
+    results["dimensions"]["text_similarity"]["sample_scores"]["page-001"] = 10**400
+
+    verdict = gate.compare(results, _baseline())
+
+    assert verdict.failed
+    assert [finding.status for finding in verdict.findings] == ["OUT_OF_RANGE_VALUE"]
+
+
+def test_a_dirty_worktree_cannot_match_a_baseline_recorded_from_a_clean_one() -> None:
+    """`worktree_dirty` was recorded on both sides but never compared, making it dead evidence.
+
+    The field exists to prove the measurement came from the committed tree, so it has to be an
+    identity field like every other provenance entry rather than decoration in the JSON.
+    """
+    results = _results()
+    results["provenance"]["worktree_dirty"] = True
+
+    verdict = gate.compare(results, _baseline())
+
+    assert verdict.failed
+    assert (
+        gate.Finding(
+            "IDENTITY_DRIFT",
+            "provenance.worktree_dirty",
+            "expected false, got true",
+        )
+        in verdict.findings
+    )
+
+
+def test_a_baseline_omitting_worktree_dirty_is_invalid() -> None:
+    """A baseline predating the field must fail closed rather than silently skip the comparison."""
+    baseline = _baseline()
+    del baseline["provenance"]["worktree_dirty"]
+
+    verdict = gate.compare(_results(), baseline)
+
+    assert verdict.failed
+    assert (
+        gate.Finding(
+            "INVALID_BASELINE",
+            "provenance.worktree_dirty",
+            "required identity field is missing from baseline",
+        )
+        in verdict.findings
+    )

--- a/tests/unit/test_omnidocbench_oracles.py
+++ b/tests/unit/test_omnidocbench_oracles.py
@@ -1,0 +1,538 @@
+"""Behavioral tests for direct annotation and AST fidelity projections."""
+
+from __future__ import annotations
+
+import pytest
+from hypothesis import given, settings
+from hypothesis import strategies as st
+
+from all2md.ast.nodes import (
+    CodeBlock,
+    Document,
+    Heading,
+    MathBlock,
+    MathInline,
+    Paragraph,
+    Table,
+    TableCell,
+    TableRow,
+    Text,
+)
+from benchmarks.omnidocbench import oracles
+from benchmarks.omnidocbench.oracles import (
+    FormulaProjection,
+    PageProjection,
+    TableProjection,
+    content_similarity,
+    project_annotation,
+    project_ast,
+    score_page,
+)
+
+pytestmark = pytest.mark.unit
+
+
+def test_annotation_projection_uses_order_and_supported_ground_truth() -> None:
+    """External facts must come from annotation fields, not from an all2md renderer."""
+    record = {
+        "page_info": {"image_path": "nested/page-7.jpg"},
+        "layout_dets": [
+            {
+                "category_type": "text_block",
+                "order": 3,
+                "text": "Body",
+                "ignore": False,
+                "line_with_spans": [
+                    {"category_type": "text_span", "text": "Body"},
+                    {"category_type": "equation_inline", "latex": "$a$"},
+                    {"category_type": "equation_inline", "latex": "$ignored$", "ignore": True},
+                ],
+            },
+            {"category_type": "code_txt", "order": 2, "text": "print(1)", "ignore": False},
+            {
+                "category_type": "table",
+                "order": 4,
+                "html": "<table><tr><th colspan='2'>Head</th></tr><tr><td>A</td><td>B</td></tr></table>",
+                "ignore": False,
+            },
+            {"category_type": "title", "order": 1, "text": "Title", "ignore": False},
+            {
+                "category_type": "equation_isolated",
+                "order": 5,
+                "latex": "$$x + y$$",
+                "ignore": False,
+            },
+            {
+                "category_type": "figure",
+                "order": 6,
+                "ignore": False,
+                "line_with_spans": [{"category_type": "equation_inline", "latex": "$b$"}],
+            },
+            {"category_type": "footer", "order": 7, "ignore": True},
+        ],
+    }
+
+    truth = project_annotation(record)
+
+    assert truth.page_id == "page-7"
+    assert truth.projection.text_blocks == ("Title", "print(1)", "Body", "Head A B")
+    assert truth.projection.block_kinds == (
+        "title",
+        "text_block",
+        "text_block",
+        "table",
+        "equation_isolated",
+    )
+    assert truth.projection.tables == (TableProjection(2, 2, 4, "Head A B"),)
+    assert truth.projection.formulas == (
+        FormulaProjection("inline", "$a$"),
+        FormulaProjection("block", "$$x + y$$"),
+        FormulaProjection("inline", "$b$"),
+    )
+    assert truth.unscored_categories == {"figure": 1}
+    assert truth.explicitly_ignored == 2
+
+
+def test_ast_projection_reads_nodes_directly_in_document_order() -> None:
+    """Scoring must inspect one AST and preserve its semantic block order."""
+    table = Table(
+        header=TableRow(cells=[TableCell(content=[Text(content="Head")], colspan=2)]),
+        rows=[
+            TableRow(
+                cells=[
+                    TableCell(content=[Text(content="A")]),
+                    TableCell(content=[Text(content="B")]),
+                ]
+            )
+        ],
+    )
+    document = Document(
+        children=[
+            Heading(level=1, content=[Text(content="Title")]),
+            CodeBlock(content="print(1)"),
+            Paragraph(
+                content=[
+                    Text(content="Body"),
+                    MathInline(
+                        content="<math>a</math>",
+                        notation="mathml",
+                        representations={"latex": "a"},
+                    ),
+                ]
+            ),
+            table,
+            MathBlock(
+                content="<math>x + y</math>",
+                notation="mathml",
+                representations={"latex": "x + y"},
+            ),
+        ]
+    )
+
+    projection = project_ast(document)
+
+    assert projection.text_blocks == ("Title", "print(1)", "Body <math>a</math>", "Head A B")
+    assert projection.block_kinds == (
+        "title",
+        "text_block",
+        "text_block",
+        "table",
+        "equation_isolated",
+    )
+    assert projection.tables == (TableProjection(2, 2, 4, "Head A B"),)
+    assert projection.formulas == (
+        FormulaProjection("inline", "a"),
+        FormulaProjection("block", "x + y"),
+    )
+
+
+def test_page_scores_have_exact_independent_dimension_semantics() -> None:
+    """Each metric must react to the fact it names rather than a shared output-length proxy."""
+    expected = PageProjection(
+        text_blocks=("A B",),
+        block_kinds=("title", "text_block", "table"),
+        tables=(TableProjection(2, 2, 4, "A B"),),
+        formulas=(FormulaProjection("block", "$$x$$"),),
+    )
+    actual = PageProjection(
+        text_blocks=("AB",),
+        block_kinds=("title", "table"),
+        tables=(TableProjection(1, 2, 2, "AB"),),
+        formulas=(),
+    )
+
+    scores = score_page(expected, actual)
+
+    assert scores == {
+        "text_content_similarity": pytest.approx(2 / 3),
+        "reading_order_similarity": pytest.approx(2 / 3),
+        "formula_presence_accuracy": 0.0,
+        "table_structure_similarity": pytest.approx(2 / 3),
+        "table_content_similarity": pytest.approx(2 / 3),
+        "formula_content_similarity": 0.0,
+    }
+
+
+def test_latin_word_boundary_loss_is_penalized_but_cjk_glyph_spacing_is_not() -> None:
+    """Losing every inter-word space must cost score; OCR's inter-glyph CJK spaces must not.
+
+    Deleting all whitespace made 'thequickbrownfox' score a perfect 1.0 against
+    'the quick brown fox' on the 316 predominantly-Latin pinned pages, so a parser that
+    regressed to space-free extraction kept full credit. The CJK rationale is real -- OCR
+    inserts spurious spaces between ideographs -- so whitespace is deleted only where it
+    touches ideographic text and collapsed to a single space everywhere else.
+    """
+    latin = PageProjection(("the quick brown fox",), ("text_block",), (), ())
+    spaceless = PageProjection(("thequickbrownfox",), ("text_block",), (), ())
+    assert score_page(latin, spaceless)["text_content_similarity"] < 0.85
+
+    cjk = PageProjection(("发票金额合计",), ("text_block",), (), ())
+    spaced_cjk = PageProjection(("发 票 金 额 合 计",), ("text_block",), (), ())
+    assert score_page(cjk, spaced_cjk)["text_content_similarity"] == 1.0
+
+
+def test_every_text_bearing_annotation_category_is_ground_truth() -> None:
+    """A parser must not score higher for dropping captions, headers, footers, or references.
+
+    The dataset annotates text in eleven categories beyond text_block/title/code_txt. Scoring
+    only that subset compared a filtered ground truth against the whole-page AST, so losing
+    9.3% of the corpus text scored 1.0 while perfect fidelity scored 0.82 -- and on 63 pinned
+    pages perfect fidelity scored exactly 0.0. The projection must cover the whole page.
+    """
+    assert {
+        "equation_caption",
+        "figure_caption",
+        "figure_footnote",
+        "footer",
+        "header",
+        "page_footnote",
+        "page_number",
+        "reference",
+        "table_caption",
+        "table_footnote",
+    } <= oracles.TEXT_CATEGORIES
+
+    record = {
+        "page_info": {"page_no": 0, "image_path": "p.jpg", "height": 10, "width": 10},
+        "layout_dets": [
+            {"category_type": "header", "text": "Journal of Things", "order": 0},
+            {"category_type": "text_block", "text": "Body", "order": 1},
+            {"category_type": "figure_caption", "text": "Figure 1. A plot", "order": 2},
+            {"category_type": "page_number", "text": "7", "order": 3},
+        ],
+    }
+
+    truth = oracles.project_annotation(record)
+
+    assert truth.projection.text_blocks == ("Journal of Things", "Body", "Figure 1. A plot", "7")
+    assert truth.projection.block_kinds == ("text_block",) * 4
+    assert truth.unscored_categories == {}
+
+    dropped = PageProjection(("Body",), ("text_block",), (), ())
+    assert score_page(truth.projection, dropped)["text_content_similarity"] < 0.3
+
+
+def test_formula_similarity_preserves_latex_case_and_semantic_whitespace() -> None:
+    """Text normalization must not conflate distinct case-sensitive LaTeX."""
+    expected = PageProjection((), (), (), (FormulaProjection("block", r"\Gamma"),))
+
+    case_score = score_page(
+        expected,
+        PageProjection((), (), (), (FormulaProjection("block", r"\gamma"),)),
+    )
+    whitespace_score = score_page(
+        PageProjection((), (), (), (FormulaProjection("block", r"\text{a b}"),)),
+        PageProjection((), (), (), (FormulaProjection("block", r"\text{ab}"),)),
+    )
+    delimited_score = score_page(
+        PageProjection((), (), (), (FormulaProjection("block", "$$x + y$$"),)),
+        PageProjection((), (), (), (FormulaProjection("block", "x + y"),)),
+    )
+
+    assert case_score["formula_content_similarity"] < 1.0
+    assert whitespace_score["formula_content_similarity"] < 1.0
+    assert delimited_score["formula_content_similarity"] == 1.0
+
+
+def test_table_alignment_recovers_later_exact_matches_without_reordering() -> None:
+    """An early omission must not shift every later table comparison, and swaps must not score as exact."""
+    alpha = TableProjection(1, 1, 1, "alpha")
+    beta = TableProjection(1, 1, 1, "beta")
+    expected = PageProjection((), ("table", "table"), (alpha, beta), ())
+
+    omitted = score_page(expected, PageProjection((), ("table",), (beta,), ()))
+    reversed_order = score_page(expected, PageProjection((), ("table", "table"), (beta, alpha), ()))
+    exact = score_page(expected, PageProjection((), ("table", "table"), (alpha, beta), ()))
+
+    assert omitted["table_content_similarity"] == pytest.approx(0.5)
+    assert exact["table_content_similarity"] == 1.0
+    assert reversed_order["table_content_similarity"] == pytest.approx(0.2)
+    assert reversed_order["table_structure_similarity"] == 1.0
+
+
+def test_formula_metrics_are_absent_when_no_page_side_has_a_formula() -> None:
+    """A parser with no math capability must not bank credit from formula-free pages."""
+    plain = PageProjection(("Body",), ("text_block",), (), ())
+
+    assert score_page(plain, plain) == {
+        "text_content_similarity": 1.0,
+        "reading_order_similarity": 1.0,
+    }
+
+    missed = score_page(
+        PageProjection((), (), (), (FormulaProjection("block", "a"),)),
+        plain,
+    )
+    assert missed["formula_presence_accuracy"] == 0.0
+    assert missed["formula_content_similarity"] == 0.0
+
+
+def test_formula_alignment_matches_only_like_kinds_in_document_order() -> None:
+    """Inline and block formulas are distinct even when their LaTeX is identical."""
+    expected = PageProjection(
+        (),
+        (),
+        (),
+        (
+            FormulaProjection("inline", "a"),
+            FormulaProjection("block", "b"),
+        ),
+    )
+
+    omitted_inline = score_page(
+        expected,
+        PageProjection((), (), (), (FormulaProjection("block", "b"),)),
+    )
+    wrong_kind = score_page(
+        PageProjection((), (), (), (FormulaProjection("inline", "x"),)),
+        PageProjection((), (), (), (FormulaProjection("block", "x"),)),
+    )
+
+    assert omitted_inline["formula_content_similarity"] == pytest.approx(0.5)
+    assert wrong_kind["formula_presence_accuracy"] == 1.0
+    assert wrong_kind["formula_content_similarity"] == 0.0
+
+
+def test_text_similarity_normalizes_unicode_and_layout_whitespace() -> None:
+    """CJK OCR spacing and compatibility glyphs must not masquerade as content loss."""
+    assert content_similarity("Ａ 中\n文", "a中文") == 1.0
+    assert content_similarity("abc", "") == 0.0
+    assert content_similarity("", "") == 1.0
+
+
+def test_text_similarity_is_exact_normalized_levenshtein() -> None:
+    """Substitutions and insertions must have the documented edit-distance cost."""
+    assert content_similarity("kitten", "sitting") == pytest.approx(4 / 7)
+
+
+def _reference_edit_distance(left: str, right: str) -> int:
+    previous = list(range(len(right) + 1))
+    for left_index, left_character in enumerate(left, 1):
+        current = [left_index]
+        for right_index, right_character in enumerate(right, 1):
+            current.append(
+                min(
+                    current[-1] + 1,
+                    previous[right_index] + 1,
+                    previous[right_index - 1] + (left_character != right_character),
+                )
+            )
+        previous = current
+    return previous[-1]
+
+
+@pytest.mark.fuzzing
+@settings(deadline=None)
+@given(
+    st.text(alphabet="abc中文", max_size=8),
+    st.text(alphabet="abc中文", max_size=8),
+)
+def test_bit_parallel_edit_distance_matches_reference(left: str, right: str) -> None:
+    """The optimized Unicode oracle must equal the simple dynamic-programming contract.
+
+    The example budget is deliberately left to the repository's Hypothesis profile, so a pull
+    request draws the ``dev`` count and the scheduled ``HYPOTHESIS_PROFILE=ci`` run draws more.
+    Pinning ``max_examples`` here would override that profile on every leg, which is what #230
+    measured as roughly 160 times more expensive in CI than locally.
+
+    Short draws cannot exercise the bit-parallel pattern's carry behaviour, so
+    :func:`test_edit_distance_is_exact_across_machine_word_boundaries` covers length explicitly.
+    """
+    assert oracles._edit_distance(left, right) == _reference_edit_distance(left, right)
+
+
+@pytest.mark.parametrize("length", [1, 31, 32, 33, 63, 64, 65, 66, 127, 128, 129, 200])
+def test_edit_distance_is_exact_across_machine_word_boundaries(length: int) -> None:
+    """Length must not change the answer, including where a bit-parallel pattern would carry.
+
+    ``_edit_distance`` is Myers' bit-vector algorithm over Python integers. Those are unbounded,
+    so there is no 64-bit block to get wrong, but nothing proved that: the property test above
+    draws at most 8 characters, so no number of examples ever crossed a word boundary. The pinned
+    corpus carries strings up to 2482 characters, so the untested range is the operational one.
+    """
+    left = "ab中文x" * (length // 5 + 1)
+    left = left[:length]
+    assert oracles._edit_distance(left, left) == 0
+    assert oracles._edit_distance(left, "") == length
+    substituted = ("z" if left[-1] != "z" else "y") + left[1:]
+    assert oracles._edit_distance(left, substituted) == _reference_edit_distance(left, substituted)
+    deleted = left[:-1]
+    assert oracles._edit_distance(left, deleted) == _reference_edit_distance(left, deleted)
+    reversed_text = left[::-1]
+    assert oracles._edit_distance(left, reversed_text) == _reference_edit_distance(left, reversed_text)
+
+
+def test_recovering_table_text_beats_deleting_the_table() -> None:
+    """A parser must never score higher for dropping a table than for recovering its cells.
+
+    Ground truth put table cell text only in ``tables``, while the AST side left it in
+    ``text_blocks`` whenever no real ``Table`` node was built. On all 317 pinned pages with table
+    ground truth, deleting the table beat emitting its cells as a paragraph -- by a full point on
+    some pages. Cell text now belongs to the text stream on both sides.
+    """
+    html = "<table><tr><td>Alpha</td><td>Beta</td></tr></table>"
+    truth = oracles.project_annotation(
+        {
+            "page_info": {"page_no": 0, "image_path": "p.jpg", "height": 100, "width": 100},
+            "layout_dets": [
+                {"category_type": "text_block", "text": "Body", "order": 0, "poly": [0, 10] * 4},
+                {"category_type": "table", "html": html, "order": 1, "poly": [0, 50] * 4},
+            ],
+        }
+    ).projection
+
+    assert truth.text_blocks == ("Body", "Alpha Beta")
+
+    kept_as_text = PageProjection(("Body", "Alpha Beta"), ("text_block", "text_block"), (), ())
+    deleted = PageProjection(("Body",), ("text_block",), (), ())
+
+    kept = score_page(truth, kept_as_text)["text_content_similarity"]
+    dropped = score_page(truth, deleted)["text_content_similarity"]
+    assert kept == 1.0
+    assert dropped < kept
+
+
+def test_unordered_running_content_is_placed_by_geometry() -> None:
+    """Dropping a header must not outscore emitting it in its true position.
+
+    Every header, footer, page number, and page footnote in the pinned dataset carries
+    ``order: null``. Sorting those last appended running content after the body, so a parser that
+    emitted the header first mismatched the ground truth and a parser that deleted the header
+    matched it better -- a mean inversion on 663 of 981 pages. A category-only rank is not enough:
+    about one page number in seven sits at the top of the page.
+    """
+    record = {
+        "page_info": {"page_no": 0, "image_path": "p.jpg", "height": 1000, "width": 800},
+        "layout_dets": [
+            {"category_type": "text_block", "text": "Body", "order": 5, "poly": [0, 400] * 4},
+            {"category_type": "header", "text": "Journal", "order": None, "poly": [0, 40] * 4},
+            {"category_type": "footer", "text": "Copyright", "order": None, "poly": [0, 960] * 4},
+            {"category_type": "page_number", "text": "7", "order": None, "poly": [0, 20] * 4},
+        ],
+    }
+
+    truth = oracles.project_annotation(record).projection
+
+    assert truth.text_blocks == ("7", "Journal", "Body", "Copyright")
+
+    visual = PageProjection(truth.text_blocks, truth.block_kinds, (), ())
+    without_header = PageProjection(("7", "Body", "Copyright"), ("text_block",) * 3, (), ())
+    assert score_page(truth, visual)["text_content_similarity"] == 1.0
+    assert score_page(truth, without_header)["text_content_similarity"] < 1.0
+
+
+def test_reversed_output_cannot_score_a_perfect_reading_order() -> None:
+    """Reading order must detect reordering, not just block-category coverage.
+
+    Eleven text categories collapse to ``text_block``, so an edit similarity over the kind
+    sequence returned exactly 1.0 for fully reversed output on 153 pinned pages, and every
+    permutation was free on the 113 pages whose kinds are a single repeated token.
+    """
+    expected = PageProjection(("Alpha", "Beta", "Gamma"), ("text_block",) * 3, (), ())
+    forward = PageProjection(("Alpha", "Beta", "Gamma"), ("text_block",) * 3, (), ())
+    reversed_blocks = PageProjection(("Gamma", "Beta", "Alpha"), ("text_block",) * 3, (), ())
+
+    assert score_page(expected, forward)["reading_order_similarity"] == 1.0
+    assert score_page(expected, reversed_blocks)["reading_order_similarity"] == 0.0
+
+
+def test_spurious_spaces_around_fullwidth_punctuation_are_ignored() -> None:
+    """Correct CJK extraction must not be penalized for the OCR artefact the rule targets.
+
+    NFKC folds fullwidth punctuation to ASCII, so running the whitespace deletion only after
+    normalization left spurious spaces beside those glyphs in place and depressed the score on
+    588 of the 743 pinned pages containing them; it now costs score on none. The substitution runs
+    on both sides of NFKC.
+    """
+    tight = PageProjection(("（6）计算：",), ("text_block",), (), ())
+    spaced = PageProjection((" （ 6 ） 计算 ： ",), ("text_block",), (), ())
+    assert score_page(tight, spaced)["text_content_similarity"] == 1.0
+
+    latin = PageProjection(("the quick brown fox",), ("text_block",), (), ())
+    spaceless = PageProjection(("thequickbrownfox",), ("text_block",), (), ())
+    assert score_page(latin, spaceless)["text_content_similarity"] < 0.85
+
+
+def test_inline_equations_inside_code_are_not_ground_truth() -> None:
+    """A ``CodeBlock`` holds a plain string, so a formula inside code can never be matched.
+
+    Harvesting that span created ground truth no AST can satisfy, which showed up as the last
+    residual monotonicity inversion: a degraded parser outscored perfect fidelity on formula
+    presence for one pinned page.
+
+    The span shape here is the one the pinned dataset actually uses: ``line_with_spans`` is a flat
+    list of spans carrying ``category_type`` directly. All 69718 spans in the pinned annotation
+    are that shape and none nests them under a ``spans`` key, so a nested fixture would be skipped
+    before reaching the guard and would pass with the guard deleted.
+    """
+    record = {
+        "page_info": {"page_no": 0, "image_path": "p.jpg", "height": 100, "width": 100},
+        "layout_dets": [
+            {
+                "category_type": "code_txt",
+                "text": "x = $a$",
+                "order": 0,
+                "poly": [0, 10] * 4,
+                "line_with_spans": [{"category_type": "equation_inline", "latex": "$a$"}],
+            }
+        ],
+    }
+
+    truth = oracles.project_annotation(record)
+
+    assert truth.projection.formulas == ()
+    assert truth.projection.text_blocks == ("x = $a$",)
+
+
+def test_identical_output_scores_a_perfect_reading_order_despite_repeated_blocks() -> None:
+    """Byte-identical output must be the ceiling, so the order term cannot self-penalize.
+
+    Matching each emitted block to its most similar ground-truth block by unconstrained argmax
+    sent every repetition of one string to the same index, which registered as an inversion and
+    capped self-comparison at 0.9973 across the pinned corpus. Ties now resolve towards the
+    block's own position.
+    """
+    page = PageProjection(("Same", "Same", "Same", "Tail"), ("text_block",) * 4, (), ())
+    assert score_page(page, page)["reading_order_similarity"] == 1.0
+
+
+def test_a_paragraph_holding_table_cells_costs_exactly_one_kind_substitution() -> None:
+    """Recovering a table as a paragraph must be charged for segmentation and nothing else.
+
+    The expected cost is one substitution in the block-kind coverage term, ``1 - 1/n``. Because
+    table cell text now sits in both text streams, that variant's blocks are byte-identical to
+    exact reproduction and sit at the same indices, so the order-agreement factor must be exactly
+    1.0. Anything lower would mean the agreement term double-charges a variant whose order is
+    right, and the ratchet would red the first time all2md starts recovering table cells.
+    """
+    truth = PageProjection(
+        ("Intro", "A B"),
+        ("text_block", "table"),
+        (TableProjection(1, 2, 2, "A B"),),
+        (),
+    )
+    paragraph = PageProjection(("Intro", "A B"), ("text_block", "text_block"), (), ())
+
+    scores = score_page(truth, paragraph)
+    assert scores["text_content_similarity"] == 1.0
+    assert scores["reading_order_similarity"] == 1 - 1 / len(truth.block_kinds)

--- a/tests/unit/test_omnidocbench_pipeline.py
+++ b/tests/unit/test_omnidocbench_pipeline.py
@@ -1,0 +1,144 @@
+"""Wiring tests that compose real benchmark evidence with the real fidelity ratchet.
+
+Every other OmniDocBench suite exercises one module against hand-built fixtures. That
+left one gap wide open: ``benchmark.normalize_results`` stamped ``schema_version`` 2
+while ``gate`` still accepted only 1, so every real ``--write-baseline`` run and every
+scheduled gate run failed identity validation even though all module suites were green.
+These tests refuse to let the two halves drift apart again by feeding genuine
+``normalize_results`` output straight into ``emit_baseline`` and ``compare``.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from benchmarks.omnidocbench import benchmark, gate, run
+from benchmarks.omnidocbench.corpus import CorpusPage, CorpusSnapshot
+from benchmarks.omnidocbench.oracles import GroundTruthPage, PageProjection
+
+pytestmark = pytest.mark.unit
+
+PARSER_RUNTIME = {
+    "pymupdf": "1.28.4",
+    "tesseract": "tesseract 5.3.0",
+    "tessdata_eng_sha256": "b" * 64,
+}
+
+
+def _snapshot(tmp_path: Path, page_ids: tuple[str, ...]) -> CorpusSnapshot:
+    return CorpusSnapshot(
+        revision="f5f559bddf50e36f7f9899d842d0006f13ce8afc",
+        annotation_path=tmp_path / "OmniDocBench.json",
+        pages=tuple(
+            CorpusPage(
+                page_id=page_id,
+                image_path=f"images/{page_id}.jpg",
+                pdf_path=tmp_path / f"{page_id}.pdf",
+                sha256="a" * 64,
+                size_bytes=100,
+            )
+            for page_id in page_ids
+        ),
+        expected_pages=len(page_ids),
+        complete=True,
+    )
+
+
+def _real_result(tmp_path: Path, scores: tuple[float, ...]) -> dict[str, object]:
+    """Build ratchet input the same way a full corpus run does."""
+    page_ids = tuple(f"page-{index}" for index in range(len(scores)))
+    return benchmark.normalize_results(
+        snapshot=_snapshot(tmp_path, page_ids),
+        ground_truth={
+            page_id: GroundTruthPage(
+                page_id=page_id,
+                projection=PageProjection(("Body",), ("text_block",), (), ()),
+                unscored_categories={},
+                explicitly_ignored=0,
+            )
+            for page_id in page_ids
+        },
+        evaluations=[
+            benchmark.PageEvaluation(
+                page_id=page_id,
+                scores={"text_content_similarity": score, "reading_order_similarity": score},
+                predicted_tables=0,
+                predicted_formulas=0,
+                duration_seconds=0.1,
+            )
+            for page_id, score in zip(page_ids, scores, strict=True)
+        ],
+        all2md_commit="c" * 40,
+        parser_runtime=PARSER_RUNTIME,
+    )
+
+
+def test_emitted_baseline_accepts_the_run_that_produced_it(tmp_path: Path) -> None:
+    """A real run must be able to bootstrap its own baseline; a schema mismatch here kills the lane."""
+    result = _real_result(tmp_path, (0.4, 0.8))
+
+    candidate = gate.emit_baseline(result, default_tolerance=0.005)
+    verdict = gate.compare(result, candidate)
+
+    assert candidate["schema_version"] == benchmark.SCHEMA_VERSION
+    assert not verdict.failed, gate.format_verdict(verdict)
+
+
+def test_gate_supports_exactly_the_schema_the_benchmark_emits() -> None:
+    """The producer and the validator share one artifact contract, not two."""
+    assert gate._SUPPORTED_SCHEMA_VERSION == benchmark.SCHEMA_VERSION
+    assert gate._SUPPORTED_ORACLE_SCHEMA_VERSION == benchmark.ORACLE_SCHEMA_VERSION
+
+
+def test_real_regression_beyond_tolerance_is_red(tmp_path: Path) -> None:
+    """A measured fidelity drop past tolerance must fail the composed pipeline."""
+    baseline = gate.emit_baseline(_real_result(tmp_path, (0.4, 0.8)), default_tolerance=0.005)
+    regressed = _real_result(tmp_path, (0.3, 0.8))
+
+    verdict = gate.compare(regressed, baseline)
+
+    assert verdict.failed
+    assert any(finding.status == "REGRESSION" for finding in verdict.findings), gate.format_verdict(verdict)
+
+
+def test_real_improvement_requires_baseline_review(tmp_path: Path) -> None:
+    """An unrecorded gain must also be red so the baseline stays the reviewed source of truth."""
+    baseline = gate.emit_baseline(_real_result(tmp_path, (0.4, 0.8)), default_tolerance=0.005)
+    improved = _real_result(tmp_path, (0.6, 0.9))
+
+    verdict = gate.compare(improved, baseline)
+
+    assert verdict.failed
+    assert any(finding.status == "UNRECORDED_IMPROVEMENT" for finding in verdict.findings), gate.format_verdict(verdict)
+
+
+def test_both_entrypoints_report_a_missing_baseline_as_a_red_verdict(tmp_path: Path) -> None:
+    """``gate`` and ``run`` must agree that the pre-bootstrap state is red, not broken.
+
+    Exit 1 means a fidelity verdict and exit 2 means a broken environment; any wrapper that
+    distinguishes them misclassifies the documented ABSENT_BASELINE state if the two
+    entrypoints disagree. The CLI used to print the red verdict and then return 2.
+    """
+    results_path = tmp_path / "current.json"
+    results_path.write_text(json.dumps(_real_result(tmp_path, (0.4, 0.8))), encoding="utf-8")
+
+    assert gate.main([str(results_path), "--baseline", str(tmp_path / "absent.json")]) == 1
+
+
+def test_the_production_entrypoint_rejects_a_duplicate_key_baseline(tmp_path: Path) -> None:
+    """The strict loader must guard the path CI actually runs.
+
+    ``gate._load_json`` rejects duplicate keys and non-finite literals precisely because a
+    reviewed ratchet cannot trust either: a human reads the first duplicate in a diff, while
+    permissive ``json.loads`` keeps the last. The workflow only ever invokes
+    ``python -m benchmarks.omnidocbench``, so reading the baseline there with plain
+    ``json.loads`` left that hardening dead exactly where the baseline is trusted.
+    """
+    baseline_path = tmp_path / "baseline.json"
+    baseline_path.write_text('{"schema_version": 2, "schema_version": 99}', encoding="utf-8")
+
+    with pytest.raises(RuntimeError, match="duplicate JSON key"):
+        run._read_json(baseline_path)

--- a/tests/unit/test_omnidocbench_run.py
+++ b/tests/unit/test_omnidocbench_run.py
@@ -1,0 +1,314 @@
+"""Behavioral tests for the OmniDocBench end-to-end command."""
+
+from __future__ import annotations
+
+import hashlib
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from benchmarks.omnidocbench import run
+
+pytestmark = pytest.mark.unit
+
+
+def _args(tmp_path: Path, *extra: str):
+    return run._build_parser().parse_args(
+        [
+            "--cache-dir",
+            str(tmp_path / "cache"),
+            *extra,
+        ]
+    )
+
+
+def _stub_scored_run(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    dirty: bool,
+    failure: bool,
+) -> dict[str, object]:
+    snapshot = SimpleNamespace(
+        revision="pinned",
+        pages=(SimpleNamespace(page_id="page-a"),),
+        expected_pages=1,
+        complete=True,
+    )
+    observed: dict[str, object] = {"events": [], "writes": []}
+
+    def fake_identity() -> tuple[str, bool]:
+        observed["events"].append("identity")
+        return "a" * 40, dirty
+
+    def fake_load(*_args, **_kwargs):
+        observed["events"].append("load")
+        return snapshot
+
+    def fake_evaluate(*_args, **_kwargs):
+        observed["events"].append("evaluate")
+        error_type = "RuntimeError" if failure else None
+        return [SimpleNamespace(error_type=error_type)]
+
+    def fake_normalize(**kwargs):
+        observed["normalize_kwargs"] = kwargs
+        failures = {"page-a": "RuntimeError: broken PDF"} if failure else {}
+        return {"provenance": {}, "conversion_failures": failures}
+
+    def fake_write(payload, path):
+        observed["writes"].append((payload, path))
+        return path
+
+    monkeypatch.setattr(run, "_git_identity", fake_identity)
+    monkeypatch.setattr(run, "load_corpus", fake_load)
+    monkeypatch.setattr(run, "_parser_runtime", lambda _languages: {"pymupdf": "1.28.4"})
+    monkeypatch.setattr(run, "load_ground_truth", lambda _snapshot: {})
+    monkeypatch.setattr(run, "evaluate_corpus", fake_evaluate)
+    monkeypatch.setattr(run, "normalize_results", fake_normalize)
+    monkeypatch.setattr(run, "write_result", fake_write)
+    return observed
+
+
+def test_limited_run_cannot_enter_the_full_corpus_gate(tmp_path: Path) -> None:
+    """A convenient smoke subset must never be mistaken for the 981-page fidelity gate."""
+    args = _args(tmp_path, "--limit", "5")
+
+    with pytest.raises(ValueError, match="--limit requires --skip-gate"):
+        run.run(args)
+
+
+def test_limited_run_cannot_emit_a_baseline(tmp_path: Path) -> None:
+    """A truncated denominator must not become the committed fidelity reference."""
+    args = _args(
+        tmp_path,
+        "--limit",
+        "5",
+        "--skip-gate",
+        "--write-baseline",
+        str(tmp_path / "baseline.json"),
+    )
+
+    with pytest.raises(ValueError, match="complete 981-page corpus"):
+        run.run(args)
+
+
+def test_download_only_validates_corpus_without_parsing(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Operators must be able to prefill the licensed cache without OCR work."""
+    snapshot = SimpleNamespace(revision="pinned", pages=(object(), object()), expected_pages=981)
+    calls: list[tuple[Path, int | None, int]] = []
+
+    def fake_load(cache_dir: Path, *, limit: int | None, workers: int):
+        calls.append((cache_dir, limit, workers))
+        return snapshot
+
+    monkeypatch.setattr(run, "load_corpus", fake_load)
+    args = _args(
+        tmp_path,
+        "--limit",
+        "2",
+        "--skip-gate",
+        "--download-only",
+        "--download-workers",
+        "3",
+    )
+
+    assert run.run(args) == 0
+    assert calls == [(tmp_path / "cache", 2, 3)]
+
+
+def test_parser_runtime_records_every_pdf_and_ocr_implementation(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A dependency or OCR-model change must alter ratchet identity instead of silently changing scores."""
+    versions = {
+        "PyMuPDF": "1.28.4",
+        "pymupdf-layout": "1.28.2",
+        "pytesseract": "0.3.13",
+        "Pillow": "11.3.0",
+    }
+    (tmp_path / "eng.traineddata").write_bytes(b"english-model")
+    (tmp_path / "chi_sim.traineddata").write_bytes(b"chinese-model")
+
+    def fake_subprocess(command, **_kwargs):
+        if command[1] == "--list-langs":
+            return SimpleNamespace(stdout=f'List of available languages in "{tmp_path}" (2):\n', stderr="")
+        return SimpleNamespace(stdout="tesseract 5.3.0\n leptonica-1.82.0\n", stderr="")
+
+    monkeypatch.setattr(run.metadata, "version", versions.__getitem__)
+    monkeypatch.setattr(run.subprocess, "run", fake_subprocess)
+
+    assert run._parser_runtime("eng+chi_sim") == {
+        "pymupdf": "1.28.4",
+        "pymupdf_layout": "1.28.2",
+        "pytesseract": "0.3.13",
+        "pillow": "11.3.0",
+        "tesseract": "tesseract 5.3.0",
+        "tessdata_chi_sim_sha256": hashlib.sha256(b"chinese-model").hexdigest(),
+        "tessdata_eng_sha256": hashlib.sha256(b"english-model").hexdigest(),
+    }
+
+
+def test_missing_ocr_language_data_fails_instead_of_scoring(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A missing traineddata file must stop the run, never silently change OCR behavior."""
+    monkeypatch.setattr(
+        run.subprocess,
+        "run",
+        lambda *_args, **_kwargs: SimpleNamespace(
+            stdout=f'List of available languages in "{tmp_path}" (0):\n', stderr=""
+        ),
+    )
+
+    with pytest.raises(RuntimeError, match="cannot read pinned OCR language data"):
+        run._language_digests("eng")
+
+
+@pytest.mark.parametrize(
+    ("status", "dirty"),
+    [("", False), (" M benchmarks/omnidocbench/run.py\n", True), ("?? new-file.py\n", True)],
+)
+def test_git_identity_records_explicit_worktree_state(
+    monkeypatch: pytest.MonkeyPatch,
+    status: str,
+    dirty: bool,
+) -> None:
+    """Committed, modified, and untracked source states must remain distinguishable."""
+    outputs = iter(["b" * 40 + "\n", status])
+    commands: list[list[str]] = []
+
+    def fake_run(command: list[str], **_kwargs):
+        commands.append(command)
+        return SimpleNamespace(stdout=next(outputs))
+
+    monkeypatch.setattr(run.subprocess, "run", fake_run)
+
+    assert run._git_identity() == ("b" * 40, dirty)
+    assert commands == [
+        ["git", "rev-parse", "HEAD"],
+        ["git", "status", "--porcelain=v1", "--untracked-files=normal"],
+    ]
+
+
+@pytest.mark.parametrize(
+    ("extra", "expected_status"),
+    [([], 1), (["--allow-conversion-failures"], 0)],
+    ids=["fail-closed", "explicitly-allowed"],
+)
+def test_skip_gate_requires_explicit_conversion_failure_permission(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    extra: list[str],
+    expected_status: int,
+) -> None:
+    """Skipping the ratchet must not silently turn failed page conversions green."""
+    _stub_scored_run(monkeypatch, dirty=False, failure=True)
+    args = _args(tmp_path, "--skip-gate", *extra)
+
+    assert run.run(args) == expected_status
+
+
+def test_gate_still_authorizes_recorded_conversion_failures(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The normal gate remains the authority for reviewed expected failures."""
+    observed = _stub_scored_run(monkeypatch, dirty=False, failure=True)
+    baseline_path = tmp_path / "baseline.json"
+    baseline_path.write_text("{}", encoding="utf-8")
+    baseline = {"expected_conversion_failures": {"page-a": "RuntimeError: broken PDF"}}
+    verdict = SimpleNamespace(failed=False)
+    comparisons: list[tuple[object, object]] = []
+    monkeypatch.setattr(run, "_read_json", lambda _path: baseline)
+    monkeypatch.setattr(
+        run,
+        "compare",
+        lambda actual, expected: comparisons.append((actual, expected)) or verdict,
+    )
+    monkeypatch.setattr(run, "format_verdict", lambda _verdict: "gate passed")
+
+    assert run.run(_args(tmp_path, "--baseline", str(baseline_path))) == 0
+    assert comparisons == [(observed["writes"][0][0], baseline)]
+
+
+def test_dirty_worktree_cannot_emit_a_baseline(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Baseline evidence must never claim a commit that excludes evaluated source edits."""
+    monkeypatch.setattr(run, "_git_identity", lambda: ("c" * 40, True))
+
+    def fail_load(*_args, **_kwargs):
+        raise AssertionError("dirty baseline must fail before corpus work")
+
+    monkeypatch.setattr(run, "load_corpus", fail_load)
+    args = _args(tmp_path, "--write-baseline", str(tmp_path / "candidate.json"))
+
+    with pytest.raises(RuntimeError, match="dirty worktree"):
+        run.run(args)
+
+
+def test_result_records_source_identity_before_evaluation(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Every result must identify both the loaded commit and its dirty-worktree state."""
+    observed = _stub_scored_run(monkeypatch, dirty=True, failure=False)
+
+    assert run.run(_args(tmp_path, "--skip-gate")) == 0
+    assert observed["events"].index("identity") < observed["events"].index("evaluate")
+    assert observed["normalize_kwargs"]["all2md_commit"] == "a" * 40
+    assert observed["normalize_kwargs"]["worktree_dirty"] is True
+
+
+def test_absent_baseline_is_a_red_gate_verdict_not_an_environment_error(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Before the first accepted baseline the gate must fail closed with ABSENT_BASELINE.
+
+    The lane ships without ``baseline.json`` and bootstraps it from a dispatched CI run. A
+    missing file previously surfaced as ``cannot read JSON from ...`` and exit 2, which
+    reports a reviewable bootstrap state as a broken environment. This pins the honest
+    contract: the ratchet still refuses to pass, but it does so as a fidelity verdict.
+    """
+    _stub_scored_run(monkeypatch, dirty=False, failure=False)
+    missing = tmp_path / "no-such-baseline.json"
+
+    verdict = run.compare({"schema_version": 2}, {})
+    assert verdict.failed
+    assert [finding.status for finding in verdict.findings] == ["ABSENT_BASELINE"]
+
+    seen: list[object] = []
+    monkeypatch.setattr(
+        run,
+        "compare",
+        lambda _actual, expected: seen.append(expected) or SimpleNamespace(failed=True),
+    )
+    monkeypatch.setattr(run, "format_verdict", lambda _verdict: "red")
+
+    assert run.run(_args(tmp_path, "--baseline", str(missing))) == 1
+    assert seen == [{}]
+
+
+def test_unlistable_tesseract_is_reported_as_an_environment_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A Tesseract that cannot list its languages must not masquerade as a fidelity regression.
+
+    ``_tessdata_dir`` shells out to ``tesseract --list-langs`` with ``check=True``. A
+    ``CalledProcessError`` is a ``SubprocessError``, not an ``OSError``, so it escaped
+    ``run.main``'s handler entirely and exited 1, the gate-FAIL code. Every sibling
+    subprocess call site converts failure into this module's ``RuntimeError`` contract so
+    ``main`` can report exit 2 instead.
+    """
+
+    def fake_run(command, **_kwargs):
+        raise run.subprocess.CalledProcessError(1, command)
+
+    monkeypatch.setattr(run.subprocess, "run", fake_run)
+
+    with pytest.raises(RuntimeError, match="cannot list the installed Tesseract languages"):
+        run._tessdata_dir()


### PR DESCRIPTION
## What

Adds `benchmarks/omnidocbench`: an external-ground-truth PDF fidelity lane that scores all2md's
AST against pinned OmniDocBench v1.0 annotations, plus a fail-closed ratchet and a monthly
scheduled workflow. This is the "independent external ground truth" item from `ROADMAP.md` (#214).

Nothing under `src/` changes. Normal dev/runtime dependencies are unchanged; the scheduled
workflow uses the existing `pdf_layout` and `ocr` extras from the lockfile.

## How it measures

- Pins every external input by immutable identity: dataset revision
  `f5f559bddf50e36f7f9899d842d0006f13ce8afc`, `OmniDocBench.json` SHA-256
  `2fafe93...533817`, 981 annotations and 981 page PDFs.
- Calls `all2md.to_ast` **once per page** and compares AST facts directly with annotation
  fields. It never renders Markdown, never reparses, and never runs the official evaluator's
  prediction parser, so the measurement cannot be contaminated by a Markdown round trip.
- Six higher-is-better dimensions: text content, reading order, table structure, table content,
  formula presence, formula content. Each records the aggregate, the eligible-page denominator,
  the population variance, and every exact page score.
- Corpus bytes are never committed or uploaded. The cache is gitignored and revision-qualified,
  the dataset is research-only, and CI artifacts contain only derived score JSON.

## Fail-closed by construction

The lane was built by attacking its own ability to produce a green:

- **Capability gaps are reported, not scored.** all2md's PDF path emits no `Table` and no
  `MathBlock`/`MathInline` nodes today, so those dimensions are reported in
  `unsupported_dimensions` rather than silently kept. Scoring is union-scoped, so a page with
  no annotated *and* no emitted item of a kind is never scored at all: a math-incapable parser
  cannot bank true negatives.
- **The ground truth is the whole page.** Every text-bearing annotation category is scored
  (`header`, `footer`, `page_number`, `figure_caption`, `table_caption`, `equation_caption`, the
  three footnote kinds, `reference`, plus `text_block`/`title`/`code_txt`). Scoring only the
  first three would compare a filtered subset with a whole-page AST, which rewards content loss:
  an empty document scored 1.0 on 63 pinned pages under that projection. It now scores 0.0.
- **Whitespace deletion is scoped to CJK.** OCR inserts spurious spaces between ideographs, so
  whitespace is deleted only where it touches ideographic text and collapsed elsewhere. Deleting
  all whitespace let total Latin word-boundary loss score a perfect 1.0 on a third of the corpus.
  The deletion runs on both sides of NFKC, because NFKC folds fullwidth punctuation to ASCII and
  would otherwise leave the spurious spaces beside those glyphs in place, depressing the score on
  588 of the 743 pinned pages that contain them, and on none after.
- **Every metric is monotone.** Three ways to be paid for losing content were found and closed:
  unordered running content (`order: null` on all 1271 `header`, 669 `page_number`, 541 `footer`,
  and 75 `page_footnote` annotations) sorted last, so deleting a header beat emitting it on 663
  pages; table cell text lived only in the annotation's `tables`, so dropping a table beat
  recovering its cells as a paragraph on all 317 pages with table ground truth; and reading order
  was an edit similarity over a category sequence that collapses eleven text categories to one
  token, so fully reversed output scored exactly 1.0 on 141 pages. Unordered content is now
  placed by polygon geometry, table text joins both text streams, and reading order is scaled by
  the order agreement of content-matched blocks. Recovering a table's cells as a paragraph now
  costs exactly one kind substitution and nothing else, so it strictly beats deleting the table on
  all 317 pages with table ground truth (text 1.0000 vs 0.6015 on those pages, identical order).
- **Identity drift is red.** Dataset revision, annotation digest, oracle schema, parser policy,
  and parser runtime (including PyMuPDF/pymupdf-layout/pytesseract/Pillow/Tesseract versions and
  the SHA-256 of each `.traineddata` file) are compared for exact equality.
- **Vacuous aggregates are red.** Zero pages, zero metrics, zero eligible items, changed
  denominators, non-finite or out-of-range values, declared values that disagree with the
  recorded samples, and loss of all page-to-page spread all fail. Unanimity is acceptable only
  when the baseline records it *and* the unanimous value is not the metric's worst possible
  score, so a genuinely 0/1-per-page metric stays reviewable while a degenerate bootstrap run
  cannot mint a permanently green baseline over a broken parser.
- **Improvements are red too.** An unrecorded improvement fails, so the baseline cannot drift
  into describing a parser that no longer exists.
- Degraded conversions count as page failures. The one exception is `table_rejected`: refusing a
  non-tabular grid is a correct decision the table and reading-order metrics already score.

## Cost and CI placement

Full evaluation is OCR-bound, so it runs only on a monthly cron or manual dispatch, on
`ubuntu-24.04`, installed with `uv sync --frozen`. Pull-request and release CI are untouched;
the 136 synthetic adapter/oracle/ratchet/wiring tests are network-free and run in the normal
unit suite.

`benchmarks/omnidocbench/baseline.json` is intentionally not in this PR. Parser-runtime identity
is part of the baseline, so a baseline recorded on my machine would report `IDENTITY_DRIFT`
against every CI run. Bootstrap it by dispatching the workflow with `record_baseline` enabled and
committing the reviewed candidate; until then the gate reports `ABSENT_BASELINE` red, which is
the documented fail-closed state.

## Verification

- `benchmarks/omnidocbench` unit lane: 136 tests pass; `black`, `ruff check --no-fix`, and
  `mypy benchmarks/omnidocbench` are clean.
- Full existing suite passes (only pre-existing xfails).
- Full pinned corpus scored locally: 981/981 pages, 981 unique IDs, 0 conversion failures;
  `text_content_similarity` 0.5058 (variance 0.1169), `reading_order_similarity` 0.1176
  (variance 0.0181), both denominators 981. `table_fidelity` and `formula_fidelity` are reported
  unsupported, each naming both the converted-page count and how many pages carry that kind of
  ground truth (317 table pages, 260 formula pages), so the erased eligibility stays measurable.
- Monotonicity proved over all 981 pinned pages, 11 degraded variants, and all 6 dimensions:
  exact reproduction of the annotation scores 1.0000/1.0000 (text/reading order) and **no**
  variant scores higher on any dimension. Drop captions and footnotes 0.9432/0.8985, drop
  headers/footers/page numbers 0.9541/0.7900, drop the header only 0.9799/0.9083, drop references
  0.9898/0.9893, drop tables 0.8712/0.9550, keep table cells as a paragraph 1.0000/0.9550,
  merge all text into one paragraph 1.0000/0.1294, reverse block order 0.3311/0.0198, empty
  document 0.0000/0.0000. On 40 real pages the parser averages 0.485 text similarity where an
  empty document averages 0.000; under the earlier filtered projection the empty document won on
  63 pages.
- Ratchet proven end to end on that full-corpus result: self-comparison green, a -0.05 score
  shift red as `REGRESSION`, a +0.05 shift red as `UNRECORDED_IMPROVEMENT`, a missing baseline
  red as `ABSENT_BASELINE`, and `emit_baseline` refuses a truncated corpus.
