### PR TITLE
test(omnidocbench): record what the corpus actually contains

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **The OmniDocBench lane records what its corpus actually contains.**
+  `provenance.corpus_characterization` counts how many pages carry a text layer, vector
+  drawings, or the single-full-page-image shape of a scan, and how many the parser ran OCR
+  on. The lane was built, gated and baselined before anyone asked that question, and the
+  answer changes what the scores mean: every page in the pinned corpus is a raster, so they
+  grade OCR rather than the PDF text and table paths. Counted from the PDF directly rather
+  than from a projection, so a parser change cannot alter what the corpus is reported to
+  contain, and excluded from the gate's identity fields so evidence like this can be added
+  without invalidating a recorded baseline.
+
 ## [1.11.0] - 2026-08-01
 
 ### Added

--- a/benchmarks/omnidocbench/README.md
+++ b/benchmarks/omnidocbench/README.md
@@ -100,6 +100,21 @@ Review the candidate's metric values, `eligible_items`, `variance`, and `toleran
 
 `baseline.json` records the run of 2026-08-01 over all 981 pinned pages at `935df18`: text content 0.5058, reading order 0.6034, block structure 0.1176. Re-record it the same way it was bootstrapped — dispatch the `OmniDocBench PDF Fidelity Gate` workflow with `record_baseline` enabled, review the uploaded candidate, and commit it. Recording the baseline from CI is required: a local run resolves different parser-runtime identity and every later CI run would report `IDENTITY_DRIFT`.
 
+`provenance.corpus_characterization` records what the corpus actually contains, counted
+over the pages that could be read: how many carry a text layer, vector drawings, or the
+single-full-page-image shape of a scan, and how many the parser ran OCR on. It exists
+because this lane was built, gated and baselined before anyone asked that question, and
+the answer turned out to decide what the scores mean — every page is a raster, so they
+grade OCR rather than the PDF text and table paths. `pages_characterized` is the
+denominator for the rest, and a file that cannot be read at all is excluded from it
+rather than counted as having no traits. The counts are read from the PDF directly rather
+than from an all2md projection, so a parser change cannot alter what the corpus is
+reported to contain. They are evidence, not identity: the corpus is already pinned by
+`dataset_revision` and `annotation_sha256`, so they cannot drift without those changing,
+and keeping them out of the gate's identity fields is what lets such evidence be added
+without invalidating a recorded baseline. **Characterize the inputs, not just the
+annotations** — schema-validating one side of a comparison proves nothing about the other.
+
 Review the candidate's numbers before committing one, rather than only its shape. Both metric defects this lane has had were caught that way and neither showed up as an error: a dimension reading 0.0267 with 894 of 981 pages at exactly zero is a passing measurement of a broken metric, and 128 of those pages scored 0.9 or better on text content at the time. A dimension pinned at one value has no range left to detect a regression with, whatever its value.
 
 Synthetic adapter, oracle, and ratchet tests run without the corpus:

--- a/benchmarks/omnidocbench/benchmark.py
+++ b/benchmarks/omnidocbench/benchmark.py
@@ -39,6 +39,11 @@ class PageEvaluation:
     degraded_events: tuple[str, ...] = ()
     error_type: str | None = None
     error: str | None = None
+    #: What the *input* PDF contains, measured before conversion, plus whether OCR ran.
+    #: Names of the traits that hold; absent means the trait was measured and is false.
+    #: ``None`` means the file could not be characterized at all, which is distinct from
+    #: "has none of these traits" and must not be counted as either.
+    traits: frozenset[str] | None = None
 
 
 def _pdf_options(ocr_languages: str) -> PdfOptions:
@@ -115,6 +120,54 @@ def _degraded_kinds(document: Any) -> tuple[str, ...]:
     return tuple(sorted(str(event["kind"]) for event in events if isinstance(event, Mapping) and "kind" in event))
 
 
