### PR TITLE
fix(api): warn on unrecognized kwargs in to_ast and from_ast

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -303,6 +303,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   deep silently dropped its deepest item, because pyth pushed a list for the level
   increase and never re-attached it (#209, #210).
 
+- **`to_ast()` and `from_ast()` now warn about keyword arguments they don't recognise.**
+  `to_markdown()` has always warned; the other two dropped unknown kwargs at a
+  `logger.debug` call nobody sees. The result looked fine, which is the bad combination:
+  `to_ast(content, filename="x.md")` is a natural thing to write, `filename` is not a
+  parameter of anything (the real one is `source_format`), so the hint was discarded,
+  detection fell through to the *plaintext* parser, and the caller got back a `Document`
+  of bare `Paragraph`s — headings, lists and tables all gone, with no error. The same
+  applied to any misspelled option name. All three entry points now route through one
+  helper, so they cannot drift apart again. Two details worth knowing: the warning
+  fires only for names that are not options of *any* format, because a real option that
+  this particular format ignores is usually the library's own doing — the CLI packager
+  forces `attachment_mode`, the MCP server sets it from server config, and `convert`
+  injects its `flavor` shorthand — and blaming the caller for those would be wrong.
+  And the existing warning pointed one frame past the caller, landing on `<sys>:0`,
+  which made it useless to act on and collapsed every such warning into a single
+  dedup entry; it now names the calling line (#273).
+
 ## [1.10.1] - 2026-07-27
 
 A maintenance release. Almost all of it is infrastructure — the harnesses this

--- a/src/all2md/api.py
+++ b/src/all2md/api.py
@@ -221,6 +221,80 @@ def _collect_nested_dataclass_kwargs(
     return {"nested": nested_kwargs, "remaining": remaining_kwargs}
 
 
+def _warn_unrecognized_kwargs(unmatched: list[str], stacklevel: int) -> None:
+    """Warn that keyword arguments matched no options field and were dropped.
+
+    Every public entry point that accepts ``**kwargs`` routes its leftovers here so
+    the warning stays identical across them. Silently discarding an option name is
+    the bad kind of failure: the call returns a plausible-looking result, so a typo
+    (or a parameter that simply doesn't exist, like ``filename``) reads as a library
+    bug rather than a caller mistake.
+
+    ``stacklevel`` is counted from the caller's frame, as if it had called
+    ``warnings.warn`` itself.
+    """
+    if not unmatched:
+        return
+    warnings.warn(
+        f"Unrecognized keyword arguments were ignored: {unmatched}. "
+        "Check the API documentation for valid parameter names.",
+        UserWarning,
+        stacklevel=stacklevel + 1,
+    )
+
+
+_ALL_OPTION_FIELD_NAMES: set[str] | None = None
+
+
+def _all_option_field_names() -> set[str]:
+    """Every field name declared by any parser or renderer options class.
+
+    Used to tell a *typo* apart from a *real option that this format ignores*.
+    Building it imports every options module, so it is computed on first use --
+    the warning path only -- and cached. Formats whose options class cannot be
+    loaded (missing optional dependency) are skipped rather than raising.
+    """
+    global _ALL_OPTION_FIELD_NAMES
+    if _ALL_OPTION_FIELD_NAMES is None:
+        names: set[str] = set()
+        for format_name in registry.list_formats():
+            for getter in (registry.get_parser_options_class, registry.get_renderer_options_class):
+                try:
+                    options_class = getter(format_name)
+                except Exception:  # pragma: no cover - defensive, optional deps
+                    continue
+                if not options_class or not is_dataclass(options_class):
+                    continue
+                # Resolve through get_type_hints rather than reading field.type: a
+                # module using `from __future__ import annotations` yields strings,
+                # which would drop every nested name and make valid options warn.
+                type_hints = _option_type_hints(options_class)
+                for field in fields(options_class):
+                    names.add(field.name)
+                    # Nested options dataclasses (e.g. network) are addressed by
+                    # their own field names at the API surface, so count them too.
+                    field_type = type_hints.get(field.name, field.type)
+                    if is_dataclass(field_type):
+                        names.update(nested.name for nested in fields(field_type))
+        _ALL_OPTION_FIELD_NAMES = names
+    return _ALL_OPTION_FIELD_NAMES
+
+
+def _warn_unknown_option_names(dropped: list[str], stacklevel: int) -> None:
+    """Warn only for dropped kwargs that are not options anywhere in all2md.
+
+    Unlike ``_split_kwargs_for_parser_and_renderer``, which sees both halves of a
+    conversion and can conclude a name is bogus, callers of this helper see only one
+    options class. A name like ``attachment_mode`` is a genuine option that this
+    particular format has no use for -- and the CLI packager, the MCP server and
+    ``convert``'s ``flavor`` shorthand all inject such options themselves. Warning
+    about those would blame the caller for something the library did, so they stay a
+    debug-level detail; only names that exist nowhere reach the user.
+    """
+    unknown = [name for name in dropped if name not in _all_option_field_names()]
+    _warn_unrecognized_kwargs(unknown, stacklevel=stacklevel + 1)
+
+
 def _create_options_from_kwargs(
     options_class: type[OptionsT] | None,
     options_type_name: str,
@@ -242,8 +316,19 @@ def _create_options_from_kwargs(
     OptionsT | None
         Options instance or None if options_class is None.
 
+    Warns
+    -----
+    UserWarning
+        If a keyword argument is not an option of any format (a typo, or a parameter
+        that does not exist such as ``filename``). Callers that pre-split kwargs
+        through ``_split_kwargs_for_parser_and_renderer`` have already filtered
+        theirs, so this only fires for entry points that pass user kwargs through
+        unfiltered (``to_ast``, ``from_ast``).
+
     """
     if not options_class:
+        # No options class for this format, so every kwarg is dropped.
+        _warn_unknown_option_names(list(kwargs), stacklevel=4)
         return None
 
     # Collect nested dataclass kwargs
@@ -282,6 +367,7 @@ def _create_options_from_kwargs(
     missing = [k for k in flat_kwargs if k not in valid_kwargs]
     if missing:
         logger.debug(f"Skipping unknown {options_type_name} options: {missing}")
+        _warn_unknown_option_names(missing, stacklevel=4)
     return options_class(**valid_kwargs)
 
 
@@ -380,13 +466,7 @@ def _split_kwargs_for_parser_and_renderer(
         else:
             unmatched.append(k)
 
-    if unmatched:
-        warnings.warn(
-            f"Unrecognized keyword arguments were ignored: {unmatched}. "
-            "Check the API documentation for valid parameter names.",
-            UserWarning,
-            stacklevel=4,
-        )
+    _warn_unrecognized_kwargs(unmatched, stacklevel=3)
 
     return parser_kwargs, renderer_kwargs
 

--- a/tests/unit/core/test_api_kwarg_validation.py
+++ b/tests/unit/core/test_api_kwarg_validation.py
@@ -1,0 +1,114 @@
+"""Unrecognized keyword arguments must warn from every public entry point.
+
+Regression tests for #273. ``to_markdown`` warned on unknown kwargs but ``to_ast``
+and ``from_ast`` dropped them silently, so a typo (or a plausible-but-nonexistent
+parameter such as ``filename``) produced a valid-looking result with no diagnostic.
+"""
+
+import warnings
+
+import pytest
+
+from all2md import from_ast, to_ast, to_markdown
+
+MARKDOWN_SRC = "# Heading\n\nBody text.\n"
+
+
+def _warnings_from(func, *args, **kwargs):
+    """Return the UserWarnings raised by a call, ignoring everything else."""
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        func(*args, **kwargs)
+    return [w for w in caught if issubclass(w.category, UserWarning) and "Unrecognized keyword" in str(w.message)]
+
+
+@pytest.mark.unit
+class TestUnrecognizedKwargsWarn:
+    """Unknown kwargs are reported, not swallowed."""
+
+    @pytest.mark.parametrize("bad_kwarg", ["filename", "bogus_xyz", "exract_title"])
+    def test_to_ast_warns(self, bad_kwarg):
+        found = _warnings_from(to_ast, MARKDOWN_SRC, **{bad_kwarg: "value"})
+        assert found, f"to_ast silently ignored {bad_kwarg!r}"
+        assert bad_kwarg in str(found[0].message)
+
+    @pytest.mark.parametrize("bad_kwarg", ["filename", "bogus_xyz", "exract_title"])
+    def test_to_markdown_warns(self, bad_kwarg):
+        found = _warnings_from(to_markdown, MARKDOWN_SRC, **{bad_kwarg: "value"})
+        assert found, f"to_markdown silently ignored {bad_kwarg!r}"
+        assert bad_kwarg in str(found[0].message)
+
+    def test_from_ast_warns(self):
+        doc = to_ast(MARKDOWN_SRC, source_format="markdown")
+        found = _warnings_from(from_ast, doc, "markdown", bogus_xyz=1)
+        assert found, "from_ast silently ignored an unknown renderer kwarg"
+        assert "bogus_xyz" in str(found[0].message)
+
+    def test_entry_points_agree(self):
+        """The whole point of #273: the same bad kwarg behaves the same everywhere."""
+        to_ast_warned = bool(_warnings_from(to_ast, MARKDOWN_SRC, filename="x.md"))
+        to_markdown_warned = bool(_warnings_from(to_markdown, MARKDOWN_SRC, filename="x.md"))
+        assert to_ast_warned == to_markdown_warned == True  # noqa: E712
+
+    def test_warning_points_at_the_caller(self):
+        """A warning attributed past the caller's frame is useless and dedups wrongly."""
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            to_ast(MARKDOWN_SRC, bogus_xyz=1)
+        assert caught
+        assert caught[0].filename == __file__, f"warning attributed to {caught[0].filename}, not the caller"
+
+
+@pytest.mark.unit
+class TestValidKwargsStaySilent:
+    """The warning must not fire for kwargs the options classes actually accept."""
+
+    def test_markdown_parser_kwarg(self):
+        assert not _warnings_from(to_ast, MARKDOWN_SRC, source_format="markdown", parse_footnotes=True)
+
+    def test_renderer_kwarg(self):
+        assert not _warnings_from(to_markdown, MARKDOWN_SRC, flavor="commonmark")
+
+    def test_nested_dataclass_kwarg(self):
+        """Fields of nested options dataclasses (e.g. network) are valid, not unmatched."""
+        assert not _warnings_from(to_markdown, "<p>x</p>", source_format="html", allow_remote_fetch=False)
+
+    def test_no_kwargs_at_all(self):
+        assert not _warnings_from(to_ast, MARKDOWN_SRC, source_format="markdown")
+
+
+@pytest.mark.unit
+class TestKnownOptionForAnotherFormatStaysQuiet:
+    """A real option that this format ignores is not a typo, and must not warn.
+
+    ``to_ast``/``from_ast`` see only one options class, so they cannot tell "bogus"
+    from "valid elsewhere". The library itself injects such options -- the CLI
+    packager forces ``attachment_mode``, the MCP server sets it from server config,
+    ``convert`` injects its ``flavor`` shorthand -- so warning here would blame the
+    caller for something they never passed.
+    """
+
+    @pytest.mark.parametrize("option_name", ["attachment_mode", "flavor", "pages"])
+    def test_real_option_from_another_format_is_silent(self, option_name):
+        assert not _warnings_from(to_ast, MARKDOWN_SRC, source_format="markdown", **{option_name: "base64"})
+
+    def test_library_injected_flavor_does_not_blame_the_caller(self):
+        """from_markdown documents `flavor`; converting to HTML must not call it bogus."""
+        from all2md import from_markdown
+
+        assert not _warnings_from(from_markdown, MARKDOWN_SRC, "html", flavor="gfm")
+
+    def test_typo_of_a_real_option_still_warns(self):
+        """The safety net still catches the case that motivated #273."""
+        assert _warnings_from(to_ast, MARKDOWN_SRC, source_format="markdown", atachment_mode="base64")
+
+
+@pytest.mark.unit
+class TestUnknownKwargsStillApplyTheGoodOnes:
+    """Warning about one bad kwarg must not discard the valid ones alongside it."""
+
+    def test_valid_kwarg_survives(self):
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            out = to_markdown(MARKDOWN_SRC, source_format="markdown", flavor="commonmark", bogus_xyz=1)
+        assert "Heading" in out


### PR DESCRIPTION
Closes #273.

`to_markdown()` warned on unknown keyword arguments; `to_ast()` and `from_ast()` dropped them at a `logger.debug` call nobody sees.

The failure was quiet and the result looked fine, which is the bad combination:

```python
to_ast(src, filename="x.md")            # ['Paragraph', 'Paragraph', ...]  <- plaintext parser
to_ast(src, source_format="markdown")   # ['Paragraph', 'Comment', ...]    <- correct
```

`filename` is not a parameter of anything (the real one is `source_format`), so the hint was discarded, detection fell through to the plaintext parser, and the caller got back a `Document` with every heading, list and table gone — and no error.

## What changed

- All three entry points route through one helper, so they cannot drift apart again. This also covers `from_ast()`, and transitively `confidence_report()`.
- **The warning fires only for names that are not options of *any* format.** A real option that this particular format ignores is usually the library's own doing — the CLI packager forces `attachment_mode`, the MCP server sets it from server config, and `convert` injects its `flavor` shorthand. Warning there would blame the caller for something they never passed. Those stay a debug-level detail; typos and non-existent parameters reach the user.
- **Corrected the stacklevel.** The existing warning used `stacklevel=4`, one frame past the caller, so it was attributed to `<sys>:0` — useless to act on, and it collapsed every such warning into a single dedup entry. It now names the calling line.

## Verification

Measured, not assumed:

- The new tests fail against the unfixed code (6 of them), so the check can actually fail.
- Controlled the warning volume across the affected suites before and after: **no new warnings**. Three that appeared mid-development (`chunk`, the MCP server, and `from_markdown(..., flavor=)`) were all library-injected options and are silenced by the known-option rule.
- One pre-existing false-blame case remains and is filed separately: the CLI packager forces `attachment_mode` and the split path still warns the user for it.
- Full `tests/unit` suite green; ruff, black and mypy clean.
- `CHANGELOG.md` scores 100 on the doc gate, controlled against `main`.

CHANGELOG entry lands under the existing `[1.11.0]` section, which is prepared but not yet tagged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)