### PR TITLE
fix(docx): clamp heading levels above 6

### DIFF
--- a/src/all2md/parsers/docx.py
+++ b/src/all2md/parsers/docx.py
@@ -592,7 +592,7 @@ class DocxToAstConverter(BaseParser):
         """Try to process paragraph as a heading. Returns Heading or None."""
         heading_match = re.match(r"Heading (\d+)", style_name)
         if heading_match:
-            level = int(heading_match.group(1))
+            level = min(6, max(1, int(heading_match.group(1))))
             content = self._process_paragraph_runs_to_inline(paragraph)
             heading = Heading(level=level, content=content)
             if style_name:

--- a/src/all2md/parsers/docx.py
+++ b/src/all2md/parsers/docx.py
@@ -2057,7 +2057,7 @@ CONVERTER_METADATA = ConverterMetadata(
     parser_required_packages=[("python-docx", "docx", "")],
     renderer_required_packages=[("python-docx", "docx", ">=1.2.0")],
     optional_packages=[],
-    import_error_message=("DOCX conversion requires 'python-docx'. " "Install with: pip install python-docx"),
+    import_error_message=("DOCX conversion requires 'python-docx'. Install with: pip install python-docx"),
     parser_options_class=DocxOptions,
     renderer_options_class="all2md.options.docx.DocxRendererOptions",
     description="Convert Microsoft Word DOCX documents to/from AST",

--- a/tests/unit/parsers/test_docx_parser.py
+++ b/tests/unit/parsers/test_docx_parser.py
@@ -189,6 +189,19 @@ class TestBasicElements:
         md = MarkdownRenderer().render_to_string(DocxToAstConverter().convert_to_ast(doc))
         assert md.startswith("Title text")
 
+    def test_heading_level_above_six_clamped(self) -> None:
+        """Heading 7/8/9 styles must clamp to Heading level 6 without ValueError."""
+        doc = docx.Document()
+        doc.add_paragraph("Deep Heading", style="Heading 7")
+
+        ast_doc = DocxToAstConverter().convert_to_ast(doc)
+
+        assert len(ast_doc.children) == 1
+        heading = ast_doc.children[0]
+        assert isinstance(heading, Heading)
+        assert heading.level == 6
+        assert heading.content[0].content == "Deep Heading"
+
     def test_inline_math_extraction(self) -> None:
         """Inline OMML equations should become MathInline nodes."""
         doc = docx.Document()


### PR DESCRIPTION
DOCX `Heading N` styles can use N greater than 6. The AST heading model tops out at 6, so large outline levels produced invalid nodes.

Clamp parsed heading levels into 1..6.