+#: Traits describing what a corpus PDF actually contains. Recorded because this lane was
+#: built, gated and baselined before anyone asked: every page turned out to be a single
+#: full-page raster, so the scores grade OCR rather than the PDF text and table paths, and
+#: nothing in the payload said so. Validating the annotation schema checks only one side of
+#: the comparison. Characterize the inputs too.
+_INPUT_TRAITS = ("text_layer", "vector_drawings", "one_full_page_image")
+#: Recorded alongside them because "no text layer" and "OCR ran" answer different questions.
+_RUN_TRAITS = ("ocr_applied",)
+
+
+def _input_traits(pdf_path: Path) -> frozenset[str] | None:
+    """Return which input traits a PDF's first page has, or ``None`` if unreadable.
+
+    Deliberately independent of all2md: it reads the file with PyMuPDF directly, so a
+    parser change can never quietly alter what the corpus is reported to contain.
+    """
+    try:
+        import fitz
+    except ImportError:
+        return None
+    try:
+        with fitz.open(pdf_path) as document:
+            if document.page_count < 1:
+                return frozenset()
+            page = document[0]
+            images = page.get_images(full=True)
+            traits = set()
+            if page.get_text().strip():
+                traits.add("text_layer")
+            if page.get_drawings():
+                traits.add("vector_drawings")
+            # One image and nothing else vector-drawn is the scanned-page-in-a-wrapper shape.
+            if len(images) == 1 and not page.get_drawings():
+                traits.add("one_full_page_image")
+            return frozenset(traits)
+    except Exception:  # noqa: BLE001 - characterization is evidence, never a reason to fail a page
+        return None
+
+
+def _ocr_applied(document: Any) -> bool:
+    """Report whether the parser actually ran OCR, rather than inferring it from emptiness."""
+    metadata = document.metadata if isinstance(document.metadata, Mapping) else {}
+    confidence = metadata.get("confidence")
+    signals = confidence.get("signals") if isinstance(confidence, Mapping) else None
+    fraction = signals.get("ocr_page_fraction") if isinstance(signals, Mapping) else None
+    return isinstance(fraction, (int, float)) and not isinstance(fraction, bool) and fraction > 0
+
+
 def _evaluate_page(
     page: CorpusPage,
     truth: GroundTruthPage,
@@ -123,6 +176,8 @@ def _evaluate_page(
     from all2md import to_ast
 
     started = time.perf_counter()
+    # Measured before conversion, so a page that fails to convert still reports what it was.
+    traits = _input_traits(page.pdf_path)
     try:
         document = to_ast(
             page.pdf_path,
@@ -140,6 +195,7 @@ def _evaluate_page(
             predicted_formulas=len(actual.formulas),
             duration_seconds=time.perf_counter() - started,
             degraded_events=_degraded_kinds(document),
+            traits=None if traits is None else traits | ({"ocr_applied"} if _ocr_applied(document) else set()),
         )
     except Exception as exc:  # noqa: BLE001 - failed pages stay in every applicable denominator
         empty = PageProjection((), (), (), ())
@@ -152,6 +208,7 @@ def _evaluate_page(
             duration_seconds=time.perf_counter() - started,
             error_type=type(exc).__name__,
             error=str(exc),
+            traits=traits,
         )
 
 
@@ -241,6 +298,12 @@ def normalize_results(
         explicitly_ignored += page.explicitly_ignored
 
     successful = sum(result.error_type is None for result in evaluations)
+    measured = [result.traits for result in evaluations if result.traits is not None]
+    corpus_characterization = {
+        "pages_characterized": len(measured),
+        **{f"pages_with_{trait}": sum(trait in traits for traits in measured) for trait in _INPUT_TRAITS},
+        **{f"pages_{trait}": sum(trait in traits for traits in measured) for trait in _RUN_TRAITS},
+    }
     return {
         "schema_version": SCHEMA_VERSION,
         "provenance": {
@@ -253,6 +316,11 @@ def normalize_results(
             "python": sys.version,
             "platform": sys.platform,
             "parser_runtime": dict(sorted(parser_runtime.items())),
+            # Evidence, not identity: the corpus is already pinned immutably by
+            # dataset_revision and annotation_sha256, so these counts cannot drift without
+            # those changing. Deliberately absent from the gate's _IDENTITY_FIELDS, which
+            # is what lets them be added without invalidating a recorded baseline.
+            "corpus_characterization": corpus_characterization,
             "parser_config": {
                 "layout_analysis_mode": "enabled",
                 "ocr": {

--- a/tests/unit/test_omnidocbench_benchmark.py
+++ b/tests/unit/test_omnidocbench_benchmark.py
@@ -302,3 +302,93 @@ def test_strict_result_json_rejects_non_finite_scores(tmp_path: Path) -> None:
     """NaN cannot enter a baseline because JSON readers disagree on its meaning."""
     with pytest.raises(ValueError, match="Out of range float values"):
         benchmark.write_result({"score": float("nan")}, tmp_path / "result.json")
+
+
+def _write_vector_pdf(path: Path) -> None:
+    """A born-digital page: real text and a ruled box."""
+    fitz = pytest.importorskip("fitz")
+    document = fitz.open()
+    page = document.new_page()
+    page.insert_text((72, 100), "Quarterly results", fontsize=12)
+    page.draw_rect(fitz.Rect(72, 120, 300, 200))
+    document.save(path)
+    document.close()
+
+
+def _write_scanned_pdf(path: Path, tmp_path: Path) -> None:
+    """A scanned page: one full-page raster, no text layer, no vector drawings."""
+    fitz = pytest.importorskip("fitz")
+    source = tmp_path / "_source.pdf"
+    _write_vector_pdf(source)
+    with fitz.open(source) as origin:
+        pixmap = origin[0].get_pixmap(dpi=72)
+        rect = origin[0].rect
+    document = fitz.open()
+    page = document.new_page(width=rect.width, height=rect.height)
+    page.insert_image(page.rect, pixmap=pixmap)
+    document.save(path)
+    document.close()
+
+
+def test_input_traits_tell_a_born_digital_page_from_a_scan(tmp_path: Path) -> None:
+    """The lane must record what its corpus contains, not assume PDFs carry text.
+
+    This is the check whose absence let an all-raster corpus be scored, gated and
+    baselined as though it exercised the PDF text and table paths.
+    """
+    vector = tmp_path / "vector.pdf"
+    scanned = tmp_path / "scanned.pdf"
+    _write_vector_pdf(vector)
+    _write_scanned_pdf(scanned, tmp_path)
+
+    assert benchmark._input_traits(vector) == frozenset({"text_layer", "vector_drawings"})
+    assert benchmark._input_traits(scanned) == frozenset({"one_full_page_image"})
+
+
+def test_an_unreadable_pdf_is_uncharacterized_rather_than_trait_free(tmp_path: Path) -> None:
+    """``None`` and "no traits" must stay distinct, or unreadable files read as scans."""
+    broken = tmp_path / "broken.pdf"
+    broken.write_bytes(b"not a pdf at all")
+
+    assert benchmark._input_traits(broken) is None
+    assert benchmark._input_traits(tmp_path / "absent.pdf") is None
+
+
+def test_characterization_counts_only_pages_it_could_measure(tmp_path: Path) -> None:
+    """An uncharacterized page must not be counted as lacking every trait."""
+    snapshot = _snapshot(tmp_path)
+    truth = {"page-a": _truth("page-a"), "page-b": _truth("page-b")}
+    evaluations = [
+        benchmark.PageEvaluation(
+            page_id="page-a",
+            scores={"text_content_similarity": 0.5},
+            predicted_tables=0,
+            predicted_formulas=0,
+            duration_seconds=0.1,
+            traits=frozenset({"one_full_page_image", "ocr_applied"}),
+        ),
+        benchmark.PageEvaluation(
+            page_id="page-b",
+            scores={"text_content_similarity": 0.5},
+            predicted_tables=0,
+            predicted_formulas=0,
+            duration_seconds=0.1,
+            traits=None,
+        ),
+    ]
+
+    payload = benchmark.normalize_results(
+        snapshot=snapshot,
+        ground_truth=truth,
+        evaluations=evaluations,
+        all2md_commit="all2md-commit",
+        parser_runtime={"pymupdf": "1.28.0"},
+    )
+
+    assert payload["provenance"]["corpus_characterization"] == {
+        "pages_characterized": 1,
+        "pages_with_text_layer": 0,
+        "pages_with_vector_drawings": 0,
+        "pages_with_one_full_page_image": 1,
+        "pages_ocr_applied": 1,
+    }

--- a/tests/unit/test_omnidocbench_gate.py
+++ b/tests/unit/test_omnidocbench_gate.py
@@ -981,3 +981,27 @@ def test_a_baseline_omitting_worktree_dirty_is_invalid() -> None:
         )
         in verdict.findings
     )
+
+
+def test_new_provenance_evidence_does_not_invalidate_a_recorded_baseline() -> None:
+    """Informational provenance must be addable without paying for a new baseline run.
+
+    Corpus characterization is evidence, not identity: the corpus is already pinned by
+    ``dataset_revision`` and ``annotation_sha256``, so these counts cannot drift without
+    those changing first. The gate compares an explicit allowlist of identity paths, and
+    this test pins that property -- adding a field to ``_IDENTITY_FIELDS`` would force an
+    ~80-minute re-record of every recorded baseline, which should be a deliberate choice
+    rather than a side effect.
+    """
+    results = _results()
+    baseline = _baseline()
+    results["provenance"]["corpus_characterization"] = {
+        "pages_characterized": 2,
+        "pages_with_text_layer": 0,
+        "pages_with_vector_drawings": 0,
+        "pages_with_one_full_page_image": 2,
+        "pages_ocr_applied": 2,
+    }
+
+    assert not gate.compare(results, baseline).failed
+    assert "provenance.corpus_characterization" not in gate._IDENTITY_FIELDS


### PR DESCRIPTION
First item of the follow-up plan after #255. Adds `provenance.corpus_characterization` so the lane declares what it actually exercises.

## Why

The lane was built, gated, baselined and merged before anyone asked what was inside the corpus PDFs. Every page turned out to be a single full-page raster, so the scores grade Tesseract plus our OCR plumbing rather than the PDF text and table paths — and nothing in the payload said so.

The annotations were validated exhaustively: required fields, hashes, integrity, page counts. That is schema validation on **one side** of a comparison. `pages_with_text_layer: 0/981` sitting in `baseline.json` would have made this unmissable during the first candidate review, instead of surfacing three weeks later because a docs claim happened to contradict a metric.

## What it records

Counted over the pages that could be read: how many carry a text layer, vector drawings, or the one-full-page-image shape of a scan, and how many the parser ran OCR on.

- `pages_characterized` is the denominator. A file that cannot be read at all is **excluded** from it rather than counted as having no traits — otherwise an unreadable PDF reads as a scan.
- Counts come from PyMuPDF **directly**, not from an all2md projection, so a parser change cannot quietly alter what the corpus is reported to contain.
- OCR is read from the parser's own `ocr_page_fraction` signal rather than inferred from a page coming back empty. "No text layer" and "OCR ran" answer different questions, and the recorded run answered only the second by accident.

## This does not invalidate the baseline recorded yesterday

Checked before writing any code, because the answer decided whether this cost an ~80-minute re-record: `_check_identity` iterates an explicit allowlist of dotted paths, and `emit_baseline` copies provenance wholesale. So informational provenance is additive and free.

That is a property worth pinning rather than rediscovering, so there is a test asserting the field is absent from `_IDENTITY_FIELDS` and that a result carrying it still passes against a baseline without it. Promoting it to an identity field turns that test red — verified.

It is the right call on the merits too, not just on cost: `dataset_revision` and `annotation_sha256` already pin the corpus immutably, so these counts cannot drift without those changing first.

## Tests verified against the defects they target

Each was run against the broken implementation it is meant to catch:

| Sabotage | Result |
| --- | --- |
| Assume a PDF has a text layer | `test_input_traits_tell_a_born_digital_page_from_a_scan` red |
| Report an unreadable file as trait-free | `test_an_unreadable_pdf_is_uncharacterized_rather_than_trait_free` red |
| Count unmeasured pages in the denominator | `test_characterization_counts_only_pages_it_could_measure` red |
| Promote the field to identity | `test_new_provenance_evidence_does_not_invalidate_a_recorded_baseline` red |

Local: ruff, black, and `mypy benchmarks/` all clean; the three OmniDocBench unit files pass.

## Next in the plan

The PMC PDF-route spike, which is a genuine go/no-go for the born-digital lane — the JATS XML fetches cleanly but the bulk PDF route is unconfirmed. Then #257's `unsupported_dimensions` wording, which is the part that actively misleads today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)