### PR TITLE
fix(asciidoc,org): keep the number an ordered list starts at

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,6 +72,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **AsciiDoc and Org: an ordered list keeps the number it starts at.** Both formats
+  renumber a list themselves, so `1.` through `n.` is all either one preserved and a
+  `List(start=5)` came back as `start=1`. The two lost it at opposite ends. AsciiDoc
+  emitted no marker at all; it now writes the `[start=N]` block attribute, and the
+  parser reads it (and consumes it, so it cannot attach to a later list). Org *did*
+  emit the number — a literal `5.` — but Org renumbers from 1 unless the first item
+  carries an explicit counter set, so the information was in the document and thrown
+  away by Org and by our own parser alike. The renderer now adds `[@5]` to the first
+  item, and the parser reads both `[@N]` and, failing that, the list's own first
+  number, which is what the Markdown parser already did. Hand-written `5. First` in
+  Org therefore starts at 5 now (#239).
+
 - **RST: all six heading levels are now distinguishable.** Two defects collapsed them,
   and both are visible on any document with more than a couple of heading levels. The
   renderer had five underline characters for six levels, so levels 5 and 6 shared `*`

--- a/src/all2md/parsers/asciidoc.py
+++ b/src/all2md/parsers/asciidoc.py
@@ -1477,6 +1477,11 @@ class AsciiDocParser(BaseParser):
             Single list node or list of top-level lists if multiple roots
 
         """
+        # `[start=N]` sits on its own line before the list, so it has already been
+        # recorded as a pending block attribute by the time we get here. Pop it rather
+        # than read it, so it cannot leak onto a later list.
+        start_attr = self.pending_block_attrs.pop("start", None)
+
         # Create a ListBuilder for managing nesting
         list_builder = ListBuilder()
 
@@ -1543,6 +1548,15 @@ class AsciiDocParser(BaseParser):
 
         # Get the built document and extract the lists
         built_doc = list_builder.get_document()
+
+        if start_attr is not None:
+            for child in built_doc.children:
+                if isinstance(child, List) and child.ordered:
+                    try:
+                        child.start = int(start_attr)
+                    except ValueError:
+                        logger.debug("Ignoring non-numeric list start attribute: %r", start_attr)
+                    break
 
         # Return single list if there's only one, otherwise return all
         if len(built_doc.children) == 1:

--- a/src/all2md/parsers/org.py
+++ b/src/all2md/parsers/org.py
@@ -1015,11 +1015,17 @@ class OrgParser(BaseParser):
         lines = block.split("\n")
         items: list[ListItem] = []
         ordered = False
+        start = 1
 
         # Check if ordered or unordered
         first_line = lines[0].strip()
-        if re.match(r"^\d+[\.\)]", first_line):
+        first_number = re.match(r"^(\d+)[\.\)]", first_line)
+        if first_number:
             ordered = True
+            # The list's own first number is its start. Taking it is what the Markdown
+            # parser already does, and without it a list written `5.` came back at 1 --
+            # the number was present in the document and discarded on the way in.
+            start = int(first_number.group(1))
 
         for line in lines:
             line_stripped = line.strip()
@@ -1037,12 +1043,19 @@ class OrgParser(BaseParser):
 
             if match:
                 item_text = (match.group(1) or "").strip()
+                # `[@N]` is Org's own counter set, and it wins over the literal number
+                # it follows -- that is the whole point of writing it.
+                counter = re.match(r"^\[@(\d+)\]\s*(.*)$", item_text, re.DOTALL)
+                if counter:
+                    if not items:
+                        start = int(counter.group(1))
+                    item_text = counter.group(2).strip()
                 if item_text:
                     items.append(ListItem(children=[Paragraph(content=self._parse_inline(item_text))]))
                 else:
                     items.append(ListItem(children=[]))
 
-        return List(ordered=ordered, items=items)
+        return List(ordered=ordered, start=start, items=items)
 
     def _parse_definition_list(self, block: str) -> DefinitionList | None:
         """Parse an Org definition list.

--- a/src/all2md/renderers/asciidoc.py
+++ b/src/all2md/renderers/asciidoc.py
@@ -424,6 +424,14 @@ class AsciiDocRenderer(NodeVisitor, InlineContentMixin, BaseRenderer):
             List to render
 
         """
+        # AsciiDoc numbers an ordered list itself, so a list that starts anywhere but
+        # 1 needs the `[start=N]` block attribute -- the renderer emitted no marker at
+        # all and the number was simply lost. The attribute goes on its own line above
+        # the list, which only works for a list that starts a block, so a nested list
+        # cannot carry one.
+        if node.ordered and node.start != 1 and not self._in_list:
+            self._output.append(f"[start={node.start}]\n")
+
         was_in_list = self._in_list
         self._in_list = True
         self._list_level += 1

--- a/src/all2md/renderers/org.py
+++ b/src/all2md/renderers/org.py
@@ -529,6 +529,11 @@ class OrgRenderer(NodeVisitor, InlineContentMixin, BaseRenderer):
                 # Use numbered list format
                 number = node.start + i
                 marker = f"{number}. "
+                # Org renumbers an ordered list from 1 unless the first item carries a
+                # counter set, so the literal `5.` alone did not survive: the number was
+                # in the document and both Org and our own parser threw it away.
+                if i == 0 and node.start != 1:
+                    marker = f"{marker}[@{node.start}] "
             else:
                 # Use bullet list format
                 marker = "- "

--- a/tests/unit/parsers/test_org_parser.py
+++ b/tests/unit/parsers/test_org_parser.py
@@ -31,6 +31,7 @@ from all2md.ast import (
     LineBreak,
     Link,
     List,
+    ListItem,
     MathBlock,
     MathInline,
     Paragraph,
@@ -323,6 +324,53 @@ class TestLists:
         lst = lists[0]
         assert lst.ordered
         assert len(lst.items) == 3
+
+    def test_the_first_number_is_the_list_start(self) -> None:
+        """A list written `5.` starts at 5, as it does in Markdown.
+
+        The number was in the document and the parser threw it away, so every
+        ordered list came back starting at 1.
+        """
+        parser = OrgParser()
+
+        doc = parser.parse("5. First\n6. Second\n")
+
+        lst = [node for node in doc.children if isinstance(node, List)][0]
+        assert lst.ordered
+        assert lst.start == 5
+        assert len(lst.items) == 2
+
+    def test_an_explicit_counter_set_wins_over_the_literal_number(self) -> None:
+        """`[@N]` is Org's own way to set the counter, so it outranks the digits."""
+        parser = OrgParser()
+
+        doc = parser.parse("1. [@7] First\n2. Second\n")
+
+        lst = [node for node in doc.children if isinstance(node, List)][0]
+        assert lst.start == 7
+        assert lst.items[0].children[0].content[0].content == "First"
+
+    def test_an_ordered_list_round_trips_its_start(self) -> None:
+        """Org renumbers from 1 unless the first item carries a counter set."""
+        from all2md.renderers.org import OrgRenderer
+
+        source = Document(
+            children=[
+                List(
+                    ordered=True,
+                    start=5,
+                    items=[ListItem(children=[Paragraph(content=[Text(content=text)])]) for text in ("a", "b")],
+                )
+            ]
+        )
+
+        rendered = OrgRenderer().render_to_string(source)
+        reparsed = OrgParser().parse(rendered)
+
+        assert "[@5]" in rendered
+        lst = [node for node in reparsed.children if isinstance(node, List)][0]
+        assert lst.start == 5
+        assert [item.children[0].content[0].content for item in lst.items] == ["a", "b"]
 
 
 @pytest.mark.unit

--- a/tests/unit/renderers/test_asciidoc_renderer.py
+++ b/tests/unit/renderers/test_asciidoc_renderer.py
@@ -216,6 +216,55 @@ class TestListItemContinuation:
 
 
 @pytest.mark.unit
+class TestOrderedListStart:
+    """An ordered list that does not start at 1 must say so."""
+
+    def test_a_start_offset_round_trips(self) -> None:
+        """AsciiDoc numbers the list itself, so the start needs `[start=N]`.
+
+        The renderer emitted no marker at all, so the number was simply dropped and
+        every ordered list came back starting at 1.
+        """
+        source = Document(
+            children=[
+                List(
+                    ordered=True,
+                    start=5,
+                    items=[ListItem(children=[Paragraph(content=[Text(content=text)])]) for text in ("a", "b")],
+                )
+            ]
+        )
+
+        rendered = AsciiDocRenderer().render_to_string(source)
+        reparsed = AsciiDocParser().parse(rendered)
+
+        assert rendered.startswith("[start=5]\n")
+        reparsed_list = reparsed.children[0]
+        assert isinstance(reparsed_list, List)
+        assert reparsed_list.start == 5
+        assert [item.children[0].content[0].content for item in reparsed_list.items] == ["a", "b"]
+
+    def test_a_list_starting_at_one_carries_no_attribute(self) -> None:
+        """The default needs no marker, and adding one would churn every document."""
+        source = Document(
+            children=[List(ordered=True, start=1, items=[ListItem(children=[Paragraph(content=[Text(content="a")])])])]
+        )
+
+        rendered = AsciiDocRenderer().render_to_string(source)
+
+        assert "start=" not in rendered
+
+    def test_a_start_does_not_leak_onto_the_next_list(self) -> None:
+        """The attribute is consumed by the list it precedes, not left pending."""
+        adoc = "[start=5]\n. a\n\nsep\n\n. b\n"
+
+        doc = AsciiDocParser().parse(adoc)
+
+        lists = [node for node in doc.children if isinstance(node, List)]
+        assert [node.start for node in lists] == [5, 1]
+
+
+@pytest.mark.unit
 class TestFootnoteFlattening:
     """Tests for footnote content flattening to inline text."""
 

--- a/tests/unit/test_roundtrip_fuzzing.py
+++ b/tests/unit/test_roundtrip_fuzzing.py
@@ -469,11 +469,6 @@ KNOWN_INVARIANT_GAPS: dict[tuple[str, str], str] = {
     ("rst", "table-caption-survives"): "renderer emits no .. table:: directive (#237)",
     ("org", "table-caption-survives"): "renderer emits no #+CAPTION line (#237)",
     ("asciidoc", "table-caption-survives"): "parser ignores the .caption line the renderer emits (#237)",
-    # The ordered-list start attribute, from opposite ends (#239): asciidoc emits
-    # no `[start=N]`, while org emits a literal `5.` its own parser will not read
-    # back as a start.
-    ("asciidoc", "ordered-list-start-survives"): "renderer emits no [start=N] attribute (#239)",
-    ("org", "ordered-list-start-survives"): "renderer emits a literal '5.' the parser does not read as start (#239)",
 }
 
 #: Formats the invariant gate covers. Text formats only: the invariants probe


### PR DESCRIPTION
Closes #239.

Both formats renumber a list themselves, so neither preserved anything but `1.` onward — a `List(start=5)` came back as `start=1` in each. They lost it at opposite ends, which is why this is one change rather than one fix applied twice.

## AsciiDoc — the renderer said nothing

```
rendered:  ". a"        # no start marker anywhere
```

AsciiDoc's syntax for this is the `[start=5]` block attribute. The renderer now emits it, and the parser reads it. The parser **pops** the pending attribute rather than reading it, so it cannot drift onto a later list:

```
[start=5]
. a

sep

. b        <- starts at 1, not 5
```

The attribute has to precede the list as a block, so a nested list cannot carry one; that limit is noted where it is emitted rather than silently producing invalid output.

## Org — the renderer said it in a form nothing reads back

```
rendered:  "5. a"       # the number IS there
```

Org renumbers an ordered list from 1 unless the first item carries an explicit counter set, so `5.` is decoration. The information was in the document and discarded by Emacs and by our own parser alike — the worst of the two failure modes, since it *looks* preserved.

The renderer now writes `5. [@5] a`, and the parser reads `[@N]` first, falling back to the list's own first number. That fallback is what the Markdown parser already did, so hand-written Org gains something too:

| input | before | after |
|---|---|---|
| `5. First` | `start=1` | `start=5` |
| `1. [@7] First` | `start=1` | `start=7` |

## Verification

Both `("asciidoc", "ordered-list-start-survives")` and `("org", "ordered-list-start-survives")` flipped to `XPASS(strict)`; entries deleted.

Six new tests, including the two hand-written Org forms and the leak case above. `tests/unit` + `tests/golden` pass; ruff, black, mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)