### PR TITLE
fix(pdf): recover block structure and reading order on OCR'd pages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,36 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Scanned PDFs now keep their block structure instead of collapsing to one paragraph.**
+  Every OCR'd page previously projected as exactly one `Paragraph` — no `Heading`, no
+  `Table`, no list structure — because the OCR result was returned as a flat string and
+  wrapped in a single synthetic block spanning the whole page, with one line, one span and
+  a hardcoded font size. Everything downstream of OCR segments on block, line and span
+  geometry, so column detection, header/footer trimming, table-region filtering and
+  block-to-node conversion all received one page-sized rectangle and had nothing left to
+  work with. Measured across all nine OmniDocBench data sources: 33 semantic blocks over 36
+  pages against 704 annotated regions. It was specific to the OCR path — under the same
+  parser policy, born-digital PDFs emit 7–20 blocks per page with real headings and tables.
+  Tesseract already assigns block, paragraph and line numbers and per-word boxes;
+  `image_to_string` discards them and `image_to_data` reports them, so OCR now returns
+  paragraphs mapped back into PDF points and the parser emits one block each. Engines that
+  cannot report layout, and any failure recovering it, fall back to the previous behaviour
+  rather than losing the page.
+- **Scanned multi-column pages no longer interleave their columns.** Sorting blocks by
+  vertical position assumes a column is one top-to-bottom run. OCR paragraph boxes are
+  tight to their glyphs rather than the wide regular blocks column detection looks for, so
+  a two-column scan was read as one column and the sort then alternated left and right
+  fragments — turning a reference list into "Norlund / 1997. Occupational / NRC / Sluiter".
+  The OCR engine already emits blocks in reading order across columns, so that order is now
+  preserved rather than rebuilt from geometry. Both fixes are scoped to OCR-derived blocks;
+  PDFs with a text layer are unaffected, and tests pin that.
+- **Scanned pages now carry usable positions.** Because paragraphs are real blocks, each one
+  reaches the AST with its own `SourceLocation.metadata['bbox']`. A scanned page went from a
+  single box covering the entire page to 54 distinct ones, so a citation into an OCR'd
+  document can resolve to a region rather than to "somewhere on this page".
+
 ## [1.11.0] - 2026-08-04
 
 ### Added

--- a/src/all2md/parsers/_ocr/__init__.py
+++ b/src/all2md/parsers/_ocr/__init__.py
@@ -12,6 +12,7 @@ in pytesseract, EasyOCR, or PyTorch until an engine is actually used.
 
 from __future__ import annotations
 
+from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
@@ -19,7 +20,61 @@ if TYPE_CHECKING:
 
     from all2md.options.pdf import PdfOptions
 
-__all__ = ["ocr_pixmap"]
+__all__ = ["OcrLine", "OcrParagraph", "ocr_pixmap", "ocr_pixmap_layout"]
+
+
+@dataclass(frozen=True, slots=True)
+class OcrLine:
+    """One recognized line of text and where it sits, in PDF points."""
+
+    text: str
+    bbox: tuple[float, float, float, float]
+
+
+@dataclass(frozen=True, slots=True)
+class OcrParagraph:
+    """A group of lines the engine considers one paragraph, in PDF points.
+
+    Carrying the engine's own grouping is the whole point: a page handed back as one
+    string has to be re-segmented by downstream geometry that no longer has any geometry
+    to work with, which is how an OCR'd page came to project as a single block.
+    """
+
+    lines: tuple[OcrLine, ...]
+    bbox: tuple[float, float, float, float]
+
+
+def ocr_pixmap_layout(
+    pix: "fitz.Pixmap",
+    page: "fitz.Page",
+    options: "PdfOptions",
+) -> list[OcrParagraph] | None:
+    """Run OCR and keep the engine's paragraph and line segmentation.
+
+    Parameters
+    ----------
+    pix : fitz.Pixmap
+        The page rendered to a pixmap at the configured OCR DPI.
+    page : fitz.Page
+        The source page, supplying the coordinate space results are mapped back into.
+    options : PdfOptions
+        PDF conversion options; ``options.ocr.engine`` selects the backend.
+
+    Returns
+    -------
+    list of OcrParagraph or None
+        Paragraphs in PDF coordinates, or ``None`` when the selected engine cannot
+        report layout, in which case the caller falls back to flat text.
+
+    """
+    if options.ocr.engine == "easyocr":
+        # EasyOCR reports per-detection boxes but no paragraph grouping, so it has no
+        # segmentation to preserve. Returning None keeps it on the flat-text path
+        # rather than inventing paragraph boundaries that the engine never asserted.
+        return None
+    from all2md.parsers._ocr.tesseract import ocr_pixmap_layout as _run
+
+    return _run(pix, page, options)
 
 
 def ocr_pixmap(pix: "fitz.Pixmap", page: "fitz.Page", options: "PdfOptions") -> str:

