### PR TITLE
chore(mcp): claim the registry namespace in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,9 @@
 
 📦 **[PyPI](https://pypi.org/project/all2md/)** · 📖 **[Documentation](https://all2md.readthedocs.io/)** · 💡 **[Examples](examples/)**
 
+<!-- mcp-name: io.github.thomas-villani/all2md -->
+
+
 ## Quick start
 
 ```bash


### PR DESCRIPTION
One-line prerequisite for listing all2md in the official MCP registry, which needs to ship **before** the v1.11.0 tag.

The registry verifies PyPI package ownership by looking for an `mcp-name:` token in the package README *as PyPI serves it*. `pyproject.toml` sets `readme = "README.md"`, so the marker has to be baked into a published dist — adding it after a release means the registry entry waits for the release after that.

```markdown
<!-- mcp-name: io.github.thomas-villani/all2md -->
```

It's an HTML comment, so nothing renders on GitHub or the PyPI project page. It sits on its own line deliberately: the token must be followed by a boundary (newline, whitespace, HTML tag, or `-->`), and gluing it to trailing punctuation prevents the match.

The namespace `io.github.thomas-villani/all2md` is what GitHub-based authentication authorises us to publish under.

Verified separately that the runtime side works, against a published dist rather than the working tree — `all2md[mcp]==1.10.1` from PyPI installs `fastmcp` and registers both `all2md` and `all2md-mcp` console scripts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)