### PR TITLE
fix(omnidocbench): measure the scan shape by area, and stop blaming the parser for it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,13 +51,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   Thanks [@santhreal](https://github.com/santhreal).
 - **The OmniDocBench lane records what its corpus actually contains.**
   `provenance.corpus_characterization` counts how many pages carry a text layer, vector
-  drawings, or the single-full-page-image shape of a scan, and how many the parser ran OCR
-  on. The lane was built, gated and baselined before anyone asked that question, and the
+  drawings, or the full-page-image shape of a scan, and how many documents the parser ran
+  OCR on. The lane was built, gated and baselined before anyone asked that question, and the
   answer changes what the scores mean: every page in the pinned corpus is a raster, so they
   grade OCR rather than the PDF text and table paths. Counted from the PDF directly rather
   than from a projection, so a parser change cannot alter what the corpus is reported to
   contain, and excluded from the gate's identity fields so evidence like this can be added
-  without invalidating a recorded baseline.
+  without invalidating a recorded baseline. Every page of a document is measured, not just
+  its first — a title page is not a sample of the article behind it — and the scan shape is
+  decided by image *area*: a page counts as scanned when one image covers at least 80% of
+  it. Calibrated against 49 pages of scanned journal back-catalogue, where the largest image
+  covered exactly 100% of every page, and 101 pages of modern born-digital articles, where
+  the largest figure reached 61%. The earlier rule of "exactly one image and no vector
+  drawings" was wrong in both directions on that sample: it fired on born-digital pages
+  carrying a single figure, and missed scans that ship a second small raster beside the page
+  image.
+- **An erased benchmark dimension no longer reads as a verdict on the parser.**
+  `unsupported_dimensions` said "all2md emitted no Table nodes on N converted page(s)",
+  which names one side of a two-sided fact. On this corpus it is the wrong side: every page
+  is a full-page raster, so the PDF table path never runs and there is nothing for it to
+  have missed. The message now states the parser's output, how many pages carry ground truth
+  for the dimension, and how many of the characterized pages are full-page images, then
+  points at `provenance.corpus_characterization` and leaves the cause to the reader (#257).
 
 ### Changed
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -236,8 +236,9 @@ People star us because "it just converted my gnarly PDF perfectly." Protect and 
   Tesseract 5.3.4 at 200 dpi plus our OCR plumbing, and all2md's native PDF text and table
   paths are never exercised. The zero tables follow from the corpus, not from a missing
   capability — a synthetic ruled table is detected identically under the benchmark's own
-  parser policy and under library defaults, so `unsupported_dimensions` currently
-  mis-attributes a corpus property to a parser gap. This is still exactly the right
+  parser policy and under library defaults. `unsupported_dimensions` used to mis-attribute
+  that corpus property to a parser gap; it now states both sides and points at
+  `provenance.corpus_characterization` instead of assigning a cause. This is still exactly the right
   instrument for **Theme 8**, whose subject *is* OCR geometry; it is the wrong one for
   "how well do we convert PDFs" in general, and the docs should not let it be read that way.
   Making the lane actionable is tracked as its own follow-up: stratified scoring, honest
@@ -601,9 +602,12 @@ round-trip asymmetries #70/#71/#72 🚢, and the Markdown round-trip losses 🚢
    **stratified scoring** (the annotations already carry `page_attribute`, which the corpus
    validates as required and the oracle then ignores — one aggregate over newspapers,
    handwritten notes, slides, textbooks and papers is not actionable, and the 9 data sources
-   are already known); **honest `unsupported_dimensions` messages** (say the corpus offers no
-   vector tables to detect, rather than implying we cannot detect tables); and the
-   **`block_structure_similarity` content floor** ([#256](https://github.com/thomas-villani/all2md/issues/256)). Tracked as [#257](https://github.com/thomas-villani/all2md/issues/257).
+   are already known); and the **`block_structure_similarity` content floor**
+   ([#256](https://github.com/thomas-villani/all2md/issues/256)). Tracked as
+   [#257](https://github.com/thomas-villani/all2md/issues/257). The third part —
+   **honest `unsupported_dimensions` messages** — is done: the message now reports the
+   input shape beside the parser's output rather than implying we cannot detect tables.
+   It needed no re-run, because it changes no score.
 8. **Theme 8: positional fidelity** (OCR geometry → provenance → layout). The external
    baseline makes this bet measurable, and the corpus being all-raster means the lane
    exercises precisely the path Theme 8 changes. Use score and denominator changes from the

--- a/benchmarks/omnidocbench/README.md
+++ b/benchmarks/omnidocbench/README.md
@@ -102,12 +102,23 @@ Review the candidate's metric values, `eligible_items`, `variance`, and `toleran
 
 `provenance.corpus_characterization` records what the corpus actually contains, counted
 over the pages that could be read: how many carry a text layer, vector drawings, or the
-single-full-page-image shape of a scan, and how many the parser ran OCR on. It exists
+full-page-image shape of a scan, and how many documents the parser ran OCR on. It exists
 because this lane was built, gated and baselined before anyone asked that question, and
 the answer turned out to decide what the scores mean — every page is a raster, so they
 grade OCR rather than the PDF text and table paths. `pages_characterized` is the
-denominator for the rest, and a file that cannot be read at all is excluded from it
-rather than counted as having no traits. The counts are read from the PDF directly rather
+denominator for the per-page counts and `documents_characterized` for the per-document
+ones; the two diverge as soon as a corpus item is an article rather than a page, which is
+why both are recorded. A file that cannot be read at all is excluded from them rather
+than counted as having no traits.
+
+Every page of a document is measured, not only its first: a title page is not a sample of
+the article behind it. A page counts as `one_full_page_image` when a single image covers at
+least 80% of it. That threshold is calibrated, not guessed — across 49 pages of scanned
+journal back-catalogue the largest image covered exactly 100% of every page, and across 101
+pages of modern born-digital articles the largest figure reached 61% with a median of 12%.
+Deciding it by counting instead ("exactly one image and no vector drawings") was wrong in
+both directions on that sample: it fired on born-digital pages carrying a single figure and
+missed scans that ship a second small raster beside the page image. The counts are read from the PDF directly rather
 than from an all2md projection, so a parser change cannot alter what the corpus is
 reported to contain. They are evidence, not identity: the corpus is already pinned by
 `dataset_revision` and `annotation_sha256`, so they cannot drift without those changing,

--- a/benchmarks/omnidocbench/benchmark.py
+++ b/benchmarks/omnidocbench/benchmark.py
@@ -27,6 +27,28 @@ class DegradedConversionError(RuntimeError):
     """Requested PDF processing degraded to a fallback path."""
 
 
+#: Traits describing what a corpus PDF actually contains. Recorded because this lane was
+#: built, gated and baselined before anyone asked: every page turned out to be a single
+#: full-page raster, so the scores grade OCR rather than the PDF text and table paths, and
+#: nothing in the payload said so. Validating the annotation schema checks only one side of
+#: the comparison. Characterize the inputs too.
+_INPUT_TRAITS = ("text_layer", "vector_drawings", "one_full_page_image")
+
+
+@dataclass(frozen=True, slots=True)
+class InputTraits:
+    """How many of a PDF's pages carry each input trait.
+
+    Counted per page rather than sampled from page 1: OmniDocBench's PDFs are one page
+    each, but an article PDF opens on a title page that is unrepresentative of the rest.
+    """
+
+    pages: int
+    text_layer: int
+    vector_drawings: int
+    one_full_page_image: int
+
+
 @dataclass(frozen=True, slots=True)
 class PageEvaluation:
     """Direct external-ground-truth scores for one page."""
@@ -39,11 +61,13 @@ class PageEvaluation:
     degraded_events: tuple[str, ...] = ()
     error_type: str | None = None
     error: str | None = None
-    #: What the *input* PDF contains, measured before conversion, plus whether OCR ran.
-    #: Names of the traits that hold; absent means the trait was measured and is false.
-    #: ``None`` means the file could not be characterized at all, which is distinct from
-    #: "has none of these traits" and must not be counted as either.
-    traits: frozenset[str] | None = None
+    #: What the *input* PDF contains, measured before conversion. ``None`` means the file
+    #: could not be characterized at all, which is distinct from "has none of these traits"
+    #: and must not be counted as either.
+    traits: InputTraits | None = None
+    #: Whether the parser actually ran OCR. ``None`` when the page never converted, so a
+    #: failed page is not reported as one the parser chose not to OCR.
+    ocr_applied: bool | None = None
 
 
 def _pdf_options(ocr_languages: str) -> PdfOptions:
@@ -120,18 +144,27 @@ def _degraded_kinds(document: Any) -> tuple[str, ...]:
     return tuple(sorted(str(event["kind"]) for event in events if isinstance(event, Mapping) and "kind" in event))
 
 
-#: Traits describing what a corpus PDF actually contains. Recorded because this lane was
-#: built, gated and baselined before anyone asked: every page turned out to be a single
-#: full-page raster, so the scores grade OCR rather than the PDF text and table paths, and
-#: nothing in the payload said so. Validating the annotation schema checks only one side of
-#: the comparison. Characterize the inputs too.
-_INPUT_TRAITS = ("text_layer", "vector_drawings", "one_full_page_image")
-#: Recorded alongside them because "no text layer" and "OCR ran" answer different questions.
-_RUN_TRAITS = ("ocr_applied",)
+#: Share of a page's area its largest image must cover to read as a scan rather than a
+#: figure. Calibrated, not guessed: across 49 pages of scanned journal back-catalogue the
+#: largest image covered exactly 100% of every page, while across 101 pages of modern
+#: born-digital articles the largest figure reached 61% and the median was 12%.
+_FULL_PAGE_IMAGE_COVERAGE = 0.8
 
 
-def _input_traits(pdf_path: Path) -> frozenset[str] | None:
-    """Return which input traits a PDF's first page has, or ``None`` if unreadable.
+def _covers_page(page: Any) -> bool:
+    """Report whether any single image on the page covers most of it."""
+    area = abs(page.rect.get_area())
+    if area <= 0:
+        return False
+    for image in page.get_images(full=True):
+        for rect in page.get_image_rects(image[0]):
+            if abs(rect.get_area()) / area >= _FULL_PAGE_IMAGE_COVERAGE:
+                return True
+    return False
+
+
+def _input_traits(pdf_path: Path) -> InputTraits | None:
+    """Count how many of a PDF's pages carry each input trait, or ``None`` if unreadable.
 
     Deliberately independent of all2md: it reads the file with PyMuPDF directly, so a
     parser change can never quietly alter what the corpus is reported to contain.
@@ -142,19 +175,22 @@ def _input_traits(pdf_path: Path) -> frozenset[str] | None:
         return None
     try:
         with fitz.open(pdf_path) as document:
-            if document.page_count < 1:
-                return frozenset()
-            page = document[0]
-            images = page.get_images(full=True)
-            traits = set()
-            if page.get_text().strip():
-                traits.add("text_layer")
-            if page.get_drawings():
-                traits.add("vector_drawings")
-            # One image and nothing else vector-drawn is the scanned-page-in-a-wrapper shape.
-            if len(images) == 1 and not page.get_drawings():
-                traits.add("one_full_page_image")
-            return frozenset(traits)
+            pages = text_layer = vector_drawings = one_full_page_image = 0
+            for page in document:
+                pages += 1
+                text_layer += bool(page.get_text().strip())
+                vector_drawings += bool(page.get_drawings())
+                # Measured by area, not by counting images and assuming: a scan is a raster
+                # the size of the page. Requiring "exactly one image and no vector drawings"
+                # instead both fired on born-digital pages carrying a single figure and
+                # missed scans that ship a second small raster beside the page image.
+                one_full_page_image += _covers_page(page)
+            return InputTraits(
+                pages=pages,
+                text_layer=text_layer,
+                vector_drawings=vector_drawings,
+                one_full_page_image=one_full_page_image,
+            )
     except Exception:  # noqa: BLE001 - characterization is evidence, never a reason to fail a page
         return None
 
@@ -195,7 +231,8 @@ def _evaluate_page(
             predicted_formulas=len(actual.formulas),
             duration_seconds=time.perf_counter() - started,
             degraded_events=_degraded_kinds(document),
-            traits=None if traits is None else traits | ({"ocr_applied"} if _ocr_applied(document) else set()),
+            traits=traits,
+            ocr_applied=_ocr_applied(document),
         )
     except Exception as exc:  # noqa: BLE001 - failed pages stay in every applicable denominator
         empty = PageProjection((), (), (), ())
@@ -245,6 +282,19 @@ def _dimension(
     }
 
 
+def _input_shape_clause(evaluations: list[PageEvaluation]) -> str:
+    """Summarize what the inputs are, so an erased dimension carries its own counter-reading."""
+    measured = [result.traits for result in evaluations if result.traits is not None]
+    pages = sum(traits.pages for traits in measured)
+    if pages == 0:
+        return "; see provenance.corpus_characterization"
+    rasters = sum(traits.one_full_page_image for traits in measured)
+    return (
+        f" ({rasters} of {pages} characterized page(s) are a full-page image); "
+        f"see provenance.corpus_characterization"
+    )
+
+
 def normalize_results(
     *,
     snapshot: CorpusSnapshot,
@@ -267,17 +317,23 @@ def normalize_results(
     # needed the erased dimension instead of only how many pages converted.
     eligible_tables = sum(1 for page in ground_truth.values() if page.projection.tables)
     eligible_formulas = sum(1 for page in ground_truth.values() if page.projection.formulas)
+    # Naming only the parser reads as a parser gap, and on this corpus that reading is wrong:
+    # every page is a full-page raster, so the PDF table path never runs at all. State both
+    # sides and the input shape, and let the reader assign the cause.
+    shape = _input_shape_clause(evaluations)
     if predicted_tables == 0:
         metric_names -= {"table_structure_similarity", "table_content_similarity"}
         unsupported["table_fidelity"] = (
-            f"all2md emitted no Table nodes on {converted} converted page(s); "
-            f"{eligible_tables} pages have table ground truth"
+            f"no Table nodes on any of the {converted} converted page(s); "
+            f"{eligible_tables} page(s) carry table ground truth. This alone does not "
+            f"separate a parser gap from the corpus's input shape{shape}"
         )
     if predicted_formulas == 0:
         metric_names -= {"formula_presence_accuracy", "formula_content_similarity"}
         unsupported["formula_fidelity"] = (
-            f"all2md emitted no MathBlock or MathInline nodes on {converted} converted page(s); "
-            f"{eligible_formulas} pages have formula ground truth"
+            f"no MathBlock or MathInline nodes on any of the {converted} converted page(s); "
+            f"{eligible_formulas} page(s) carry formula ground truth. This alone does not "
+            f"separate a parser gap from the corpus's input shape{shape}"
         )
 
     dimensions: dict[str, dict[str, Any]] = {}
@@ -300,9 +356,13 @@ def normalize_results(
     successful = sum(result.error_type is None for result in evaluations)
     measured = [result.traits for result in evaluations if result.traits is not None]
     corpus_characterization = {
-        "pages_characterized": len(measured),
-        **{f"pages_with_{trait}": sum(trait in traits for traits in measured) for trait in _INPUT_TRAITS},
-        **{f"pages_{trait}": sum(trait in traits for traits in measured) for trait in _RUN_TRAITS},
+        # Both denominators, because they diverge the moment a corpus item is an article
+        # rather than a page, and a page count over an unstated number of files says little.
+        "documents_characterized": len(measured),
+        "pages_characterized": sum(traits.pages for traits in measured),
+        **{f"pages_with_{trait}": sum(getattr(traits, trait) for traits in measured) for trait in _INPUT_TRAITS},
+        # Document-level: the parser reports OCR per conversion, not per page.
+        "documents_ocr_applied": sum(1 for result in evaluations if result.ocr_applied),
     }
     return {
         "schema_version": SCHEMA_VERSION,

--- a/tests/unit/test_omnidocbench_benchmark.py
+++ b/tests/unit/test_omnidocbench_benchmark.py
@@ -115,6 +115,7 @@ def test_evaluation_calls_to_ast_once_and_scores_the_returned_document(
             predicted_tables=0,
             predicted_formulas=0,
             duration_seconds=results[0].duration_seconds,
+            ocr_applied=False,
         )
     ]
 
@@ -282,8 +283,9 @@ def test_normalization_records_variance_failures_and_unsupported_dimensions(tmp_
     assert "formula_content_similarity" not in payload["dimensions"]
     assert payload["unsupported_dimensions"] == {
         "formula_fidelity": (
-            "all2md emitted no MathBlock or MathInline nodes on 1 converted page(s); "
-            "0 pages have formula ground truth"
+            "no MathBlock or MathInline nodes on any of the 1 converted page(s); "
+            "0 page(s) carry formula ground truth. This alone does not separate a parser "
+            "gap from the corpus's input shape; see provenance.corpus_characterization"
         )
     }
     assert payload["conversion_failures"] == {"page-b": "RuntimeError: broken PDF"}
@@ -330,6 +332,21 @@ def _write_scanned_pdf(path: Path, tmp_path: Path) -> None:
     document.close()
 
 
+def _write_illustrated_pdf(path: Path, tmp_path: Path) -> None:
+    """A born-digital page carrying one figure: text, no vector drawings, one small image."""
+    fitz = pytest.importorskip("fitz")
+    source = tmp_path / "_figure_source.pdf"
+    _write_vector_pdf(source)
+    with fitz.open(source) as origin:
+        pixmap = origin[0].get_pixmap(dpi=36)
+    document = fitz.open()
+    page = document.new_page()
+    page.insert_text((72, 100), "Figure 1 shows the assay results.", fontsize=12)
+    page.insert_image(fitz.Rect(72, 120, 220, 240), pixmap=pixmap)
+    document.save(path)
+    document.close()
+
+
 def test_input_traits_tell_a_born_digital_page_from_a_scan(tmp_path: Path) -> None:
     """The lane must record what its corpus contains, not assume PDFs carry text.
 
@@ -341,8 +358,48 @@ def test_input_traits_tell_a_born_digital_page_from_a_scan(tmp_path: Path) -> No
     _write_vector_pdf(vector)
     _write_scanned_pdf(scanned, tmp_path)
 
-    assert benchmark._input_traits(vector) == frozenset({"text_layer", "vector_drawings"})
-    assert benchmark._input_traits(scanned) == frozenset({"one_full_page_image"})
+    assert benchmark._input_traits(vector) == benchmark.InputTraits(
+        pages=1, text_layer=1, vector_drawings=1, one_full_page_image=0
+    )
+    assert benchmark._input_traits(scanned) == benchmark.InputTraits(
+        pages=1, text_layer=0, vector_drawings=0, one_full_page_image=1
+    )
+
+
+def test_a_page_with_one_figure_is_not_reported_as_a_scan(tmp_path: Path) -> None:
+    """An illustrated born-digital page also has one image and no vector drawings.
+
+    Defining the scan shape by counting images would have mislabelled such pages the moment
+    this characterization was pointed at a corpus that has any, which is the whole point of
+    it. Area is the property that actually separates a scan from a figure.
+    """
+    illustrated = tmp_path / "illustrated.pdf"
+    _write_illustrated_pdf(illustrated, tmp_path)
+
+    traits = benchmark._input_traits(illustrated)
+    assert traits is not None
+    assert traits.text_layer == 1
+    assert traits.vector_drawings == 0
+    assert traits.one_full_page_image == 0
+
+
+def test_input_traits_count_every_page_not_just_the_first(tmp_path: Path) -> None:
+    """A title page is not a sample of the document behind it."""
+    fitz = pytest.importorskip("fitz")
+    scanned = tmp_path / "scanned.pdf"
+    _write_scanned_pdf(scanned, tmp_path)
+    mixed = tmp_path / "mixed.pdf"
+    document = fitz.open()
+    document.new_page().insert_text((72, 100), "Title only", fontsize=18)
+    with fitz.open(scanned) as source:
+        document.insert_pdf(source)
+        document.insert_pdf(source)
+    document.save(mixed)
+    document.close()
+
+    assert benchmark._input_traits(mixed) == benchmark.InputTraits(
+        pages=3, text_layer=1, vector_drawings=0, one_full_page_image=2
+    )
 
 
 def test_an_unreadable_pdf_is_uncharacterized_rather_than_trait_free(tmp_path: Path) -> None:
@@ -352,6 +409,50 @@ def test_an_unreadable_pdf_is_uncharacterized_rather_than_trait_free(tmp_path: P
 
     assert benchmark._input_traits(broken) is None
     assert benchmark._input_traits(tmp_path / "absent.pdf") is None
+
+
+def test_an_erased_dimension_reports_the_input_shape_not_a_parser_verdict(tmp_path: Path) -> None:
+    """Saying all2md emitted no Table nodes reads as a parser gap. Here it is not one.
+
+    Every page is a full-page raster, so the PDF table path never runs and there is nothing
+    for it to have missed. The message must put the parser's output beside what the inputs
+    are and leave the cause to the reader, or the payload argues for a conclusion it cannot
+    support.
+    """
+    snapshot = _snapshot(tmp_path, ("page-a",))
+    truth = {
+        "page-a": GroundTruthPage(
+            page_id="page-a",
+            projection=PageProjection(("Body",), ("text_block",), ("<table><tr><td>1</td></tr></table>",), ()),
+            unscored_categories={},
+            explicitly_ignored=0,
+        )
+    }
+    evaluations = [
+        benchmark.PageEvaluation(
+            page_id="page-a",
+            scores={"text_content_similarity": 0.5},
+            predicted_tables=0,
+            predicted_formulas=0,
+            duration_seconds=0.1,
+            traits=benchmark.InputTraits(pages=1, text_layer=0, vector_drawings=0, one_full_page_image=1),
+            ocr_applied=True,
+        )
+    ]
+
+    payload = benchmark.normalize_results(
+        snapshot=snapshot,
+        ground_truth=truth,
+        evaluations=evaluations,
+        all2md_commit="all2md-commit",
+        parser_runtime={"pymupdf": "1.28.0"},
+    )
+
+    message = payload["unsupported_dimensions"]["table_fidelity"]
+    assert "all2md emitted" not in message
+    assert "1 page(s) carry table ground truth" in message
+    assert "1 of 1 characterized page(s) are a full-page image" in message
+    assert "provenance.corpus_characterization" in message
 
 
 def test_characterization_counts_only_pages_it_could_measure(tmp_path: Path) -> None:
@@ -365,7 +466,8 @@ def test_characterization_counts_only_pages_it_could_measure(tmp_path: Path) -> 
             predicted_tables=0,
             predicted_formulas=0,
             duration_seconds=0.1,
-            traits=frozenset({"one_full_page_image", "ocr_applied"}),
+            traits=benchmark.InputTraits(pages=1, text_layer=0, vector_drawings=0, one_full_page_image=1),
+            ocr_applied=True,
         ),
         benchmark.PageEvaluation(
             page_id="page-b",
@@ -386,9 +488,10 @@ def test_characterization_counts_only_pages_it_could_measure(tmp_path: Path) -> 
     )
 
     assert payload["provenance"]["corpus_characterization"] == {
+        "documents_characterized": 1,
         "pages_characterized": 1,
         "pages_with_text_layer": 0,
         "pages_with_vector_drawings": 0,
         "pages_with_one_full_page_image": 1,
-        "pages_ocr_applied": 1,
+        "documents_ocr_applied": 1,
     }

--- a/tests/unit/test_omnidocbench_gate.py
+++ b/tests/unit/test_omnidocbench_gate.py
@@ -996,11 +996,12 @@ def test_new_provenance_evidence_does_not_invalidate_a_recorded_baseline() -> No
     results = _results()
     baseline = _baseline()
     results["provenance"]["corpus_characterization"] = {
+        "documents_characterized": 2,
         "pages_characterized": 2,
         "pages_with_text_layer": 0,
         "pages_with_vector_drawings": 0,
         "pages_with_one_full_page_image": 2,
-        "pages_ocr_applied": 2,
+        "documents_ocr_applied": 2,
     }
 
     assert not gate.compare(results, baseline).failed


### PR DESCRIPTION
Two corrections to the corpus characterization shipped in `a042f71`, both surfaced while probing PMC as a born-digital corpus for the next benchmark lane. Neither touches a score or a gate identity field, so **no baseline re-record is required**.

## `one_full_page_image` was a count standing in for a shape

It meant "exactly one image and no vector drawings". On real data that is wrong in *both* directions:

- it fires on born-digital pages carrying a single figure (3 of 36 image-bearing pages in the PMC sample), and
- it misses scans that ship a second small raster beside the page image (7 of 49 scanned pages).

It now asks whether a single image covers at least 80% of the page. The threshold is calibrated, not picked:

| corpus | pages | largest-image coverage |
|---|---|---|
| scanned journal back-catalogue | 49 | min **100%**, median 100% |
| modern born-digital articles | 101 | max **61%**, median 12% |

A ~40-point gap on either side of 80%.

## It read page 0 only

Exact for OmniDocBench's one-page PDFs, wrong for anything else — a title page is not a sample of the article behind it. Traits are now per-page counts over the whole document. `provenance.corpus_characterization` reports both `pages_characterized` and a new `documents_characterized`: identical on this corpus, and they diverge the moment a corpus item is an article rather than a page.

`ocr_applied` moves out of the trait set onto `PageEvaluation`, since the parser reports OCR per conversion rather than per page. It is tri-state, so a page that never converted is not reported as one the parser declined to OCR (`pages_ocr_applied` → `documents_ocr_applied`).

## `unsupported_dimensions` blamed the parser for a corpus property (#257)

It said *"all2md emitted no Table nodes on N converted page(s)"* — one side of a two-sided fact, and on this corpus the wrong side: every page is a full-page raster, so the PDF table path never runs and there is nothing for it to have missed.

It now states the parser's output, how many pages carry ground truth for the dimension, and how many characterized pages are full-page images, then points at `provenance.corpus_characterization` and leaves the cause to the reader. This is one of the three parts of #257; stratified scoring and the #256 content floor remain open, and #257 stays open for them.

## Verification

The new tests were checked against the *old* predicate to confirm they can fail:

| fixture | old verdict | new verdict |
|---|---|---|
| one-figure born-digital page | `one_full_page_image` ❌ | not a scan ✅ |
| 3-page doc, title page + 2 scans | 0 scans (saw page 0 only) ❌ | 2 scans ✅ |

Root-markdown fidelity gate re-run locally after the CHANGELOG/ROADMAP edits: all 9 documents pass, README unchanged at its 97 floor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