--- a/src/all2md/parsers/_ocr/tesseract.py
+++ b/src/all2md/parsers/_ocr/tesseract.py
@@ -19,9 +19,12 @@ from all2md.parsers._pdf_ocr import detect_page_language
 from all2md.utils.decorators import requires_dependencies
 
 if TYPE_CHECKING:
+    from collections.abc import Iterable
+
     import fitz
 
     from all2md.options.pdf import PdfOptions
+    from all2md.parsers._ocr import OcrParagraph
 
 logger = logging.getLogger(__name__)
 
@@ -80,3 +83,132 @@ def ocr_pixmap(pix: "fitz.Pixmap", page: "fitz.Page", options: "PdfOptions") -> 
 
     logger.debug(f"OCR extracted {len(ocr_text)} characters using language '{lang}' at {ocr_opts.dpi} DPI")
     return ocr_text
+
+
+def _resolve_language(page: "fitz.Page", options: "PdfOptions") -> str:
+    ocr_opts = options.ocr
+    if ocr_opts.auto_detect_language:
+        return detect_page_language(page, options)
+    if isinstance(ocr_opts.languages, list):
+        return "+".join(ocr_opts.languages)
+    return str(ocr_opts.languages)
+
+
+@requires_dependencies("pdf", DEPS_PDF_OCR)
+def ocr_pixmap_layout(
+    pix: "fitz.Pixmap",
+    page: "fitz.Page",
+    options: "PdfOptions",
+) -> "list[OcrParagraph] | None":
+    """Extract text from a pixmap while keeping Tesseract's own segmentation.
+
+    ``image_to_string`` discards the block, paragraph and line numbers Tesseract already
+    assigns, and everything downstream of OCR segments on geometry. ``image_to_data``
+    reports them alongside per-word boxes, so the page can be handed on as the paragraphs
+    the engine actually found instead of one page-sized blob.
+
+    Parameters
+    ----------
+    pix : fitz.Pixmap
+        Page rendered to an RGB pixmap.
+    page : fitz.Page
+        Source page, supplying the coordinate space and language auto-detection.
+    options : PdfOptions
+        PDF conversion options containing OCR settings.
+
+    Returns
+    -------
+    list of OcrParagraph or None
+        Paragraphs in PDF points, or ``None`` if Tesseract reported no usable words.
+
+    Raises
+    ------
+    RuntimeError
+        If the Tesseract binary is not installed or not on PATH.
+
+    """
+    import pytesseract
+    from PIL import Image
+
+    from all2md.parsers._ocr import OcrLine, OcrParagraph
+
+    ocr_opts = options.ocr
+    lang = _resolve_language(page, options)
+    img = Image.frombytes("RGB", (pix.width, pix.height), pix.samples)
+    config = ocr_opts.tesseract_config if ocr_opts.tesseract_config else ""
+
+    try:
+        data = pytesseract.image_to_data(img, lang=lang, config=config, output_type=pytesseract.Output.DICT)
+    except pytesseract.TesseractNotFoundError as e:
+        raise RuntimeError(
+            "Tesseract OCR is not installed or not in PATH. "
+            "Please install Tesseract: "
+            "https://github.com/tesseract-ocr/tesseract/wiki"
+        ) from e
+    except Exception as e:  # noqa: BLE001 - keep extraction resilient per-page
+        logger.warning(f"OCR layout extraction failed for page: {e}")
+        return None
+
+    # Map pixel space back to PDF points from the rendered size rather than from the DPI
+    # setting, so a pixmap clamped or rounded by PyMuPDF still lands in the right place.
+    if not pix.width or not pix.height:
+        return None
+    scale_x = page.rect.width / pix.width
+    scale_y = page.rect.height / pix.height
+
+    # (block_num, par_num) is Tesseract's paragraph; line_num splits it into lines.
+    words: dict[tuple[int, int], dict[int, list[tuple[str, tuple[float, float, float, float]]]]] = {}
+    for index, raw_text in enumerate(data.get("text", [])):
+        text = (raw_text or "").strip()
+        if not text:
+            continue
+        try:
+            confidence = float(data["conf"][index])
+        except (KeyError, IndexError, TypeError, ValueError):
+            confidence = -1.0
+        # Tesseract marks non-text rows with -1; they carry boxes but no readable content.
+        if confidence < 0:
+            continue
+        left = page.rect.x0 + data["left"][index] * scale_x
+        top = page.rect.y0 + data["top"][index] * scale_y
+        box = (
+            left,
+            top,
+            left + data["width"][index] * scale_x,
+            top + data["height"][index] * scale_y,
+        )
+        paragraph_key = (data["block_num"][index], data["par_num"][index])
+        words.setdefault(paragraph_key, {}).setdefault(data["line_num"][index], []).append((text, box))
+
+    if not words:
+        return None
+
+    paragraphs: list[OcrParagraph] = []
+    for paragraph_key in sorted(words):
+        lines: list[OcrLine] = []
+        for line_number in sorted(words[paragraph_key]):
+            entries = words[paragraph_key][line_number]
+            lines.append(
+                OcrLine(
+                    text=" ".join(text for text, _ in entries),
+                    bbox=_union(box for _, box in entries),
+                )
+            )
+        if lines:
+            paragraphs.append(OcrParagraph(lines=tuple(lines), bbox=_union(line.bbox for line in lines)))
+
+    logger.debug(
+        f"OCR recovered {len(paragraphs)} paragraph(s) and "
+        f"{sum(len(p.lines) for p in paragraphs)} line(s) using language '{lang}' at {ocr_opts.dpi} DPI"
+    )
+    return paragraphs
+
+
+def _union(boxes: "Iterable[tuple[float, float, float, float]]") -> tuple[float, float, float, float]:
+    collected = list(boxes)
+    return (
+        min(box[0] for box in collected),
+        min(box[1] for box in collected),
+        max(box[2] for box in collected),
+        max(box[3] for box in collected),
+    )

