### PR TITLE
fix(epub): walk nested TOC tuples when building headings

### DIFF
--- a/src/all2md/parsers/epub.py
+++ b/src/all2md/parsers/epub.py
@@ -188,7 +188,6 @@ class EpubToAstConverter(BaseParser):
 
         return Document(children=children)
 
-
     def _process_toc_items(self, items: Any, level: int = 2) -> list[Node]:
         """Recursively turn ebooklib TOC entries into heading nodes."""
         nodes: list[Node] = []
@@ -295,7 +294,7 @@ CONVERTER_METADATA = ConverterMetadata(
     parser_required_packages=[("ebooklib", "ebooklib", "")],
     renderer_required_packages=[("ebooklib", "ebooklib", ">=0.17")],
     optional_packages=[],
-    import_error_message=("ePub conversion requires 'ebooklib'. " "Install with: pip install ebooklib"),
+    import_error_message=("ePub conversion requires 'ebooklib'. Install with: pip install ebooklib"),
     parser_options_class=EpubOptions,
     renderer_options_class="all2md.options.epub.EpubRendererOptions",
     priority=8,

--- a/src/all2md/parsers/epub.py
+++ b/src/all2md/parsers/epub.py
@@ -188,6 +188,22 @@ class EpubToAstConverter(BaseParser):
 
         return Document(children=children)
 
+
+    def _process_toc_items(self, items: Any, level: int = 2) -> list[Node]:
+        """Recursively turn ebooklib TOC entries into heading nodes."""
+        nodes: list[Node] = []
+        if isinstance(items, (list, tuple)):
+            if len(items) == 2 and hasattr(items[0], "title") and isinstance(items[1], (list, tuple)):
+                section_or_link, subitems = items
+                nodes.append(Heading(level=min(level, 6), content=[Text(content=section_or_link.title)]))
+                nodes.extend(self._process_toc_items(subitems, level + 1))
+            else:
+                for subitem in items:
+                    nodes.extend(self._process_toc_items(subitem, level))
+        elif hasattr(items, "title"):
+            nodes.append(Heading(level=min(level, 6), content=[Text(content=items.title)]))
+        return nodes
+
     def _build_toc(self, book: Any) -> list[Node]:
         """Build table of contents from EPUB.
 
@@ -211,11 +227,7 @@ class EpubToAstConverter(BaseParser):
         # Add TOC heading
         nodes.append(Heading(level=1, content=[Text(content="Table of Contents")]))
 
-        # Process TOC items
-        for item in toc:
-            if hasattr(item, "title"):
-                nodes.append(Heading(level=2, content=[Text(content=item.title)]))
-
+        nodes.extend(self._process_toc_items(toc, level=2))
         return nodes
 
     def extract_metadata(self, document: Any) -> DocumentMetadata:

--- a/tests/integration/parsers/test_epub_conversion.py
+++ b/tests/integration/parsers/test_epub_conversion.py
@@ -18,6 +18,7 @@ from fixtures.generators.epub_fixtures import (
 from utils import assert_markdown_valid
 
 from all2md import EpubOptions
+from all2md.ast import Heading
 from all2md import to_markdown as epub_to_markdown
 from all2md.exceptions import MalformedFileError, ParsingError
 from all2md.options import MarkdownRendererOptions
@@ -77,6 +78,25 @@ class TestEpubIntegrationBasic:
         assert isinstance(result, str)
         assert "Chapter 1: Introduction" in result
         assert_markdown_valid(result)
+
+    def test_epub_build_toc_nested_tuples(self) -> None:
+        """Nested ebooklib TOC tuples must yield section and chapter headings."""
+        from ebooklib import epub
+
+        from all2md.parsers.epub import EpubToAstConverter
+
+        book = epub.EpubBook()
+        sec1 = epub.Section("Part 1")
+        chap1 = epub.Link("c1.xhtml", "Chapter 1", "c1")
+        chap2 = epub.Link("c2.xhtml", "Chapter 2", "c2")
+        book.toc = ((sec1, (chap1, chap2)),)
+
+        nodes = EpubToAstConverter()._build_toc(book)
+        titles = [n.content[0].content for n in nodes if isinstance(n, Heading)]
+        assert titles == ["Table of Contents", "Part 1", "Chapter 1", "Chapter 2"]
+        levels = [n.level for n in nodes if isinstance(n, Heading)]
+        assert levels == [1, 2, 3, 3]
+
 
     def test_simple_epub_with_toc_disabled(self, temp_dir):
         """Test conversion with table of contents disabled."""

--- a/tests/integration/parsers/test_epub_conversion.py
+++ b/tests/integration/parsers/test_epub_conversion.py
@@ -18,8 +18,8 @@ from fixtures.generators.epub_fixtures import (
 from utils import assert_markdown_valid
 
 from all2md import EpubOptions
-from all2md.ast import Heading
 from all2md import to_markdown as epub_to_markdown
+from all2md.ast import Heading
 from all2md.exceptions import MalformedFileError, ParsingError
 from all2md.options import MarkdownRendererOptions
 

--- a/tests/integration/parsers/test_epub_conversion.py
+++ b/tests/integration/parsers/test_epub_conversion.py
@@ -97,7 +97,6 @@ class TestEpubIntegrationBasic:
         levels = [n.level for n in nodes if isinstance(n, Heading)]
         assert levels == [1, 2, 3, 3]
 
-
     def test_simple_epub_with_toc_disabled(self, temp_dir):
         """Test conversion with table of contents disabled."""
         epub_content = create_simple_epub()


### PR DESCRIPTION
ebooklib TOC entries are often nested `(section, [children])` tuples. The flat TOC walk only kept top-level objects with `.title`, dropping nested chapter headings.

Walk nested list/tuple structures recursively when building TOC headings.
