### PR TITLE
fix(openapi): handle null components sections

### DIFF
--- a/src/all2md/parsers/openapi.py
+++ b/src/all2md/parsers/openapi.py
@@ -788,7 +788,8 @@ class OpenApiParser(BaseParser):
         nodes: list[Node] = []
 
         # Get schemas from components (OpenAPI 3.x) or definitions (Swagger 2.0)
-        schemas = spec.get("components", {}).get("schemas", {})
+        components = spec.get("components")
+        schemas = components.get("schemas", {}) if isinstance(components, dict) else {}
         if not schemas:
             schemas = spec.get("definitions", {})
 

--- a/tests/unit/parsers/test_openapi_parser.py
+++ b/tests/unit/parsers/test_openapi_parser.py
@@ -359,6 +359,23 @@ paths: {}
         with pytest.raises(ParsingError, match="missing required 'info' section"):
             parser.parse(spec.encode("utf-8"))
 
+    def test_null_components_section(self) -> None:
+        """Explicit components: null must not crash schema section build."""
+        spec = """openapi: 3.0.0
+info:
+  title: Test API
+  version: 1.0.0
+paths: {}
+components: null
+"""
+        parser = OpenApiParser()
+        doc = parser.parse(spec.encode("utf-8"))
+        from all2md.renderers.markdown import MarkdownRenderer
+
+        md = MarkdownRenderer().render_to_string(doc)
+        assert md.startswith("# Test API")
+        assert "1.0.0" in md
+
     def test_max_schema_depth(self) -> None:
         """Test max_schema_depth option."""
         spec = """openapi: 3.0.0


### PR DESCRIPTION
`components: null` made schema loading call `.get` on None and abort the parse.

Only read `components.schemas` when `components` is a dict.
