### PR TITLE
fix(asciidoc,rst,org): carry a table caption in both directions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,6 +72,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Table captions survive a round trip in AsciiDoc, RST and Org.** All three have a
+  caption syntax and none of them used it in both directions. AsciiDoc already *wrote*
+  the caption as a `.My caption` block title, and its parser ignored the line, so the
+  caption made the trip out and not the trip in. RST emitted a bare grid with nowhere
+  to put one; it now uses the `.. table::` directive, which takes the caption as its
+  argument and the table as its indented body, and reads it back. Org emitted nothing;
+  it now writes the `#+CAPTION:` affiliated keyword. Doing that also narrowed the
+  filter that keeps `#+TITLE:` and friends out of the body text, which previously
+  dropped every `#+KEYWORD:` line and would have eaten the caption with them — it now
+  works from a list of genuinely document-level keywords. One visible consequence: an
+  RST table caption that used to vanish on conversion now reaches the output, so
+  RST→Markdown gains an italic line above the table. Markdown has no caption syntax
+  and its arm of this is still open (#237).
+
 - **AsciiDoc and Org: an ordered list keeps the number it starts at.** Both formats
   renumber a list themselves, so `1.` through `n.` is all either one preserved and a
   `List(start=5)` came back as `start=1`. The two lost it at opposite ends. AsciiDoc

--- a/src/all2md/parsers/asciidoc.py
+++ b/src/all2md/parsers/asciidoc.py
@@ -778,6 +778,18 @@ class AsciiDocParser(BaseParser):
 
         self.current_token_index = saved_index
 
+    @staticmethod
+    def _block_title_match(line: str) -> str | None:
+        """Return the text of a `.Title` block-title line, or None if it is not one.
+
+        A leading `..` is not a title -- that is how AsciiDoc escapes the marker -- and
+        neither is `. ` with a space, which is an ordered list item.
+        """
+        stripped = line.strip()
+        if len(stripped) < 2 or not stripped.startswith(".") or stripped[1] in ". \t":
+            return None
+        return stripped[1:].strip() or None
+
     def _parse_block(self) -> Node | list[Node] | None:
         """Parse a single block-level element.
 
@@ -793,6 +805,20 @@ class AsciiDocParser(BaseParser):
         if token.type == TokenType.ATTRIBUTE:
             self._advance()
             return None
+
+        # A block title -- `.My caption` on the line above a block. The renderer has
+        # always emitted one for a table's caption; nothing here read it back, so the
+        # caption made the trip out and not the trip in. Recognized only directly above
+        # a table, and only with the delimiter or a block attribute in between, so an
+        # ordinary paragraph opening with a period is still a paragraph.
+        if token.type == TokenType.TEXT_LINE and self._block_title_match(token.content):
+            offset = 1
+            while self._peek_token(offset).type == TokenType.BLOCK_ATTRIBUTE:
+                offset += 1
+            if self._peek_token(offset).type == TokenType.TABLE_DELIMITER:
+                self.pending_block_attrs["title"] = self._block_title_match(token.content)
+                self._advance()
+                return None
 
         # Comment (block-level //)
         if token.type == TokenType.COMMENT:
@@ -1868,6 +1894,7 @@ class AsciiDocParser(BaseParser):
         """
         # Consume pending attributes
         attrs = self._consume_pending_attrs()
+        caption = attrs.get("title")
 
         # Skip opening delimiter
         self._advance()
@@ -1919,7 +1946,7 @@ class AsciiDocParser(BaseParser):
         if self._current_token().type == TokenType.TABLE_DELIMITER:
             self._advance()
 
-        return Table(header=header, rows=rows)
+        return Table(header=header, rows=rows, caption=caption)
 
     def _parse_table_row(self, line: str) -> TableRow:
         r"""Parse a table row from a line.

--- a/src/all2md/parsers/org.py
+++ b/src/all2md/parsers/org.py
@@ -60,6 +60,28 @@ from all2md.utils.metadata import DocumentMetadata
 
 logger = logging.getLogger(__name__)
 
+#: Keywords that describe the document rather than the block beneath them. These are
+#: read into the metadata, so they are dropped from the body above the first heading
+#: instead of being printed twice. Affiliated keywords such as ``#+CAPTION:`` are
+#: deliberately absent: they belong to the block that follows.
+_FILE_PROPERTY_KEYWORDS = frozenset(
+    {
+        "AUTHOR",
+        "DATE",
+        "DESCRIPTION",
+        "EMAIL",
+        "FILETAGS",
+        "KEYWORDS",
+        "LANGUAGE",
+        "OPTIONS",
+        "PROPERTY",
+        "SETUPFILE",
+        "STARTUP",
+        "SUBTITLE",
+        "TITLE",
+    }
+)
+
 
 class OrgParser(BaseParser):
     r"""Convert Org-Mode to AST representation.
@@ -223,6 +245,10 @@ class OrgParser(BaseParser):
         with a code block silently lost it. The same block parsed correctly one line
         lower, under a heading, because only this preamble path filtered.
 
+        Only keywords that really are file-level qualify. Org spells affiliated
+        keywords such as ``#+CAPTION:`` the same way, and those belong to the block
+        underneath them rather than to the document.
+
         Lines inside a block are left exactly as they are: a ``#+TITLE:`` written
         inside a source block is code, not a document property.
         """
@@ -239,7 +265,8 @@ class OrgParser(BaseParser):
                 in_block = True
                 filtered_lines.append(line)
                 continue
-            if re.match(r"^#\+\w[\w-]*:", stripped):
+            keyword = re.match(r"^#\+([\w-]+):", stripped)
+            if keyword and keyword.group(1).upper() in _FILE_PROPERTY_KEYWORDS:
                 continue
             filtered_lines.append(line)
         return "\n".join(filtered_lines).strip()
@@ -650,6 +677,17 @@ class OrgParser(BaseParser):
             if not block:
                 continue
 
+            # `#+CAPTION:` is an affiliated keyword: it belongs to the block written
+            # under it, and no blank line separates the two, so it arrives at the head
+            # of this block rather than as one of its own.
+            caption = None
+            caption_match = re.match(r"^#\+CAPTION:\s*(.*)$", block.split("\n", 1)[0], re.IGNORECASE)
+            if caption_match:
+                caption = caption_match.group(1).strip() or None
+                block = block.split("\n", 1)[1].strip() if "\n" in block else ""
+                if not block:
+                    continue
+
             # Check for horizontal rules (5+ dashes)
             if re.match(r"^-{5,}$", block):
                 result.append(ThematicBreak())
@@ -683,6 +721,8 @@ class OrgParser(BaseParser):
             if block.startswith("|"):
                 table = self._parse_table(block)
                 if table:
+                    if caption:
+                        table.caption = caption
                     result.append(table)
                 continue
 

--- a/src/all2md/parsers/rst.py
+++ b/src/all2md/parsers/rst.py
@@ -570,6 +570,14 @@ class RestructuredTextParser(BaseParser):
         rows = []
         alignments: list[Literal["left", "center", "right"] | None] = []
 
+        # A `.. table:: Caption` directive puts the caption in a title child of the
+        # table itself, which is where the caption written by our renderer arrives.
+        caption = None
+        for child in node.children:
+            if isinstance(child, docutils_nodes.title):
+                caption = child.astext()
+                break
+
         # Find tgroup which contains table structure
         tgroup = None
         for child in node.children:
@@ -578,7 +586,7 @@ class RestructuredTextParser(BaseParser):
                 break
 
         if tgroup is None:
-            return Table(header=None, rows=[], alignments=[])
+            return Table(header=None, rows=[], alignments=[], caption=caption)
 
         # Process thead (header) and tbody (body)
         for child in tgroup.children:
@@ -596,7 +604,7 @@ class RestructuredTextParser(BaseParser):
                         cells = self._process_table_row_cells(row_node)
                         rows.append(TableRow(cells=cells, is_header=False))
 
-        return Table(header=header, rows=rows, alignments=alignments)
+        return Table(header=header, rows=rows, alignments=alignments, caption=caption)
 
     def _process_table_row_cells(self, row_node: Any) -> list[TableCell]:
         """Process table row cells.

--- a/src/all2md/renderers/org.py
+++ b/src/all2md/renderers/org.py
@@ -595,6 +595,11 @@ class OrgRenderer(NodeVisitor, InlineContentMixin, BaseRenderer):
         if not rows_to_render:
             return
 
+        # Org attaches a caption to the block below it with `#+CAPTION:`. Nothing was
+        # emitted at all, so the caption was dropped on the way out.
+        if node.caption:
+            self._output.append(f"#+CAPTION: {node.caption}\n")
+
         # Compute grid dimensions accounting for colspan/rowspan
         num_rows = len(rows_to_render)
         num_cols = self._compute_table_columns(rows_to_render)

--- a/src/all2md/renderers/rst.py
+++ b/src/all2md/renderers/rst.py
@@ -15,6 +15,7 @@ generate RST output.
 from __future__ import annotations
 
 import re
+import textwrap
 from pathlib import Path
 from typing import IO, Union
 
@@ -387,6 +388,21 @@ class RestructuredTextRenderer(NodeVisitor, InlineContentMixin, BaseRenderer):
             Table to render
 
         """
+        # A caption needs the `.. table::` directive, which takes the caption as its
+        # argument and the table as its indented body. Without it the caption was
+        # simply not written -- the renderer emitted a bare grid and the text was gone.
+        if node.caption:
+            self._output.append(f".. table:: {node.caption}\n\n")
+            start = len(self._output)
+            if self.options.table_style == "grid":
+                self._render_grid_table(node)
+            else:
+                self._render_simple_table(node)
+            body = "".join(self._output[start:])
+            del self._output[start:]
+            self._output.append(textwrap.indent(body, "   "))
+            return
+
         if self.options.table_style == "grid":
             self._render_grid_table(node)
         else:

--- a/tests/golden/__snapshots__/test_generated_fixtures_golden.ambr
+++ b/tests/golden/__snapshots__/test_generated_fixtures_golden.ambr
@@ -475,6 +475,8 @@
       return f"Hello, {name}!"
   ```
   
+  *Sample Data*
+  
   | Column A | Column B |
   |---|---|
   | Alpha | 1 |

--- a/tests/golden/__snapshots__/test_textual_formats_golden.ambr
+++ b/tests/golden/__snapshots__/test_textual_formats_golden.ambr
@@ -234,6 +234,8 @@
       return f"Hello, {name}!"
   ```
   
+  *Sample Data*
+  
   | Column A | Column B |
   |---|---|
   | Alpha | 1 |

--- a/tests/unit/parsers/test_org_parser.py
+++ b/tests/unit/parsers/test_org_parser.py
@@ -40,6 +40,8 @@ from all2md.ast import (
     Subscript,
     Superscript,
     Table,
+    TableCell,
+    TableRow,
     Text,
     ThematicBreak,
     Underline,
@@ -1138,6 +1140,53 @@ Task body content.
 
         # LOGBOOK and CLOSED may or may not be present due to orgparse limitations
         # Just verify the document parses without error
+
+
+@pytest.mark.unit
+class TestTableCaption:
+    """Org attaches a caption to the block under it with an affiliated keyword."""
+
+    def test_a_caption_round_trips(self) -> None:
+        """Nothing was emitted at all, so the caption was dropped on the way out."""
+        from all2md.renderers.org import OrgRenderer
+
+        source = Document(
+            children=[
+                Table(
+                    header=TableRow(cells=[TableCell(content=[Text(content="A")])]),
+                    rows=[TableRow(cells=[TableCell(content=[Text(content="1")])])],
+                    caption="My caption",
+                )
+            ]
+        )
+
+        rendered = OrgRenderer().render_to_string(source)
+        reparsed = OrgParser().parse(rendered)
+
+        assert rendered.startswith("#+CAPTION: My caption")
+        table = [node for node in reparsed.children if isinstance(node, Table)][0]
+        assert table.caption == "My caption"
+
+    def test_a_caption_is_read_below_a_heading_too(self) -> None:
+        """Body text under a heading takes a different path than the preamble."""
+        org = "* H\n\n#+CAPTION: Cap\n| A |\n|---|\n| 1 |\n"
+
+        doc = OrgParser().parse(org)
+
+        table = [node for node in doc.children if isinstance(node, Table)][0]
+        assert table.caption == "Cap"
+
+    def test_a_file_property_is_still_kept_out_of_the_body(self) -> None:
+        """Only genuinely file-level keywords are filtered, not every `#+KEYWORD:`.
+
+        `#+CAPTION:` is spelled the same way and belongs to the block underneath it,
+        so the filter now works from a list of document-level keywords rather than
+        dropping the lot.
+        """
+        doc = OrgParser().parse("#+TITLE: T\n\nBody\n")
+
+        assert doc.metadata.get("title") == "T"
+        assert [type(node) for node in doc.children] == [Paragraph]
 
 
 @pytest.mark.unit

--- a/tests/unit/renderers/test_asciidoc_renderer.py
+++ b/tests/unit/renderers/test_asciidoc_renderer.py
@@ -265,6 +265,50 @@ class TestOrderedListStart:
 
 
 @pytest.mark.unit
+class TestTableCaption:
+    """A table caption must survive both directions."""
+
+    def test_a_caption_round_trips(self) -> None:
+        """The renderer already wrote `.My caption`; nothing read it back.
+
+        AsciiDoc's block title is the line above a block, so the caption made the
+        trip out and not the trip in, and every table came back with caption=None.
+        """
+        source = Document(
+            children=[
+                Table(
+                    header=TableRow(cells=[TableCell(content=[Text(content="A")])]),
+                    rows=[TableRow(cells=[TableCell(content=[Text(content="1")])])],
+                    caption="My caption",
+                )
+            ]
+        )
+
+        rendered = AsciiDocRenderer().render_to_string(source)
+        reparsed = AsciiDocParser().parse(rendered)
+
+        assert rendered.startswith(".My caption")
+        table = [node for node in reparsed.children if isinstance(node, Table)][0]
+        assert table.caption == "My caption"
+
+    def test_a_block_title_survives_an_intervening_attribute_line(self) -> None:
+        """`[cols=...]` may sit between the title and the table."""
+        adoc = '.Cap\n[cols="1,1"]\n|===\n|A |B\n|===\n'
+
+        doc = AsciiDocParser().parse(adoc)
+
+        table = [node for node in doc.children if isinstance(node, Table)][0]
+        assert table.caption == "Cap"
+
+    def test_a_paragraph_opening_with_a_period_is_still_a_paragraph(self) -> None:
+        """The title is only recognized directly above a table, not everywhere."""
+        doc = AsciiDocParser().parse(".Not a title, just prose.\n")
+
+        assert len(doc.children) == 1
+        assert doc.children[0].content[0].content == ".Not a title, just prose."
+
+
+@pytest.mark.unit
 class TestFootnoteFlattening:
     """Tests for footnote content flattening to inline text."""
 

--- a/tests/unit/renderers/test_rst_renderer.py
+++ b/tests/unit/renderers/test_rst_renderer.py
@@ -317,6 +317,62 @@ class TestTables:
 
 
 @pytest.mark.unit
+class TestTableCaption:
+    """A caption needs the `.. table::` directive; a bare grid has nowhere to put it."""
+
+    @pytest.mark.parametrize("style", ["grid", "simple"])
+    def test_a_caption_round_trips(self, style: str) -> None:
+        """The renderer emitted a bare table, so the caption text was simply gone."""
+        from all2md.parsers.rst import RestructuredTextParser
+
+        source = Document(
+            children=[
+                Table(
+                    header=TableRow(
+                        cells=[
+                            TableCell(content=[Text(content="A")]),
+                            TableCell(content=[Text(content="B")]),
+                        ]
+                    ),
+                    rows=[
+                        TableRow(
+                            cells=[
+                                TableCell(content=[Text(content="1")]),
+                                TableCell(content=[Text(content="2")]),
+                            ]
+                        )
+                    ],
+                    caption="My caption",
+                )
+            ]
+        )
+
+        rendered = RestructuredTextRenderer(RstRendererOptions(table_style=style)).render_to_string(source)
+        reparsed = RestructuredTextParser().parse(rendered)
+
+        assert rendered.startswith(".. table:: My caption")
+        table = [node for node in reparsed.children if isinstance(node, Table)][0]
+        assert table.caption == "My caption"
+        assert len(table.rows) == 1
+
+    def test_a_table_without_a_caption_stays_a_bare_grid(self) -> None:
+        """The directive is only for captions; adding it everywhere would churn output."""
+        source = Document(
+            children=[
+                Table(
+                    header=TableRow(cells=[TableCell(content=[Text(content="A")])]),
+                    rows=[TableRow(cells=[TableCell(content=[Text(content="1")])])],
+                )
+            ]
+        )
+
+        rendered = RestructuredTextRenderer().render_to_string(source)
+
+        assert ".. table::" not in rendered
+        assert rendered.startswith("+---+")
+
+
+@pytest.mark.unit
 class TestDefinitionLists:
     """Tests for definition list rendering."""
 

--- a/tests/unit/test_roundtrip_fuzzing.py
+++ b/tests/unit/test_roundtrip_fuzzing.py
@@ -461,14 +461,13 @@ INVARIANTS: dict[str, tuple[Document, object, object]] = {
 #: different fix from a renderer that emits nothing. Prefer measuring the
 #: rendered output before trusting a reason in this table.
 KNOWN_INVARIANT_GAPS: dict[tuple[str, str], str] = {
-    # Table captions, all four for different reasons (#237). asciidoc renders
-    # `.My caption` correctly and its parser ignores the line; markdown has no
-    # caption syntax and demotes it to an italic paragraph, which also injects a
-    # node that was not in the input; rst and org emit nothing at all.
+    # The last of the four table-caption entries (#237). asciidoc, rst and org each
+    # have a caption syntax and now use it. Markdown has none, and the current
+    # behaviour is worse than a dropped attribute: the caption is demoted to an
+    # italic paragraph, which injects a node that was not in the input. Whether to
+    # keep that and document it as lossy, or round-trip through an HTML comment, is
+    # a deliberate choice about output aimed at human readers, so it is still open.
     ("markdown", "table-caption-survives"): "renderer demotes the caption to an italic paragraph (#237)",
-    ("rst", "table-caption-survives"): "renderer emits no .. table:: directive (#237)",
-    ("org", "table-caption-survives"): "renderer emits no #+CAPTION line (#237)",
-    ("asciidoc", "table-caption-survives"): "parser ignores the .caption line the renderer emits (#237)",
 }
 
 #: Formats the invariant gate covers. Text formats only: the invariants probe


### PR DESCRIPTION
Three of the four arms of #237. **Stacked on #248** — merge that first, and this retargets to `main` automatically.

The dependency is real, not cosmetic: reading `#+CAPTION:` back in Org requires the preamble keyword filter from #248, which currently deletes every `#+` line above the first heading.

## Each format lost it in a different place

| format | before | now |
|---|---|---|
| **asciidoc** | renderer wrote `.My caption`; the parser ignored the line | block title read back — but only directly above a table |
| **rst** | bare grid, nowhere to put a caption | `.. table:: Caption` with the table as its indented body |
| **org** | nothing emitted | `#+CAPTION:` affiliated keyword |

AsciiDoc is the interesting one: the caption made the trip *out* and not the trip *in*, so it looked half-implemented rather than missing. The block title is recognized only directly above a table (across any intervening `[cols=...]` line), so a paragraph opening with a period is still a paragraph — pinned by a test.

## What Org's arm dragged in

`#+CAPTION:` is spelled exactly like `#+TITLE:`, and the filter that keeps file properties out of the body above the first heading dropped **every** `#+KEYWORD:` line — so it would have eaten the caption before the table parser ever saw it. That filter now works from a list of genuinely document-level keywords (`TITLE`, `AUTHOR`, `DATE`, `OPTIONS`, …) rather than the shape of the line. Affiliated keywords belong to the block underneath them, not to the document.

## The markdown arm is deliberately left open

Markdown has no caption syntax, and the current behaviour is worse than a dropped attribute: the caption is demoted to an italic paragraph, which **injects a node that was not in the input**. Keeping that and documenting it as lossy, versus round-tripping through an HTML comment, is a choice about output meant for human readers rather than a defect with one right answer. That entry stays in the allowlist with the reason rewritten to say so.

## Visible output change

An RST table caption that used to vanish now reaches the output, so RST→Markdown gains an italic line above the table. Two golden snapshots record it. It is a strict improvement on silently deleting the text, but it is a change.

Eight new tests. `tests/unit` + `tests/golden` pass; ruff, black, mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)