### PR TITLE
fix(asciidoc): end a table row after the last cell, not after a delimiter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,6 +72,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **AsciiDoc: a table no longer gains a phantom column.** Rows were written with a
+  trailing delimiter — `|A |B |` — and AsciiDoc reads whatever follows the final `|`
+  as one more cell, so every N-column table parsed back as N+1. It was silent and it
+  did not depend on the contents: a one-column table came back with two. The extra
+  column also persisted into anything converted onward from that AsciiDoc. Each cell
+  is now introduced by its own delimiter and the row ends with the last cell's content.
+  Fixing the renderer exposed the matching parser gap: a span spec belongs to the cell
+  *after* it, so canonical AsciiDoc writes `|A 2+|B`, and the parser only recognized
+  the spec when it stood alone in its own segment — the form the old renderer happened
+  to emit. Hand-written `|A 2+|B` silently lost the span. Both forms parse now. Output
+  changes for anyone diffing rendered AsciiDoc tables (#235).
+
 - **Org: a source block above the first heading is no longer deleted.** Text before the
   first `*` heading went through a filter meant to keep file properties such as
   `#+TITLE:` out of the body, and it dropped *every* line starting with `#+`. Org spells

--- a/src/all2md/parsers/asciidoc.py
+++ b/src/all2md/parsers/asciidoc.py
@@ -1999,6 +1999,22 @@ class AsciiDocParser(BaseParser):
             # Strip whitespace but preserve empty cells
             content_text = part.strip()
 
+            # A span spec that belongs to the *next* cell sits at the end of this
+            # segment. Canonical AsciiDoc writes `|A 2+|B`, so splitting on `|`
+            # leaves `A 2+` here and `B` after; only the standalone `|A |2+|B`
+            # form, which our renderer used to emit, put the spec in a segment of
+            # its own. A spec has to be set off by whitespace or be the whole
+            # segment, so a cell reading `C2+` stays content.
+            if self.options.parse_table_spans:
+                trailing = re.search(r"(?:^|(?<=\s))(\d+)?(?:\.(\d+))?([+*])$", content_text)
+                if trailing and (trailing.group(1) or trailing.group(2)):
+                    if trailing.group(3) == "+":
+                        pending_colspan = int(trailing.group(1)) if trailing.group(1) else None
+                        pending_rowspan = int(trailing.group(2)) if trailing.group(2) else None
+                    elif trailing.group(1):
+                        pending_colspan = int(trailing.group(1))
+                    content_text = content_text[: trailing.start()].strip()
+
             # If content is empty and we have a span, this is likely a standalone
             # span spec (like |2+| where the content is in the next part)
             # Save the span for the next cell and skip this part

--- a/src/all2md/renderers/asciidoc.py
+++ b/src/all2md/renderers/asciidoc.py
@@ -516,14 +516,19 @@ class AsciiDocRenderer(NodeVisitor, InlineContentMixin, BaseRenderer):
             return ""
 
         def render_row(cells: list[TableCell]) -> None:
-            # A span spec attaches to the cell after the `|` it precedes, so the
-            # first cell's spec has to replace the row-opening `|` rather than
-            # follow it — otherwise it would apply to a phantom empty cell.
-            self._output.append((cell_span(cells[0]) if cells else "") or "|")
+            # Every cell is *introduced* by its `|`, and the row ends with the last
+            # cell's content. A trailing delimiter would open one more cell: AsciiDoc
+            # reads whatever follows the final `|` as another cell, so a row written
+            # `|A |B |` parsed as three columns and every N-column table came back
+            # with N+1. A span spec such as `2+|` carries its own delimiter, which is
+            # why it replaces the `|` rather than following it.
+            if not cells:
+                return
             for index, cell in enumerate(cells):
                 content = self._render_inline_content(cell.content)
-                prefix = "" if index == 0 else cell_span(cell)
-                self._output.append(f"{prefix}{content} |")
+                delimiter = cell_span(cell) or "|"
+                separator = "" if index == 0 else " "
+                self._output.append(f"{separator}{delimiter}{content}")
             self._output.append("\n")
 
         # Render header

--- a/tests/golden/__snapshots__/test_renderer_outputs_golden.ambr
+++ b/tests/golden/__snapshots__/test_renderer_outputs_golden.ambr
@@ -23,9 +23,9 @@
   
   .Key Metrics
   |===
-  |Metric |Value |
-  |Velocity |22.5 m/s |
-  |Acceleration |9.8 m/s^2 |
+  |Metric |Value
+  |Velocity |22.5 m/s
+  |Acceleration |9.8 m/s^2
   |===
   
   '''

--- a/tests/unit/renderers/test_asciidoc_renderer.py
+++ b/tests/unit/renderers/test_asciidoc_renderer.py
@@ -908,15 +908,41 @@ class TestTableRendering:
         result = AsciiDocRenderer().render_to_string(doc)
 
         # The leading cell's spec replaces the row-opening `|`; a `|2+|Wide`
-        # form would read as an empty cell followed by a spanning one.
-        assert result == "|===\n2+|Wide |.3+|Tall |2.3+|Both |\n|===\n"
+        # form would read as an empty cell followed by a spanning one. The row
+        # ends with the last cell's content and no trailing delimiter.
+        assert result == "|===\n2+|Wide .3+|Tall 2.3+|Both\n|===\n"
 
         reparsed = AsciiDocParser().parse(result)
         table = reparsed.children[0]
         assert isinstance(table, Table)
         cells = table.header.cells if table.header else table.rows[0].cells
-        assert [(c.colspan, c.rowspan) for c in cells[:3]] == [(2, 1), (1, 3), (2, 3)]
-        assert [c.content[0].content for c in cells[:3]] == ["Wide", "Tall", "Both"]
+        assert len(cells) == 3
+        assert [(c.colspan, c.rowspan) for c in cells] == [(2, 1), (1, 3), (2, 3)]
+        assert [c.content[0].content for c in cells] == ["Wide", "Tall", "Both"]
+
+    @pytest.mark.parametrize("columns", [1, 2, 3, 5])
+    def test_a_table_round_trips_with_the_column_count_it_was_given(self, columns: int) -> None:
+        """A row must not end with a delimiter, which would open one more cell.
+
+        AsciiDoc reads whatever follows the final `|` as another cell, so the
+        `|A |B |` form the renderer used to emit parsed as three columns. Every
+        table was affected regardless of its contents -- an N-column table came
+        back with N+1, silently, and the spurious column persisted into anything
+        converted onward from that AsciiDoc.
+        """
+        header = TableRow(cells=[TableCell(content=[Text(content=f"h{i}")]) for i in range(columns)])
+        body = TableRow(cells=[TableCell(content=[Text(content=f"c{i}")]) for i in range(columns)])
+        doc = Document(children=[Table(header=header, rows=[body])])
+
+        rendered = AsciiDocRenderer().render_to_string(doc)
+        reparsed = AsciiDocParser().parse(rendered)
+
+        table = reparsed.children[0]
+        assert isinstance(table, Table)
+        assert table.header is not None
+        assert len(table.header.cells) == columns
+        assert [len(row.cells) for row in table.rows] == [columns]
+        assert [cell.content[0].content for cell in table.header.cells] == [f"h{i}" for i in range(columns)]
 
 
 @pytest.mark.unit

--- a/tests/unit/test_roundtrip_fuzzing.py
+++ b/tests/unit/test_roundtrip_fuzzing.py
@@ -479,10 +479,6 @@ KNOWN_INVARIANT_GAPS: dict[tuple[str, str], str] = {
         "asciidoc",
         "heading-levels-survive",
     ): "renderer offsets every level by one; level 6 overflows and is dropped (#236)",
-    # asciidoc writes a trailing pipe after the last cell, which its parser reads
-    # as an extra empty column. This is not specific to duplicate headers — every
-    # table goes in with N columns and comes back with N+1 (#235).
-    ("asciidoc", "duplicate-header-labels-survive"): "trailing pipe adds a phantom column to every table (#235)",
     # The ordered-list start attribute, from opposite ends (#239): asciidoc emits
     # no `[start=N]`, while org emits a literal `5.` its own parser will not read
     # back as a start.


### PR DESCRIPTION
Closes #235.

## Renderer

Rows were written `|A |B |`. AsciiDoc reads whatever follows the final `|` as one more cell, so every table came back one column wider:

| columns rendered | columns after round trip (before) | after |
|---|---|---|
| 1 | 2 | 1 |
| 2 | 3 | 2 |
| 3 | 4 | 3 |
| 5 | 6 | 5 |

Silent, independent of contents, and the spurious column persisted into anything converted onward from that AsciiDoc. Each cell is now introduced by its own delimiter and the row ends with the last cell's content.

## Parser (the half the issue didn't predict)

Removing the trailing pipe broke the existing colspan/rowspan test, which turned out to be the interesting result rather than an inconvenience.

A span spec applies to the cell **after** it, so canonical AsciiDoc writes:

```asciidoc
|A 2+|B
```

The parser only looked for a spec at the *start* of a `|`-delimited segment — i.e. the standalone `|A |2+|B` shape the old renderer happened to emit. So hand-written AsciiDoc using the canonical form silently lost its spans, and that only surfaced here because the renderer stopped producing the non-canonical form that hid it.

A spec at the end of a segment now carries to the next cell. Both forms parse:

| input | result |
|---|---|
| `\|A 2+\|B` (canonical) | `B` with colspan 2 |
| `\|A \|2+\|B` (old renderer) | `B` with colspan 2 |
| `\|C2+ \|B` | `C2+` stays content — a spec must be set off by whitespace |

## Verification

- `("asciidoc", "duplicate-header-labels-survive")` flipped to `XPASS(strict)`; entry deleted. Its name understated the defect — that invariant is simply the only one that happens to check table width.
- New parametrized round-trip test over 1/2/3/5 columns, so the count is asserted directly rather than incidentally.
- The existing span test now asserts exactly 3 cells; it previously sliced `cells[:3]`, which was quietly tolerating the phantom fourth.
- Golden AsciiDoc snapshot updated for the new row form (the only snapshot affected).
- `tests/unit` + `tests/golden` pass; ruff, black, mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)