### PR TITLE
fix(ast): preserve non-text nodes during inline consolidation

### DIFF
--- a/src/all2md/ast/transforms.py
+++ b/src/all2md/ast/transforms.py
@@ -1283,7 +1283,7 @@ class InlineFormattingConsolidator(NodeTransformer):
         return result
 
     def _has_nested_formatting(self, node: Strong | Emphasis) -> bool:
-        """Check if a formatting node contains nested formatting (not just text).
+        """Check if a formatting node contains nested formatting or non-text nodes.
 
         Parameters
         ----------
@@ -1293,11 +1293,11 @@ class InlineFormattingConsolidator(NodeTransformer):
         Returns
         -------
         bool
-            True if node contains nested Strong/Emphasis, False if only Text/Code
+            True if node contains nested formatting or non-text nodes, False if only Text children
 
         """
         for child in node.content:
-            if isinstance(child, (Strong, Emphasis)):
+            if not isinstance(child, Text):
                 return True
         return False
 
@@ -1500,6 +1500,10 @@ class InlineFormattingConsolidator(NodeTransformer):
                         source_location=node.source_location,
                     )
                 )
+            elif isinstance(node, (Strikethrough, Mark, Underline, Superscript, Subscript)):
+                # Recursively consolidate other inline container nodes
+                consolidated_children = self._consolidate_inline_nodes(node.content)
+                processed.append(replace_node_children(node, consolidated_children))
             else:
                 processed.append(node)
 

--- a/tests/unit/ast/test_ast_transforms.py
+++ b/tests/unit/ast/test_ast_transforms.py
@@ -1076,4 +1076,3 @@ class TestInlineFormattingConsolidator:
         assert len(strike_node.content) == 1
         assert isinstance(strike_node.content[0], Strong)
         assert strike_node.content[0].content[0].content == "textmore"
-

--- a/tests/unit/ast/test_ast_transforms.py
+++ b/tests/unit/ast/test_ast_transforms.py
@@ -1018,3 +1018,62 @@ class TestInlineFormattingConsolidator:
         assert isinstance(result, Paragraph)
         # Empty Strong should be removed
         assert len(result.content) == 0
+
+    def test_preserve_non_text_inline_nodes_in_formatting(self) -> None:
+        """Non-text inline nodes inside Strong must not be flattened to plain text."""
+        img = Image(url="icon.png", alt_text="link icon")
+        link = Link(url="http://example.com", content=[Text(content="Example")])
+        code = Code(content="x")
+        para = Paragraph(
+            content=[
+                Strong(
+                    content=[
+                        Text(content="Click here: "),
+                        img,
+                        Text(content=" "),
+                        link,
+                        Text(content=" use "),
+                        code,
+                    ]
+                )
+            ]
+        )
+        consolidator = InlineFormattingConsolidator()
+        result = consolidator.transform(para)
+
+        assert isinstance(result, Paragraph)
+        assert len(result.content) == 1
+        strong_node = result.content[0]
+        assert isinstance(strong_node, Strong)
+        types = [type(n).__name__ for n in strong_node.content]
+        assert types == ["Text", "Image", "Text", "Link", "Text", "Code"]
+        assert strong_node.content[0].content == "Click here: "
+        assert strong_node.content[1] == img
+        assert strong_node.content[3] == link
+        assert strong_node.content[5].content == "x"
+
+    def test_consolidate_strikethrough_container(self) -> None:
+        """Inline container nodes like Strikethrough are recursively consolidated."""
+        from all2md.ast import Strikethrough
+
+        para = Paragraph(
+            content=[
+                Strikethrough(
+                    content=[
+                        Strong(content=[Text(content="text")]),
+                        Strong(content=[Text(content="more")]),
+                    ]
+                )
+            ]
+        )
+        consolidator = InlineFormattingConsolidator()
+        result = consolidator.transform(para)
+
+        assert isinstance(result, Paragraph)
+        assert len(result.content) == 1
+        strike_node = result.content[0]
+        assert isinstance(strike_node, Strikethrough)
+        assert len(strike_node.content) == 1
+        assert isinstance(strike_node.content[0], Strong)
+        assert strike_node.content[0].content[0].content == "textmore"
+


### PR DESCRIPTION
Inline formatting consolidation treated only nested Strong/Emphasis as structure worth preserving. Images, links, and code inside Strong/Emphasis could be flattened away.

Treat any non-Text child as structure to keep, and recurse other inline containers.
