### PR TITLE
fix(asciidoc): render one heading marker per level

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,6 +72,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **AsciiDoc: heading levels no longer shift, and level 6 is no longer dropped.** The
+  renderer added one `=` to every level, reserving a bare `=` for a document title it
+  never actually wrote. Nothing read it back that way — the parser counts `=` and
+  returns that number — so every heading came back one level deeper than it went in.
+  Level 6 was worse than shifted: it rendered as seven `=`, which is not a heading at
+  any level, so the node was dropped and six headings became five. AsciiDoc has exactly
+  six markers for six levels, so all six only fit if level 1 is a single `=` — which is
+  what the renderer's own docstring already claimed it did. Output changes: a level-1
+  heading is now `= Title` rather than `== Title` (#236).
+
 - **AsciiDoc: a table no longer gains a phantom column.** Rows were written with a
   trailing delimiter — `|A |B |` — and AsciiDoc reads whatever follows the final `|`
   as one more cell, so every N-column table parsed back as N+1. It was silent and it

--- a/src/all2md/renderers/asciidoc.py
+++ b/src/all2md/renderers/asciidoc.py
@@ -289,9 +289,16 @@ class AsciiDocRenderer(NodeVisitor, InlineContentMixin, BaseRenderer):
     def visit_heading(self, node: Heading) -> None:
         """Render a Heading node.
 
-        AsciiDoc uses = prefix syntax for all headings. The number of = characters
-        determines the heading level: = is document title (level 0), == is section
-        level 1, === is section level 2, etc.
+        AsciiDoc marks a heading with one ``=`` per level, so an AST level maps to
+        that many characters.
+
+        The mapping used to add one, reserving ``=`` for a document title the
+        renderer never actually wrote. Nothing read it back that way -- the parser
+        counts ``=`` and returns that number -- so every heading came back one level
+        deeper, and level 6 rendered as seven ``=``, which is not a heading at any
+        level: the node was dropped, six headings in and five out. AsciiDoc has
+        exactly six markers for six levels, so fitting all of them requires using
+        ``=`` for level 1.
 
         Parameters
         ----------
@@ -301,9 +308,7 @@ class AsciiDocRenderer(NodeVisitor, InlineContentMixin, BaseRenderer):
         """
         content = self._render_inline_content(node.content)
 
-        # AsciiDoc levels: = is document title (level 0), == is section level 1, === is section level 2, etc.
-        # Map AST heading levels to AsciiDoc: level 1 -> ==, level 2 -> ===, etc.
-        prefix = "=" * (node.level + 1)
+        prefix = "=" * max(1, min(node.level, 6))
         self._output.append(f"{prefix} {content}")
 
     def visit_paragraph(self, node: Paragraph) -> None:

--- a/tests/golden/__snapshots__/test_renderer_outputs_golden.ambr
+++ b/tests/golden/__snapshots__/test_renderer_outputs_golden.ambr
@@ -7,7 +7,7 @@
   
   // HTML by Reviewer (2025-01-01): Reviewer note: ensure consistent tone across sections.
   
-  == Renderer Showcase
+  = Renderer Showcase
   
   Inline math such as stem:[E = mc^2] pairs with *bold emphasis* and a link to link:https://example.com[Example].<!-- DOCX_REVIEW by Reviewer: Consider expanding this introduction. -->
   

--- a/tests/unit/parsers/test_asciidoc_parser.py
+++ b/tests/unit/parsers/test_asciidoc_parser.py
@@ -3,6 +3,8 @@
 
 import threading
 
+import pytest
+
 from all2md.ast import (
     BlockQuote,
     Code,
@@ -1120,43 +1122,43 @@ code here
 class TestAsciiDocHeadingLevels:
     """Tests for correct heading level mapping."""
 
-    def test_heading_level_1_maps_to_double_equals(self) -> None:
-        """Test that AST level 1 maps to == (section level 1)."""
+    def test_heading_level_1_maps_to_a_single_equals(self) -> None:
+        """AST level 1 is one ``=``, which is what the parser reads back as level 1."""
         doc = Document(children=[Heading(level=1, content=[Text(content="Section 1")])])
         renderer = AsciiDocRenderer()
         output = renderer.render_to_string(doc)
 
-        assert "== Section 1" in output
-        # Verify it's exactly two equals signs, not one or three
-        assert output.strip().startswith("==")
-        assert not output.strip().startswith("===")
-        assert not output.strip().startswith("= ")
+        assert output.strip() == "= Section 1"
 
-    def test_heading_level_2_maps_to_triple_equals(self) -> None:
-        """Test that AST level 2 maps to === (section level 2)."""
-        doc = Document(children=[Heading(level=2, content=[Text(content="Section 2")])])
+    @pytest.mark.parametrize("level", [1, 2, 3, 4, 5, 6])
+    def test_a_level_renders_as_that_many_equals_signs(self, level: int) -> None:
+        """One marker per level.
+
+        The renderer used to add one, reserving ``=`` for a document title it never
+        wrote, so every heading was rendered one level deeper than it was.
+        """
+        doc = Document(children=[Heading(level=level, content=[Text(content=f"Level {level}")])])
         renderer = AsciiDocRenderer()
+
         output = renderer.render_to_string(doc)
 
-        assert "=== Section 2" in output
+        assert output.strip() == f"{'=' * level} Level {level}"
 
-    def test_heading_level_3_maps_to_quadruple_equals(self) -> None:
-        """Test that AST level 3 maps to ==== (section level 3)."""
-        doc = Document(children=[Heading(level=3, content=[Text(content="Section 3")])])
-        renderer = AsciiDocRenderer()
-        output = renderer.render_to_string(doc)
+    def test_every_level_survives_a_round_trip(self) -> None:
+        """Six levels in, six levels out.
 
-        assert "==== Section 3" in output
+        AsciiDoc has exactly six heading markers, so the old off-by-one left no room
+        for the deepest one: level 6 rendered as seven ``=``, which is not a heading at
+        any level. That node was silently dropped and six headings came back as five.
+        """
+        doc = Document(children=[Heading(level=level, content=[Text(content=f"h{level}")]) for level in range(1, 7)])
 
-    def test_heading_levels_1_through_6(self) -> None:
-        """Test all heading levels map correctly."""
-        for level in range(1, 7):
-            doc = Document(children=[Heading(level=level, content=[Text(content=f"Level {level}")])])
-            renderer = AsciiDocRenderer()
-            output = renderer.render_to_string(doc)
+        rendered = AsciiDocRenderer().render_to_string(doc)
+        reparsed = AsciiDocParser().parse(rendered)
 
-            expected_prefix = "=" * (level + 1)
-            assert f"{expected_prefix} Level {level}" in output
+        headings = [node for node in reparsed.children if isinstance(node, Heading)]
+        assert [heading.level for heading in headings] == [1, 2, 3, 4, 5, 6]
+        assert [heading.content[0].content for heading in headings] == [f"h{level}" for level in range(1, 7)]
 
 
 class TestAsciiDocInlineCodeDelimiters:

--- a/tests/unit/renderers/test_asciidoc_renderer.py
+++ b/tests/unit/renderers/test_asciidoc_renderer.py
@@ -41,35 +41,33 @@ class TestHeadingRendering:
     """Tests for heading rendering - only ATX style is valid AsciiDoc."""
 
     def test_heading_level_1(self):
-        """Test h1 renders with == prefix."""
+        """Test h1 renders with = prefix."""
         doc = Document(children=[Heading(level=1, content=[Text(content="Title")])])
         renderer = AsciiDocRenderer()
         result = renderer.render_to_string(doc)
-        assert "== Title" in result
+        assert "= Title" in result
 
     def test_heading_level_2(self):
-        """Test h2 renders with === prefix."""
+        """Test h2 renders with == prefix."""
         doc = Document(children=[Heading(level=2, content=[Text(content="Subtitle")])])
         renderer = AsciiDocRenderer()
         result = renderer.render_to_string(doc)
-        assert "=== Subtitle" in result
+        assert "== Subtitle" in result
 
     def test_heading_level_3(self):
-        """Test h3 renders with ==== prefix."""
+        """Test h3 renders with === prefix."""
         doc = Document(children=[Heading(level=3, content=[Text(content="Section")])])
         renderer = AsciiDocRenderer()
         result = renderer.render_to_string(doc)
-        assert "==== Section" in result
+        assert "=== Section" in result
 
     def test_no_setext_style(self):
         """Test that setext-style underlines are not used (not valid AsciiDoc)."""
         doc = Document(children=[Heading(level=1, content=[Text(content="Title")])])
         renderer = AsciiDocRenderer()
         result = renderer.render_to_string(doc)
-        # Should NOT have underline
-        assert "====" not in result or "== Title" in result
-        # Should have ATX style
-        assert "== Title" in result
+        # Should NOT have an underline on the line below
+        assert result.strip() == "= Title"
 
 
 @pytest.mark.unit
@@ -1035,7 +1033,7 @@ class TestEdgeCases:
         renderer = AsciiDocRenderer()
         result = renderer.render_to_string(doc)
 
-        assert "== Title" in result
+        assert "= Title" in result
         assert "*bold*" in result
         assert "_italic_" in result
         assert "* Item" in result

--- a/tests/unit/test_roundtrip_fuzzing.py
+++ b/tests/unit/test_roundtrip_fuzzing.py
@@ -472,13 +472,6 @@ KNOWN_INVARIANT_GAPS: dict[tuple[str, str], str] = {
     # rst derives heading level from the underline character, and the renderer
     # uses `*` for both level 5 and level 6, so the two collapse (#238).
     ("rst", "heading-levels-survive"): "underline character reused for levels 5 and 6 (#238)",
-    # asciidoc offsets every level by one (a level-1 heading renders as `==`),
-    # which pushes level 6 to a seven-`=` line that is not a heading at all, so
-    # six headings go in and five come back (#236).
-    (
-        "asciidoc",
-        "heading-levels-survive",
-    ): "renderer offsets every level by one; level 6 overflows and is dropped (#236)",
     # The ordered-list start attribute, from opposite ends (#239): asciidoc emits
     # no `[start=N]`, while org emits a literal `5.` its own parser will not read
     # back as a start.


### PR DESCRIPTION
Closes #236.

The renderer added one `=` to every level, reserving a bare `=` for a document title it never wrote. Nothing read it back that way — the parser counts `=` and returns that number — so the two sides disagreed:

```
AST level:   1     2      3       4        5         6
rendered:    ==    ===    ====    =====    ======    =======
parsed back: 2     3      4       5        6         (not a heading)
```

Level 6 was worse than shifted. Seven `=` is not a heading at any level, so the node was dropped and six headings came back as five.

AsciiDoc has exactly six markers for six levels, so all six only fit if level 1 is a single `=`. That is also what the renderer's own class docstring already claimed it did:

```python
>>> print(asciidoc)
= Title
```

## Why not keep `=` reserved

The alternative — leave the offset and teach the parser to subtract one — can only carry five levels, because level 6 still has nowhere to go. There is no arrangement that fits six levels into six markers while holding one back.

## Tests

`TestAsciiDocHeadingLevels` is where this should have been caught. It asserted the marker count in one direction only, with the off-by-one written into the expectation (`"=" * (level + 1)`), so it passed while the round trip lost a heading. It now checks both: a parametrized marker assertion over all six levels, plus a round-trip test asserting `[1, 2, 3, 4, 5, 6]` comes back intact.

Four tests across two files encoded the old convention and are updated. `("asciidoc", "heading-levels-survive")` flipped to `XPASS(strict)`; entry deleted.

## Output change

A level-1 heading is now `= Title` rather than `== Title`. The golden AsciiDoc snapshot is updated. `tests/unit` + `tests/golden` pass; ruff, black, mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)