### PR TITLE
fix(html): preserve table cell colspan, rowspan, and alignment

### DIFF
--- a/src/all2md/parsers/html.py
+++ b/src/all2md/parsers/html.py
@@ -1402,6 +1402,17 @@ class HtmlToAstConverter(BaseParser):
 
         return None
 
+    @staticmethod
+    def _parse_cell_span_attr(tag: Any, attr: str) -> int:
+        val = tag.get(attr)
+        if val is not None:
+            try:
+                parsed = int(str(val).strip())
+                return max(1, parsed)
+            except (ValueError, TypeError):
+                pass
+        return 1
+
     def _process_table_row_cells(
         self, tr: Any, collect_alignments: bool = False
     ) -> tuple[list[TableCell], list[str | None]]:
@@ -1411,9 +1422,12 @@ class HtmlToAstConverter(BaseParser):
         # Direct children only: recursive find_all duplicates nested td/th into the outer row
         for cell in tr.find_all(["th", "td"], recursive=False):
             content = self._process_table_cell_content(cell)
-            cells.append(TableCell(content=content))
+            alignment = self._get_alignment(cell)
+            colspan = self._parse_cell_span_attr(cell, "colspan")
+            rowspan = self._parse_cell_span_attr(cell, "rowspan")
+            cells.append(TableCell(content=content, colspan=colspan, rowspan=rowspan, alignment=alignment))
             if collect_alignments:
-                alignments.append(self._get_alignment(cell))
+                alignments.append(alignment)
         return cells, alignments
 
     def _process_thead_section(self, node: Any) -> tuple[TableRow | None, list[TableRow], list[str | None]]:

--- a/src/all2md/parsers/html.py
+++ b/src/all2md/parsers/html.py
@@ -1528,7 +1528,7 @@ class HtmlToAstConverter(BaseParser):
             if not alignments:
                 alignments = [None] * len(header.cells)
 
-        return Table(header=header, rows=rows, alignments=alignments, caption=caption)  # type: ignore[arg-type]
+        return Table(header=header, rows=rows, alignments=alignments, caption=caption)
 
     def _process_definition_list_to_ast(self, node: Any) -> DefinitionList:
         """Process dl element to DefinitionList node.

--- a/src/all2md/parsers/html.py
+++ b/src/all2md/parsers/html.py
@@ -22,6 +22,7 @@ from typing import IO, Any, Optional, Union
 from urllib.parse import urljoin, urlparse
 
 from all2md.ast import (
+    Alignment,
     BlockQuote,
     Code,
     CodeBlock,

--- a/src/all2md/parsers/html.py
+++ b/src/all2md/parsers/html.py
@@ -1431,7 +1431,7 @@ class HtmlToAstConverter(BaseParser):
                 alignments.append(alignment)
         return cells, alignments
 
-    def _process_thead_section(self, node: Any) -> tuple[TableRow | None, list[TableRow], list[str | None]]:
+    def _process_thead_section(self, node: Any) -> tuple[TableRow | None, list[TableRow], list[Alignment | None]]:
         """Process thead section. Returns (header, extra_rows, alignments)."""
         thead = node.find("thead")
         if not thead:
@@ -1456,13 +1456,13 @@ class HtmlToAstConverter(BaseParser):
 
     def _process_tbody_rows(
         self, node: Any, has_header: bool
-    ) -> tuple[TableRow | None, list[TableRow], list[str | None]]:
+    ) -> tuple[TableRow | None, list[TableRow], list[Alignment | None]]:
         """Process tbody or direct rows. Returns (header_if_found, rows, alignments)."""
         tbody = node.find("tbody")
         row_container = tbody if tbody else node
         header = None
         rows = []
-        alignments: list[str | None] = []
+        alignments: list[Alignment | None] = []
 
         for tr in row_container.find_all("tr", recursive=False):
             if has_header and tr.parent.name == "thead":

--- a/src/all2md/parsers/html.py
+++ b/src/all2md/parsers/html.py
@@ -1415,7 +1415,7 @@ class HtmlToAstConverter(BaseParser):
 
     def _process_table_row_cells(
         self, tr: Any, collect_alignments: bool = False
-    ) -> tuple[list[TableCell], list[str | None]]:
+    ) -> tuple[list[TableCell], list[Alignment | None]]:
         """Process cells in a table row. Returns (cells, alignments)."""
         cells = []
         alignments = []
@@ -2323,7 +2323,7 @@ class HtmlToAstConverter(BaseParser):
 
         return sanitize_language_identifier(fallback)
 
-    def _get_alignment(self, cell: Any) -> str | None:
+    def _get_alignment(self, cell: Any) -> Alignment | None:
         """Get table cell alignment.
 
         Parameters

--- a/tests/unit/parsers/test_html_parser.py
+++ b/tests/unit/parsers/test_html_parser.py
@@ -531,6 +531,34 @@ class TestTables:
         assert len(table.header.cells) == 2
         assert len(table.rows) == 2
 
+    def test_table_cell_colspan_rowspan_alignment(self) -> None:
+        """Test table cells preserve colspan, rowspan, and alignment attributes."""
+        html = """
+        <table>
+            <thead>
+                <tr><th colspan="2" rowspan="3" align="center">Header Spanned</th></tr>
+            </thead>
+            <tbody>
+                <tr><td colspan="4" rowspan="5" align="right">Data Spanned</td></tr>
+            </tbody>
+        </table>
+        """
+        converter = HtmlToAstConverter()
+        doc = converter.convert_to_ast(html)
+
+        table = doc.children[0]
+        assert isinstance(table, Table)
+        assert table.header is not None
+        header_cell = table.header.cells[0]
+        assert header_cell.colspan == 2
+        assert header_cell.rowspan == 3
+        assert header_cell.alignment == "center"
+
+        row_cell = table.rows[0].cells[0]
+        assert row_cell.colspan == 4
+        assert row_cell.rowspan == 5
+        assert row_cell.alignment == "right"
+
     def test_empty_tr_without_cells_skipped(self) -> None:
         """Empty <tr></tr> must not become a 0-cell header row."""
         converter = HtmlToAstConverter()


### PR DESCRIPTION
HTML table cells with colspan/rowspan/align were converted to default 1x1 cells, losing layout.

Parse span attributes and alignment onto `TableCell`.
