### PR TITLE
fix(rst): give every heading level its own identity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,6 +72,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **RST: all six heading levels are now distinguishable.** Two defects collapsed them,
+  and both are visible on any document with more than a couple of heading levels. The
+  renderer had five underline characters for six levels, so levels 5 and 6 shared `*`
+  — and RST derives a heading's level from the order in which each underline character
+  *first appears*, which makes two levels sharing a character the same level. The
+  default gains a sixth character (`"`), and a repeated character is now rejected by
+  `RstRendererOptions` rather than silently merging two levels. Separately, on the
+  parsing side, docutils was promoting a lone top-level section's title to the document
+  title and a lone subsection's to the subtitle. That takes both out of the section
+  tree, so the depth count restarted underneath them: a document reading `Title` then
+  `Section` came back with **both at level 1**, and six properly nested headings came
+  back `[1, 2, 1, 2, 3, 4]`. Sections stay sections now (`doctitle_xform` off, as
+  Sphinx does), so the level is the nesting depth. Bibliographic fields written under
+  a title are still read as metadata — docutils only lifts them into a `docinfo` node
+  when it promotes the title, so they are now read from the field list directly (#238).
+
 - **AsciiDoc: heading levels no longer shift, and level 6 is no longer dropped.** The
   renderer added one `=` to every level, reserving a bare `=` for a document title it
   never actually wrote. Nothing read it back that way — the parser counts `=` and

--- a/docs/source/options.rst
+++ b/docs/source/options.rst
@@ -9499,11 +9499,11 @@ reStructuredText output.
 
 **heading_chars**
 
-   Characters for heading underlines (h1-h5)
+   Characters for heading underlines (h1-h6), one per level, none repeated
 
    :Type: ``str``
    :CLI flag: ``--rst-renderer-heading-chars``
-   :Default: ``'=-~^*'``
+   :Default: ``'=-~^*"'``
    :Importance: advanced
 
 **table_style**

--- a/docs/source/python_api.rst
+++ b/docs/source/python_api.rst
@@ -1214,7 +1214,7 @@ Basic Conversion
 
    # With options
    options = RstRendererOptions(
-       heading_chars="=-~^*",           # Customize heading underlines
+       heading_chars='=-~^*"',          # Customize heading underlines
        table_style="grid",              # Use grid tables
        code_directive_style="directive" # Use .. code-block:: directives
    )
@@ -1269,9 +1269,9 @@ Customizing RST Output
 
    from all2md.renderers.rst import RestructuredTextRenderer, RstRendererOptions
 
-   # Custom heading characters (level 1-5)
+   # Custom heading characters (levels 1-6, one each, none repeated)
    options = RstRendererOptions(
-       heading_chars="#*+=",        # Different underline chars
+       heading_chars="#*+=~^",      # Different underline chars
        table_style="simple",        # Simple tables instead of grid
        code_directive_style="double_colon",  # Use :: for code blocks
        line_length=100              # Target line wrapping
@@ -1303,7 +1303,7 @@ Complete round-trip conversion example:
 
    # Render back to RST with custom options
    options = RstRendererOptions(
-       heading_chars="=-~^*",
+       heading_chars='=-~^*"',
        table_style="grid"
    )
    renderer = RestructuredTextRenderer(options)

--- a/src/all2md/constants.py
+++ b/src/all2md/constants.py
@@ -1020,7 +1020,11 @@ DEFAULT_PPTX_STRICT_LIST_DETECTION = False
 # Format-Specific Constants - reStructuredText (RST)
 # =============================================================================
 
-DEFAULT_RST_HEADING_CHARS = "=-~^*"
+#: One underline character per heading level, h1 to h6. reStructuredText derives a
+#: level from the order in which each character first appears, so two levels sharing a
+#: character are the same level. Six levels therefore need six distinct characters --
+#: this held only five, and level 6 reused level 5's.
+DEFAULT_RST_HEADING_CHARS = '=-~^*"'
 DEFAULT_RST_TABLE_STYLE: RstTableStyle = "grid"
 DEFAULT_RST_CODE_STYLE: RstCodeStyle = "directive"
 DEFAULT_RST_LINE_LENGTH = 80

--- a/src/all2md/options/rst.py
+++ b/src/all2md/options/rst.py
@@ -94,9 +94,13 @@ class RstRendererOptions(BaseRendererOptions):
 
     Parameters
     ----------
-    heading_chars : str, default "=-~^*"
-        Characters to use for heading underlines from h1 to h5.
-        First character is for level 1, second for level 2, etc.
+    heading_chars : str, default '=-~^*"'
+        Characters to use for heading underlines from h1 to h6.
+        First character is for level 1, second for level 2, etc. No character may
+        repeat: RST derives a heading's level from the order in which each underline
+        character first appears, so two levels sharing one are read back as the same
+        level. A string shorter than six characters collapses the deepest levels onto
+        the last one for the same reason.
     table_style : {"grid", "simple"}, default "grid"
         Table rendering style:
         - "grid": Grid tables with +---+ borders
@@ -156,7 +160,10 @@ class RstRendererOptions(BaseRendererOptions):
 
     heading_chars: str = field(
         default=DEFAULT_RST_HEADING_CHARS,
-        metadata={"help": "Characters for heading underlines (h1-h5)", "importance": "advanced"},
+        metadata={
+            "help": "Characters for heading underlines (h1-h6), one per level, none repeated",
+            "importance": "advanced",
+        },
     )
     table_style: RstTableStyle = field(
         default=DEFAULT_RST_TABLE_STYLE,
@@ -216,3 +223,15 @@ class RstRendererOptions(BaseRendererOptions):
         # Validate non-empty heading chars
         if not self.heading_chars or len(self.heading_chars) == 0:
             raise ValueError("heading_chars must not be empty")
+
+        # A repeated character silently merges two levels, because RST derives a level
+        # from the order in which each character first appears rather than from the
+        # character itself. That is how the default lost the distinction between levels
+        # 5 and 6, so it is worth rejecting rather than diagnosing again later.
+        duplicates = sorted({char for char in self.heading_chars if self.heading_chars.count(char) > 1})
+        if duplicates:
+            raise ValueError(
+                f"heading_chars must not repeat a character, got {self.heading_chars!r} "
+                f"(repeated: {', '.join(repr(char) for char in duplicates)}). "
+                "RST reads two levels sharing an underline character as the same level."
+            )

--- a/src/all2md/parsers/rst.py
+++ b/src/all2md/parsers/rst.py
@@ -131,6 +131,16 @@ class RestructuredTextParser(BaseParser):
                 "report_level": 5 if not self.options.strict_mode else 2,
                 "halt_level": 5 if not self.options.strict_mode else 3,
                 "warning_stream": None,
+                # Keep every section a section. By default docutils promotes a lone
+                # top-level section's title to the document title (and a lone
+                # subsection's to the subtitle), which removes those levels from the
+                # tree -- so a document reading `Title` / `Section` came back with both
+                # at level 1, and six properly nested headings came back [1, 2, 1, 2,
+                # 3, 4] because the count restarted after the two promotions. Sphinx
+                # turns these off for the same reason. The title is still read as
+                # metadata; it is taken from the first section's title either way.
+                "doctitle_xform": False,
+                "sectsubtitle_xform": False,
             }
             doctree = publish_doctree(rst_content, settings_overrides=settings_overrides)
         except Exception as e:
@@ -886,28 +896,48 @@ class RestructuredTextParser(BaseParser):
 
         metadata = DocumentMetadata()
 
-        # Look for docinfo node in document children
+        # Bibliographic fields reach us in one of two shapes. docutils only promotes a
+        # leading field list to a `docinfo` node when it also promotes the document
+        # title, and we keep every section a section (see the doctitle_xform override
+        # in `parse`), so the usual `Title` / `:author:` layout now leaves a plain
+        # field_list inside the first section. Read both, or turning off the promotion
+        # would silently drop the author of every document written that way.
+        fields: list[Any] = []
         for child in document.children:
             if isinstance(child, docutils_nodes.docinfo):
-                # Process docinfo fields
-                for field in child.children:
-                    if isinstance(field, docutils_nodes.author):
-                        metadata.author = field.astext()
-                    elif isinstance(field, docutils_nodes.date):
-                        metadata.creation_date = field.astext()
-                    elif isinstance(field, docutils_nodes.version):
-                        metadata.custom["version"] = field.astext()
-                    elif isinstance(field, docutils_nodes.field):
-                        # Custom field
-                        field_name = None
-                        field_body = None
-                        for subfield in field.children:
-                            if isinstance(subfield, docutils_nodes.field_name):
-                                field_name = subfield.astext()
-                            elif isinstance(subfield, docutils_nodes.field_body):
-                                field_body = subfield.astext()
-                        if field_name and field_body:
-                            metadata.custom[field_name.lower()] = field_body
+                fields.extend(child.children)
+        first_section = next((c for c in document.children if isinstance(c, docutils_nodes.section)), None)
+        if first_section is not None:
+            for subchild in first_section.children:
+                if isinstance(subchild, docutils_nodes.field_list):
+                    fields.extend(subchild.children)
+                    break
+
+        for field in fields:
+            if isinstance(field, docutils_nodes.author):
+                metadata.author = field.astext()
+            elif isinstance(field, docutils_nodes.date):
+                metadata.creation_date = field.astext()
+            elif isinstance(field, docutils_nodes.version):
+                metadata.custom["version"] = field.astext()
+            elif isinstance(field, docutils_nodes.field):
+                # An un-promoted field carries its name as text rather than as a node
+                # type, so the well-known ones are recognized here instead.
+                field_name = None
+                field_body = None
+                for subfield in field.children:
+                    if isinstance(subfield, docutils_nodes.field_name):
+                        field_name = subfield.astext()
+                    elif isinstance(subfield, docutils_nodes.field_body):
+                        field_body = subfield.astext()
+                if field_name and field_body:
+                    key = field_name.lower()
+                    if key == "author":
+                        metadata.author = field_body
+                    elif key == "date":
+                        metadata.creation_date = field_body
+                    else:
+                        metadata.custom[key] = field_body
 
         # Try to extract title from first section or standalone title
         for child in document.children:

--- a/tests/golden/__snapshots__/test_generated_fixtures_golden.ambr
+++ b/tests/golden/__snapshots__/test_generated_fixtures_golden.ambr
@@ -459,7 +459,7 @@
   
   > **Note:** This demonstrates typical reStructuredText constructs.
   
-  # Section Heading
+  ## Section Heading
   
   Paragraph with **bold** and *italic* text and a [reference](https://example.com) link.
   

--- a/tests/golden/__snapshots__/test_textual_formats_golden.ambr
+++ b/tests/golden/__snapshots__/test_textual_formats_golden.ambr
@@ -218,7 +218,7 @@
   
   > **Note:** This demonstrates typical reStructuredText constructs.
   
-  # Section Heading
+  ## Section Heading
   
   Paragraph with **bold** and *italic* text and a [reference](https://example.com) link.
   

--- a/tests/unit/parsers/test_rst_parser.py
+++ b/tests/unit/parsers/test_rst_parser.py
@@ -79,14 +79,12 @@ Level 3
         parser = RestructuredTextParser()
         doc = parser.parse(rst.strip())
 
-        # Should have 3 headings
-        # Note: docutils interprets first as title, second as subtitle, third as section
+        # Nesting depth is the level. docutils would otherwise promote the first
+        # section's title to the document title and the second's to the subtitle,
+        # removing both from the section tree and restarting the count below them.
         headings = [node for node in doc.children if isinstance(node, Heading)]
         assert len(headings) == 3
-        assert headings[0].level == 1  # title
-        assert headings[1].level == 2  # subtitle
-        # Third heading is inside a section, so level may differ
-        assert headings[2].level >= 1
+        assert [heading.level for heading in headings] == [1, 2, 3]
 
     def test_deeply_nested_headings(self) -> None:
         """Test parsing deeply nested sections (> 6 levels) clamps heading level to 6."""
@@ -108,7 +106,7 @@ Level 3
             return res
 
         headings = collect_headings(doc)
-        assert [h.level for h in headings] == [1, 2, 1, 2, 3, 4, 5, 6, 6]
+        assert [h.level for h in headings] == [1, 2, 3, 4, 5, 6, 6, 6, 6]
         assert headings[-1].level == 6
 
     def test_simple_paragraph(self) -> None:

--- a/tests/unit/renderers/test_rst_renderer.py
+++ b/tests/unit/renderers/test_rst_renderer.py
@@ -430,6 +430,73 @@ Title
         assert "**bold**" in generated_rst
         assert "*italic*" in generated_rst
 
+    def test_every_heading_level_survives_a_round_trip(self) -> None:
+        """Six levels in, six levels out.
+
+        Two things collapsed them. The renderer had only five underline characters,
+        so levels 5 and 6 shared one -- and RST derives a level from the order in
+        which each character first appears, which makes two levels sharing a
+        character the *same* level. Separately, docutils promoted the first section's
+        title to the document title and the second's to the subtitle, taking both out
+        of the section tree so the depth count restarted below them: the trip used to
+        return [1, 2, 1, 2, 3, 4].
+        """
+        from all2md.parsers.rst import RestructuredTextParser
+
+        doc = Document(children=[Heading(level=level, content=[Text(content=f"h{level}")]) for level in range(1, 7)])
+
+        rendered = RestructuredTextRenderer().render_to_string(doc)
+        reparsed = RestructuredTextParser().parse(rendered)
+
+        headings = [node for node in reparsed.children if isinstance(node, Heading)]
+        assert [heading.level for heading in headings] == [1, 2, 3, 4, 5, 6]
+        assert [heading.content[0].content for heading in headings] == [f"h{level}" for level in range(1, 7)]
+
+    def test_the_default_underline_characters_are_all_distinct(self) -> None:
+        """The defaults have to cover six levels without reusing a character."""
+        options = RstRendererOptions()
+
+        assert len(options.heading_chars) >= 6
+        assert len(set(options.heading_chars)) == len(options.heading_chars)
+
+    def test_a_repeated_underline_character_is_rejected(self) -> None:
+        """A repeat silently merges two levels, so it is refused rather than diagnosed."""
+        with pytest.raises(ValueError, match="must not repeat a character"):
+            RstRendererOptions(heading_chars="=-=")
+
+    def test_nesting_depth_below_a_title_keeps_counting(self) -> None:
+        """The document title is a heading like any other, not a level of its own.
+
+        docutils promoted a lone top-level section's title to the document title and a
+        lone subsection's to the subtitle, taking both out of the section tree, so the
+        depth count restarted underneath them: this document returned [1, 2, 1].
+        """
+        from all2md.parsers.rst import RestructuredTextParser
+
+        rst = "Title\n=====\n\nSection\n-------\n\nSub\n~~~\n\nBody.\n"
+
+        doc = RestructuredTextParser().parse(rst)
+
+        headings = [node for node in doc.children if isinstance(node, Heading)]
+        assert [heading.level for heading in headings] == [1, 2, 3]
+
+    def test_bibliographic_fields_below_a_title_are_still_metadata(self) -> None:
+        """Keeping sections unpromoted must not cost the author of every document.
+
+        docutils only lifts a leading field list into a ``docinfo`` node when it also
+        promotes the title, so with promotion off the fields stay a plain field list
+        inside the first section and have to be read there.
+        """
+        from all2md.parsers.rst import RestructuredTextParser
+
+        rst = "Title\n=====\n\n:author: Me\n:version: 1.0\n\nBody.\n"
+
+        doc = RestructuredTextParser().parse(rst)
+
+        assert doc.metadata.get("title") == "Title"
+        assert doc.metadata.get("author") == "Me"
+        assert doc.metadata.get("version") == "1.0"
+
 
 @pytest.mark.unit
 class TestTextEscaping:

--- a/tests/unit/test_roundtrip_fuzzing.py
+++ b/tests/unit/test_roundtrip_fuzzing.py
@@ -469,9 +469,6 @@ KNOWN_INVARIANT_GAPS: dict[tuple[str, str], str] = {
     ("rst", "table-caption-survives"): "renderer emits no .. table:: directive (#237)",
     ("org", "table-caption-survives"): "renderer emits no #+CAPTION line (#237)",
     ("asciidoc", "table-caption-survives"): "parser ignores the .caption line the renderer emits (#237)",
-    # rst derives heading level from the underline character, and the renderer
-    # uses `*` for both level 5 and level 6, so the two collapse (#238).
-    ("rst", "heading-levels-survive"): "underline character reused for levels 5 and 6 (#238)",
     # The ordered-list start attribute, from opposite ends (#239): asciidoc emits
     # no `[start=N]`, while org emits a literal `5.` its own parser will not read
     # back as a start.


### PR DESCRIPTION
Closes #238.

Two defects collapsed the six levels, one on each side of the trip. The issue named the first; the second turned up while verifying the fix.

## Renderer: five characters for six levels

```
h1  ==      h2  --      h3  ~~
h4  ^^      h5  **      h6  **      <- same character
```

RST derives a heading's level from the order in which each underline character *first appears*, so two levels sharing a character are the same level. The default gains a sixth (`"`), and `RstRendererOptions` now **rejects** a repeated character rather than silently merging two levels — that is the check which would have caught this.

## Parser: docutils was deleting two levels from the tree

By default docutils promotes a lone top-level section's title to the document title, and a lone subsection's to the subtitle. Both leave the section tree, so the depth count restarts underneath them. Measured on `main`:

| document | levels returned | correct |
|---|---|---|
| `Title` / `Section` | `[1, 1]` | `[1, 2]` |
| `Title` / `Section` / `Sub` | `[1, 2, 1]` | `[1, 2, 3]` |
| six nested headings | `[1, 2, 1, 2, 3, 4]` | `[1, 2, 3, 4, 5, 6]` |

A document's title and its first section coming back at the same level is a bug on its own, independent of the round trip. `doctitle_xform` and `sectsubtitle_xform` are now off, which is what Sphinx does for the same reason, and the level is simply the nesting depth.

### The regression that fix nearly caused

docutils only lifts a leading field list into a `docinfo` node **when it promotes the title**. Turning promotion off leaves the fields as a plain field list inside the first section — so `:author:` in the ordinary layout

```rst
Title
=====

:author: Me
```

silently stopped being extracted. Measured before committing; `extract_metadata` now reads both shapes, and a test pins it.

## Tests

Five new tests in `TestRoundTrip`. Three fail against `HEAD~` (the six-level round trip, the distinct-defaults check, the repeated-character rejection); the nesting-depth test fails against `main` on the three-level document above. The metadata test passes both before and after by design — it guards the regression this change could have introduced rather than a fix.

Two existing parser tests had the promotion artifact written straight into their expectations (`[1, 2, 1, 2, 3, 4, 5, 6, 6]`) and are corrected.

`("rst", "heading-levels-survive")` flipped to `XPASS(strict)`; entry deleted.

## Output and doc changes

A level-6 heading is underlined with `"` instead of `*`. Two golden snapshots change, both because a section under a document title is now correctly rendered as `##` rather than `#`. The generated `options.rst` and the hand-written RST examples in `python_api.rst` are updated — the examples showed 4- and 5-character strings, which under the new rule are legal but collapse the deepest levels.

`tests/unit` + `tests/golden` pass; ruff, black, mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)