### PR TITLE
fix(openapi): ignore null path items in paths mapping

### DIFF
--- a/src/all2md/parsers/openapi.py
+++ b/src/all2md/parsers/openapi.py
@@ -518,6 +518,8 @@ class OpenApiParser(BaseParser):
             untagged: list[tuple[str, str, dict[str, Any]]] = []
 
             for path, path_item in paths.items():
+                if not isinstance(path_item, dict):
+                    continue
                 for method, operation in path_item.items():
                     if method.upper() not in ["GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS", "HEAD", "TRACE"]:
                         continue
@@ -552,6 +554,8 @@ class OpenApiParser(BaseParser):
         else:
             # List sequentially
             for path, path_item in paths.items():
+                if not isinstance(path_item, dict):
+                    continue
                 for method, operation in path_item.items():
                     if method.upper() not in ["GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS", "HEAD", "TRACE"]:
                         continue

--- a/tests/unit/parsers/test_openapi_parser.py
+++ b/tests/unit/parsers/test_openapi_parser.py
@@ -359,6 +359,32 @@ paths: {}
         with pytest.raises(ParsingError, match="missing required 'info' section"):
             parser.parse(spec.encode("utf-8"))
 
+    def test_null_path_item(self) -> None:
+        """Null/non-dict path items must be skipped; valid neighbors still render."""
+        spec = """openapi: 3.0.0
+info:
+  title: Test API
+  version: 1.0.0
+paths:
+  /null-endpoint: null
+  /string-endpoint: not-a-mapping
+  /valid-endpoint:
+    get:
+      summary: Valid endpoint
+      responses:
+        '200':
+          description: Success
+"""
+        parser = OpenApiParser()
+        doc = parser.parse(spec.encode("utf-8"))
+        from all2md.renderers.markdown import MarkdownRenderer
+
+        md = MarkdownRenderer().render_to_string(doc)
+        assert "GET /valid-endpoint" in md
+        assert "Valid endpoint" in md
+        assert "/null-endpoint" not in md
+        assert "/string-endpoint" not in md
+
     def test_max_schema_depth(self) -> None:
         """Test max_schema_depth option."""
         spec = """openapi: 3.0.0


### PR DESCRIPTION
OpenAPI YAML often includes null path placeholders. Parsing called `.items()` on those values and failed the whole conversion.

Repro: a spec with `/x: null` next to a valid `/y` path raised `ParsingError: 'NoneType' object has no attribute 'items'` on main.

Skip non-dict path items and keep converting the rest.
