### PR TITLE
fix(markdown): default comment_mode to html so comments stay comments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -329,10 +329,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `Comment`. `"html"` is the only mode that is a fixed point, and it is what every other
   renderer already does — each defaults to its own native comment syntax, and textile,
   which offers the identical three choices, already defaulted to `"html"`. Markdown was
-  the lone outlier. `"blockquote"` remains available via `--markdown-comment-mode` for
-  the DOCX reviewer-comment case it was chosen for. Found by our own quality gate: it is
-  what blocked adding an `mcp-name` registry marker to `README.md`, which dropped the
-  README's round-trip fidelity from 97 to 96 and failed the build (#271, #272).
+  the lone outlier. Found by our own quality gate: it is what blocked adding an
+  `mcp-name` registry marker to `README.md`, which dropped the README's round-trip
+  fidelity from 97 to 96 and failed the build (#271, #272).
+
+  One visible consequence to know about: converting a DOCX with reviewer comments to
+  Markdown now emits `<!-- Comment ... -->` rather than a bracketed `[Comment by ...]`
+  glued to the end of the annotated sentence, so the annotations no longer show up in
+  the rendered prose. They are still there, and in fact carry more than before — the
+  HTML form keeps the author *and* the timestamp, where the visible form dropped the
+  timestamp. Pass `comment_mode="blockquote"` (or `--markdown-comment-mode blockquote`)
+  to get the old, reader-visible output back; that is the case the previous default was
+  chosen for, and it is now opt-in rather than the default for every Markdown document.
 
 ## [1.10.1] - 2026-07-27
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -320,6 +320,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   which made it useless to act on and collapsed every such warning into a single
   dedup entry; it now names the calling line (#273).
 
+- **An HTML comment stays a comment when rendering Markdown.** `comment_mode` defaulted
+  to `"blockquote"`, so `<!-- note -->` — valid Markdown, and invisible when rendered —
+  came out as a visible `> note`, and an inline comment was glued into the middle of a
+  sentence as `[Comment by Reviewer: ...]`. That is a content-fidelity bug rather than a
+  formatting preference: the round trip added text a reader can see, and it was not even
+  reversible, since the blockquote reads back as a `BlockQuote` node rather than a
+  `Comment`. `"html"` is the only mode that is a fixed point, and it is what every other
+  renderer already does — each defaults to its own native comment syntax, and textile,
+  which offers the identical three choices, already defaulted to `"html"`. Markdown was
+  the lone outlier. `"blockquote"` remains available via `--markdown-comment-mode` for
+  the DOCX reviewer-comment case it was chosen for. Found by our own quality gate: it is
+  what blocked adding an `mcp-name` registry marker to `README.md`, which dropped the
+  README's round-trip fidelity from 97 to 96 and failed the build (#271, #272).
+
 ## [1.10.1] - 2026-07-27
 
 A maintenance release. Almost all of it is infrastructure — the harnesses this

--- a/docs/source/options.rst
+++ b/docs/source/options.rst
@@ -5446,7 +5446,7 @@ The Markdown format has no dedicated CLI flags. The common Markdown formatting f
    How to render Comment and CommentInline nodes: html (HTML comments <!-- -->), blockquote (quoted blocks with attribution), ignore (skip comment nodes entirely). Controls presentation of comments from DOCX, HTML, and other formats that support annotations.
 
    :Type: ``Literal['html', 'blockquote', 'ignore']``
-   :Default: ``'blockquote'``
+   :Default: ``'html'``
    :Choices: ``html``, ``blockquote``, ``ignore``
    :Importance: core
 
@@ -11460,7 +11460,7 @@ modules to ensure consistent Markdown generation.
 
    :Type: ``Literal['html', 'blockquote', 'ignore']``
    :CLI flag: ``--markdown-comment-mode``
-   :Default: ``'blockquote'``
+   :Default: ``'html'``
    :Choices: ``html``, ``blockquote``, ``ignore``
    :Importance: core
 

--- a/src/all2md/constants.py
+++ b/src/all2md/constants.py
@@ -338,7 +338,12 @@ DEFAULT_ATTACHMENT_BASE_URL = None
 NEAR_SOURCE_ATTACHMENT_DIRNAME = ".attachments"
 
 # Comment handling defaults (general)
-DEFAULT_COMMENT_MODE: CommentMode = "blockquote"
+# "html" rather than "blockquote": an HTML comment is valid Markdown and invisible when
+# rendered, so emitting it as a blockquote promotes an annotation to visible body text and
+# changes the node type on the way back (Comment -> BlockQuote). "html" is the only mode
+# that round-trips to itself. Every other renderer already defaults to its own native
+# comment syntax -- textile, with the identical three choices, defaults to "html" too.
+DEFAULT_COMMENT_MODE: CommentMode = "html"
 DEFAULT_COMMENT_RENDER_MODE: CommentRenderMode = "preserve"
 
 # Comment handling defaults (format-specific)

--- a/src/all2md/options/markdown.py
+++ b/src/all2md/options/markdown.py
@@ -271,13 +271,15 @@ class MarkdownRendererOptions(BaseRendererOptions):
         - "sanitize": Remove dangerous elements/attributes (requires bleach for best results)
         Note: This does not affect fenced code blocks with language="html", which are
         always rendered as code and are already safe.
-    comment_mode : {"html", "blockquote", "ignore"}, default "blockquote"
+    comment_mode : {"html", "blockquote", "ignore"}, default "html"
         How to render Comment and CommentInline AST nodes:
         - "html": Render as HTML comments (<!-- Comment text -->)
         - "blockquote": Render as blockquotes with attribution ([Comment by Author: text])
         - "ignore": Skip comment nodes entirely
         This controls presentation of comments from DOCX reviewer comments, HTML comments,
-        and other format-specific annotations.
+        and other format-specific annotations. The default keeps a comment a comment:
+        "blockquote" makes an invisible annotation visible and reads back as a BlockQuote
+        rather than a Comment, so use it when surfacing reviewer notes is the point.
 
     """
 

--- a/tests/golden/__snapshots__/test_renderer_outputs_golden.ambr
+++ b/tests/golden/__snapshots__/test_renderer_outputs_golden.ambr
@@ -77,13 +77,11 @@
 # ---
 # name: TestMarkdownRendererGolden.test_markdown_renderer_complex_document
   '''
-  > *Comment by Reviewer (2025-01-01)*
-  > 
-  > Reviewer note: ensure consistent tone across sections.
+  <!-- Comment by Reviewer (2025-01-01): Reviewer note: ensure consistent tone across sections. -->
   
   # Renderer Showcase
   
-  Inline math such as $E = mc^2$ pairs with **bold emphasis** and a link to [Example](https://example.com "Example Site").[Comment by Reviewer: Consider expanding this introduction.]
+  Inline math such as $E = mc^2$ pairs with **bold emphasis** and a link to [Example](https://example.com "Example Site").<!-- Comment by Reviewer: Consider expanding this introduction. -->
   
   $$
   \int_0^1 x^2\,dx = \frac{1}{3}

--- a/tests/integration/formats/docx/test_docx_footnotes_endnotes.py
+++ b/tests/integration/formats/docx/test_docx_footnotes_endnotes.py
@@ -46,7 +46,7 @@ def test_docx_fixture_contains_expected_notes() -> None:
 
 @pytest.mark.integration
 def test_docx_inline_comments_render_inline() -> None:
-    """DOCX comments render inline when configured."""
+    """DOCX comments render inline, next to the text they annotate."""
     options = DocxOptions(
         include_comments=True,
         comments_position="inline",
@@ -58,4 +58,32 @@ def test_docx_inline_comments_render_inline() -> None:
 
     assert "I decided not to think of something funny." in markdown_output
     assert "comment1" in markdown_output
-    assert "-->" not in markdown_output
+
+    # Inline means on the same line as the sentence it annotates, not hoisted away.
+    annotated = [line for line in markdown_output.split("\n") if "comment1" in line]
+    assert len(annotated) == 1
+    assert "Something hilarious" in annotated[0]
+
+    # Default comment_mode is "html" (#272): the annotation stays an annotation rather
+    # than being promoted into the body prose the reader sees. It carries more than the
+    # visible form did -- the author and the timestamp both survive.
+    assert "<!-- Comment comment1 by Thomas Villani" in markdown_output
+    assert "-->" in markdown_output
+
+
+@pytest.mark.integration
+def test_docx_inline_comments_can_be_made_visible() -> None:
+    """The reviewer-comment use case is opt-in rather than the default (#272).
+
+    ``comment_mode="blockquote"`` is what surfaces an annotation as text a reader can
+    see; it is the mode the old default was chosen for.
+    """
+    options = DocxOptions(include_comments=True, comments_position="inline")
+    document = DocxToAstConverter(options=options).parse(DOCX_FIXTURE_PATH)
+
+    markdown_output = MarkdownRenderer(
+        MarkdownRendererOptions(flavor="pandoc", comment_mode="blockquote")
+    ).render_to_string(document)
+
+    assert "[Comment comment1 by Thomas Villani: I decided not to think of something funny.]" in markdown_output
+    assert "<!--" not in markdown_output

--- a/tests/unit/renderers/test_markdown_renderer.py
+++ b/tests/unit/renderers/test_markdown_renderer.py
@@ -1550,3 +1550,55 @@ class TestDefinitionListRendering:
         dls = [n for n in ast.children if isinstance(n, DefinitionList)]
         assert len(dls) == 1
         assert len(dls[0].items) == 2
+
+
+@pytest.mark.unit
+class TestCommentModeDefault:
+    """A comment must stay a comment by default (#272).
+
+    The default was ``blockquote``, which rendered an HTML comment -- valid Markdown,
+    and invisible when rendered -- as visible body text. That is a content-fidelity
+    bug rather than a formatting preference: the round trip added text a reader can
+    see, and the node came back as a ``BlockQuote`` instead of a ``Comment``.
+    """
+
+    def test_default_is_html(self):
+        from all2md.options.markdown import MarkdownRendererOptions
+
+        assert MarkdownRendererOptions().comment_mode == "html"
+
+    def test_comment_round_trips_to_itself(self):
+        """`html` is the only mode that is a fixed point."""
+        from all2md import to_ast
+        from all2md.ast import Comment
+        from all2md.renderers.markdown import MarkdownRenderer
+
+        source = "Some text.\n\n<!-- mcp-name: io.github.example/tool -->\n\nMore.\n"
+        ast = to_ast(source, source_format="markdown")
+        assert any(isinstance(node, Comment) for node in ast.children)
+
+        rendered = MarkdownRenderer().render_to_string(ast)
+        assert "<!-- mcp-name: io.github.example/tool -->" in rendered
+        assert "> mcp-name" not in rendered
+
+        reparsed = to_ast(rendered, source_format="markdown")
+        assert [type(n).__name__ for n in reparsed.children] == [type(n).__name__ for n in ast.children]
+
+    def test_comment_does_not_become_visible_text(self):
+        from all2md import to_ast
+        from all2md.renderers.markdown import MarkdownRenderer
+
+        ast = to_ast("<!-- internal note -->\n", source_format="markdown")
+        rendered = MarkdownRenderer().render_to_string(ast)
+        # The annotation must not be promoted out of a comment into prose.
+        assert not rendered.lstrip().startswith(">")
+
+    def test_blockquote_mode_still_available(self):
+        """The DOCX reviewer-comment use case is opt-in, not removed."""
+        from all2md import to_ast
+        from all2md.options.markdown import MarkdownRendererOptions
+        from all2md.renderers.markdown import MarkdownRenderer
+
+        ast = to_ast("<!-- please review -->\n", source_format="markdown")
+        rendered = MarkdownRenderer(options=MarkdownRendererOptions(comment_mode="blockquote")).render_to_string(ast)
+        assert "> please review" in rendered


### PR DESCRIPTION
Closes #272.

`MarkdownRendererOptions.comment_mode` defaulted to `"blockquote"`, so an HTML comment — valid Markdown, and invisible when rendered — came out as visible body text:

```
in :  <!-- mcp-name: io.github.thomas-villani/all2md -->
out:  > mcp-name: io.github.thomas-villani/all2md
```

The golden snapshot showed the inline case is worse than the issue described: a comment was glued into the middle of a sentence as `...a link to [Example](https://example.com).[Comment by Reviewer: Consider expanding this introduction.]`

## Why `html` is the right default

Two findings, both measured rather than argued:

**It is the only mode that is a fixed point.** `blockquote` is not merely visible, it is *irreversible* — the node type changes on the way back:

| mode | output | reparsed |
|---|---|---|
| `blockquote` | `> mcp-name: x/y` | `Paragraph`, **`BlockQuote`**, `Paragraph` |
| `html` | `<!-- mcp-name: x/y -->` | `Paragraph`, **`Comment`**, `Paragraph` |
| `ignore` | *(dropped)* | `Paragraph`, `Paragraph` |

**Markdown was the lone outlier.** Every other renderer already defaults to its own native comment syntax — html/docx/odt/odp `native`, latex `percent`, org/asciidoc `comment`, mediawiki/dokuwiki `html`. Textile offers the *identical* three choices (`html`/`blockquote`/`ignore`) and already defaulted to `html`. This answers the issue's "worth checking the other renderers" question: they already agree with each other.

`blockquote` remains available via `--markdown-comment-mode` for the DOCX reviewer-comment case it was chosen for.

## Verification

- **Golden snapshot updated** — `tests/golden` is outside `tests/unit`, so this change passes `pytest tests/unit` and fails CI without the snapshot update. Diff is scoped to the one Markdown snapshot, and the new output now matches MediaWiki's already-correct form.
- **New tests fail against the unfixed code** (3 of 4; the fourth asserts `blockquote` is still available, which is correct both ways).
- **Unblocks the `mcp-name` marker.** Adding it to `README.md` previously dropped fidelity 97 → 96 and failed the gate (#271). Measured on this branch: **97 with and without the marker.**
- Full `tests/unit` and `tests/golden` green; doc gate green on all 9 root `*.md`; ruff, black, mypy clean.
- `docs/source/options.rst` regenerated (2 lines, both the default).

CHANGELOG entry lands under the existing `[1.11.0]` section, which is prepared but not yet tagged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)