### PR TITLE
fix(pdf): honor escaped pipes in markdown table row fallback

### DIFF
--- a/src/all2md/parsers/pdf.py
+++ b/src/all2md/parsers/pdf.py
@@ -2960,9 +2960,11 @@ class PdfToAstConverter(BaseParser):
         if row_line.endswith("|"):
             row_line = row_line[:-1]
 
+        # The AST holds unescaped text: restore the placeholder as a bare "|" and let the
+        # renderer re-escape it. Keeping the backslash here would escape it a second time.
         escaped_pipe_placeholder = "\x00PIPE\x00"
         row_line_escaped = row_line.replace(r"\|", escaped_pipe_placeholder)
-        cells = [cell.replace(escaped_pipe_placeholder, r"\|").strip() for cell in row_line_escaped.split("|")]
+        cells = [cell.replace(escaped_pipe_placeholder, "|").strip() for cell in row_line_escaped.split("|")]
         return cells
 
     def _collect_image_exclusion_regions(self, layout: "PageLayoutPredictions | None") -> list[Any]:

--- a/src/all2md/parsers/pdf.py
+++ b/src/all2md/parsers/pdf.py
@@ -2953,14 +2953,16 @@ class PdfToAstConverter(BaseParser):
             Cell contents
 
         """
-        # Remove leading/trailing pipes and split
+        # Remove leading/trailing pipes and split, respecting escaped pipes (\|)
         row_line = row_line.strip()
         if row_line.startswith("|"):
             row_line = row_line[1:]
         if row_line.endswith("|"):
             row_line = row_line[:-1]
 
-        cells = [cell.strip() for cell in row_line.split("|")]
+        escaped_pipe_placeholder = "\x00PIPE\x00"
+        row_line_escaped = row_line.replace(r"\|", escaped_pipe_placeholder)
+        cells = [cell.replace(escaped_pipe_placeholder, r"\|").strip() for cell in row_line_escaped.split("|")]
         return cells
 
     def _collect_image_exclusion_regions(self, layout: "PageLayoutPredictions | None") -> list[Any]:

--- a/tests/unit/parsers/test_pdf_parser.py
+++ b/tests/unit/parsers/test_pdf_parser.py
@@ -268,6 +268,15 @@ class TestTableDetection:
         assert isinstance(ast_doc, Document)
 
 
+
+    def test_parse_markdown_table_row_escaped_pipe(self) -> None:
+        r"""Escaped pipes inside a cell must not split the cell."""
+        converter = PdfToAstConverter()
+        row = r"| cell1 \| extended | cell2 |"
+        cells = converter._parse_markdown_table_row(row)
+        assert cells == [r"cell1 \| extended", "cell2"]
+
+
 @pytest.mark.unit
 class TestImageExtraction:
     """Tests for image extraction."""

--- a/tests/unit/parsers/test_pdf_parser.py
+++ b/tests/unit/parsers/test_pdf_parser.py
@@ -267,8 +267,6 @@ class TestTableDetection:
         # Tables should be flattened to paragraphs
         assert isinstance(ast_doc, Document)
 
-
-
     def test_parse_markdown_table_row_escaped_pipe(self) -> None:
         r"""Escaped pipes inside a cell must not split the cell."""
         converter = PdfToAstConverter()

--- a/tests/unit/parsers/test_pdf_parser.py
+++ b/tests/unit/parsers/test_pdf_parser.py
@@ -268,11 +268,26 @@ class TestTableDetection:
         assert isinstance(ast_doc, Document)
 
     def test_parse_markdown_table_row_escaped_pipe(self) -> None:
-        r"""Escaped pipes inside a cell must not split the cell."""
+        r"""Escaped pipes inside a cell must not split the cell, and land unescaped in the AST."""
         converter = PdfToAstConverter()
         row = r"| cell1 \| extended | cell2 |"
         cells = converter._parse_markdown_table_row(row)
-        assert cells == [r"cell1 \| extended", "cell2"]
+        assert cells == ["cell1 | extended", "cell2"]
+
+    def test_escaped_pipe_cell_survives_render(self) -> None:
+        r"""A cell holding a literal pipe is escaped exactly once on the way back out."""
+        from all2md.ast import TableCell, TableRow, Text
+        from all2md.renderers.markdown import MarkdownRenderer
+
+        converter = PdfToAstConverter()
+        cells = converter._parse_markdown_table_row(r"| cell1 \| extended | cell2 |")
+        table = Table(
+            header=TableRow(cells=[TableCell(content=[Text(content=c)]) for c in cells], is_header=True),
+            rows=[],
+        )
+        md = MarkdownRenderer().render_to_string(Document(children=[table]))
+        assert r"| cell1 \| extended | cell2 |" in md
+        assert "\\\\" not in md
 
 
 @pytest.mark.unit


### PR DESCRIPTION
The PDF markdown table row fallback split on every `|`, including escaped `\|`, so cells with literal pipes fractured.

Mask escaped pipes before splitting and restore them in the cell text.
