### PR TITLE
ci: test on Windows for Python 3.13

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -133,6 +133,47 @@ jobs:
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
+  test-windows:
+    name: Test (Windows, Python 3.13)
+    runs-on: windows-latest
+
+    # Every other job in this file runs on ubuntu-latest, so until now nothing here could
+    # see a POSIX-only assumption. `benchmarks/omnidocbench` shipped a cache lock built on
+    # `fcntl.flock` that refused to run at all off POSIX: CI was green while the same
+    # commit failed 21 tests and produced 4 mypy errors on a Windows checkout. Windows is
+    # a supported platform for a library whose users mostly arrive through the CLI, so it
+    # gets a leg.
+    #
+    # One version, not a matrix: what this covers is the OS, and paying five times for it
+    # would buy interpreter differences the ubuntu matrix already reports. 3.13 because it
+    # is the fastest of the versions we support.
+    #
+    # It keeps `matrix_single`, which the ubuntu legs drop. That exclusion is sound for its
+    # own reason -- parser and renderer logic does not vary by interpreter -- but it does
+    # vary by OS: path separators, filename rules, newline translation, and the locale
+    # encoding are exactly what those tests touch. `generative` is excluded for the same
+    # reason as on 3.12: it is fixed-seed and belongs on a schedule (fuzz-corpus.yml).
+    #
+    # PYTHONUTF8 is deliberately not set. A Windows user gets the ANSI code page by
+    # default on 3.13, so setting it here would hide the encoding failures they would hit.
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v7
+
+      - name: Set up Python 3.13
+        uses: actions/setup-python@v7
+        with:
+          python-version: "3.13"
+          cache: 'pip'
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e ".[all,dev]"
+
+      - name: Run tests
+        run: pytest tests/ -v --durations=25 -m "not generative"
+
   roundtrip:
     name: Roundtrip Fidelity Gate
     runs-on: ubuntu-latest
@@ -426,7 +467,7 @@ jobs:
     # (The Release created here uses GITHUB_TOKEN, whose `release: published`
     # event would not start release.yml anyway.)
     if: startsWith(github.ref, 'refs/tags/v')
-    needs: [lint-and-typecheck, docs, test, roundtrip, startup, security-semgrep, security-bandit]
+    needs: [lint-and-typecheck, docs, test, test-windows, roundtrip, startup, security-semgrep, security-bandit]
     runs-on: ubuntu-latest
 
     steps:

--- a/tests/e2e/test_view_cli.py
+++ b/tests/e2e/test_view_cli.py
@@ -28,7 +28,9 @@ class TestViewCLIEndToEnd:
         """Clean up test environment."""
         cleanup_test_dir(self.temp_dir)
 
-    def _run_cli(self, args: list[str], mock_browser: bool = True) -> subprocess.CompletedProcess:
+    def _run_cli(
+        self, args: list[str], mock_browser: bool = True, cwd: Path | None = None
+    ) -> subprocess.CompletedProcess:
         """Run the CLI as a subprocess.
 
         Parameters
@@ -37,6 +39,8 @@ class TestViewCLIEndToEnd:
             Command line arguments to pass to the CLI
         mock_browser : bool
             If True, mock webbrowser.open to prevent browser launches
+        cwd : Path | None
+            Working directory for the subprocess. Defaults to the repository root.
 
         Returns
         -------
@@ -55,7 +59,7 @@ class TestViewCLIEndToEnd:
 
         return subprocess.run(
             cmd,
-            cwd=self.cli_path.parent.parent.parent,
+            cwd=cwd or self.cli_path.parent.parent.parent,
             capture_output=True,
             text=True,
             env=env,
@@ -362,14 +366,18 @@ The quadratic formula: $x = \\frac{-b \\pm \\sqrt{b^2-4ac}}{2a}$
         md_file = self._create_test_markdown()
         output_file = self.temp_dir / "output.html"
 
-        # Use relative path notation
-        rel_path = os.path.relpath(md_file, Path.cwd())
+        # Run from the file's own directory rather than relativizing against the
+        # repository root: on Windows the temp dir and the checkout can sit on
+        # different drives, and a relative path between two drives does not exist --
+        # `os.path.relpath` raises ValueError before the CLI is ever invoked. The
+        # GitHub Windows runner checks out to D: and puts TEMP on C:, so this test
+        # could only ever have passed where both happened to share a drive.
+        rel_path = md_file.name
 
-        result = self._run_cli(["view", rel_path, "--keep", str(output_file)])
+        result = self._run_cli(["view", rel_path, "--keep", str(output_file)], cwd=self.temp_dir)
 
-        # May succeed or fail depending on working directory
-        # Just verify it handles relative paths without crashing
-        assert result.returncode == 0 or "Error" in result.stderr
+        assert result.returncode == 0, result.stderr
+        assert output_file.exists()
 
     def test_view_preserves_markdown_formatting(self):
         """Test that view preserves markdown formatting in HTML output."""


### PR DESCRIPTION
Every job in `ci.yml` runs on `ubuntu-latest`, so nothing in CI could see a POSIX-only assumption.

That cost us a whole module last week: `benchmarks/omnidocbench` shipped a cache lock built on `fcntl.flock` that refused to run at all off POSIX. CI was green on the same commit that failed 21 tests and produced 4 mypy errors on a Windows checkout — it was caught only because the suite got run there by hand (#244).

**What the leg does**

- `windows-latest`, Python 3.13 only. What it covers is the OS; the ubuntu matrix already reports interpreter differences, and 3.13 is the fastest version we support.
- Keeps `matrix_single`, which the ubuntu legs drop. That exclusion is sound for its own reason — parser and renderer logic does not vary by interpreter — but it does vary by OS: path separators, filename rules, newline translation and the locale encoding are exactly what those tests touch.
- Excludes `generative` for the same reason the 3.12 leg does: fixed-seed, belongs on a schedule.
- `PYTHONUTF8` is deliberately unset, so the leg sees the ANSI code page a Windows user gets by default on 3.13 rather than hiding their encoding failures.
- Added to the `release` job's `needs`, so a tagged release is gated on it too.

**Verification**

The full non-`generative` suite was run on a Windows 11 checkout before wiring the gate, so this is not expected to land red. The cost is one more required job; the ubuntu legs run ~6m, so budget roughly double that here — worth measuring on this run before deciding whether it wants `-n auto`.

**Still open after this**

Lint and type checks cover `src/` and `tests/` only — `benchmarks/` (~2,700 lines) is in no gate. Separate change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)