--- a/src/all2md/parsers/pdf.py
+++ b/src/all2md/parsers/pdf.py
@@ -1201,7 +1201,9 @@ class PdfToAstConverter(BaseParser):
                         "dir": (1, 0),  # Horizontal text direction
                     }
                 )
-            blocks.append({"type": 0, "bbox": paragraph.bbox, "lines": lines})
+            # Marked so the reading-order sort can leave these alone: the engine emitted
+            # them in reading order already. See _build_sorted_column_items.
+            blocks.append({"type": 0, "bbox": paragraph.bbox, "lines": lines, "_engine_segmented": True})
         return blocks
 
     def _detect_page_tables(
@@ -1479,7 +1481,15 @@ class PdfToAstConverter(BaseParser):
                 items.append(("block", block["bbox"][1], block))
         for table in col_tables:
             items.append(("table", table["bbox"].y0, table))
-        items.sort(key=lambda x: x[1])
+
+        # Sorting by y assumes one column of blocks. When an OCR engine segmented the page
+        # it has already emitted its blocks in reading order, including across columns that
+        # our own column detection may have missed -- and on a two-column page that it read
+        # as one, the y sort interleaves left and right into nonsense. Trust the engine's
+        # order instead. Scoped to engine-segmented pages with no tables to interleave;
+        # native blocks keep the existing behaviour exactly.
+        if col_tables or not items or not all(item[2].get("_engine_segmented") for item in items):
+            items.sort(key=lambda x: x[1])
         return items
 
     def _process_table_item(self, item_data: dict, page: "fitz.Page", page_num: int) -> Node | None:

--- a/src/all2md/parsers/pdf.py
+++ b/src/all2md/parsers/pdf.py
@@ -24,6 +24,8 @@ from all2md.utils.parser_helpers import attachment_result_to_image_node
 if TYPE_CHECKING:
     import fitz
 
+    from all2md.parsers._ocr import OcrParagraph
+
 from dataclasses import dataclass, field
 
 from all2md.ast import (
@@ -1134,6 +1136,74 @@ class PdfToAstConverter(BaseParser):
             if pix is not None:
                 pix = None
 
+    @staticmethod
+    def _ocr_page_to_layout(page: "fitz.Page", options: PdfOptions) -> "list[OcrParagraph] | None":
+        """OCR a page and keep the engine's paragraph segmentation.
+
+        Parameters
+        ----------
+        page : fitz.Page
+            PDF page to extract text from
+        options : PdfOptions
+            PDF conversion options containing OCR settings
+
+        Returns
+        -------
+        list of OcrParagraph or None
+            Paragraphs in PDF coordinates, or ``None`` if the engine reports no layout.
+
+        """
+        import fitz
+
+        from all2md.parsers._ocr import ocr_pixmap_layout
+
+        zoom = options.ocr.dpi / 72.0
+        pix = None
+        try:
+            mat = fitz.Matrix(zoom, zoom)
+            pix = page.get_pixmap(matrix=mat)
+            return ocr_pixmap_layout(pix, page, options)
+        except Exception as exc:  # noqa: BLE001 - layout is an enhancement, never a reason to lose the page
+            # Falling back to flat text costs segmentation, which is bad; letting this
+            # propagate would cost the page's text entirely, which is worse.
+            logger.debug(f"OCR layout recovery unavailable, falling back to flat text: {exc}")
+            return None
+        finally:
+            if pix is not None:
+                pix = None
+
+    @staticmethod
+    def _blocks_from_ocr_layout(paragraphs: "list[OcrParagraph]") -> list[dict]:
+        """Shape OCR paragraphs like PyMuPDF text blocks so downstream stages see geometry.
+
+        Font size is estimated from line height in points. It is not the true point size,
+        but it is monotonic in it, which is what the size-relative heading and body-text
+        heuristics actually consume.
+        """
+        blocks: list[dict] = []
+        for paragraph in paragraphs:
+            lines = []
+            for line in paragraph.lines:
+                height = max(line.bbox[3] - line.bbox[1], 1.0)
+                lines.append(
+                    {
+                        "spans": [
+                            {
+                                "text": line.text,
+                                "font": "OCR",
+                                "size": round(height, 2),
+                                "flags": 0,
+                                "color": 0,
+                                "bbox": line.bbox,
+                            }
+                        ],
+                        "bbox": line.bbox,
+                        "dir": (1, 0),  # Horizontal text direction
+                    }
+                )
+            blocks.append({"type": 0, "bbox": paragraph.bbox, "lines": lines})
+        return blocks
+
     def _detect_page_tables(
         self, page: "fitz.Page", page_num: int, total_pages: int
     ) -> tuple[list[dict], list[Any], list[Any]]:
@@ -1248,13 +1318,31 @@ class PdfToAstConverter(BaseParser):
             return all_blocks, False
 
         try:
+            # Prefer the engine's own paragraph segmentation. Flattening a page to one
+            # string forces every later stage -- column detection, header/footer trimming,
+            # table-region filtering, block segmentation -- to re-derive structure from
+            # geometry that no longer exists, so an OCR'd page projected as a single
+            # page-sized block no matter what was on it.
+            paragraphs = self._ocr_page_to_layout(page, self.options)
+            if paragraphs:
+                ocr_blocks = self._blocks_from_ocr_layout(paragraphs)
+                if self.options.merge_hyphenated_words:
+                    # Now that OCR carries real spans, the normal walker applies.
+                    dehyphenate_blocks(ocr_blocks)
+                self._ocr_pages_applied += 1
+                if self.options.ocr.preserve_existing_text and extracted_text.strip():
+                    logger.debug(f"Supplementing existing text with {len(ocr_blocks)} OCR block(s)")
+                    return [*all_blocks, *ocr_blocks], True
+                logger.debug(f"Replacing PyMuPDF text with {len(ocr_blocks)} OCR block(s)")
+                return ocr_blocks, True
+
             ocr_text = self._ocr_page_to_text(page, self.options)
 
             if not ocr_text.strip():
                 logger.warning("OCR returned empty text, keeping original extraction")
                 return all_blocks, False
 
-            # OCR returns a flat string rather than the span structure
+            # This engine returns a flat string rather than the span structure
             # dehyphenate_blocks() walks, so line-break hyphenation ("be-\nwusst")
             # is merged here on the text instead. Same rules, same option.
             if self.options.merge_hyphenated_words:
@@ -1624,7 +1712,9 @@ class PdfToAstConverter(BaseParser):
             if not is_in_table:
                 text_blocks.append(block)
 
-        # Apply column detection if enabled
+        # Apply column detection if enabled. It runs on OCR-derived blocks too: the engine
+        # numbers its blocks in its own order, which is not reading order on multi-column
+        # and poster layouts, and sorting them into columns measurably recovers it.
         if self.options.detect_columns and self.options.column_detection_mode not in ("disabled", "force_single"):
             force_multi = self.options.column_detection_mode == "force_multi"
             columns = detect_columns(

--- a/src/all2md/parsers/pdf.py
+++ b/src/all2md/parsers/pdf.py
@@ -1168,9 +1168,6 @@ class PdfToAstConverter(BaseParser):
             # propagate would cost the page's text entirely, which is worse.
             logger.debug(f"OCR layout recovery unavailable, falling back to flat text: {exc}")
             return None
-        finally:
-            if pix is not None:
-                pix = None
 
     @staticmethod
     def _blocks_from_ocr_layout(paragraphs: "list[OcrParagraph]") -> list[dict]:

--- a/tests/unit/parsers/test_pdf_ocr.py
+++ b/tests/unit/parsers/test_pdf_ocr.py
@@ -525,3 +525,131 @@ class TestPdfOptionsWithOCR:
         assert options.ocr.mode == "force"
         assert options.ocr.languages == "fra"
         assert options.ocr.dpi == 600
+
+
+def _tesseract_data() -> dict:
+    """Two paragraphs, the second of two lines, in the shape ``image_to_data`` returns."""
+    rows = [
+        # (block, par, line, text, left, top, width, height, conf)
+        (1, 1, 1, "Quarterly", 100, 100, 90, 20, 96.0),
+        (1, 1, 1, "Results", 200, 100, 70, 20, 95.0),
+        (2, 1, 1, "Revenue", 100, 300, 80, 14, 90.0),
+        (2, 1, 1, "rose", 190, 300, 40, 14, 91.0),
+        (2, 1, 2, "sharply", 100, 320, 60, 14, 89.0),
+        # Tesseract emits structural rows with conf -1 and no readable content.
+        (2, 1, 2, "", 0, 0, 0, 0, -1.0),
+    ]
+    return {
+        "block_num": [row[0] for row in rows],
+        "par_num": [row[1] for row in rows],
+        "line_num": [row[2] for row in rows],
+        "text": [row[3] for row in rows],
+        "left": [row[4] for row in rows],
+        "top": [row[5] for row in rows],
+        "width": [row[6] for row in rows],
+        "height": [row[7] for row in rows],
+        "conf": [row[8] for row in rows],
+    }
+
+
+class TestOCRLayoutRecovery:
+    """OCR must hand back the engine's own segmentation, not one page-sized blob.
+
+    Returning a flat string made every OCR'd page project as exactly one Paragraph --
+    measured at 0.92 semantic blocks per page against a median of 12 annotated regions,
+    across all nine OmniDocBench sources. Everything downstream of OCR segments on
+    block/line/span geometry, so a single page-sized rectangle leaves it nothing to work
+    with: no headings, no tables, no columns, no header/footer trimming.
+    """
+
+    @patch("fitz.Matrix")
+    @patch("pytesseract.image_to_data")
+    @patch("PIL.Image")
+    def test_paragraphs_and_lines_survive_with_real_geometry(
+        self, mock_image: Mock, mock_data: Mock, mock_matrix_class: Mock
+    ) -> None:
+        mock_page = Mock()
+        mock_page.rect.width = 612.0
+        mock_page.rect.height = 792.0
+        mock_page.rect.x0 = 0.0
+        mock_page.rect.y0 = 0.0
+        mock_pix = Mock()
+        mock_pix.width = 1224  # rendered at 2x, so PDF points are pixels / 2
+        mock_pix.height = 1584
+        mock_pix.samples = b"pixels"
+        mock_page.get_pixmap.return_value = mock_pix
+        mock_image.frombytes.return_value = Mock()
+        mock_data.return_value = _tesseract_data()
+
+        options = PdfOptions(ocr=OCROptions(enabled=True, languages="eng", dpi=144))
+        paragraphs = PdfToAstConverter._ocr_page_to_layout(mock_page, options)
+
+        assert paragraphs is not None
+        assert len(paragraphs) == 2, "block_num/par_num grouping must survive"
+        assert [len(p.lines) for p in paragraphs] == [1, 2]
+        assert paragraphs[0].lines[0].text == "Quarterly Results"
+        assert paragraphs[1].lines[1].text == "sharply", "conf -1 rows must not add empty words"
+        # Pixels map back to PDF points, so the boxes are usable by downstream geometry.
+        assert paragraphs[0].lines[0].bbox == (50.0, 50.0, 135.0, 60.0)
+        assert paragraphs[0].bbox != paragraphs[1].bbox
+
+    @patch("fitz.Matrix")
+    @patch("pytesseract.image_to_data")
+    @patch("PIL.Image")
+    def test_a_page_with_no_recognized_words_reports_no_layout(
+        self, mock_image: Mock, mock_data: Mock, mock_matrix_class: Mock
+    ) -> None:
+        """``None`` keeps the caller on the flat-text path instead of inventing one empty block."""
+        mock_page = Mock()
+        mock_page.rect.width = 612.0
+        mock_page.rect.height = 792.0
+        mock_page.rect.x0 = 0.0
+        mock_page.rect.y0 = 0.0
+        mock_pix = Mock()
+        mock_pix.width = 612
+        mock_pix.height = 792
+        mock_pix.samples = b"pixels"
+        mock_page.get_pixmap.return_value = mock_pix
+        mock_image.frombytes.return_value = Mock()
+        mock_data.return_value = {
+            "block_num": [1],
+            "par_num": [1],
+            "line_num": [1],
+            "text": [""],
+            "left": [0],
+            "top": [0],
+            "width": [0],
+            "height": [0],
+            "conf": [-1.0],
+        }
+
+        options = PdfOptions(ocr=OCROptions(enabled=True, languages="eng"))
+
+        assert PdfToAstConverter._ocr_page_to_layout(mock_page, options) is None
+
+    def test_blocks_carry_distinct_boxes_rather_than_the_whole_page(self) -> None:
+        """The regression itself: N paragraphs must become N blocks, not one page-sized block."""
+        from all2md.parsers._ocr import OcrLine, OcrParagraph
+
+        paragraphs = [
+            OcrParagraph(lines=(OcrLine("Title", (50.0, 50.0, 135.0, 70.0)),), bbox=(50.0, 50.0, 135.0, 70.0)),
+            OcrParagraph(
+                lines=(
+                    OcrLine("Body one", (50.0, 150.0, 200.0, 157.0)),
+                    OcrLine("Body two", (50.0, 160.0, 200.0, 167.0)),
+                ),
+                bbox=(50.0, 150.0, 200.0, 167.0),
+            ),
+        ]
+
+        blocks = PdfToAstConverter._blocks_from_ocr_layout(paragraphs)
+
+        assert len(blocks) == 2
+        assert [len(block["lines"]) for block in blocks] == [1, 2]
+        assert {block["bbox"] for block in blocks} == {(50.0, 50.0, 135.0, 70.0), (50.0, 150.0, 200.0, 167.0)}
+        assert all(block["type"] == 0 for block in blocks)
+        # Size tracks line height, so the size-relative heading heuristics see a taller
+        # title against shorter body text instead of one hardcoded value everywhere.
+        title_size = blocks[0]["lines"][0]["spans"][0]["size"]
+        body_size = blocks[1]["lines"][0]["spans"][0]["size"]
+        assert title_size > body_size

--- a/tests/unit/parsers/test_pdf_ocr.py
+++ b/tests/unit/parsers/test_pdf_ocr.py
@@ -653,3 +653,54 @@ class TestOCRLayoutRecovery:
         title_size = blocks[0]["lines"][0]["spans"][0]["size"]
         body_size = blocks[1]["lines"][0]["spans"][0]["size"]
         assert title_size > body_size
+
+
+class TestEngineReadingOrderIsPreserved:
+    """Sorting blocks by y assumes one column, and destroys OCR reading order.
+
+    OCR paragraph boxes are tight to their glyphs rather than the wide regular blocks
+    ``detect_columns`` looks for, so a two-column scan reports one column. The y sort then
+    interleaves left and right into alternating fragments: on a two-column reference page
+    it turned "Norlund / NRC / Official" into "Norlund / 1997.Occupational / NRC / Sluiter".
+    Content survives (character multiset overlap 1.000) while sequence similarity falls to
+    0.579, which is the signature of reordering rather than loss.
+    """
+
+    @staticmethod
+    def _blocks(engine_segmented: bool) -> list[dict]:
+        """Two columns: left at x=43 then right at x=312, each already in reading order."""
+        left = [{"type": 0, "bbox": (43.0, y, 300.0, y + 20.0), "lines": []} for y in (72.0, 102.0, 132.0)]
+        right = [{"type": 0, "bbox": (312.0, y, 570.0, y + 20.0), "lines": []} for y in (72.0, 102.0, 132.0)]
+        blocks = left + right
+        if engine_segmented:
+            for block in blocks:
+                block["_engine_segmented"] = True
+        return blocks
+
+    def test_native_blocks_are_still_sorted_by_y(self) -> None:
+        """Every non-OCR PDF must keep the existing ordering behaviour."""
+        converter = PdfToAstConverter()
+
+        items = converter._build_sorted_column_items(self._blocks(engine_segmented=False), [])
+
+        # y sort interleaves the two columns: 72, 72, 102, 102, 132, 132.
+        assert [item[1] for item in items] == [72.0, 72.0, 102.0, 102.0, 132.0, 132.0]
+
+    def test_engine_segmented_blocks_keep_the_engine_order(self) -> None:
+        converter = PdfToAstConverter()
+
+        items = converter._build_sorted_column_items(self._blocks(engine_segmented=True), [])
+
+        # Left column entire, then right column entire -- as the engine emitted them.
+        assert [item[2]["bbox"][0] for item in items] == [43.0, 43.0, 43.0, 312.0, 312.0, 312.0]
+        assert [item[1] for item in items] == [72.0, 102.0, 132.0, 72.0, 102.0, 132.0]
+
+    def test_a_table_on_the_page_falls_back_to_sorting(self) -> None:
+        """A table has to be placed relative to the text, and only y can do that."""
+        converter = PdfToAstConverter()
+        fitz = pytest.importorskip("fitz")
+        table = {"bbox": fitz.Rect(43.0, 110.0, 570.0, 130.0)}
+
+        items = converter._build_sorted_column_items(self._blocks(engine_segmented=True), [table])
+
+        assert [item[1] for item in items] == [72.0, 72.0, 102.0, 102.0, 110.0, 132.0, 132.0]


### PR DESCRIPTION
Closes the segmentation half of #279. Two defects, the second of which only became visible once the first was fixed.

## 1. Every OCR'd page collapsed to a single `Paragraph`

No `Heading`, no `Table`, no list structure, regardless of what was on the page. Measured across all nine OmniDocBench data sources: **33 semantic blocks over 36 pages against 704 annotated regions** (ratio 0.047), where the median page carries 12 annotated regions.

`_ocr_page_to_text()` returned a flat `str`, and the caller wrapped the whole page in one synthetic block holding one line holding one span, with `bbox = page.rect`, `font="OCR"`, `size=11`. Everything downstream of OCR segments on block/line/span geometry — column detection, header/footer trimming, table-region filtering, block-to-node conversion — so all of it received a single page-sized rectangle of uniform font.

It was the OCR path specifically, **not** the PDF parser: under the same parser policy, born-digital PDFs emit 7–20 blocks per page with real `Heading` and `Table` nodes.

Tesseract already assigns block, paragraph and line numbers plus per-word boxes. `image_to_string` discards them; `image_to_data` reports them. OCR now returns those paragraphs, mapped back into PDF points from the rendered pixmap size rather than from the DPI setting, and the parser emits one block per paragraph.

## 2. Splitting the page exposed a column-interleaving bug

`_build_sorted_column_items` sorts blocks by `bbox[1]`, which assumes a column is one top-to-bottom run. OCR paragraph boxes are tight to their glyphs rather than the wide regular blocks `detect_columns` looks for, so a two-column scan reports **one** column and the sort then alternates left and right:

```
engine order:  Norlund(43,72)   NRC(43,102)              Official(43,132)
after y-sort:  Norlund(43,72)   1997.Occupational(324,72) NRC(43,102)  Sluiter(312,102)
```

The flat path was immune only because a single block cannot be interleaved. The engine already emits blocks in reading order across columns, so that order is now preserved instead of rebuilt from geometry we had just discarded.

## Results

36 pages spread across all nine sources, scored against the flat-text path on identical inputs:

| dimension | before | after | delta |
|---|---|---|---|
| `block_structure_similarity` | 0.1110 | **0.3243** | **+0.2133** |
| `reading_order_similarity` | 0.6409 | 0.6088 | −0.0321 |
| `text_content_similarity` | 0.5197 | 0.5022 | −0.0175 |

Reproducing the pre-fix path locally scores 0.1110 against CI's recorded baseline of 0.1176, so the local measurement tracks CI.

## Blast radius

Both fixes are **scoped to OCR-derived blocks**. `MERGE_THRESHOLD` and `column_gap_threshold` are untouched and native PyMuPDF blocks keep their exact behaviour. Two tests assert the *old* behaviour still holds for non-OCR blocks (`test_native_blocks_are_still_sorted_by_y`, and the table-present fallback), so anyone who later generalises these will be told they have changed every PDF the library converts.

Engines that cannot report layout, and any failure recovering it, fall back to the previous flat-text path rather than losing the page. The five pre-existing OCR tests pass **unchanged**.

## Side effect: positions on scanned pages

Because paragraphs are real blocks, each reaches the AST with its own `SourceLocation.metadata['bbox']`. A scanned page went from **1** box covering the whole page to **54** distinct ones, so a citation into an OCR'd document can resolve to a region instead of "somewhere on this page".

## Hypotheses tested and refuted

Recorded so they are not retried:

1. Blocks dropped by layout-predicted table regions — layout analysis on and off give byte-identical results.
2. Our column detector double-segmenting Tesseract's output — gating it off made text *worse*.
3. Column mis-detection driving the damage — the three worst pages detect **one** column, where the column code is inert.
4. Paragraph merging — merging changes where blocks divide but not the text stream; text and reading-order scores were identical to four decimals with it on and off, and never-merging made block structure worse (0.3248 → 0.2692).

(4) also invalidated an *experiment* rather than a hypothesis: disabling `detect_columns` never tested engine ordering, because the y-sort runs regardless of how many columns were found.

## Not in scope

- **Heading classification on scans.** `_pdf_headers.py:218` builds its font-size histogram from `page.get_text("dict")` on the raw page, which is empty on a scan. Block structure compares *category* sequences and every OCR block still projects as `text_block`, so ~0.32 is roughly the ceiling until blocks can be typed.
- **Making the absolute-point thresholds size-relative for all PDFs.** Page widths span 387–2481pt in this corpus, so `MERGE_THRESHOLD = 5.0` and `column_gap_threshold = 20` are not scale-invariant. That wants a wider evidence base than this branch has.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
