### PR TITLE
fix(openapi): handle null components sections

### DIFF
--- a/src/all2md/parsers/openapi.py
+++ b/src/all2md/parsers/openapi.py
@@ -792,7 +792,8 @@ class OpenApiParser(BaseParser):
         nodes: list[Node] = []
 
         # Get schemas from components (OpenAPI 3.x) or definitions (Swagger 2.0)
-        schemas = spec.get("components", {}).get("schemas", {})
+        components = spec.get("components")
+        schemas = components.get("schemas", {}) if isinstance(components, dict) else {}
         if not schemas:
             schemas = spec.get("definitions", {})
 

--- a/tests/unit/parsers/test_openapi_parser.py
+++ b/tests/unit/parsers/test_openapi_parser.py
@@ -385,6 +385,23 @@ paths:
         assert "/null-endpoint" not in md
         assert "/string-endpoint" not in md
 
+    def test_null_components_section(self) -> None:
+        """Explicit components: null must not crash schema section build."""
+        spec = """openapi: 3.0.0
+info:
+  title: Test API
+  version: 1.0.0
+paths: {}
+components: null
+"""
+        parser = OpenApiParser()
+        doc = parser.parse(spec.encode("utf-8"))
+        from all2md.renderers.markdown import MarkdownRenderer
+
+        md = MarkdownRenderer().render_to_string(doc)
+        assert md.startswith("# Test API")
+        assert "1.0.0" in md
+
     def test_max_schema_depth(self) -> None:
         """Test max_schema_depth option."""
         spec = """openapi: 3.0.0


### PR DESCRIPTION
Rebase of #261 onto current `main`. The original branch conflicted with #260 (both added a test at the same point in `tests/unit/parsers/test_openapi_parser.py`); resolved as union — both tests are kept.

`components: null` made schema loading call `.get` on `None` and abort the parse. Only read `components.schemas` when `components` is a dict.

Authored by @santhreal (commit authorship preserved). Supersedes #261.