### PR TITLE
fix(odt): clamp heading outline levels above 6

### DIFF
--- a/src/all2md/parsers/odt.py
+++ b/src/all2md/parsers/odt.py
@@ -354,7 +354,7 @@ class OdtToAstConverter(BaseParser):
             AST heading node
 
         """
-        level = int(h.getAttribute("outlinelevel") or 1)
+        level = min(6, max(1, int(h.getAttribute("outlinelevel") or 1)))
         content = self._process_text_runs(h, doc)
         return Heading(level=level, content=content)
 

--- a/tests/unit/parsers/test_odt_parser.py
+++ b/tests/unit/parsers/test_odt_parser.py
@@ -1,0 +1,24 @@
+"""Unit tests for ODT parser."""
+
+import pytest
+from odf import opendocument, text
+
+from all2md.ast import Heading
+from all2md.parsers.odt import OdtToAstConverter
+
+
+@pytest.mark.unit
+def test_odt_heading_level_above_six_clamped() -> None:
+    """ODT heading elements with outlinelevel >= 7 must clamp to Heading level 6."""
+    doc = opendocument.OpenDocumentText()
+    h = text.H(outlinelevel="7", text="Deep ODT Heading")
+    doc.text.addElement(h)
+
+    converter = OdtToAstConverter()
+    ast_doc = converter.convert_to_ast(doc)
+
+    assert len(ast_doc.children) == 1
+    heading = ast_doc.children[0]
+    assert isinstance(heading, Heading)
+    assert heading.level == 6
+    assert heading.content[0].content == "Deep ODT Heading"


### PR DESCRIPTION
ODT outline levels can exceed 6. Unclamped values produced invalid AST headings.

Clamp outline levels into the AST maximum of 6.
