### PR TITLE
benchmarks: pinned PMC born-digital corpus fetcher + characterization

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -105,6 +105,10 @@ benchmarks/corpus/.test/
 # External-ground-truth benchmark
 benchmarks/omnidocbench/.cache/
 
+# Born-digital ground truth: article bytes are fetched, never committed. The manifest
+# beside them IS committed -- it is what pins the corpus in place of a dataset revision.
+benchmarks/pmc/.cache/
+
 .claude/
 broken/
 design/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **A pinned PMC Open Access corpus for born-digital PDF benchmarking**
+  (`benchmarks/pmc`). The existing external ground-truth lane is 981 rasters, so it
+  measures the OCR path; nothing external covered text-layer extraction, vector table
+  detection or layout-derived reading order, which is most real-world PDF conversion.
+  Articles come from the `pmc-oa-opendata` bucket, where each versioned prefix holds the
+  publisher PDF beside its JATS XML — publisher-produced ground truth with real sections,
+  paragraphs and table cell markup. The bucket has no corpus-wide revision to pin against,
+  so a committed manifest of SHA-256 digests for both files of all 66 articles takes that
+  role: loading never lists the bucket, revalidates every byte, and keys its cache by the
+  manifest digest. Selection keeps an article when its JATS has at least one `<p>` and its
+  PDF carries vector drawings; every rejected candidate is recorded by reason. Corpus
+  bytes are not committed, and this ships no oracle or gate — those follow separately.
+
 ### Fixed
 
 - **Scanned PDFs now keep their block structure instead of collapsing to one paragraph.**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   independent of the filter that selected it: 750 pages, 100% with a text layer, 81.1%
   with vector drawings, **0% with the single-full-page-image scan shape** — the inverse of
   the raster lane, and the zero was checked against a known scan first to confirm the test
-  can fire at all.
+  can fire at all. An `align` command measures whether article-level JATS truth can be
+  projected onto PDF pages: **90.2% of blocks place onto a page or an identifiable
+  adjacent pair**, with a 1.9% miss rate. Placement is content-only, never using extracted
+  reading order, so it cannot quietly grade the reading-order metric against itself — and
+  it ships with a control that scores every block against a different article's pages,
+  where the false-placement rate is 0.8%.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   manifest digest. Selection keeps an article when its JATS has at least one `<p>` and its
   PDF carries vector drawings; every rejected candidate is recorded by reason. Corpus
   bytes are not committed, and this ships no oracle or gate — those follow separately.
+  A `characterize` command measures what the built corpus actually contains, deliberately
+  independent of the filter that selected it: 750 pages, 100% with a text layer, 81.1%
+  with vector drawings, **0% with the single-full-page-image scan shape** — the inverse of
+  the raster lane, and the zero was checked against a known scan first to confirm the test
+  can fire at all.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   with vector drawings, **0% with the single-full-page-image scan shape** — the inverse of
   the raster lane, and the zero was checked against a known scan first to confirm the test
   can fire at all. An `align` command measures whether article-level JATS truth can be
-  projected onto PDF pages: **90.2% of blocks place onto a page or an identifiable
+  projected onto PDF pages: **95.7% of blocks place onto a page or an identifiable
   adjacent pair**, with a 1.9% miss rate. Placement is content-only, never using extracted
   reading order, so it cannot quietly grade the reading-order metric against itself — and
   it ships with a control that scores every block against a different article's pages,

--- a/benchmarks/pmc/README.md
+++ b/benchmarks/pmc/README.md
@@ -53,26 +53,31 @@ structural markup. **The `<p>` test is the real discriminator, and it caught eve
 before the PDF was ever fetched** — which is also why the vector arm never got the chance
 to fire.
 
-The vector arm was then tested against three known scans on its own. It *can* reject
-(`PMC10000000.1` has no drawings on any page), but it **accepted two of the three**:
+Testing the vector arm against those articles on its own exposed something sharper: the
+bucket holds **two different kinds of non-born-digital material**, and only one of them is
+a scan.
 
-| article | pages | drawings/page (median) | verdict on its own |
-| --- | --- | --- | --- |
-| `PMC5000000.1` (scan) | 28 | 1.0 | would **accept** ✗ |
-| `PMC5000022.1` (scan) | 22 | 1.0 | would **accept** ✗ |
-| `PMC10000000.1` (scan) | 11 | 0.0 | reject ✓ |
-| `PMC10000015.1` (born-digital) | 5 | 6.0 | accept ✓ |
-| `PMC10000026.1` (born-digital) | 16 | 5.0 | accept ✓ |
-| `PMC10500000.1` (born-digital) | 2 | 15.5 | accept ✓ |
+| article | producer | fonts | pages | vector pages | ≥80%-area image pages |
+| --- | --- | --- | --- | --- | --- |
+| `PMC10000000.1` | ABBYY FineReader 14 | 2 | 11 | **0** | **11** |
+| `PMC5000000.1` | iTextSharp 5.4.1 | **1** (`CourierStd`) | 28 | **28** | 0 |
+| `PMC5000022.1` | iTextSharp 5.4.1 | **1** | 22 | **22** | 0 |
 
-Scanned pages carry **exactly one** drawing — a page frame. `bool(page.get_drawings())`
-cannot see the difference between that and a real figure; a *count* threshold could.
+1. **Raster scans with an OCR text layer** (`PMC10000000.1`, ABBYY). Both geometric tests
+   catch these: no vector drawings, and a page-sized image on every page.
+2. **OCR text dumps re-typeset into a PDF** (`PMC5000000.1`, iTextSharp, a single Courier
+   face, 1722 characters of monospace on page one). **No PDF-geometry test catches these**
+   — geometrically they *are* born-digital. They have a text layer on every page, no large
+   images at all, and their one "vector drawing" per page is a page-sized background
+   rectangle that `bool(page.get_drawings())` happily reads as a figure.
 
 **This corrects the plan**, which called vector drawings "the clean discriminator" on the
-strength of a nine-article spike. It is a backstop, not the discriminator. The corpus is
-unaffected — every accepted article passed **both** arms, and none was admitted on the
-weak arm alone — but calibrating that threshold belongs to step 2, on real data, not to a
-guess made from three articles here.
+strength of a nine-article spike. Against kind 1 it is redundant with the image test;
+against kind 2 it is actively fooled. Only the ground-truth side — does the JATS have
+paragraphs — reveals kind 2 at all.
+
+The corpus is unaffected: every accepted article passed both arms, none was admitted on
+the weak one alone, and neither kind survives (see below).
 
 ### The other two calibrations, which held
 
@@ -127,22 +132,38 @@ than committing a manifest that a bad link quietly thinned out.
 
 ## What comes next, and what must not be assumed
 
-**Step 2 — characterize before designing the oracle.** Run the corpus characterization
-over the built corpus and confirm the aggregate matches the spike (vector drawings high,
-single-full-page-image ~0). If it disagrees, stop and find out why.
+**Step 2 — characterization: DONE, and it agrees with the spike.** Measured over all 66
+articles / **750 pages** with the sibling lane's own `_input_traits`, so the two lanes are
+comparable:
 
-The filter guarantees *at least one* vector page per article, so it partly determines that
-result. What it does not determine — and what step 2 actually checks — is the aggregate
-*distribution* across all pages.
+| trait | corpus | OmniDocBench (the OCR lane) |
+| --- | --- | --- |
+| text layer | **100.0%** | — |
+| vector drawings | **81.1%** | ~2% |
+| one ≥80%-area image (scan shape) | **0.0%** | ~100% |
 
-**Carry the finding above into step 2:** a high aggregate vector-drawing rate is *not*
-evidence that the corpus is born-digital, because scans score on that metric too. Pair it
-with drawings-per-page and with the ≥80%-page-area image test, and set the threshold
-there rather than assuming this one.
+Median 10 pages per article; drawings per page median 5.0, with 76.1% of pages carrying
+two or more. The exact inverse of the raster lane, which is the point.
 
-This is also why the manifest deliberately records **no PDF page traits**. Reading the
-filter's own premise back out of the manifest and calling it characterization would be a
-measurement that cannot fail.
+**`0.0%` was checked for vacuity before being believed.** A zero is only evidence if the
+instrument can produce a non-zero: run against the known raster scan, the scan-shape test
+fires on **11 of 11** pages. It works.
+
+Neither kind of junk survived into the corpus:
+
+- **Raster scans:** 0 of 750 pages have the scan shape.
+- **Re-typeset OCR dumps:** the giveaway is a single embedded font. The **minimum font
+  count across all 66 articles is 6**; the dump had exactly 1.
+
+A caution for anyone extending this: `"modified using iText"` in the producer string is
+**not** the dump signature — PMC post-processes ordinary publisher PDFs with iText, and 14
+of the 66 carry it while having 6+ diverse subset fonts and 39–175 JATS paragraphs. The
+signature is iText *as sole producer* with a single monospace face.
+
+This is also why the manifest deliberately records **no PDF page traits**. The
+characterization above had to be an independent measurement; reading the filter's own
+premise back out of the manifest and calling it a result would have been a measurement
+that cannot fail.
 
 **Step 3 — the oracle, and the alignment decision.** JATS describes a whole *article*
 with no page boundaries; OmniDocBench annotates *pages*. Either this lane scores

--- a/benchmarks/pmc/README.md
+++ b/benchmarks/pmc/README.md
@@ -165,11 +165,62 @@ characterization above had to be an independent measurement; reading the filter'
 premise back out of the manifest and calling it a result would have been a measurement
 that cannot fail.
 
-**Step 3 — the oracle, and the alignment decision.** JATS describes a whole *article*
-with no page boundaries; OmniDocBench annotates *pages*. Either this lane scores
-per-article, or article truth is projected onto pages. That decision is **open and
-reserved**, and this fetcher is deliberately agnostic to it: it exposes whole articles and
-no page structure.
+**Step 3 — the oracle, and the alignment decision.** JATS describes a whole *article* with
+no page boundaries; OmniDocBench annotates *pages*. `benchmarks.pmc align` measures
+whether article truth can be projected onto pages well enough to score per page.
+
+Over all 66 articles / 4,153 blocks, matching **content only**:
+
+| outcome | share |
+| --- | --- |
+| **clean** — one page clearly wins | 75.6% |
+| **spans** — two *adjacent* pages, an ordinary page break | 14.6% |
+| **split** — two *non-adjacent* pages, a real ambiguity | 7.9% |
+| **missing** — not found | 1.9% |
+| | **90.2% placeable** |
+
+Per kind: `<p>` 90.5% placeable / 2.0% missing, `<table-wrap>` 92.2% / 1.4%,
+`<fig>` 85.0% / 0.4% — figures are weakest, at 14.5% `split`.
+
+**The probe validates itself on every run.** Scoring the same blocks against a *different*
+article's pages gives a false-placement rate of **0.8%**. A placement rate means nothing
+unless the method can fail, and two earlier versions of this probe produced confident
+wrong answers — see the module docstring, which records both.
+
+**Placement is order-free on purpose.** It never consults the reading order all2md
+extracts, only whether a page's text contains a block's n-grams. Aligning by extracted
+order would make page assignment depend on the very thing this lane grades. A useful
+consequence: float displacement stops mattering for *assignment*, because a figure is
+found where it renders rather than where JATS cites it.
+
+Where that does **not** help is reading order *within* a page: JATS gives document order,
+and for a page carrying a floated figure the correct order is a layout question JATS does
+not answer. That is where the residual risk sits.
+
+**The ~9.8% `split` + `missing` is the error budget.** Those blocks must be excluded *and
+reported*, never quietly dropped.
+
+### Score whole articles too, not instead
+
+Per-page and per-article scoring fail differently, so the lane should carry both:
+
+- **Per-page is blind to cross-page reading order.** It resets at every page boundary, so
+  emitting pages out of order, duplicating one, or dropping one can still score well.
+- **Per-article pays no alignment tax.** It does not need to know which page a block is
+  on, so it scores **100% of blocks rather than 90.2%** — including the `split`/`missing`
+  bucket, which is disproportionately figures and floats, exactly the hard cases. It is
+  not a weaker per-page; it has a larger denominator.
+- They **audit each other**: a sharp disagreement on one document is evidence the
+  *alignment* failed there, not the parser.
+- Per-article cannot localize, and dilutes — a mangled page 7 of 20 barely moves it.
+
+Two things to measure before trusting an article-level number, rather than assume: whether
+the `_locate`-based order metric stays sensitive over a whole-article sequence instead of
+saturating, and whether article scores actually spread across the corpus. If everything
+lands at 0.98 it is a gate that cannot fail.
+
+**Still reserved:** the `spans` assignment policy (first page, or both) and whether
+`<fig>`'s `split` rate deserves special handling. The fetcher stays agnostic to all of it.
 
 ## Licences
 

--- a/benchmarks/pmc/README.md
+++ b/benchmarks/pmc/README.md
@@ -173,14 +173,27 @@ Over all 66 articles / 4,153 blocks, matching **content only**:
 
 | outcome | share |
 | --- | --- |
-| **clean** — one page clearly wins | 75.6% |
-| **spans** — two *adjacent* pages, an ordinary page break | 14.6% |
-| **split** — two *non-adjacent* pages, a real ambiguity | 7.9% |
+| **clean** — one page clearly wins | 86.2% |
+| **spans** — two *adjacent* pages, an ordinary page break | 9.5% |
+| **split** — two *non-adjacent* pages, a real ambiguity | 2.4% |
 | **missing** — not found | 1.9% |
-| | **90.2% placeable** |
+| | **95.7% placeable** |
 
-Per kind: `<p>` 90.5% placeable / 2.0% missing, `<table-wrap>` 92.2% / 1.4%,
-`<fig>` 85.0% / 0.4% — figures are weakest, at 14.5% `split`.
+Per kind: `<p>` 95.5% placeable / 2.0% missing, `<table-wrap>` 95.7% / 1.4%,
+`<fig>` **97.8% / 0.4%** — figures are the *best*-behaved category.
+
+**Completeness is checked before ambiguity, and that ordering was a real defect once.**
+A page holding essentially all of a block holds the block; another page echoing its
+wording — body text restating a figure caption, a running header, a repeated table label
+— does not make it two-paged. Checking the runner-up first made **71% of `split` blocks,
+and 88% of split figures**, read as ambiguous when their top page already held 100% of
+them. Fixing the order moved placement from 90.2% to 95.7% and cut the error budget from
+9.8% to 4.3%, **with the mismatch control unchanged at 0.8%** — so the gain was real and
+not bought with false positives. Figures went from apparently worst (61.8% clean) to best
+(92.5%).
+
+Equal-scoring pages break toward the **earliest**; without that the sort silently
+preferred the last page.
 
 **The probe validates itself on every run.** Scoring the same blocks against a *different*
 article's pages gives a false-placement rate of **0.8%**. A placement rate means nothing
@@ -197,7 +210,7 @@ Where that does **not** help is reading order *within* a page: JATS gives docume
 and for a page carrying a floated figure the correct order is a layout question JATS does
 not answer. That is where the residual risk sits.
 
-**The ~9.8% `split` + `missing` is the error budget.** Those blocks must be excluded *and
+**The ~4.3% `split` + `missing` is the error budget.** Those blocks must be excluded *and
 reported*, never quietly dropped.
 
 ### Score whole articles too, not instead
@@ -207,9 +220,8 @@ Per-page and per-article scoring fail differently, so the lane should carry both
 - **Per-page is blind to cross-page reading order.** It resets at every page boundary, so
   emitting pages out of order, duplicating one, or dropping one can still score well.
 - **Per-article pays no alignment tax.** It does not need to know which page a block is
-  on, so it scores **100% of blocks rather than 90.2%** — including the `split`/`missing`
-  bucket, which is disproportionately figures and floats, exactly the hard cases. It is
-  not a weaker per-page; it has a larger denominator.
+  on, so it scores **100% of blocks rather than 95.7%** — including the `split`/`missing`
+  bucket. It is not a weaker per-page; it has a larger denominator.
 - They **audit each other**: a sharp disagreement on one document is evidence the
   *alignment* failed there, not the parser.
 - Per-article cannot localize, and dilutes — a mangled page 7 of 20 barely moves it.
@@ -219,8 +231,9 @@ the `_locate`-based order metric stays sensitive over a whole-article sequence i
 saturating, and whether article scores actually spread across the corpus. If everything
 lands at 0.98 it is a gate that cannot fail.
 
-**Still reserved:** the `spans` assignment policy (first page, or both) and whether
-`<fig>`'s `split` rate deserves special handling. The fetcher stays agnostic to all of it.
+**Decided 2026-08-05:** a `spans` block **counts on both** of its pages. `<fig>` needs no
+special handling — the case for excluding it rested on a 14.5% split rate that was a
+classifier artifact; the real figure is 1.8%.
 
 ## Licences
 

--- a/benchmarks/pmc/README.md
+++ b/benchmarks/pmc/README.md
@@ -1,0 +1,157 @@
+# PMC born-digital corpus
+
+External ground truth for **born-digital** PDF conversion: text-layer extraction, vector
+table detection, layout-derived reading order. This is the gap the OmniDocBench lane does
+not cover — that corpus is 981 rasters, so it measures the OCR path.
+
+**This directory is step 1 of that lane, and step 1 only: the corpus fetcher.** There is
+no oracle and no gate here yet, by design.
+
+## What it is
+
+Articles come from the PMC Open Access AWS bucket, `pmc-oa-opendata`, which stores each
+article under a versioned per-article prefix with the publisher PDF beside its JATS XML:
+
+```
+PMC11000001.1/PMC11000001.1.pdf     <- born-digital publisher PDF
+PMC11000001.1/PMC11000001.1.xml     <- JATS ground truth, same prefix
+```
+
+JATS is publisher-produced and already structured — sections, paragraphs, captions, and
+tables with real cell markup. That is why PMC was chosen over arXiv, where LaTeX means
+macro expansion and moving floats and you end up fighting the ground truth.
+
+## The manifest is the pin
+
+This bucket has **no corpus-wide revision**. Article versions bump independently and
+decade-old articles carry recent reprocessing timestamps, so there is nothing to pin the
+way the OmniDocBench lane pins a Hugging Face dataset revision.
+
+`manifest.json` plays that role: it records a SHA-256 and size for **both** the PDF and
+the XML of every selected article, and it is committed. `load_corpus` never lists the
+bucket — it materializes exactly what the manifest names and revalidates every byte
+against it. The manifest's own digest keys the cache directory, so editing the manifest
+produces a new cache rather than re-blessing files chosen under different rules.
+
+Article bytes are never committed. Only the manifest is.
+
+## Selection
+
+An article is kept when **its JATS has at least one `<p>` and its PDF carries vector
+drawings on some page**.
+
+### Which half of that filter actually works — measured, and not what was expected
+
+The build ledger settled this. Of 105 candidates: **32 rejected `no_paragraphs`, 0
+rejected `no_vector_drawings`.**
+
+A filter arm that never fires deserves suspicion, so it was checked directly. The
+`no_paragraphs` articles turned out to be the scanned 19th-century back catalogue: their
+JATS `<body>` holds a single `<preformat>` element containing raw OCR dump
+(`"Editorial\r\nCHICAGO MEDICAL SOCIETY.\r\nJan. 18th…"`), 24–99 KB of it, with zero
+structural markup. **The `<p>` test is the real discriminator, and it caught every scan
+before the PDF was ever fetched** — which is also why the vector arm never got the chance
+to fire.
+
+The vector arm was then tested against three known scans on its own. It *can* reject
+(`PMC10000000.1` has no drawings on any page), but it **accepted two of the three**:
+
+| article | pages | drawings/page (median) | verdict on its own |
+| --- | --- | --- | --- |
+| `PMC5000000.1` (scan) | 28 | 1.0 | would **accept** ✗ |
+| `PMC5000022.1` (scan) | 22 | 1.0 | would **accept** ✗ |
+| `PMC10000000.1` (scan) | 11 | 0.0 | reject ✓ |
+| `PMC10000015.1` (born-digital) | 5 | 6.0 | accept ✓ |
+| `PMC10000026.1` (born-digital) | 16 | 5.0 | accept ✓ |
+| `PMC10500000.1` (born-digital) | 2 | 15.5 | accept ✓ |
+
+Scanned pages carry **exactly one** drawing — a page frame. `bool(page.get_drawings())`
+cannot see the difference between that and a real figure; a *count* threshold could.
+
+**This corrects the plan**, which called vector drawings "the clean discriminator" on the
+strength of a nine-article spike. It is a backstop, not the discriminator. The corpus is
+unaffected — every accepted article passed **both** arms, and none was admitted on the
+weak arm alone — but calibrating that threshold belongs to step 2, on real data, not to a
+guess made from three articles here.
+
+### The other two calibrations, which held
+
+- **A text layer is not a born-digital signal.** Scans ship an embedded OCR layer; a
+  sample of scanned back-catalogue pages was 100% scans and 100% text-layer. Confirmed
+  again above: all three known scans have text on every page.
+- **`<p> > 0`, not `<sec> > 0`.** `PMC3500001.1` has 13 paragraphs and zero sections.
+  Requiring sections would bias the corpus toward long research papers and quietly narrow
+  what the lane measures. The build bears this out — `PMC10500000.1` was accepted with 3
+  paragraphs and `PMC8500015.1` with 4.
+
+### Sampling
+
+Selection walks from seeds spread every 500k across the ID range, taking every 11th listed
+prefix so a run of same-issue articles from one publisher cannot stand in for a corpus.
+`limit` on the load side selects an **evenly spaced** subset for the same reason, never
+the first N.
+
+**The scanned material is not confined to the front of the ID range** — another
+correction. `PMC10000000.1`, a 2023-era identifier, is a scanned 1890s medical society
+editorial: back-catalogue digitization projects receive *modern* PMCIDs when deposited.
+Sampling off the front is still wrong, but spreading the seeds is not by itself protection
+against scans; the `<p>` filter is.
+
+Note also that bucket listing is **lexicographic, not numeric**: `start-after=PMC1000000`
+lands on `PMC10000000`, because an 8-digit id sorts before a 7-digit one. Seeds are
+`start-after` anchors, not positions in the ID range.
+
+## Rejections are recorded; network failures are not rejections
+
+Every dropped candidate is written into the manifest by article id with its reason. A
+silent filter is the same defect as a silent truncation.
+
+Network failures are tracked **separately** and never enter the rejection ledger. A
+rejection is a statement about an article; an unreachable host is a statement about the
+run. A build that loses more than 10% of its candidates to network failure aborts rather
+than committing a manifest that a bad link quietly thinned out.
+
+## Usage
+
+```bash
+# Summarize the committed manifest. No network access.
+.venv/Scripts/python.exe -m benchmarks.pmc show
+
+# Materialize and verify the pinned corpus.
+.venv/Scripts/python.exe -m benchmarks.pmc load
+.venv/Scripts/python.exe -m benchmarks.pmc load --limit 10     # evenly spaced subset
+
+# Rebuild the manifest by walking the bucket. Run by hand; commit the result.
+.venv/Scripts/python.exe -m benchmarks.pmc build --per-seed 3
+```
+
+## What comes next, and what must not be assumed
+
+**Step 2 — characterize before designing the oracle.** Run the corpus characterization
+over the built corpus and confirm the aggregate matches the spike (vector drawings high,
+single-full-page-image ~0). If it disagrees, stop and find out why.
+
+The filter guarantees *at least one* vector page per article, so it partly determines that
+result. What it does not determine — and what step 2 actually checks — is the aggregate
+*distribution* across all pages.
+
+**Carry the finding above into step 2:** a high aggregate vector-drawing rate is *not*
+evidence that the corpus is born-digital, because scans score on that metric too. Pair it
+with drawings-per-page and with the ≥80%-page-area image test, and set the threshold
+there rather than assuming this one.
+
+This is also why the manifest deliberately records **no PDF page traits**. Reading the
+filter's own premise back out of the manifest and calling it characterization would be a
+measurement that cannot fail.
+
+**Step 3 — the oracle, and the alignment decision.** JATS describes a whole *article*
+with no page boundaries; OmniDocBench annotates *pages*. Either this lane scores
+per-article, or article truth is projected onto pages. That decision is **open and
+reserved**, and this fetcher is deliberately agnostic to it: it exposes whole articles and
+no page structure.
+
+## Licences
+
+The OA subset is not uniformly licensed. Each article's licence is read out of its own
+JATS `ali:license_ref`/`license` element and recorded in the manifest. `show` prints the
+breakdown. Nothing here redistributes article content — only digests.

--- a/benchmarks/pmc/__init__.py
+++ b/benchmarks/pmc/__init__.py
@@ -1,0 +1,10 @@
+"""PMC Open Access born-digital benchmark corpus.
+
+Step 1 of the born-digital ground-truth lane: a pinned, integrity-checked article corpus
+and the committed manifest that pins it.  The oracle and the page-alignment decision are
+deliberately *not* here.
+"""
+
+from __future__ import annotations
+
+__all__ = ["corpus"]

--- a/benchmarks/pmc/__main__.py
+++ b/benchmarks/pmc/__main__.py
@@ -104,6 +104,39 @@ def _characterize(args: argparse.Namespace) -> int:
     return 0
 
 
+def _align(args: argparse.Namespace) -> int:
+    from benchmarks.pmc.alignment import measure
+
+    snapshot = corpus.load_corpus(
+        Path(args.cache),
+        manifest_path=None if args.manifest is None else Path(args.manifest),
+        limit=args.limit,
+        workers=args.workers,
+    )
+    report = measure(snapshot.articles)
+    print(f"articles   : {report.articles}")
+    print(f"blocks     : {report.scored} scored ({report.verdicts['too_short']} too short to place)")
+    print("placement  :")
+    for verdict in ("clean", "spans", "split", "missing"):
+        count = report.verdicts[verdict]
+        print(f"    {verdict:9s} {count:6d}  {report.share(count):6.1%}")
+    print(f"  placeable (clean + spans): {report.share(report.placeable):.1%}")
+    print()
+    # Ships with the tool rather than being remembered: a placement rate is meaningless
+    # unless the same method fails on the wrong article.
+    print("control    : same blocks against a DIFFERENT article's pages")
+    print(f"    false placement rate    {report.control_false_placement:6.1%}  (want ~0%)")
+    print()
+    print("by kind    :")
+    for kind, counts in report.by_kind.items():
+        scored = sum(count for verdict, count in counts.items() if verdict != "too_short")
+        if not scored:
+            continue
+        row = "  ".join(f"{v}={counts[v] / scored:5.1%}" for v in ("clean", "spans", "split", "missing"))
+        print(f"    {kind:11s} n={scored:5d}  {row}")
+    return 0
+
+
 def main(argv: list[str] | None = None) -> int:
     """Run the PMC corpus command line.
 
@@ -146,6 +179,16 @@ def main(argv: list[str] | None = None) -> int:
     characterize.add_argument("--limit", type=int, default=None, help="evenly spaced subset size")
     characterize.add_argument("--workers", type=int, default=8, help="concurrent download workers")
     characterize.set_defaults(handler=_characterize)
+
+    align = subparsers.add_parser(
+        "align",
+        help="measure whether JATS blocks can be projected onto PDF pages, with its own control",
+    )
+    align.add_argument("--manifest", default=None, help="manifest path (default: the committed one)")
+    align.add_argument("--cache", default=str(DEFAULT_CACHE), help="cache directory")
+    align.add_argument("--limit", type=int, default=None, help="evenly spaced subset size")
+    align.add_argument("--workers", type=int, default=8, help="concurrent download workers")
+    align.set_defaults(handler=_align)
 
     show = subparsers.add_parser("show", help="summarize the committed manifest without any network access")
     show.add_argument("--manifest", default=None, help="manifest path (default: the committed one)")

--- a/benchmarks/pmc/__main__.py
+++ b/benchmarks/pmc/__main__.py
@@ -1,0 +1,124 @@
+"""Command line entry point for the PMC born-digital corpus.
+
+``build`` walks the bucket and writes the manifest; it is run by hand and its output is
+committed.  ``load`` and ``show`` operate on the committed manifest alone and never list
+the bucket, so they are the reproducible half.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from collections import Counter
+from pathlib import Path
+
+from benchmarks.pmc import corpus
+
+DEFAULT_CACHE = Path(__file__).with_name(".cache")
+
+
+def _build(args: argparse.Namespace) -> int:
+    report = corpus.build_manifest(
+        Path(args.out),
+        workspace=Path(args.cache),
+        per_seed=args.per_seed,
+        stride=args.stride,
+        max_candidates_per_seed=args.max_candidates,
+        progress=None if args.quiet else lambda line: print(line, flush=True),
+    )
+    print()
+    print(f"manifest   : {report.manifest_path}")
+    print(f"candidates : {report.candidates}")
+    print(f"accepted   : {len(report.accepted)}")
+    print("rejected   :")
+    for reason, count in sorted(report.rejection_counts.items()):
+        print(f"    {reason:20s} {count:4d}")
+    # Reported separately from rejections because it is a property of the run, not of any
+    # article: a network failure must never be readable as evidence about the corpus.
+    print(f"unavailable: {len(report.unavailable)}")
+    for article_id, error in sorted(report.unavailable.items()):
+        print(f"    {article_id:20s} {error}")
+    return 0
+
+
+def _load(args: argparse.Namespace) -> int:
+    snapshot = corpus.load_corpus(
+        Path(args.cache),
+        manifest_path=None if args.manifest is None else Path(args.manifest),
+        limit=args.limit,
+        workers=args.workers,
+    )
+    print(f"manifest   : {snapshot.manifest_path}")
+    print(f"pin        : {snapshot.manifest_sha256}")
+    print(f"articles   : {len(snapshot.articles)} of {snapshot.expected_articles}")
+    print(f"complete   : {snapshot.complete}")
+    total = sum(article.pdf_size_bytes + article.xml_size_bytes for article in snapshot.articles)
+    print(f"bytes      : {total:,}")
+    return 0
+
+
+def _show(args: argparse.Namespace) -> int:
+    manifest = corpus.read_manifest(
+        corpus.DEFAULT_MANIFEST if args.manifest is None else Path(args.manifest),
+    )
+    print(f"manifest   : {manifest.path}")
+    print(f"pin        : {manifest.sha256}")
+    print(f"bucket     : {manifest.bucket}")
+    print(f"articles   : {len(manifest.articles)}")
+    print(f"rejected   : {len(manifest.rejected)}")
+    print("licences   :")
+    for licence, count in sorted(Counter(a.licence for a in manifest.articles).items()):
+        print(f"    {count:4d}  {licence}")
+    print("rejections :")
+    for reason, count in sorted(Counter(manifest.rejected.values()).items()):
+        print(f"    {count:4d}  {reason}")
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Run the PMC corpus command line.
+
+    Parameters
+    ----------
+    argv : list[str] or None, optional
+        Argument vector, defaulting to ``sys.argv[1:]``.
+
+    Returns
+    -------
+    int
+        Process exit status.
+
+    """
+    parser = argparse.ArgumentParser(prog="benchmarks.pmc", description=__doc__)
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    build = subparsers.add_parser("build", help="walk the bucket and write a pinned manifest")
+    build.add_argument("--out", default=str(corpus.DEFAULT_MANIFEST), help="manifest path to write")
+    build.add_argument("--cache", default=str(DEFAULT_CACHE), help="workspace for candidate downloads")
+    build.add_argument("--per-seed", type=int, default=3, help="articles to accept per ID-range seed")
+    build.add_argument("--stride", type=int, default=corpus.DEFAULT_STRIDE, help="take every Nth listed prefix")
+    build.add_argument("--max-candidates", type=int, default=60, help="give up on a seed after N candidates")
+    build.add_argument("--quiet", action="store_true", help="suppress per-candidate progress")
+    build.set_defaults(handler=_build)
+
+    load = subparsers.add_parser("load", help="materialize and verify the committed corpus")
+    load.add_argument("--manifest", default=None, help="manifest path (default: the committed one)")
+    load.add_argument("--cache", default=str(DEFAULT_CACHE), help="cache directory")
+    load.add_argument("--limit", type=int, default=None, help="evenly spaced subset size")
+    load.add_argument("--workers", type=int, default=8, help="concurrent download workers")
+    load.set_defaults(handler=_load)
+
+    show = subparsers.add_parser("show", help="summarize the committed manifest without any network access")
+    show.add_argument("--manifest", default=None, help="manifest path (default: the committed one)")
+    show.set_defaults(handler=_show)
+
+    args = parser.parse_args(argv)
+    try:
+        return int(args.handler(args))
+    except corpus.CorpusError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/benchmarks/pmc/__main__.py
+++ b/benchmarks/pmc/__main__.py
@@ -75,6 +75,35 @@ def _show(args: argparse.Namespace) -> int:
     return 0
 
 
+def _characterize(args: argparse.Namespace) -> int:
+    from benchmarks.pmc.characterize import characterize
+
+    snapshot = corpus.load_corpus(
+        Path(args.cache),
+        manifest_path=None if args.manifest is None else Path(args.manifest),
+        limit=args.limit,
+        workers=args.workers,
+    )
+    result = characterize(snapshot)
+    print(f"articles                   : {len(result.articles)}")
+    print(f"pages                      : {result.pages}")
+    if result.unreadable:
+        print(f"unreadable                 : {', '.join(result.unreadable)}")
+    for label, pages in (
+        ("text layer", result.text_layer_pages),
+        ("vector drawings", result.vector_drawing_pages),
+        ("one full-page image (scan)", result.scan_shape_pages),
+    ):
+        print(f"  {label:26s} {pages:5d} / {result.pages} = {result.share(pages):6.1%}")
+    print(f"drawings per page (median) : {result.median_drawings_per_page:.1f}")
+    for label, pages in sorted(result.pages_by_drawing_count.items()):
+        print(f"  pages with {label:12s}    {pages:5d} = {result.share(pages):6.1%}")
+    # One embedded font is the signature of an OCR dump re-typeset into a PDF, which no
+    # geometric test can distinguish from a born-digital file.
+    print(f"fewest fonts in an article : {result.min_font_count}")
+    return 0
+
+
 def main(argv: list[str] | None = None) -> int:
     """Run the PMC corpus command line.
 
@@ -107,6 +136,16 @@ def main(argv: list[str] | None = None) -> int:
     load.add_argument("--limit", type=int, default=None, help="evenly spaced subset size")
     load.add_argument("--workers", type=int, default=8, help="concurrent download workers")
     load.set_defaults(handler=_load)
+
+    characterize = subparsers.add_parser(
+        "characterize",
+        help="measure what the built corpus contains, independently of the selection filter",
+    )
+    characterize.add_argument("--manifest", default=None, help="manifest path (default: the committed one)")
+    characterize.add_argument("--cache", default=str(DEFAULT_CACHE), help="cache directory")
+    characterize.add_argument("--limit", type=int, default=None, help="evenly spaced subset size")
+    characterize.add_argument("--workers", type=int, default=8, help="concurrent download workers")
+    characterize.set_defaults(handler=_characterize)
 
     show = subparsers.add_parser("show", help="summarize the committed manifest without any network access")
     show.add_argument("--manifest", default=None, help="manifest path (default: the committed one)")

--- a/benchmarks/pmc/alignment.py
+++ b/benchmarks/pmc/alignment.py
@@ -1,0 +1,311 @@
+"""Locate JATS article blocks on PDF pages, and measure how well that can be done.
+
+This is the feasibility probe behind the page-alignment decision, not the oracle. It
+answers one question with evidence: *can article-level ground truth be projected onto
+pages cleanly enough to score per page?*
+
+Two properties are deliberate and load-bearing.
+
+**Order-free.** Placement never consults the reading order all2md extracts -- only whether
+a page's text contains a block's n-grams. Aligning by extracted order would make page
+assignment depend on the very thing the lane grades, and the reading-order metric would
+partly be marking its own homework.
+
+**Self-validating.** `measure` scores every block a second time against a *different*
+article's pages. A placement rate that does not collapse on that control is measuring
+nothing, so the control ships with the tool rather than being a thing someone remembers to
+do. Two earlier versions of this probe reported confident, wholly wrong numbers:
+
+- bag-of-words overlap made every page score highly on stopwords alone, reporting 57% of
+  blocks as ambiguous;
+- joining JATS element text without a separator fused ``<label>Table 2</label>`` onto its
+  caption as the token ``2obtained``, corrupting an n-gram at every element boundary and
+  making tables look 32% unlocatable when the real figure is 1.4%.
+
+Neither was a property of the corpus. Both looked plausible.
+"""
+
+from __future__ import annotations
+
+import re
+import unicodedata
+from collections import Counter
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Iterable, Sequence
+
+#: Token n-gram width. Five is long enough that ordinary prose cannot collide by chance --
+#: the mismatch control puts the false-placement rate under 1% -- and short enough to
+#: survive a line break or a hyphenation fix inside a paragraph.
+NGRAM = 5
+
+#: Below this share of a block's n-grams, the best page is not considered a match at all.
+PLACEMENT_MIN = 0.30
+
+#: A runner-up page holding at least this share means the block is genuinely on two pages.
+#: Adjacent runner-up is an ordinary page break; non-adjacent is a real ambiguity.
+RUNNER_UP_MIN = 0.15
+
+#: Blocks with fewer n-grams than this carry too little text to place, and are reported
+#: separately rather than counted as failures.
+MIN_NGRAMS = 4
+
+#: JATS elements worth placing on a page.
+PLACEABLE_TAGS = ("p", "table-wrap", "fig")
+
+VERDICTS = ("clean", "spans", "split", "missing", "too_short")
+
+_WORD = re.compile(r"[a-z0-9]+")
+_SOFT_HYPHEN = "­"
+_LINE_HYPHEN = re.compile(r"-\s*\n\s*")
+
+
+@dataclass(frozen=True, slots=True)
+class BlockPlacement:
+    """Where one JATS block was found in a PDF.
+
+    Attributes
+    ----------
+    kind : str
+        JATS tag, one of `PLACEABLE_TAGS`.
+    verdict : str
+        ``clean`` (one page wins), ``spans`` (two adjacent pages), ``split`` (two
+        non-adjacent pages), ``missing``, or ``too_short``.
+    page : int or None
+        Zero-based best page; for ``spans``, the earlier of the two.
+    runner_up_page : int or None
+        Second-best page when one scored above `RUNNER_UP_MIN`.
+    top_share : float
+        Share of the block's n-grams found on the best page.
+
+    """
+
+    kind: str
+    verdict: str
+    page: int | None
+    runner_up_page: int | None
+    top_share: float
+
+
+@dataclass(frozen=True, slots=True)
+class AlignmentReport:
+    """Corpus-wide placement measurement, with its own control.
+
+    Attributes
+    ----------
+    verdicts : dict[str, int]
+        Verdict counts over every scored block.
+    by_kind : dict[str, dict[str, int]]
+        Verdict counts per JATS tag.
+    control_verdicts : dict[str, int]
+        Verdict counts for the same blocks scored against a different article's pages.
+    articles : int
+        Articles measured.
+
+    """
+
+    verdicts: dict[str, int]
+    by_kind: dict[str, dict[str, int]]
+    control_verdicts: dict[str, int]
+    articles: int
+
+    @property
+    def scored(self) -> int:
+        """Blocks that carried enough text to place."""
+        return sum(count for verdict, count in self.verdicts.items() if verdict != "too_short")
+
+    @property
+    def placeable(self) -> int:
+        """Blocks resolved to a page or to an identifiable adjacent pair."""
+        return self.verdicts.get("clean", 0) + self.verdicts.get("spans", 0)
+
+    @property
+    def control_false_placement(self) -> float:
+        """Share of blocks 'placed' against the wrong article -- the instrument's noise floor."""
+        scored = sum(count for verdict, count in self.control_verdicts.items() if verdict != "too_short")
+        if not scored:
+            return 0.0
+        placed = self.control_verdicts.get("clean", 0) + self.control_verdicts.get("spans", 0)
+        return placed / scored
+
+    def share(self, count: int) -> float:
+        """Return ``count`` as a share of scored blocks.
+
+        Parameters
+        ----------
+        count : int
+            Block count to express as a share.
+
+        Returns
+        -------
+        float
+            Fraction in ``[0, 1]``, or ``0.0`` when nothing was scored.
+
+        """
+        return count / self.scored if self.scored else 0.0
+
+
+def normalize(text: str) -> list[str]:
+    """Reduce text to comparable lowercase alphanumeric tokens.
+
+    De-hyphenates across line breaks and drops soft hyphens, so a word broken by the
+    typesetter still matches the JATS spelling.
+
+    Parameters
+    ----------
+    text : str
+        Raw text from either side of the comparison.
+
+    Returns
+    -------
+    list[str]
+        Token sequence.
+
+    """
+    folded = unicodedata.normalize("NFKD", text).lower().replace(_SOFT_HYPHEN, "")
+    return _WORD.findall(_LINE_HYPHEN.sub("", folded))
+
+
+def ngrams(tokens: Sequence[str]) -> set[tuple[str, ...]]:
+    """Return the set of token `NGRAM`-grams.
+
+    Parameters
+    ----------
+    tokens : Sequence[str]
+        Normalized tokens.
+
+    Returns
+    -------
+    set[tuple[str, ...]]
+        Distinct n-grams; a set because repetition carries no placement information.
+
+    """
+    return {tuple(tokens[index : index + NGRAM]) for index in range(len(tokens) - NGRAM + 1)}
+
+
+def page_ngrams(pdf_path: Path) -> list[set[tuple[str, ...]]]:
+    """Index each PDF page by its token n-grams.
+
+    Parameters
+    ----------
+    pdf_path : pathlib.Path
+        PDF to index.
+
+    Returns
+    -------
+    list[set[tuple[str, ...]]]
+        One n-gram set per page, in page order.
+
+    """
+    import fitz
+
+    with fitz.open(pdf_path) as document:
+        return [ngrams(normalize(page.get_text())) for page in document]
+
+
+def jats_blocks(root: Any) -> list[tuple[str, str]]:
+    """Extract placeable blocks from a parsed JATS tree.
+
+    Element text is joined with a **space**, never concatenated. Concatenation fuses
+    ``<label>Table 2</label>`` onto the following caption into a single bogus token and
+    corrupts an n-gram at every element boundary -- which made tables look unlocatable
+    when they are not.
+
+    Parameters
+    ----------
+    root : xml.etree.ElementTree.Element
+        Parsed JATS article.
+
+    Returns
+    -------
+    list[tuple[str, str]]
+        ``(tag, text)`` pairs in document order.
+
+    """
+    blocks: list[tuple[str, str]] = []
+    for element in root.iter():
+        tag = element.tag.rsplit("}", 1)[-1] if isinstance(element.tag, str) else ""
+        if tag in PLACEABLE_TAGS:
+            blocks.append((tag, " ".join(element.itertext())))
+    return blocks
+
+
+def place_block(block: set[tuple[str, ...]], pages: Sequence[set[tuple[str, ...]]]) -> BlockPlacement:
+    """Decide which page a block sits on, using content overlap only.
+
+    Parameters
+    ----------
+    block : set[tuple[str, ...]]
+        The block's n-grams.
+    pages : Sequence[set[tuple[str, ...]]]
+        Per-page n-gram sets, in page order.
+
+    Returns
+    -------
+    BlockPlacement
+        Verdict and supporting shares. ``kind`` is left empty for the caller to fill.
+
+    """
+    if len(block) < MIN_NGRAMS or not pages:
+        return BlockPlacement("", "too_short", None, None, 0.0)
+    shares = sorted(
+        ((len(block & page) / len(block), index) for index, page in enumerate(pages)),
+        reverse=True,
+    )
+    top_share, top_page = shares[0]
+    second_share, second_page = shares[1] if len(shares) > 1 else (0.0, None)
+    if top_share < PLACEMENT_MIN:
+        return BlockPlacement("", "missing", None, None, top_share)
+    if second_share >= RUNNER_UP_MIN and second_page is not None:
+        if abs(top_page - second_page) == 1:
+            return BlockPlacement("", "spans", min(top_page, second_page), max(top_page, second_page), top_share)
+        return BlockPlacement("", "split", top_page, second_page, top_share)
+    return BlockPlacement("", "clean", top_page, None, top_share)
+
+
+def measure(articles: Iterable[Any]) -> AlignmentReport:
+    """Measure placement across a corpus, including the mismatch control.
+
+    Parameters
+    ----------
+    articles : Iterable
+        `benchmarks.pmc.corpus.CorpusArticle` values with readable PDF and XML paths.
+
+    Returns
+    -------
+    AlignmentReport
+        Verdict counts, per-kind breakdown, and the control's false-placement rate.
+
+    """
+    from benchmarks.pmc.corpus import _parse_jats
+
+    indexed: list[tuple[str, list[set[tuple[str, ...]]], list[tuple[str, set[tuple[str, ...]]]]]] = []
+    for article in articles:
+        root, _ = _parse_jats(article.xml_path.read_bytes())
+        pages = page_ngrams(article.pdf_path)
+        blocks = [(kind, ngrams(normalize(text))) for kind, text in jats_blocks(root)]
+        indexed.append((article.article_id, pages, blocks))
+
+    verdicts: Counter[str] = Counter()
+    control: Counter[str] = Counter()
+    by_kind: dict[str, Counter[str]] = {tag: Counter() for tag in PLACEABLE_TAGS}
+
+    for position, (_article_id, pages, blocks) in enumerate(indexed):
+        if not pages:
+            continue
+        # Pair each article with its neighbour rather than a random one, so the control is
+        # deterministic and reproduces exactly on a re-run.
+        _, other_pages, _ = indexed[(position + 1) % len(indexed)]
+        for kind, block in blocks:
+            placement = place_block(block, pages)
+            verdicts[placement.verdict] += 1
+            by_kind[kind][placement.verdict] += 1
+            if other_pages:
+                control[place_block(block, other_pages).verdict] += 1
+
+    return AlignmentReport(
+        verdicts={verdict: verdicts.get(verdict, 0) for verdict in VERDICTS},
+        by_kind={kind: {verdict: counts.get(verdict, 0) for verdict in VERDICTS} for kind, counts in by_kind.items()},
+        control_verdicts={verdict: control.get(verdict, 0) for verdict in VERDICTS},
+        articles=len(indexed),
+    )

--- a/benchmarks/pmc/alignment.py
+++ b/benchmarks/pmc/alignment.py
@@ -46,6 +46,14 @@ PLACEMENT_MIN = 0.30
 #: Adjacent runner-up is an ordinary page break; non-adjacent is a real ambiguity.
 RUNNER_UP_MIN = 0.15
 
+#: A page holding at least this share of a block holds the *whole* block, so the block
+#: cannot be split across pages no matter what a runner-up scores. Checking the runner-up
+#: first was a real defect: body text reusing a figure caption's wording made 71% of
+#: "split" blocks -- and 88% of split figures -- ambiguous when their top page already held
+#: 100% of them. Not 1.0, because normalization and de-hyphenation can cost an n-gram or
+#: two on a legitimate whole-block match.
+COMPLETE_MIN = 0.95
+
 #: Blocks with fewer n-grams than this carry too little text to place, and are reported
 #: separately rather than counted as failures.
 MIN_NGRAMS = 4
@@ -248,14 +256,23 @@ def place_block(block: set[tuple[str, ...]], pages: Sequence[set[tuple[str, ...]
     """
     if len(block) < MIN_NGRAMS or not pages:
         return BlockPlacement("", "too_short", None, None, 0.0)
-    shares = sorted(
-        ((len(block & page) / len(block), index) for index, page in enumerate(pages)),
+    # Negate the index so that equal shares break toward the *earliest* page. Without it
+    # the sort silently preferred the last page, which is arbitrary; first occurrence is
+    # both deterministic and the conventional reading of a duplicated block.
+    ranked = sorted(
+        ((len(block & page) / len(block), -index) for index, page in enumerate(pages)),
         reverse=True,
     )
+    shares = [(share, -negated_index) for share, negated_index in ranked]
     top_share, top_page = shares[0]
     second_share, second_page = shares[1] if len(shares) > 1 else (0.0, None)
     if top_share < PLACEMENT_MIN:
         return BlockPlacement("", "missing", None, None, top_share)
+    # Completeness before ambiguity. A page holding essentially all of a block holds the
+    # block; another page echoing its wording -- body text restating a figure caption, a
+    # running header, a repeated table label -- does not make it two-paged.
+    if top_share >= COMPLETE_MIN:
+        return BlockPlacement("", "clean", top_page, None, top_share)
     if second_share >= RUNNER_UP_MIN and second_page is not None:
         if abs(top_page - second_page) == 1:
             return BlockPlacement("", "spans", min(top_page, second_page), max(top_page, second_page), top_share)

--- a/benchmarks/pmc/characterize.py
+++ b/benchmarks/pmc/characterize.py
@@ -1,0 +1,176 @@
+"""Step 2 of the born-digital lane: measure what the built corpus actually contains.
+
+Deliberately independent of the selection filter and of all2md.  The filter guarantees
+*at least one* vector page per article, so reading that fact back out and calling it
+characterization would be a measurement that cannot fail; these numbers come from
+PyMuPDF directly, per page, over the whole corpus.
+
+The per-page trait counts reuse the OmniDocBench lane's own ``_input_traits``, so the two
+corpora are measured with one calibrated instrument and their numbers are comparable.
+Two signals are added here because the build proved the trait booleans are not enough:
+
+``drawings_per_page``
+    A boolean "has vector drawings" cannot tell a page-sized background rectangle from a
+    figure.  The count can.
+
+``min_font_count``
+    The signature of an OCR text dump re-typeset into a PDF, which is geometrically
+    indistinguishable from a born-digital file: one embedded font, usually monospace.
+"""
+
+from __future__ import annotations
+
+import statistics
+from dataclasses import dataclass
+from pathlib import Path
+
+from benchmarks.pmc.corpus import CorpusSnapshot
+
+
+@dataclass(frozen=True, slots=True)
+class ArticleTraits:
+    """Per-article measurement, kept so an outlier can be named rather than averaged away.
+
+    Attributes
+    ----------
+    article_id : str
+        Versioned article identifier.
+    pages : int
+        Page count.
+    text_layer, vector_drawings, one_full_page_image : int
+        Pages carrying each trait.
+    median_drawings : float
+        Median vector drawings per page.
+    font_count : int
+        Distinct embedded fonts across the document.
+
+    """
+
+    article_id: str
+    pages: int
+    text_layer: int
+    vector_drawings: int
+    one_full_page_image: int
+    median_drawings: float
+    font_count: int
+
+
+@dataclass(frozen=True, slots=True)
+class CorpusCharacterization:
+    """Aggregate description of a built corpus.
+
+    Attributes
+    ----------
+    articles : tuple[ArticleTraits, ...]
+        Per-article measurements.
+    pages : int
+        Total pages measured.
+    text_layer_pages, vector_drawing_pages, scan_shape_pages : int
+        Pages carrying each trait across the whole corpus.
+    pages_by_drawing_count : dict[str, int]
+        Pages with zero, exactly one, and two or more vector drawings.
+    median_drawings_per_page : float
+        Median across every page in the corpus.
+    unreadable : tuple[str, ...]
+        Articles PyMuPDF could not open.
+
+    """
+
+    articles: tuple[ArticleTraits, ...]
+    pages: int
+    text_layer_pages: int
+    vector_drawing_pages: int
+    scan_shape_pages: int
+    pages_by_drawing_count: dict[str, int]
+    median_drawings_per_page: float
+    unreadable: tuple[str, ...]
+
+    @property
+    def min_font_count(self) -> int:
+        """Fewest embedded fonts in any article; 1 is the re-typeset-OCR signature."""
+        return min((entry.font_count for entry in self.articles), default=0)
+
+    def share(self, pages: int) -> float:
+        """Return ``pages`` as a share of the corpus, or ``0.0`` for an empty corpus.
+
+        Parameters
+        ----------
+        pages : int
+            Page count to express as a share.
+
+        Returns
+        -------
+        float
+            Fraction in ``[0, 1]``.
+
+        """
+        return pages / self.pages if self.pages else 0.0
+
+
+def characterize(snapshot: CorpusSnapshot) -> CorpusCharacterization:
+    """Measure the input traits of every page of a materialized corpus.
+
+    Parameters
+    ----------
+    snapshot : CorpusSnapshot
+        Corpus to measure, as returned by `benchmarks.pmc.corpus.load_corpus`.
+
+    Returns
+    -------
+    CorpusCharacterization
+        Aggregate and per-article measurements.
+
+    """
+    import fitz
+
+    from benchmarks.omnidocbench.benchmark import _input_traits
+
+    entries: list[ArticleTraits] = []
+    unreadable: list[str] = []
+    drawings: list[int] = []
+
+    for article in snapshot.articles:
+        traits = _input_traits(article.pdf_path)
+        measured = _measure_pdf(fitz, article.pdf_path)
+        if traits is None or measured is None:
+            unreadable.append(article.article_id)
+            continue
+        counts, font_count = measured
+        drawings.extend(counts)
+        entries.append(
+            ArticleTraits(
+                article_id=article.article_id,
+                pages=traits.pages,
+                text_layer=traits.text_layer,
+                vector_drawings=traits.vector_drawings,
+                one_full_page_image=traits.one_full_page_image,
+                median_drawings=statistics.median(counts) if counts else 0.0,
+                font_count=font_count,
+            )
+        )
+
+    return CorpusCharacterization(
+        articles=tuple(entries),
+        pages=sum(entry.pages for entry in entries),
+        text_layer_pages=sum(entry.text_layer for entry in entries),
+        vector_drawing_pages=sum(entry.vector_drawings for entry in entries),
+        scan_shape_pages=sum(entry.one_full_page_image for entry in entries),
+        pages_by_drawing_count={
+            "zero": sum(count == 0 for count in drawings),
+            "one": sum(count == 1 for count in drawings),
+            "two_or_more": sum(count >= 2 for count in drawings),
+        },
+        median_drawings_per_page=statistics.median(drawings) if drawings else 0.0,
+        unreadable=tuple(unreadable),
+    )
+
+
+def _measure_pdf(fitz: object, pdf_path: Path) -> tuple[list[int], int] | None:
+    """Return per-page drawing counts and the distinct embedded font count."""
+    try:
+        with fitz.open(pdf_path) as document:  # type: ignore[attr-defined]
+            counts = [len(page.get_drawings()) for page in document]
+            fonts = {font[3] for page in document for font in page.get_fonts(full=True)}
+    except Exception:  # noqa: BLE001 - characterization is evidence, never a reason to fail
+        return None
+    return counts, len(fonts)

--- a/benchmarks/pmc/corpus.py
+++ b/benchmarks/pmc/corpus.py
@@ -637,7 +637,11 @@ def _atomic_write_json(path: Path, payload: dict[str, Any]) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
     staging_path = path.parent / f".{path.name}.{os.getpid()}.{uuid4().hex}.tmp"
     try:
-        with staging_path.open("w", encoding="utf-8") as output:
+        # Explicit LF, not the platform default: the manifest's own digest is this
+        # corpus's pin, and .gitattributes checks the file out as LF everywhere. Writing
+        # CRLF on Windows would make the builder compute a pin no other machine can
+        # reproduce from the same committed bytes.
+        with staging_path.open("w", encoding="utf-8", newline="\n") as output:
             json.dump(payload, output, indent=2, sort_keys=True)
             output.write("\n")
             output.flush()

--- a/benchmarks/pmc/corpus.py
+++ b/benchmarks/pmc/corpus.py
@@ -1,0 +1,1040 @@
+"""Pinned PMC Open Access born-digital corpus: manifest build and cache load.
+
+The PMC ``pmc-oa-opendata`` bucket has **no corpus-wide revision** the way a Hugging
+Face dataset does -- article versions bump independently and decade-old articles carry
+recent reprocessing timestamps.  A committed manifest of per-object SHA-256 digests
+plays the role ``dataset_revision`` plays for the OmniDocBench lane, and it is the whole
+reason this corpus cannot drift the way ``benchmarks/corpus`` does.
+
+Two entry points, deliberately separated:
+
+``build_manifest``
+    Walks the bucket, applies the born-digital selection filter, and writes the manifest.
+    Network-heavy, non-deterministic (the bucket gains articles), and run by hand.
+
+``load_corpus``
+    Reads the committed manifest and materializes exactly the articles it names.  Never
+    lists the bucket, so what it produces is fixed by the manifest bytes alone.
+
+Unlike the OmniDocBench adapter this needs no separate cache index: the committed
+manifest *is* the trusted digest record, so every load revalidates every selected file
+against it directly.
+
+This module is deliberately agnostic about whether the eventual lane scores per-page or
+per-article -- it exposes whole articles and no page structure.  It also records no PDF
+page traits: the born-digital characterization is a separate step that must measure the
+built corpus independently, not read back the filter's own premise.
+"""
+
+from __future__ import annotations
+
+import errno
+import hashlib
+import json
+import os
+import re
+import sys
+import time
+import urllib.error
+import urllib.request
+from concurrent.futures import ThreadPoolExecutor
+from contextlib import contextmanager, suppress
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Callable, Iterator, Sequence
+from urllib.parse import quote
+from uuid import uuid4
+from xml.etree import ElementTree
+
+BUCKET = "pmc-oa-opendata"
+BUCKET_BASE = f"https://{BUCKET}.s3.amazonaws.com"
+MANIFEST_SCHEMA_VERSION = 1
+MANIFEST_FILENAME = "manifest.json"
+DEFAULT_MANIFEST = Path(__file__).with_name(MANIFEST_FILENAME)
+USER_AGENT = "all2md-benchmark-corpus"
+DEFAULT_TIMEOUT = 120
+
+_S3_NS = "{http://s3.amazonaws.com/doc/2006-03-01/}"
+_ALI_LICENSE_REF = "{http://www.niso.org/schemas/ali/1.0/}license_ref"
+_SHA256_RE = re.compile(r"[0-9a-f]{64}\Z")
+_ARTICLE_ID_RE = re.compile(r"PMC(?P<pmcid>[0-9]+)\.(?P<version>[0-9]+)\Z")
+
+#: Numeric anchors spread across the PMCID range.  Selection **never** starts at the front
+#: of the bucket: the numerically-first PMCIDs are one 19th-century journal's scanned back
+#: catalogue, and a sample drawn there is 100% scans while still showing a text layer on
+#: every page.  Listing order is lexicographic, so these are seeds for ``start-after`` and
+#: not an ordering.  Many seeds taking few articles each beats few seeds taking many: the
+#: spread across publishers and eras is the point, and a large ``per_seed`` just walks
+#: further into one region.
+DEFAULT_SEEDS: tuple[str, ...] = tuple(f"PMC{value}" for value in range(1_500_000, 12_500_000, 500_000))
+
+#: Candidates are taken every ``DEFAULT_STRIDE``-th prefix rather than consecutively.
+#: Adjacent PMCIDs are typically the same journal issue, so a consecutive run would draw
+#: one publisher's template repeatedly and call it a corpus.
+DEFAULT_STRIDE = 11
+
+#: Transient failures get a patient, exponentially backed-off retry rather than a fast
+#: one: a walk of several hundred candidates will meet a DNS blip, and a blip must not be
+#: allowed to look like a corpus property.
+_RETRIES = 5
+_RETRY_CEILING_SECONDS = 8.0
+
+#: A build that loses this share of its candidates to network failure is not measuring the
+#: bucket, it is measuring the link.  Past experience on the sibling lane: a DNS blip once
+#: shrank a 100-document gate to 50 and every other signal stayed green.
+_MAX_UNAVAILABLE_SHARE = 0.1
+
+#: Reasons a candidate can be dropped.  Every rejection is recorded in the manifest by
+#: article id -- a silent filter here is the same defect as a silent truncation.
+#:
+#: Network failures are deliberately **not** in this list.  A rejection is a statement
+#: about the article; an unreachable host is a statement about the run, and conflating the
+#: two would bake a transient outage into a committed manifest as though it were evidence.
+REJECTION_REASONS = (
+    "xml_missing",
+    "xml_unparsable",
+    "no_paragraphs",
+    "pdf_missing",
+    "pdf_unreadable",
+    "no_vector_drawings",
+)
+
+
+class CorpusError(RuntimeError):
+    """Base error for an unusable PMC corpus."""
+
+
+class CorpusDownloadError(CorpusError):
+    """A required artifact could not be downloaded."""
+
+
+class ArtifactMissingError(CorpusDownloadError):
+    """The remote object does not exist (HTTP 404)."""
+
+
+class CorpusIntegrityError(CorpusError):
+    """A downloaded artifact did not match its manifest contract."""
+
+
+class CorpusCacheError(CorpusError):
+    """A warm cache or the manifest itself failed validation."""
+
+
+class CorpusSelectionError(CorpusError):
+    """The bucket walk could not produce the requested corpus."""
+
+
+@dataclass(frozen=True, slots=True)
+class CorpusArticle:
+    """One pinned PMC Open Access article.
+
+    Attributes
+    ----------
+    article_id : str
+        Versioned bucket prefix, for example ``"PMC11000001.1"``.
+    pmcid : str
+        Unversioned PMC identifier, for example ``"PMC11000001"``.
+    version : int
+        Article version carried by the bucket prefix.
+    pdf_path : pathlib.Path
+        Local path to the validated publisher PDF.
+    xml_path : pathlib.Path
+        Local path to the validated JATS XML.
+    pdf_sha256, xml_sha256 : str
+        Lowercase SHA-256 digests, equal to the manifest by construction.
+    pdf_size_bytes, xml_size_bytes : int
+        Exact cached sizes in bytes.
+    licence : str
+        Licence recorded by the JATS ``ali:license_ref``/``license`` element.
+    paragraphs : int
+        Number of JATS ``<p>`` elements, the born-digital body test.
+
+    """
+
+    article_id: str
+    pmcid: str
+    version: int
+    pdf_path: Path
+    xml_path: Path
+    pdf_sha256: str
+    pdf_size_bytes: int
+    xml_sha256: str
+    xml_size_bytes: int
+    licence: str
+    paragraphs: int
+
+
+@dataclass(frozen=True, slots=True)
+class CorpusSnapshot:
+    """Validated view of a pinned PMC cache.
+
+    Attributes
+    ----------
+    manifest_path : pathlib.Path
+        Manifest the snapshot was materialized from.
+    manifest_sha256 : str
+        Digest of the manifest bytes; this is the corpus pin.
+    bucket : str
+        Source bucket recorded in the manifest.
+    articles : tuple[CorpusArticle, ...]
+        Validated articles selected for this invocation.
+    expected_articles : int
+        Article count of the complete pinned corpus.
+    complete : bool
+        ``True`` only when the caller requested the whole manifest.  Supplying a
+        ``limit`` always produces ``False``, even when it equals the manifest size.
+
+    """
+
+    manifest_path: Path
+    manifest_sha256: str
+    bucket: str
+    articles: tuple[CorpusArticle, ...]
+    expected_articles: int
+    complete: bool
+
+
+@dataclass(frozen=True, slots=True)
+class ManifestArticle:
+    """One article's pinned identity, exactly as committed."""
+
+    article_id: str
+    pdf_sha256: str
+    pdf_size_bytes: int
+    xml_sha256: str
+    xml_size_bytes: int
+    licence: str
+    paragraphs: int
+
+
+@dataclass(frozen=True, slots=True)
+class Manifest:
+    """Parsed and validated manifest contents."""
+
+    path: Path
+    sha256: str
+    bucket: str
+    articles: tuple[ManifestArticle, ...]
+    rejected: dict[str, str]
+    selection: dict[str, Any]
+
+
+@dataclass(frozen=True, slots=True)
+class BuildReport:
+    """Outcome of a bucket walk.
+
+    Attributes
+    ----------
+    manifest_path : pathlib.Path
+        Manifest that was written.
+    accepted : tuple[str, ...]
+        Article ids kept, in manifest order.
+    rejected : dict[str, str]
+        Article id to rejection reason, for every candidate that was dropped.
+    rejection_counts : dict[str, int]
+        Rejection reason to count, covering every reason in `REJECTION_REASONS`.
+    unavailable : dict[str, str]
+        Article id to error text, for candidates lost to network failure rather than to
+        the selection filter.  Kept apart from `rejected` on purpose.
+    candidates : int
+        Total candidate prefixes examined.
+
+    """
+
+    manifest_path: Path
+    accepted: tuple[str, ...]
+    rejected: dict[str, str]
+    rejection_counts: dict[str, int]
+    unavailable: dict[str, str]
+    candidates: int
+
+
+def load_corpus(
+    cache_dir: Path,
+    *,
+    manifest_path: Path | None = None,
+    limit: int | None = None,
+    workers: int = 8,
+) -> CorpusSnapshot:
+    """Materialize the pinned PMC corpus named by a committed manifest.
+
+    Every selected PDF and JATS file is revalidated against the manifest digest on each
+    call, whether it was just downloaded or found warm in the cache.
+
+    Parameters
+    ----------
+    cache_dir : pathlib.Path
+        Directory under which downloaded article bytes are kept.
+    manifest_path : pathlib.Path or None, optional
+        Manifest to pin against.  Defaults to the committed
+        ``benchmarks/pmc/manifest.json``.
+    limit : int or None, optional
+        Positive number of articles for an explicitly incomplete smoke run.  Selection
+        is **evenly spaced across the manifest**, never the first ``limit`` entries --
+        manifest order is lexicographic by PMCID, so a prefix would draw one era of the
+        archive and quietly stop being a spread sample.
+    workers : int, optional
+        Positive number of concurrent download workers.
+
+    Returns
+    -------
+    CorpusSnapshot
+        Fully validated full or explicitly incomplete corpus view.
+
+    Raises
+    ------
+    ValueError
+        If ``limit`` or ``workers`` is outside its supported range.
+    CorpusCacheError
+        If the manifest is unreadable or a cached artifact fails validation.
+    CorpusDownloadError
+        If a manifest artifact cannot be downloaded.
+    CorpusIntegrityError
+        If a freshly downloaded artifact does not match the manifest.
+
+    """
+    if isinstance(workers, bool) or not isinstance(workers, int) or workers < 1:
+        raise ValueError("workers must be a positive integer")
+    manifest = read_manifest(DEFAULT_MANIFEST if manifest_path is None else Path(manifest_path))
+    selected = _select(manifest.articles, limit)
+
+    corpus_dir = _prepare_cache_dir(Path(cache_dir), manifest.sha256)
+    with _cache_lock(corpus_dir, manifest.sha256):
+        articles = _materialize(selected, corpus_dir, workers=workers)
+    return CorpusSnapshot(
+        manifest_path=manifest.path,
+        manifest_sha256=manifest.sha256,
+        bucket=manifest.bucket,
+        articles=articles,
+        expected_articles=len(manifest.articles),
+        complete=limit is None,
+    )
+
+
+def _select(articles: tuple[ManifestArticle, ...], limit: int | None) -> tuple[ManifestArticle, ...]:
+    if limit is None:
+        return articles
+    if isinstance(limit, bool) or not isinstance(limit, int):
+        raise ValueError("limit must be an integer or None")
+    if not 1 <= limit <= len(articles):
+        raise ValueError(f"limit must be between 1 and {len(articles)}")
+    step = len(articles) / limit
+    return tuple(articles[int(index * step)] for index in range(limit))
+
+
+def read_manifest(manifest_path: Path) -> Manifest:
+    """Parse and fully validate a committed corpus manifest.
+
+    Parameters
+    ----------
+    manifest_path : pathlib.Path
+        Manifest file to read.
+
+    Returns
+    -------
+    Manifest
+        Validated manifest, including the digest of its own bytes.
+
+    Raises
+    ------
+    CorpusCacheError
+        If the manifest is missing, unreadable, or violates its schema.
+
+    """
+    manifest_path = Path(manifest_path)
+    if manifest_path.is_symlink() or not manifest_path.is_file():
+        raise CorpusCacheError(f"corpus manifest is not a regular file: {manifest_path}")
+    raw = manifest_path.read_bytes()
+    try:
+        payload = json.loads(raw)
+    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise CorpusCacheError(f"corpus manifest is not valid JSON: {exc}") from exc
+    if not isinstance(payload, dict):
+        raise CorpusCacheError("corpus manifest root must be an object")
+
+    required = {"schema_version", "bucket", "selection", "articles", "rejected", "rejection_counts"}
+    if set(payload) != required:
+        raise CorpusCacheError("corpus manifest schema does not match this adapter")
+    if payload["schema_version"] != MANIFEST_SCHEMA_VERSION:
+        raise CorpusCacheError(
+            f"corpus manifest schema version mismatch: expected {MANIFEST_SCHEMA_VERSION}, "
+            f"got {payload['schema_version']!r}"
+        )
+    if payload["bucket"] != BUCKET:
+        raise CorpusCacheError(f"corpus manifest bucket mismatch: expected {BUCKET!r}, got {payload['bucket']!r}")
+    for key in ("selection", "articles", "rejected", "rejection_counts"):
+        if not isinstance(payload[key], dict):
+            raise CorpusCacheError(f"corpus manifest {key} must be an object")
+    if not payload["articles"]:
+        raise CorpusCacheError("corpus manifest names no articles")
+
+    articles: list[ManifestArticle] = []
+    article_fields = {"pdf_sha256", "pdf_size_bytes", "xml_sha256", "xml_size_bytes", "licence", "paragraphs"}
+    for article_id, row in payload["articles"].items():
+        _parse_article_id(article_id, source="corpus manifest")
+        if not isinstance(row, dict) or set(row) != article_fields:
+            raise CorpusCacheError(f"corpus manifest row schema mismatch for {article_id!r}")
+        for field in ("pdf_sha256", "xml_sha256"):
+            if not isinstance(row[field], str) or _SHA256_RE.fullmatch(row[field]) is None:
+                raise CorpusCacheError(f"corpus manifest {field} is invalid for {article_id!r}")
+        for field in ("pdf_size_bytes", "xml_size_bytes", "paragraphs"):
+            value = row[field]
+            if isinstance(value, bool) or not isinstance(value, int) or value <= 0:
+                raise CorpusCacheError(f"corpus manifest {field} is invalid for {article_id!r}")
+        if not isinstance(row["licence"], str) or not row["licence"].strip():
+            raise CorpusCacheError(f"corpus manifest licence is invalid for {article_id!r}")
+        articles.append(
+            ManifestArticle(
+                article_id=article_id,
+                pdf_sha256=row["pdf_sha256"],
+                pdf_size_bytes=row["pdf_size_bytes"],
+                xml_sha256=row["xml_sha256"],
+                xml_size_bytes=row["xml_size_bytes"],
+                licence=row["licence"],
+                paragraphs=row["paragraphs"],
+            )
+        )
+
+    rejected = payload["rejected"]
+    for article_id, reason in rejected.items():
+        _parse_article_id(article_id, source="corpus manifest rejection")
+        if reason not in REJECTION_REASONS:
+            raise CorpusCacheError(f"corpus manifest records unknown rejection reason {reason!r}")
+        if article_id in payload["articles"]:
+            raise CorpusCacheError(f"corpus manifest both accepts and rejects {article_id!r}")
+
+    return Manifest(
+        path=manifest_path,
+        sha256=hashlib.sha256(raw).hexdigest(),
+        bucket=payload["bucket"],
+        articles=tuple(sorted(articles, key=lambda entry: entry.article_id)),
+        rejected=dict(rejected),
+        selection=dict(payload["selection"]),
+    )
+
+
+def _parse_article_id(article_id: Any, *, source: str) -> tuple[str, int]:
+    if not isinstance(article_id, str):
+        raise CorpusCacheError(f"{source} article id must be a string")
+    match = _ARTICLE_ID_RE.fullmatch(article_id)
+    if match is None:
+        raise CorpusCacheError(f"{source} article id is malformed: {article_id!r}")
+    return f"PMC{match['pmcid']}", int(match["version"])
+
+
+def _prepare_cache_dir(cache_dir: Path, manifest_sha256: str) -> Path:
+    if cache_dir.exists() and (cache_dir.is_symlink() or not cache_dir.is_dir()):
+        raise CorpusCacheError(f"cache directory is not a real directory: {cache_dir}")
+    cache_dir.mkdir(parents=True, exist_ok=True)
+    # Keyed by the manifest digest, which is this corpus's pin: a manifest edit yields a
+    # new directory rather than re-blessing files selected under different rules.
+    corpus_dir = cache_dir / manifest_sha256[:16]
+    if corpus_dir.exists() and corpus_dir.is_symlink():
+        raise CorpusCacheError(f"corpus cache must not be a symlink: {corpus_dir}")
+    corpus_dir.mkdir(parents=True, exist_ok=True)
+    _require_contained(corpus_dir, cache_dir)
+    return corpus_dir
+
+
+def _require_contained(path: Path, root: Path) -> None:
+    try:
+        path.resolve().relative_to(root.resolve())
+    except ValueError as exc:
+        raise CorpusCacheError(f"cache artifact escapes supplied directory: {path}") from exc
+
+
+# An OS-level file lock rather than a lock directory, on both platforms: a cold
+# materialization runs inside it, so a crashed holder must not leave the cache
+# permanently unopenable.  The branch is on `sys.platform` so a type checker analyses
+# only the branch that exists on the host.
+if sys.platform == "win32":
+    import msvcrt
+
+    _LOCK_CONTENTION_ERRNOS = frozenset({errno.EACCES, errno.EDEADLOCK, errno.EDEADLK})
+
+    def _acquire_lock(descriptor: int) -> None:
+        os.lseek(descriptor, 0, os.SEEK_SET)
+        while True:
+            try:
+                msvcrt.locking(descriptor, msvcrt.LK_NBLCK, 1)
+                return
+            except OSError as exc:
+                if exc.errno not in _LOCK_CONTENTION_ERRNOS:
+                    raise CorpusCacheError(f"cannot lock corpus cache: {exc}") from exc
+                time.sleep(0.05)
+
+    def _release_lock(descriptor: int) -> None:
+        os.lseek(descriptor, 0, os.SEEK_SET)
+        msvcrt.locking(descriptor, msvcrt.LK_UNLCK, 1)
+
+else:
+    import fcntl
+
+    def _acquire_lock(descriptor: int) -> None:
+        fcntl.flock(descriptor, fcntl.LOCK_EX)
+
+    def _release_lock(descriptor: int) -> None:
+        fcntl.flock(descriptor, fcntl.LOCK_UN)
+
+
+@contextmanager
+def _cache_lock(corpus_dir: Path, manifest_sha256: str) -> Iterator[None]:
+    lock_path = corpus_dir / f".lock-{manifest_sha256[:16]}"
+    flags = os.O_RDWR | os.O_CREAT
+    for name in ("O_NOFOLLOW", "O_BINARY", "O_NOINHERIT"):
+        flags |= getattr(os, name, 0)
+    try:
+        descriptor = os.open(lock_path, flags, 0o600)
+    except OSError as exc:
+        raise CorpusCacheError(f"cannot open corpus cache lock: {exc}") from exc
+    try:
+        _acquire_lock(descriptor)
+        try:
+            yield
+        finally:
+            _release_lock(descriptor)
+    finally:
+        os.close(descriptor)
+
+
+def _materialize(
+    selected: tuple[ManifestArticle, ...],
+    corpus_dir: Path,
+    *,
+    workers: int,
+) -> tuple[CorpusArticle, ...]:
+    def materialize(entry: ManifestArticle) -> CorpusArticle:
+        pmcid, version = _parse_article_id(entry.article_id, source="corpus manifest")
+        article_dir = corpus_dir / "articles" / entry.article_id
+        _require_contained(article_dir, corpus_dir)
+        article_dir.mkdir(parents=True, exist_ok=True)
+        pdf_path = article_dir / f"{entry.article_id}.pdf"
+        xml_path = article_dir / f"{entry.article_id}.xml"
+        _ensure_artifact(
+            pdf_path,
+            url=_object_url(entry.article_id, "pdf"),
+            sha256=entry.pdf_sha256,
+            size_bytes=entry.pdf_size_bytes,
+            label=f"PDF {entry.article_id}",
+        )
+        _ensure_artifact(
+            xml_path,
+            url=_object_url(entry.article_id, "xml"),
+            sha256=entry.xml_sha256,
+            size_bytes=entry.xml_size_bytes,
+            label=f"JATS {entry.article_id}",
+        )
+        return CorpusArticle(
+            article_id=entry.article_id,
+            pmcid=pmcid,
+            version=version,
+            pdf_path=pdf_path,
+            xml_path=xml_path,
+            pdf_sha256=entry.pdf_sha256,
+            pdf_size_bytes=entry.pdf_size_bytes,
+            xml_sha256=entry.xml_sha256,
+            xml_size_bytes=entry.xml_size_bytes,
+            licence=entry.licence,
+            paragraphs=entry.paragraphs,
+        )
+
+    if len(selected) == 1:
+        return (materialize(selected[0]),)
+    with ThreadPoolExecutor(max_workers=min(workers, len(selected))) as executor:
+        return tuple(executor.map(materialize, selected))
+
+
+def _ensure_artifact(
+    path: Path,
+    *,
+    url: str,
+    sha256: str,
+    size_bytes: int,
+    label: str,
+) -> None:
+    """Guarantee ``path`` holds exactly the manifest's bytes, downloading if needed."""
+    if path.exists():
+        if path.is_symlink() or not path.is_file():
+            raise CorpusCacheError(f"cached {label} is not a regular file: {path}")
+        if path.stat().st_size == size_bytes and _sha256(path) == sha256:
+            return
+        # A warm file that disagrees with the manifest is replaced, not trusted and not
+        # fatal: partial writes happen, and the digest check below still gates the result.
+        path.unlink()
+
+    _download(url, path, label=label)
+    actual_size = path.stat().st_size
+    actual_digest = _sha256(path)
+    if actual_size != size_bytes or actual_digest != sha256:
+        path.unlink(missing_ok=True)
+        raise CorpusIntegrityError(
+            f"{label} does not match the manifest: expected {sha256} ({size_bytes} bytes), "
+            f"got {actual_digest} ({actual_size} bytes)"
+        )
+
+
+def _object_url(article_id: str, suffix: str) -> str:
+    name = quote(f"{article_id}/{article_id}.{suffix}", safe="/")
+    return f"{BUCKET_BASE}/{name}"
+
+
+def _open_url(url: str, *, timeout: int = DEFAULT_TIMEOUT) -> Any:
+    request = urllib.request.Request(url, headers={"User-Agent": USER_AGENT})
+    return urllib.request.urlopen(request, timeout=timeout)  # noqa: S310 - fixed https bucket
+
+
+def _http_get(url: str, *, label: str, retries: int = _RETRIES, timeout: int = DEFAULT_TIMEOUT) -> bytes:
+    """Fetch ``url`` into memory, distinguishing a genuine 404 from a transient failure."""
+    last: Exception | None = None
+    for attempt in range(retries):
+        try:
+            with _open_url(url, timeout=timeout) as response:
+                return bytes(response.read())
+        except urllib.error.HTTPError as exc:
+            if exc.code == 404:
+                raise ArtifactMissingError(f"{label} does not exist: {url}") from exc
+            last = exc
+        except OSError as exc:
+            last = exc
+        time.sleep(min(_RETRY_CEILING_SECONDS, 2.0**attempt))
+    raise CorpusDownloadError(f"failed to download {label}: {last}")
+
+
+def _download(url: str, destination: Path, *, label: str, retries: int = _RETRIES) -> None:
+    """Stream ``url`` to ``destination`` atomically."""
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    staging_path = destination.parent / f".{destination.name}.{os.getpid()}.{uuid4().hex}.download"
+    last: Exception | None = None
+    try:
+        for attempt in range(retries):
+            try:
+                with _open_url(url) as response, staging_path.open("wb") as output:
+                    for chunk in iter(lambda: response.read(1 << 16), b""):
+                        output.write(chunk)
+                staging_path.replace(destination)
+                return
+            except urllib.error.HTTPError as exc:
+                if exc.code == 404:
+                    raise ArtifactMissingError(f"{label} does not exist: {url}") from exc
+                last = exc
+            except OSError as exc:
+                last = exc
+            time.sleep(0.5 * (attempt + 1))
+        raise CorpusDownloadError(f"failed to download {label}: {last}")
+    finally:
+        staging_path.unlink(missing_ok=True)
+
+
+def _sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as input_file:
+        for block in iter(lambda: input_file.read(1 << 20), b""):
+            digest.update(block)
+    return digest.hexdigest()
+
+
+def _atomic_write_json(path: Path, payload: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    staging_path = path.parent / f".{path.name}.{os.getpid()}.{uuid4().hex}.tmp"
+    try:
+        with staging_path.open("w", encoding="utf-8") as output:
+            json.dump(payload, output, indent=2, sort_keys=True)
+            output.write("\n")
+            output.flush()
+            os.fsync(output.fileno())
+        staging_path.replace(path)
+    finally:
+        staging_path.unlink(missing_ok=True)
+
+
+# ---------------------------------------------------------------------------
+# Manifest construction
+# ---------------------------------------------------------------------------
+
+
+#: The five entities XML defines itself.  Everything else in a JATS file is declared by a
+#: DTD the bucket does not ship alongside the article.
+_XML_BUILTIN_ENTITIES = frozenset({"amp", "lt", "gt", "apos", "quot"})
+_NAMED_ENTITY_RE = re.compile(rb"&([A-Za-z][A-Za-z0-9._-]*);")
+
+
+def _neutralize_entities(payload: bytes) -> bytes:
+    """Replace externally-declared named entities with the Unicode replacement character.
+
+    JATS routinely references entities (``&mu;``, ``&emsp;``) declared in DTDs the bucket
+    does not ship.  Dropping those articles would bias the corpus toward whichever
+    publishers happen to avoid them.  Numeric references are left alone, and nothing is
+    ever resolved *externally* -- there is no fetch and no local file read, only a
+    substitution on bytes already in hand.
+    """
+    return _NAMED_ENTITY_RE.sub(
+        lambda match: match.group(0) if match.group(1).decode("ascii") in _XML_BUILTIN_ENTITIES else b"&#xFFFD;",
+        payload,
+    )
+
+
+def _parse_jats(payload: bytes) -> tuple[ElementTree.Element, bool]:
+    """Parse JATS bytes, reporting whether entity neutralization was needed.
+
+    Strict parsing is tried first so a well-formed article is never rewritten, and the
+    fallback is counted rather than applied invisibly.
+    """
+    try:
+        return ElementTree.fromstring(payload), False
+    except ElementTree.ParseError:
+        return ElementTree.fromstring(_neutralize_entities(payload)), True
+
+
+def _count_local(root: ElementTree.Element, tag: str) -> int:
+    return sum(1 for element in root.iter() if _local_name(element.tag) == tag)
+
+
+def _local_name(tag: Any) -> str:
+    return tag.rsplit("}", 1)[-1] if isinstance(tag, str) else ""
+
+
+def _extract_licence(root: ElementTree.Element) -> str:
+    """Read the article licence out of the JATS itself, in decreasing order of precision."""
+    for reference in root.iter(_ALI_LICENSE_REF):
+        if reference.text and reference.text.strip():
+            return reference.text.strip()
+    for element in root.iter():
+        if _local_name(element.tag) != "license":
+            continue
+        for key, value in element.attrib.items():
+            if _local_name(key) == "href" and value.strip():
+                return value.strip()
+        license_type = element.attrib.get("license-type")
+        if isinstance(license_type, str) and license_type.strip():
+            return license_type.strip()
+    return "unrecorded"
+
+
+def _has_vector_drawings(pdf_path: Path) -> bool | None:
+    """Report whether any page carries vector drawings, or ``None`` if unreadable.
+
+    Read with PyMuPDF directly rather than through all2md, for the same reason the
+    OmniDocBench characterization is: a parser change must never alter what the corpus
+    is reported to contain.
+
+    **This is a backstop, not the born-digital discriminator** -- measured, against the
+    plan's expectation.  Scanned pages carry exactly one drawing (a page frame), so a
+    boolean test accepted two of three known scans on its own; the JATS ``<p>`` test is
+    what actually separates them, and it runs first.  A drawings-per-page threshold would
+    separate 1.0 from a born-digital median of 2-15, but calibrating it belongs to the
+    characterization step, on the whole corpus rather than on three articles.  See
+    ``README.md``.
+    """
+    try:
+        import fitz
+    except ImportError as exc:  # pragma: no cover - build-time dependency
+        raise CorpusSelectionError("PyMuPDF is required to build the PMC corpus manifest") from exc
+    try:
+        with fitz.open(pdf_path) as document:
+            return any(bool(page.get_drawings()) for page in document)
+    except Exception:  # noqa: BLE001 - an unreadable PDF is a rejection, not a crash
+        return None
+
+
+def list_article_prefixes(start_after: str, *, max_keys: int = 200) -> tuple[tuple[str, ...], str | None]:
+    """List one page of versioned article prefixes at or after ``start_after``.
+
+    Parameters
+    ----------
+    start_after : str
+        Key to resume after.  Listing order is lexicographic, so this is a seed rather
+        than a numeric position.
+    max_keys : int, optional
+        Maximum prefixes to request in one page.
+
+    Returns
+    -------
+    tuple[tuple[str, ...], str | None]
+        Article ids in listing order, and the continuation token if more remain.
+
+    """
+    url = f"{BUCKET_BASE}/?list-type=2&delimiter=%2F&start-after={quote(start_after, safe='')}&max-keys={int(max_keys)}"
+    return _parse_listing(_http_get(url, label=f"listing after {start_after}"))
+
+
+def _list_continuation(token: str, *, max_keys: int = 200) -> tuple[tuple[str, ...], str | None]:
+    url = (
+        f"{BUCKET_BASE}/?list-type=2&delimiter=%2F&continuation-token={quote(token, safe='')}&max-keys={int(max_keys)}"
+    )
+    return _parse_listing(_http_get(url, label="listing continuation"))
+
+
+def _parse_listing(payload: bytes) -> tuple[tuple[str, ...], str | None]:
+    try:
+        root = ElementTree.fromstring(payload)
+    except ElementTree.ParseError as exc:
+        raise CorpusSelectionError(f"bucket listing is not valid XML: {exc}") from exc
+    prefixes: list[str] = []
+    for element in root.findall(f"{_S3_NS}CommonPrefixes"):
+        prefix = element.findtext(f"{_S3_NS}Prefix") or ""
+        article_id = prefix.rstrip("/")
+        if _ARTICLE_ID_RE.fullmatch(article_id):
+            prefixes.append(article_id)
+    truncated = (root.findtext(f"{_S3_NS}IsTruncated") or "").strip().lower() == "true"
+    token = root.findtext(f"{_S3_NS}NextContinuationToken") if truncated else None
+    return tuple(prefixes), token
+
+
+def build_manifest(
+    destination: Path,
+    *,
+    workspace: Path,
+    seeds: Sequence[str] = DEFAULT_SEEDS,
+    per_seed: int = 3,
+    stride: int = DEFAULT_STRIDE,
+    max_candidates_per_seed: int = 60,
+    progress: Callable[[str], None] | None = None,
+) -> BuildReport:
+    """Walk the bucket, apply the born-digital filter, and write a pinned manifest.
+
+    Selection keeps an article only when its JATS has at least one ``<p>`` **and** its
+    PDF carries vector drawings on some page.  The ``<p>`` test is deliberately not a
+    ``<sec>`` test: short unsectioned pieces are born-digital too, and requiring sections
+    would bias the corpus toward long research papers.
+
+    A text layer is *not* part of the filter, because scans ship an embedded OCR layer.
+    The ``<p>`` test carries the discrimination: scanned back-catalogue articles deposit
+    their body as one ``<preformat>`` blob of raw OCR text and so have zero paragraphs.
+    See `_has_vector_drawings` for why its arm is only a backstop.
+
+    Parameters
+    ----------
+    destination : pathlib.Path
+        Manifest path to write.
+    workspace : pathlib.Path
+        Directory for candidate downloads.  Accepted articles are left in place so a
+        build also warms a cache; rejected ones are removed.
+    seeds : Sequence[str], optional
+        ``start-after`` seeds spread across the PMCID range.
+    per_seed : int, optional
+        Articles to accept per seed, so no single era dominates the corpus.
+    stride : int, optional
+        Take every ``stride``-th listed prefix, to avoid drawing a run of same-issue
+        articles from one publisher.
+    max_candidates_per_seed : int, optional
+        Give up on a seed after this many candidates, so one barren region cannot stall
+        the walk indefinitely.
+    progress : Callable[[str], None] or None, optional
+        Receives one line per candidate outcome.
+
+    Returns
+    -------
+    BuildReport
+        Accepted ids plus the full rejection ledger.
+
+    Raises
+    ------
+    ValueError
+        If a numeric parameter is outside its supported range.
+    CorpusSelectionError
+        If no article survives selection.
+
+    """
+    limits = (("per_seed", per_seed), ("stride", stride), ("max_candidates_per_seed", max_candidates_per_seed))
+    for name, value in limits:
+        if isinstance(value, bool) or not isinstance(value, int) or value < 1:
+            raise ValueError(f"{name} must be a positive integer")
+    if not seeds:
+        raise ValueError("seeds must not be empty")
+
+    emit = progress if progress is not None else (lambda _message: None)
+    workspace = Path(workspace)
+    workspace.mkdir(parents=True, exist_ok=True)
+
+    accepted: dict[str, ManifestArticle] = {}
+    rejected: dict[str, str] = {}
+    unavailable: dict[str, str] = {}
+    candidates = 0
+    entity_fallbacks = 0
+
+    for seed in seeds:
+        emit(f"seed {seed}")
+        kept = 0
+        examined = 0
+        token: str | None = None
+        offset = 0
+        while kept < per_seed and examined < max_candidates_per_seed:
+            try:
+                if token is None:
+                    prefixes, token = list_article_prefixes(seed)
+                else:
+                    prefixes, token = _list_continuation(token)
+            except CorpusDownloadError as exc:
+                # A seed whose listing is unreachable is abandoned, not silently treated
+                # as an exhausted region; the unavailable ledger below is what makes the
+                # difference visible.
+                unavailable[seed] = str(exc)
+                emit(f"  unavailable {seed}: listing failed")
+                break
+            if not prefixes:
+                break
+            for index, article_id in enumerate(prefixes):
+                if (offset + index) % stride:
+                    continue
+                if article_id in accepted or article_id in rejected or article_id in unavailable:
+                    continue
+                if kept >= per_seed or examined >= max_candidates_per_seed:
+                    break
+                examined += 1
+                candidates += 1
+                try:
+                    entry, reason, neutralized = _evaluate_candidate(article_id, workspace)
+                except CorpusDownloadError as exc:
+                    unavailable[article_id] = str(exc)
+                    emit(f"  unavailable {article_id}: {exc}")
+                    continue
+                entity_fallbacks += int(neutralized)
+                if entry is None:
+                    rejected[article_id] = reason or "xml_missing"
+                    emit(f"  reject {article_id}: {rejected[article_id]}")
+                    continue
+                accepted[article_id] = entry
+                kept += 1
+                emit(f"  accept {article_id}: {entry.paragraphs} <p>, {entry.licence}")
+            offset += len(prefixes)
+            if token is None:
+                break
+
+    if not accepted:
+        raise CorpusSelectionError("bucket walk accepted no articles")
+    # Fail loudly rather than committing a manifest that a bad link quietly thinned out.
+    if unavailable and len(unavailable) > max(2, int(_MAX_UNAVAILABLE_SHARE * candidates)):
+        raise CorpusSelectionError(
+            f"bucket walk lost {len(unavailable)} of {candidates} candidates to network failure; "
+            "this measures the link, not the corpus -- rerun when the network is healthy"
+        )
+
+    rejection_counts = dict.fromkeys(REJECTION_REASONS, 0)
+    for reason in rejected.values():
+        rejection_counts[reason] += 1
+
+    payload = {
+        "schema_version": MANIFEST_SCHEMA_VERSION,
+        "bucket": BUCKET,
+        "selection": {
+            "seeds": list(seeds),
+            "per_seed": per_seed,
+            "stride": stride,
+            "max_candidates_per_seed": max_candidates_per_seed,
+            "candidates": candidates,
+            "xml_entity_fallbacks": entity_fallbacks,
+            "unavailable": sorted(unavailable),
+            "filter": "JATS <p> > 0 and vector drawings on some PDF page",
+        },
+        "articles": {
+            article_id: {
+                "pdf_sha256": entry.pdf_sha256,
+                "pdf_size_bytes": entry.pdf_size_bytes,
+                "xml_sha256": entry.xml_sha256,
+                "xml_size_bytes": entry.xml_size_bytes,
+                "licence": entry.licence,
+                "paragraphs": entry.paragraphs,
+            }
+            for article_id, entry in sorted(accepted.items())
+        },
+        "rejected": dict(sorted(rejected.items())),
+        "rejection_counts": rejection_counts,
+    }
+    destination = Path(destination)
+    _atomic_write_json(destination, payload)
+    _promote_workspace(workspace, destination, accepted)
+    return BuildReport(
+        manifest_path=destination,
+        accepted=tuple(sorted(accepted)),
+        rejected=dict(sorted(rejected.items())),
+        rejection_counts=rejection_counts,
+        unavailable=dict(sorted(unavailable.items())),
+        candidates=candidates,
+    )
+
+
+def _promote_workspace(workspace: Path, manifest_path: Path, accepted: dict[str, ManifestArticle]) -> None:
+    """Move the accepted downloads into the digest-keyed layout `load_corpus` reads.
+
+    The build cannot write there directly -- the digest that names the directory does not
+    exist until the manifest does.  Without this a fresh build leaves several hundred
+    megabytes on disk that the very next load re-downloads, so the promotion is what makes
+    "a build also warms the cache" true rather than merely claimed.
+
+    Best-effort by design: a failure here costs a re-download, and must never invalidate a
+    manifest that is already written and correct.
+    """
+    try:
+        digest = hashlib.sha256(manifest_path.read_bytes()).hexdigest()
+    except OSError:
+        return
+    source_root = workspace / "articles"
+    target_root = workspace / digest[:16] / "articles"
+    if not source_root.is_dir() or source_root.resolve() == target_root.resolve():
+        return
+    for article_id in accepted:
+        source = source_root / article_id
+        target = target_root / article_id
+        if not source.is_dir() or target.exists():
+            continue
+        with suppress(OSError):
+            target.parent.mkdir(parents=True, exist_ok=True)
+            source.replace(target)
+    with suppress(OSError):
+        source_root.rmdir()
+
+
+def _evaluate_candidate(article_id: str, workspace: Path) -> tuple[ManifestArticle | None, str | None, bool]:
+    """Apply the born-digital filter to one candidate, cheapest test first.
+
+    Returns the accepted entry or a rejection reason, plus whether the JATS needed
+    entity neutralization to parse.
+    """
+    article_dir = workspace / "articles" / article_id
+    article_dir.mkdir(parents=True, exist_ok=True)
+    xml_path = article_dir / f"{article_id}.xml"
+    pdf_path = article_dir / f"{article_id}.pdf"
+
+    def drop(reason: str, neutralized: bool) -> tuple[None, str, bool]:
+        pdf_path.unlink(missing_ok=True)
+        # Leave no empty directory behind for an article the corpus does not contain.
+        with suppress(OSError):
+            article_dir.rmdir()
+        return None, reason, neutralized
+
+    try:
+        xml_bytes = _http_get(_object_url(article_id, "xml"), label=f"JATS {article_id}")
+    except ArtifactMissingError:
+        return drop("xml_missing", False)
+    try:
+        root, neutralized = _parse_jats(xml_bytes)
+    except ElementTree.ParseError:
+        return drop("xml_unparsable", False)
+    paragraphs = _count_local(root, "p")
+    if paragraphs <= 0:
+        return drop("no_paragraphs", neutralized)
+
+    try:
+        _download(_object_url(article_id, "pdf"), pdf_path, label=f"PDF {article_id}")
+    except ArtifactMissingError:
+        return drop("pdf_missing", neutralized)
+    has_drawings = _has_vector_drawings(pdf_path)
+    if has_drawings is None:
+        return drop("pdf_unreadable", neutralized)
+    if not has_drawings:
+        return drop("no_vector_drawings", neutralized)
+
+    xml_path.write_bytes(xml_bytes)
+    return (
+        ManifestArticle(
+            article_id=article_id,
+            pdf_sha256=_sha256(pdf_path),
+            pdf_size_bytes=pdf_path.stat().st_size,
+            xml_sha256=hashlib.sha256(xml_bytes).hexdigest(),
+            xml_size_bytes=len(xml_bytes),
+            licence=_extract_licence(root),
+            paragraphs=paragraphs,
+        ),
+        None,
+        neutralized,
+    )

--- a/benchmarks/pmc/corpus.py
+++ b/benchmarks/pmc/corpus.py
@@ -722,12 +722,12 @@ def _has_vector_drawings(pdf_path: Path) -> bool | None:
     is reported to contain.
 
     **This is a backstop, not the born-digital discriminator** -- measured, against the
-    plan's expectation.  Scanned pages carry exactly one drawing (a page frame), so a
-    boolean test accepted two of three known scans on its own; the JATS ``<p>`` test is
-    what actually separates them, and it runs first.  A drawings-per-page threshold would
-    separate 1.0 from a born-digital median of 2-15, but calibrating it belongs to the
-    characterization step, on the whole corpus rather than on three articles.  See
-    ``README.md``.
+    plan's expectation.  The bucket holds two kinds of non-born-digital material and this
+    test handles neither well: against a raster scan it is redundant with the
+    page-area image test, and against an OCR text dump re-typeset into a PDF it is
+    actively fooled, because such a file's one "drawing" per page is a page-sized
+    background rectangle.  Geometrically those files *are* born-digital; only the JATS
+    ``<p>`` test reveals them, and it runs first.  See ``README.md``.
     """
     try:
         import fitz

--- a/benchmarks/pmc/manifest.json
+++ b/benchmarks/pmc/manifest.json
@@ -1,0 +1,616 @@
+{
+  "articles": {
+    "PMC10000015.1": {
+      "licence": "https://creativecommons.org/licenses/by/3.0/",
+      "paragraphs": 24,
+      "pdf_sha256": "d6ec867dbdbe5dd7c6754467a422777820838d36594241a4152861594d849e2e",
+      "pdf_size_bytes": 400095,
+      "xml_sha256": "09339e8884bbb0d5fd9ee55e24a6606387e74df3004cbade401b6b133ecf3da9",
+      "xml_size_bytes": 39117
+    },
+    "PMC10000026.1": {
+      "licence": "https://creativecommons.org/licenses/by/4.0/",
+      "paragraphs": 66,
+      "pdf_sha256": "4afa5ea155419511e476cedcab4c2b97dbd0533895e6203344a9807af19feb2b",
+      "pdf_size_bytes": 2559900,
+      "xml_sha256": "eb110894a044f9f3d8d180c9c616cbd3a903ff5da1e4b54fb0451add40ba9635",
+      "xml_size_bytes": 137887
+    },
+    "PMC10000037.1": {
+      "licence": "https://creativecommons.org/licenses/by/4.0/",
+      "paragraphs": 42,
+      "pdf_sha256": "481535ceb89f05ffafea308c5e75644cc3f0c76dd101cbefc7e4deac13628fb5",
+      "pdf_size_bytes": 2379177,
+      "xml_sha256": "00c452a297db6185f2546aa8f5080cdb3aa795198b5995d02d813bdbcaedbb78",
+      "xml_size_bytes": 138283
+    },
+    "PMC10500000.1": {
+      "licence": "https://creativecommons.org/licenses/by-nc/4.0/",
+      "paragraphs": 3,
+      "pdf_sha256": "87b10df7212e10510e542ec8618b8a1f1e1aa205853ac5fc3cef36d96861a0ba",
+      "pdf_size_bytes": 264985,
+      "xml_sha256": "67584c3d12a458162645f5f6fb136e568c4dd5ff3bd2520f3e9ece1f52ce5056",
+      "xml_size_bytes": 13215
+    },
+    "PMC10500011.1": {
+      "licence": "https://creativecommons.org/licenses/by/4.0/",
+      "paragraphs": 51,
+      "pdf_sha256": "f8be12bca79acf7892465e13cd118d1000581a05820c9bc63dddeafa204253e9",
+      "pdf_size_bytes": 5763047,
+      "xml_sha256": "b2007241e3d887ae528f6c5266df8b14c31983dd872585fe42cd2283f21cb52f",
+      "xml_size_bytes": 128720
+    },
+    "PMC10500022.1": {
+      "licence": "https://creativecommons.org/licenses/by-nc-nd/4.0/",
+      "paragraphs": 50,
+      "pdf_sha256": "c552ddb4313a1937036dfe069f44c196df5718e1630509bdd899add2c276cb08",
+      "pdf_size_bytes": 2470339,
+      "xml_sha256": "2401e44b6234d28bf34c8462122a0ef7d6a06273e467961a1996ce7560c0a4ff",
+      "xml_size_bytes": 79267
+    },
+    "PMC11000000.1": {
+      "licence": "https://creativecommons.org/licenses/by-nc-nd/4.0/",
+      "paragraphs": 22,
+      "pdf_sha256": "d9e941059f8dddbd9087f5e5cf42d43eb8d9f0bf25b92580d1db073902dcce32",
+      "pdf_size_bytes": 2194265,
+      "xml_sha256": "c982b8bf7167544f57703266814451f4a6722051bb730a44c1931d6836df923f",
+      "xml_size_bytes": 41377
+    },
+    "PMC11000011.1": {
+      "licence": "https://creativecommons.org/licenses/by/4.0/",
+      "paragraphs": 64,
+      "pdf_sha256": "ddc5a5421d0878e4bd72c3348be627565e9e9edc5c23f87bf0d4de049807788c",
+      "pdf_size_bytes": 4829374,
+      "xml_sha256": "b724e3c933e10c5acf3b1d5253b19983985828cfc85f63f186a4580c315def1b",
+      "xml_size_bytes": 316408
+    },
+    "PMC11000022.1": {
+      "licence": "https://creativecommons.org/licenses/by-nc/4.0/",
+      "paragraphs": 42,
+      "pdf_sha256": "d711918cea857c3f6694ed9235f9127d7accc4634b86da2906b0d0f84e561d07",
+      "pdf_size_bytes": 1780546,
+      "xml_sha256": "746e77c4dafb1fdbca3eae89d771f23ae8ac25f6379a90739a5f390ecdaf9ba9",
+      "xml_size_bytes": 105792
+    },
+    "PMC11500000.1": {
+      "licence": "https://creativecommons.org/licenses/by-nc-nd/4.0/",
+      "paragraphs": 39,
+      "pdf_sha256": "eba5a0fe4fb3ca38a237a39c0f8cae3d395bd530d31050cdbe097631167f3978",
+      "pdf_size_bytes": 1750699,
+      "xml_sha256": "ac96266c8bcf82fbd11cbd3987e657b6b07001ef80c98cc32cb6e36a83df3ff0",
+      "xml_size_bytes": 62475
+    },
+    "PMC11500014.1": {
+      "licence": "https://creativecommons.org/licenses/by-nc-nd/4.0/",
+      "paragraphs": 57,
+      "pdf_sha256": "52a65726f49f0c5f0e79bf7398c0ee6045a899b07c148703ce6bdb37f72e060d",
+      "pdf_size_bytes": 3771574,
+      "xml_sha256": "4a4839a7607e702638eeb313aba901cef49256e80198a88b944e751830a2aac4",
+      "xml_size_bytes": 128619
+    },
+    "PMC11500027.1": {
+      "licence": "https://creativecommons.org/licenses/by-nc-nd/4.0/",
+      "paragraphs": 69,
+      "pdf_sha256": "bb0edec3b9f839be828a6dd764a13b656bc9b412449231032a11718b0a982031",
+      "pdf_size_bytes": 939240,
+      "xml_sha256": "220c0ec3f06c63324b4b21e9f5ddea6ed4a2c64226951166c136074432dc91c4",
+      "xml_size_bytes": 55144
+    },
+    "PMC12000001.1": {
+      "licence": "https://creativecommons.org/licenses/by/4.0/",
+      "paragraphs": 79,
+      "pdf_sha256": "6715bb5afacd9cc8864b0ae363383a7d0b0bf46d88bef0294c96f704f313e012",
+      "pdf_size_bytes": 1830828,
+      "xml_sha256": "c214acfa68f93f7ca269a0c6e82f68a67fac94c7da383c6c73bdce12a5c46804",
+      "xml_size_bytes": 223858
+    },
+    "PMC12000012.1": {
+      "licence": "https://creativecommons.org/licenses/by/4.0/",
+      "paragraphs": 93,
+      "pdf_sha256": "e52bdbdd7982da668b47b77e99c2f60002aad38bb65f342dddcc3648aca97040",
+      "pdf_size_bytes": 2712437,
+      "xml_sha256": "d03fd41260603f0e88ccb7d04b8b716a6987719c5a136962a742c31fc8e3081b",
+      "xml_size_bytes": 262545
+    },
+    "PMC12000023.1": {
+      "licence": "https://creativecommons.org/licenses/by/4.0/",
+      "paragraphs": 32,
+      "pdf_sha256": "122915a7ca28811994dd1a2f74869f5549beb274c8610ddece752075d05d07b7",
+      "pdf_size_bytes": 572055,
+      "xml_sha256": "cb8f8a86ad4e4b14d5696378cf470878d307d78c36a70e8eed3d535ed96a4c2e",
+      "xml_size_bytes": 71231
+    },
+    "PMC150011.1": {
+      "licence": "unrecorded",
+      "paragraphs": 24,
+      "pdf_sha256": "249e95b22fd90d1b4dca49cedde885a36535a3854659e27ba53896b6513e84e7",
+      "pdf_size_bytes": 232116,
+      "xml_sha256": "7f46db0f3aeee4c7193d091f81328e5a1ee1282e42b0cd0ac6467fd1a157d18c",
+      "xml_size_bytes": 31067
+    },
+    "PMC1500805.1": {
+      "licence": "https://creativecommons.org/licenses/by/2.0/",
+      "paragraphs": 111,
+      "pdf_sha256": "2caaac11a9a658fdb2745f03b6cefe7bc3fff3be9ac1acc18e89ed2bde82c6b0",
+      "pdf_size_bytes": 367196,
+      "xml_sha256": "0edda590ad6191133ebb4a6a212e599ce4b5f7c44da2603e9a059c775b45fdf9",
+      "xml_size_bytes": 165432
+    },
+    "PMC1500944.1": {
+      "licence": "unrecorded",
+      "paragraphs": 58,
+      "pdf_sha256": "393398a90bf1de12b83bf874e1aef204d3841a68cadec5001a1c82defe504752",
+      "pdf_size_bytes": 339540,
+      "xml_sha256": "204d5fca1770ae5f560e10119e234102761c68e53110e45d244171269ca768a9",
+      "xml_size_bytes": 67819
+    },
+    "PMC2000230.1": {
+      "licence": "https://creativecommons.org/licenses/by-nc/2.0/",
+      "paragraphs": 46,
+      "pdf_sha256": "a310dc5528078179b2879ec2eed6eb4651ae6b09db064942ff8229958a6b4153",
+      "pdf_size_bytes": 239272,
+      "xml_sha256": "c6d3e02515ade9cce68a23300d56a45d39eca9764379080d6263d79af185782f",
+      "xml_size_bytes": 99789
+    },
+    "PMC2000354.1": {
+      "licence": "https://creativecommons.org/licenses/by/4.0/",
+      "paragraphs": 60,
+      "pdf_sha256": "1a0a5956bcd5010da012ab2f5b336218eab28e0472248994837cabfbb22fc611",
+      "pdf_size_bytes": 320792,
+      "xml_sha256": "dba0e081eaddf0d686962c3ecce371e3ae606dabc290ffbc2d876c2b2a0ae734",
+      "xml_size_bytes": 128282
+    },
+    "PMC2000466.1": {
+      "licence": "https://creativecommons.org/licenses/by/2.0/",
+      "paragraphs": 19,
+      "pdf_sha256": "963fb328ed93586a063d37d6b81c6f4f22cea20a924a404f779c0a407f774a9b",
+      "pdf_size_bytes": 454170,
+      "xml_sha256": "a8fd365fcb783d1cf283134ca412b30311b3237f29aeb7d9aa9e6cd78d678600",
+      "xml_size_bytes": 43013
+    },
+    "PMC2500000.1": {
+      "licence": "https://creativecommons.org/licenses/by/2.0/",
+      "paragraphs": 66,
+      "pdf_sha256": "d1afe66b6d39145cc5efa217c7c29aec15083e5e916a6c3c0d177ba21c11e0f1",
+      "pdf_size_bytes": 316763,
+      "xml_sha256": "3d49e0eae3241a1bd9afa6bea20a50bee79a3a907a7f140652ab65b97db9e9c5",
+      "xml_size_bytes": 79859
+    },
+    "PMC2500011.1": {
+      "licence": "https://creativecommons.org/licenses/by/2.0/",
+      "paragraphs": 39,
+      "pdf_sha256": "243ccd7386d2074d91da1a642540122748ffd47a741fe5fd00dfee32ba7fe657",
+      "pdf_size_bytes": 332922,
+      "xml_sha256": "1f3871f4df188120c9254dc070112fc810a140b2b65f1d6593e823001727ffd0",
+      "xml_size_bytes": 61505
+    },
+    "PMC2500022.1": {
+      "licence": "https://creativecommons.org/licenses/by/2.0/",
+      "paragraphs": 45,
+      "pdf_sha256": "42aeba58233997a7defe1505a79101ce3ac143f7e0cafe2982696a5c9adb0b82",
+      "pdf_size_bytes": 729820,
+      "xml_sha256": "21a23433da5f303922257117b57fd25b1451c3cb1a350bdbe88c40a2d9ff3827",
+      "xml_size_bytes": 114520
+    },
+    "PMC3000000.1": {
+      "licence": "open-access",
+      "paragraphs": 28,
+      "pdf_sha256": "537b807e3453ba5eac61d5d32a3ba34162c360061289730419bf86ce1fa84926",
+      "pdf_size_bytes": 551899,
+      "xml_sha256": "0c9a74f74fdb33414ab0bab4c264df3715e08130d2d0cba6974b3a96ea57574e",
+      "xml_size_bytes": 37871
+    },
+    "PMC3000079.1": {
+      "licence": "https://creativecommons.org/licenses/by/3.0/",
+      "paragraphs": 99,
+      "pdf_sha256": "189bcb6f8bc2343889559f062074e09651628751339f1111396abb925f2f6929",
+      "pdf_size_bytes": 521436,
+      "xml_sha256": "11fe403e522d201eab645161adbfef35b9633b6b3a7b30ad65394e3d9e8fa856",
+      "xml_size_bytes": 279366
+    },
+    "PMC3000090.1": {
+      "licence": "https://creativecommons.org/licenses/by/3.0/",
+      "paragraphs": 27,
+      "pdf_sha256": "3d292d22565f024ed67b0c2311208da1753dcf4a08a4c13e6659796c78584bd3",
+      "pdf_size_bytes": 194913,
+      "xml_sha256": "d76f93b6b6e64e8f6e586fa12a3513e1101b881279ae052da80af009b161fce4",
+      "xml_size_bytes": 49260
+    },
+    "PMC3500000.1": {
+      "licence": "https://creativecommons.org/licenses/by/2.0/",
+      "paragraphs": 8,
+      "pdf_sha256": "e25a2eb1486b1703d499fff0fe670f21195f53f0bd19ab8c5e3d1c8bc92b7d83",
+      "pdf_size_bytes": 116404,
+      "xml_sha256": "475345507f1de98a3a7a2546efdb5a4dd26fe19abccf8e0e3ea3874459b4f8e5",
+      "xml_size_bytes": 46174
+    },
+    "PMC3500011.1": {
+      "licence": "https://creativecommons.org/licenses/by-nc-sa/3.0/",
+      "paragraphs": 41,
+      "pdf_sha256": "ea9d1543d824be050b1d10d31fb14e5f8cb5f08d14ec08fae00c06b9fffff439",
+      "pdf_size_bytes": 1595251,
+      "xml_sha256": "fbba493e769d542214b12058ae78f98861e259c31cba29c32b8e7355b463830b",
+      "xml_size_bytes": 67858
+    },
+    "PMC3500022.1": {
+      "licence": "https://creativecommons.org/licenses/by-nc-sa/3.0/",
+      "paragraphs": 37,
+      "pdf_sha256": "78bd06553cf357276e5c02876f6cb92a3a71dd8b8cdcc0dfa70b299502b494df",
+      "pdf_size_bytes": 822335,
+      "xml_sha256": "c577a775d5ba03ebd25d263546dccfcc4db8948be4659ef6559dcc7ddb803b83",
+      "xml_size_bytes": 56018
+    },
+    "PMC4000001.1": {
+      "licence": "https://creativecommons.org/licenses/by/2.0/",
+      "paragraphs": 44,
+      "pdf_sha256": "50c431998db5a17d2418b7300d230fe485a90993d4a059546670b951450a0053",
+      "pdf_size_bytes": 223579,
+      "xml_sha256": "1c9f50b6bd73e3509c952da5b9a8a19afd1aabeb589afc4b65a766ce15cca2b0",
+      "xml_size_bytes": 53636
+    },
+    "PMC4000047.1": {
+      "licence": "https://creativecommons.org/licenses/by/2.0/",
+      "paragraphs": 54,
+      "pdf_sha256": "eaae4695b662450f220cbd6cea5f07a8d59ede7637f778de69872b399db58a6d",
+      "pdf_size_bytes": 1067407,
+      "xml_sha256": "e928567d4eafefa7788438dc416ac44f75a6dd5664693cff50883975b516af2f",
+      "xml_size_bytes": 106160
+    },
+    "PMC4000057.1": {
+      "licence": "https://creativecommons.org/licenses/by/2.0/",
+      "paragraphs": 155,
+      "pdf_sha256": "0b1922ef9d3c8440460895674a14695647f9875856624f83026e04b477800a25",
+      "pdf_size_bytes": 839005,
+      "xml_sha256": "51d376e8d736bb1f8b654ae42438850ad929b8530e9d26875df344e73803d967",
+      "xml_size_bytes": 132952
+    },
+    "PMC4500000.1": {
+      "licence": "https://creativecommons.org/licenses/by-nc-nd/3.0/",
+      "paragraphs": 15,
+      "pdf_sha256": "7dbb2eb443387fd676170bfaf24f3d9ed44d7b25e418b0c0481d04ea800d51d5",
+      "pdf_size_bytes": 439553,
+      "xml_sha256": "847de0f7f91dd0ff1497d38d708eee4d5cfe6b318300374f659cb7242aac8af3",
+      "xml_size_bytes": 40808
+    },
+    "PMC4500011.1": {
+      "licence": "https://creativecommons.org/licenses/by-nc-nd/3.0/",
+      "paragraphs": 10,
+      "pdf_sha256": "e51de9e9192f131d5c5075378d7574ba5f673c57d56f44c9c300645ad24aa97f",
+      "pdf_size_bytes": 563747,
+      "xml_sha256": "16fdd3fb1b9e48898ce93dd49a8eb7903b8df3e2ee342c0a5b08a642b163ff2d",
+      "xml_size_bytes": 52597
+    },
+    "PMC4500022.1": {
+      "licence": "https://creativecommons.org/licenses/by-nc-nd/3.0/",
+      "paragraphs": 26,
+      "pdf_sha256": "0696e438746ad8f8393f7f3b98586a3c3022e4cfab4d224ad9b65ade1198f261",
+      "pdf_size_bytes": 469953,
+      "xml_sha256": "ea95cbc2d0923ee559be86ad4d878e223856326a9c57f8eebd90feaac8c2a8bc",
+      "xml_size_bytes": 45798
+    },
+    "PMC5000011.1": {
+      "licence": "https://creativecommons.org/licenses/by/4.0/",
+      "paragraphs": 103,
+      "pdf_sha256": "1b1a2dcc4e866328dd6274a6472b6516cd1667ec39f804d7957fb973d56540cd",
+      "pdf_size_bytes": 364329,
+      "xml_sha256": "34baef0f440ecea6e4d029d2ca8aeecceab6b7a2ca6e81b6b982c6d16769c0ae",
+      "xml_size_bytes": 70290
+    },
+    "PMC5000402.1": {
+      "licence": "https://creativecommons.org/licenses/by/4.0/",
+      "paragraphs": 59,
+      "pdf_sha256": "fa024880f42c1453b6e56e110edfca0dcf71e788a578b14e15cd56d801736b38",
+      "pdf_size_bytes": 475305,
+      "xml_sha256": "fcc150998fcc4b3788fa2c25d8d74d8b38a5260ac8a5891b60122aa3617c3d16",
+      "xml_size_bytes": 66003
+    },
+    "PMC5000413.1": {
+      "licence": "https://creativecommons.org/licenses/by/4.0/",
+      "paragraphs": 98,
+      "pdf_sha256": "a40cb01e1e529e31370522149dedefd7634a4b33b361211b51e7ea9f08af4e4b",
+      "pdf_size_bytes": 1121182,
+      "xml_sha256": "6467f74ea174b2f3fa1d32615dda4b61ccd486af49fdef0374bfac7b0867b66e",
+      "xml_size_bytes": 138377
+    },
+    "PMC5500000.1": {
+      "licence": "https://creativecommons.org/publicdomain/zero/1.0/",
+      "paragraphs": 118,
+      "pdf_sha256": "6c77c12e190afbc6687cc93af27ee17afa6ab17d00a919a2242674f49bb47d88",
+      "pdf_size_bytes": 14021564,
+      "xml_sha256": "c2182bd815c821927d93bd736436866a57dfd797603e716f893a90f4b3eac80e",
+      "xml_size_bytes": 113458
+    },
+    "PMC5500023.1": {
+      "licence": "https://creativecommons.org/licenses/by-nd/4.0/",
+      "paragraphs": 38,
+      "pdf_sha256": "caffd67460cedca943c49035358fc8554ef3afc6cdb64f3f468a41ed2fdb28d8",
+      "pdf_size_bytes": 435283,
+      "xml_sha256": "7ac8c59600cc025d2624d9729deb2ccf645b39793b315c74e41d5e6bb576fbd5",
+      "xml_size_bytes": 66280
+    },
+    "PMC5500034.1": {
+      "licence": "https://creativecommons.org/licenses/by-nc-nd/4.0/",
+      "paragraphs": 29,
+      "pdf_sha256": "57c42cdda45ad156c33052c3f076cd122740723bc085596309151e39b2a3aa4f",
+      "pdf_size_bytes": 267731,
+      "xml_sha256": "a49e2edf8993eb40200bf2a11be7eb7c60789a820b23148f6a2becbd481b17b1",
+      "xml_size_bytes": 62293
+    },
+    "PMC6000000.1": {
+      "licence": "https://creativecommons.org/licenses/by/4.0/",
+      "paragraphs": 48,
+      "pdf_sha256": "8011cfef1a31ba28d21a22504ab70693d14feede7c55118667c6986c978f3ef1",
+      "pdf_size_bytes": 1516933,
+      "xml_sha256": "4a8f2c0872b839e6196373ce5082a7f9363536bf25d1a3cca2d79ed5159e956b",
+      "xml_size_bytes": 80201
+    },
+    "PMC6000011.1": {
+      "licence": "https://creativecommons.org/licenses/by/3.0/",
+      "paragraphs": 19,
+      "pdf_sha256": "4349ca8ea934061b4ffa23c04ec6cae022a8d2c6cec328909553294a49758da3",
+      "pdf_size_bytes": 881928,
+      "xml_sha256": "2b02c1719d52157cabcab3c60fb69482b6cc2a4698e4e9d502a0581ae5c31d41",
+      "xml_size_bytes": 52318
+    },
+    "PMC6000022.1": {
+      "licence": "https://creativecommons.org/licenses/by/3.0/",
+      "paragraphs": 55,
+      "pdf_sha256": "5be7b17477397973328685d830f77986d41f4e1404ebbf6e0006cc61e4d82a06",
+      "pdf_size_bytes": 1258473,
+      "xml_sha256": "4c3351a38c69bb992d3fd76acd1ca340a2a0fa0b319cce32652c7f4a70762578",
+      "xml_size_bytes": 76714
+    },
+    "PMC6500000.1": {
+      "licence": "https://creativecommons.org/licenses/by/4.0/",
+      "paragraphs": 57,
+      "pdf_sha256": "606064ea3b6cb4ff00f6c7953d09583b902d0d9f43af148fd1331adfe8a52112",
+      "pdf_size_bytes": 1934507,
+      "xml_sha256": "a3ef4d88759491cac676151873b3c65dcbb753c1002998a2570994c86901c17d",
+      "xml_size_bytes": 93609
+    },
+    "PMC6500011.1": {
+      "licence": "https://creativecommons.org/licenses/by/4.0/",
+      "paragraphs": 63,
+      "pdf_sha256": "84884425ff9fa20310b97ccb7308d46b826d3387728bed0d99858a319c3e6afc",
+      "pdf_size_bytes": 644991,
+      "xml_sha256": "89e98c9622738e0a1a200d09aaee86e731499e9a2f5d35431b8430d382f86057",
+      "xml_size_bytes": 84952
+    },
+    "PMC6500022.1": {
+      "licence": "https://creativecommons.org/licenses/by/4.0/",
+      "paragraphs": 107,
+      "pdf_sha256": "43d474e64c898675db941ccfa44e9393eae84ba596966029606e9c7ca8643049",
+      "pdf_size_bytes": 2555404,
+      "xml_sha256": "e9c4d14feea9ab1c1d7084ae9e4d6de1c58210af5dabd8c0bb372d91ce7a0dde",
+      "xml_size_bytes": 127681
+    },
+    "PMC7000039.1": {
+      "licence": "https://creativecommons.org/licenses/by-nc-nd/4.0/",
+      "paragraphs": 43,
+      "pdf_sha256": "f2e3faede11344b4d06f0e9a9fad09e0f00ff0f9c01ec03ae399cbc7d59e5940",
+      "pdf_size_bytes": 630481,
+      "xml_sha256": "6d5b24a53ad422344a08733baad603158dd11ba27dc0e68355dc014e59845b65",
+      "xml_size_bytes": 90486
+    },
+    "PMC7000140.1": {
+      "licence": "https://creativecommons.org/licenses/by/4.0/",
+      "paragraphs": 40,
+      "pdf_sha256": "e7be718c097113160816d0cde56393af94fe6fd9a7d26f3f257bdfa4dadf5ce1",
+      "pdf_size_bytes": 2443752,
+      "xml_sha256": "22ac0423c06afff086395d487241be56aab2ed84d2c0bf11e58b31ecd2ae5970",
+      "xml_size_bytes": 75187
+    },
+    "PMC7000152.1": {
+      "licence": "https://creativecommons.org/licenses/by-nc-nd/4.0/",
+      "paragraphs": 26,
+      "pdf_sha256": "bb013911bbe757d93b92db3378b03fa2ad92fe59a26ca2c2e827914ff4c1792a",
+      "pdf_size_bytes": 2328647,
+      "xml_sha256": "3e26b3dd369f1e723af076e80a13d8247d712177da7cd8368b4bc15f7915e2c2",
+      "xml_size_bytes": 287517
+    },
+    "PMC7500000.1": {
+      "licence": "https://creativecommons.org/licenses/by/4.0/",
+      "paragraphs": 50,
+      "pdf_sha256": "93e8500904e563a0bfb6513387df181f496859e2715df75a64a2006d55e65413",
+      "pdf_size_bytes": 1676248,
+      "xml_sha256": "1752c962d367cec92ab23826c2fd0d6c5ca10e6a6537ccbee1b4df0de86d173a",
+      "xml_size_bytes": 80832
+    },
+    "PMC7500012.1": {
+      "licence": "https://creativecommons.org/licenses/by/4.0/",
+      "paragraphs": 84,
+      "pdf_sha256": "5cc69dda39e4d9e17184f665f702631ba0fe4dc0136859f839a541f2696305cd",
+      "pdf_size_bytes": 3173414,
+      "xml_sha256": "c8c55d066f828d9c60071b9d4a6f5ed19f4e08102d2eb1ca001f6532279e1386",
+      "xml_size_bytes": 154071
+    },
+    "PMC7500025.1": {
+      "licence": "https://creativecommons.org/licenses/by/4.0/",
+      "paragraphs": 175,
+      "pdf_sha256": "47476fed705a22a391005c8cdc87e536f17954f6dd99e5ba882174109e83d69b",
+      "pdf_size_bytes": 1553929,
+      "xml_sha256": "843fc70bedcd6450c5779039e7be008869de2fd6bbe985eb6b4e8a77e37057ca",
+      "xml_size_bytes": 207766
+    },
+    "PMC8000011.1": {
+      "licence": "https://creativecommons.org/licenses/by/4.0/",
+      "paragraphs": 67,
+      "pdf_sha256": "f88c3f3d9a87c432db7c819d67c527ea660d3ac735e47f11ed6cf97e57a0a100",
+      "pdf_size_bytes": 7154118,
+      "xml_sha256": "29c65c504f0c095e484056ba3edf8fefc58018c98b1e57d4d9640e39ea43aee6",
+      "xml_size_bytes": 120444
+    },
+    "PMC8000027.1": {
+      "licence": "https://creativecommons.org/licenses/by-nc-nd/4.0/",
+      "paragraphs": 16,
+      "pdf_sha256": "219010e74164e7843bb2b7633a9ea34b71613a3b21e04e46d5373ba326179ee2",
+      "pdf_size_bytes": 820181,
+      "xml_sha256": "d292e4dcee03759c3adb1facee71afd7d8f3006f462e0420008cc30b177c83ae",
+      "xml_size_bytes": 39925
+    },
+    "PMC8000039.1": {
+      "licence": "https://creativecommons.org/licenses/by/4.0/",
+      "paragraphs": 37,
+      "pdf_sha256": "16aceef9f59dbc2994b6fd9f45fc71edb75b2dd1dbb826c67cf37d29d84c7271",
+      "pdf_size_bytes": 1938399,
+      "xml_sha256": "9b23f89d501c2dcfbcdf6753deece51db92e8a55953d8b0ac2e351e2d7919127",
+      "xml_size_bytes": 67704
+    },
+    "PMC8500002.2": {
+      "licence": "https://academic.oup.com/pages/standard-publication-reuse-rights",
+      "paragraphs": 51,
+      "pdf_sha256": "658a353975c5e470e804ba5ec2977ab516969d8550298c33a77fca6fb0f52888",
+      "pdf_size_bytes": 8641474,
+      "xml_sha256": "a298a10b6f64e0c9f13ff1090e32b8a5cac7439c150326c979c2034a97f01a2a",
+      "xml_size_bytes": 60085
+    },
+    "PMC8500015.1": {
+      "licence": "https://creativecommons.org/licenses/by-nc-nd/4.0/",
+      "paragraphs": 4,
+      "pdf_sha256": "4456e85d6bc64147e28d96d425c0ec1468557de188f730feb9beee8c68ba47a9",
+      "pdf_size_bytes": 801751,
+      "xml_sha256": "48522913c3a16ad72f4ac222d75383d7dbe0215991b9974aba232c8a1dc944ce",
+      "xml_size_bytes": 11133
+    },
+    "PMC8500047.2": {
+      "licence": "https://creativecommons.org/licenses/by-nc/4.0/",
+      "paragraphs": 91,
+      "pdf_sha256": "4fddbd43e586d47aaebbb7177536458ba56cc84d73c3c2db2eee9219077a20a4",
+      "pdf_size_bytes": 163441,
+      "xml_sha256": "751107176c2973474e493bffa88f9dbae143d3b71cf4f099f5ebb035d88789ea",
+      "xml_size_bytes": 116486
+    },
+    "PMC9000000.1": {
+      "licence": "unrecorded",
+      "paragraphs": 144,
+      "pdf_sha256": "562bbb2c06c33d430d6f4b2ed8cfd183f544b17109f544fcb037d2eba85053d3",
+      "pdf_size_bytes": 3174833,
+      "xml_sha256": "b26755eccaf53057643a63ad687d2f7c70431414e09047ebac123a32938bb1a9",
+      "xml_size_bytes": 185375
+    },
+    "PMC9000011.1": {
+      "licence": "https://creativecommons.org/licenses/by/4.0/",
+      "paragraphs": 108,
+      "pdf_sha256": "fcf9641090f2d2e7d0a3fda41b4b2d427b484bac467aaaa376beffbabd1e596e",
+      "pdf_size_bytes": 10349050,
+      "xml_sha256": "ff84a9e6af5047be77aa3d632bcce45ed9cceb750c77424fa2318f720dbbc429",
+      "xml_size_bytes": 165401
+    },
+    "PMC9000022.1": {
+      "licence": "https://creativecommons.org/licenses/by/4.0/",
+      "paragraphs": 64,
+      "pdf_sha256": "7407458b1c38f2b1f2c35f43d960a9c2a3af74c3cfde2885fac4e15d51ca9b9d",
+      "pdf_size_bytes": 5225200,
+      "xml_sha256": "054ea7798db2731413fe7ed8d25f260da0d005dc538ac5e0588c1b35c356068b",
+      "xml_size_bytes": 126017
+    },
+    "PMC9500000.1": {
+      "licence": "https://creativecommons.org/licenses/by-nc-nd/4.0/",
+      "paragraphs": 87,
+      "pdf_sha256": "962d05583d2b20c9b6aafa5f399c656588c8423c6fc50fc22a51d085af4b6751",
+      "pdf_size_bytes": 17229770,
+      "xml_sha256": "442e7af5433a953af0d0b37a8e07b8c0680d0b8e3fb928ebb9c07278f1f86ba6",
+      "xml_size_bytes": 126450
+    },
+    "PMC9500026.1": {
+      "licence": "https://creativecommons.org/licenses/by/4.0/",
+      "paragraphs": 77,
+      "pdf_sha256": "1fd7d1da6abddc4827f645ff5fc681443182156953c665cef40696e6021ed0ad",
+      "pdf_size_bytes": 2801351,
+      "xml_sha256": "a6734f3d742485dd99396d12acb12961c5416194675db5aa178e5bdd25de2943",
+      "xml_size_bytes": 184943
+    },
+    "PMC9500042.1": {
+      "licence": "https://creativecommons.org/licenses/by/4.0/",
+      "paragraphs": 59,
+      "pdf_sha256": "071fe35726fa3905ea532c02955079f00ab840174750dc8c1a6b7edde54e58ef",
+      "pdf_size_bytes": 5406076,
+      "xml_sha256": "222882cd6e552b557140b15faa31874da855ed59d038221d8bd8647d7c376e90",
+      "xml_size_bytes": 117973
+    }
+  },
+  "bucket": "pmc-oa-opendata",
+  "rejected": {
+    "PMC10000000.1": "no_paragraphs",
+    "PMC4000013.1": "pdf_missing",
+    "PMC4000025.1": "pdf_missing",
+    "PMC4000036.1": "pdf_missing",
+    "PMC5000000.1": "no_paragraphs",
+    "PMC5000022.1": "no_paragraphs",
+    "PMC5000033.1": "no_paragraphs",
+    "PMC5000044.1": "no_paragraphs",
+    "PMC5000055.1": "no_paragraphs",
+    "PMC5000113.1": "no_paragraphs",
+    "PMC5000124.1": "no_paragraphs",
+    "PMC5000135.1": "no_paragraphs",
+    "PMC5000146.1": "no_paragraphs",
+    "PMC5000157.1": "no_paragraphs",
+    "PMC5000168.1": "no_paragraphs",
+    "PMC5000179.1": "no_paragraphs",
+    "PMC5000190.1": "no_paragraphs",
+    "PMC5000201.1": "no_paragraphs",
+    "PMC5000212.1": "no_paragraphs",
+    "PMC5000223.1": "no_paragraphs",
+    "PMC5000234.1": "no_paragraphs",
+    "PMC5000245.1": "no_paragraphs",
+    "PMC5000256.1": "no_paragraphs",
+    "PMC5000267.1": "no_paragraphs",
+    "PMC5000278.1": "no_paragraphs",
+    "PMC5000289.1": "no_paragraphs",
+    "PMC5000300.1": "no_paragraphs",
+    "PMC5000311.1": "no_paragraphs",
+    "PMC5000322.1": "no_paragraphs",
+    "PMC5000333.1": "no_paragraphs",
+    "PMC5000344.1": "no_paragraphs",
+    "PMC5000355.1": "no_paragraphs",
+    "PMC5000366.1": "no_paragraphs",
+    "PMC5000377.1": "no_paragraphs",
+    "PMC5000388.1": "no_paragraphs",
+    "PMC5500012.1": "pdf_missing",
+    "PMC7000126.1": "pdf_missing",
+    "PMC8000000.1": "pdf_missing",
+    "PMC9500016.1": "pdf_missing"
+  },
+  "rejection_counts": {
+    "no_paragraphs": 32,
+    "no_vector_drawings": 0,
+    "pdf_missing": 7,
+    "pdf_unreadable": 0,
+    "xml_missing": 0,
+    "xml_unparsable": 0
+  },
+  "schema_version": 1,
+  "selection": {
+    "candidates": 105,
+    "filter": "JATS <p> > 0 and vector drawings on some PDF page",
+    "max_candidates_per_seed": 60,
+    "per_seed": 3,
+    "seeds": [
+      "PMC1500000",
+      "PMC2000000",
+      "PMC2500000",
+      "PMC3000000",
+      "PMC3500000",
+      "PMC4000000",
+      "PMC4500000",
+      "PMC5000000",
+      "PMC5500000",
+      "PMC6000000",
+      "PMC6500000",
+      "PMC7000000",
+      "PMC7500000",
+      "PMC8000000",
+      "PMC8500000",
+      "PMC9000000",
+      "PMC9500000",
+      "PMC10000000",
+      "PMC10500000",
+      "PMC11000000",
+      "PMC11500000",
+      "PMC12000000"
+    ],
+    "stride": 11,
+    "unavailable": [],
+    "xml_entity_fallbacks": 0
+  }
+}

--- a/tests/unit/test_pmc_corpus.py
+++ b/tests/unit/test_pmc_corpus.py
@@ -1,0 +1,463 @@
+"""Regression tests for the pinned PMC born-digital corpus adapter."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from benchmarks.pmc import corpus
+
+pytestmark = pytest.mark.unit
+
+
+def _pdf_bytes(article_id: str) -> bytes:
+    return f"%PDF-1.7\nsynthetic {article_id}\n%%EOF\n".encode()
+
+
+def _xml_bytes(article_id: str) -> bytes:
+    return f"<article><body><p>{article_id}</p></body></article>".encode()
+
+
+def _article_row(article_id: str) -> dict[str, Any]:
+    pdf = _pdf_bytes(article_id)
+    xml = _xml_bytes(article_id)
+    return {
+        "pdf_sha256": hashlib.sha256(pdf).hexdigest(),
+        "pdf_size_bytes": len(pdf),
+        "xml_sha256": hashlib.sha256(xml).hexdigest(),
+        "xml_size_bytes": len(xml),
+        "licence": "https://creativecommons.org/licenses/by/4.0/",
+        "paragraphs": 12,
+    }
+
+
+def _manifest_payload(article_ids: list[str] | None = None, **overrides: Any) -> dict[str, Any]:
+    ids = article_ids if article_ids is not None else ["PMC2000001.1", "PMC7000002.1", "PMC9000003.2"]
+    payload: dict[str, Any] = {
+        "schema_version": corpus.MANIFEST_SCHEMA_VERSION,
+        "bucket": corpus.BUCKET,
+        "selection": {"seeds": ["PMC2000000"], "per_seed": 1, "stride": 11},
+        "articles": {article_id: _article_row(article_id) for article_id in ids},
+        "rejected": {"PMC5500001.1": "pdf_missing"},
+        "rejection_counts": dict.fromkeys(corpus.REJECTION_REASONS, 0) | {"pdf_missing": 1},
+    }
+    payload.update(overrides)
+    return payload
+
+
+def _write_manifest(tmp_path: Path, payload: dict[str, Any] | None = None) -> Path:
+    manifest_path = tmp_path / "manifest.json"
+    manifest_path.write_text(
+        json.dumps(payload if payload is not None else _manifest_payload(), indent=2, sort_keys=True),
+        encoding="utf-8",
+    )
+    return manifest_path
+
+
+def _install_downloader(monkeypatch: pytest.MonkeyPatch) -> list[str]:
+    """Serve synthetic article bytes and record every URL fetched."""
+    calls: list[str] = []
+
+    def download(url: str, destination: Path, *, label: str, retries: int = 0) -> None:
+        calls.append(url)
+        article_id = Path(url).stem
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        payload = _pdf_bytes(article_id) if url.endswith(".pdf") else _xml_bytes(article_id)
+        destination.write_bytes(payload)
+
+    monkeypatch.setattr(corpus, "_download", download)
+    return calls
+
+
+# ---------------------------------------------------------------------------
+# Manifest validation
+# ---------------------------------------------------------------------------
+
+
+def test_read_manifest_accepts_a_well_formed_manifest(tmp_path: Path) -> None:
+    manifest = corpus.read_manifest(_write_manifest(tmp_path))
+
+    assert [entry.article_id for entry in manifest.articles] == [
+        "PMC2000001.1",
+        "PMC7000002.1",
+        "PMC9000003.2",
+    ]
+    assert manifest.bucket == corpus.BUCKET
+    assert manifest.rejected == {"PMC5500001.1": "pdf_missing"}
+
+
+def test_manifest_digest_is_the_pin(tmp_path: Path) -> None:
+    manifest_path = _write_manifest(tmp_path)
+    expected = hashlib.sha256(manifest_path.read_bytes()).hexdigest()
+
+    assert corpus.read_manifest(manifest_path).sha256 == expected
+
+
+@pytest.mark.parametrize(
+    ("mutate", "match"),
+    [
+        (lambda p: p.__setitem__("schema_version", 99), "schema version mismatch"),
+        (lambda p: p.__setitem__("bucket", "somewhere-else"), "bucket mismatch"),
+        (lambda p: p.__setitem__("articles", {}), "names no articles"),
+        (lambda p: p.pop("rejection_counts"), "schema does not match"),
+        (lambda p: p.__setitem__("extra_key", 1), "schema does not match"),
+        (lambda p: p.__setitem__("rejected", {"PMC1.1": "gremlins"}), "unknown rejection reason"),
+        (lambda p: p.__setitem__("rejected", {"not-an-id": "pdf_missing"}), "article id is malformed"),
+    ],
+)
+def test_read_manifest_rejects_malformed_manifests(tmp_path: Path, mutate: Any, match: str) -> None:
+    payload = _manifest_payload()
+    mutate(payload)
+
+    with pytest.raises(corpus.CorpusCacheError, match=match):
+        corpus.read_manifest(_write_manifest(tmp_path, payload))
+
+
+@pytest.mark.parametrize(
+    ("field", "value", "match"),
+    [
+        ("pdf_sha256", "nothex", "pdf_sha256 is invalid"),
+        ("xml_sha256", "a" * 63, "xml_sha256 is invalid"),
+        ("pdf_size_bytes", 0, "pdf_size_bytes is invalid"),
+        ("xml_size_bytes", -1, "xml_size_bytes is invalid"),
+        ("paragraphs", 0, "paragraphs is invalid"),
+        ("licence", "  ", "licence is invalid"),
+    ],
+)
+def test_read_manifest_rejects_invalid_article_rows(tmp_path: Path, field: str, value: Any, match: str) -> None:
+    payload = _manifest_payload()
+    payload["articles"]["PMC2000001.1"][field] = value
+
+    with pytest.raises(corpus.CorpusCacheError, match=match):
+        corpus.read_manifest(_write_manifest(tmp_path, payload))
+
+
+def test_read_manifest_rejects_an_article_that_is_both_accepted_and_rejected(tmp_path: Path) -> None:
+    payload = _manifest_payload()
+    payload["rejected"] = {"PMC2000001.1": "pdf_missing"}
+
+    with pytest.raises(corpus.CorpusCacheError, match="both accepts and rejects"):
+        corpus.read_manifest(_write_manifest(tmp_path, payload))
+
+
+def test_read_manifest_rejects_a_missing_file(tmp_path: Path) -> None:
+    with pytest.raises(corpus.CorpusCacheError, match="not a regular file"):
+        corpus.read_manifest(tmp_path / "absent.json")
+
+
+# ---------------------------------------------------------------------------
+# Selection
+# ---------------------------------------------------------------------------
+
+
+def test_limit_selects_a_spread_not_a_prefix() -> None:
+    """The regression this adapter exists downstream of.
+
+    Manifest order is lexicographic by PMCID, so taking the first ``limit`` entries would
+    draw one era of the archive.  Both sibling lanes shipped that bug; this one must not.
+    """
+    articles = tuple(
+        corpus.ManifestArticle(
+            article_id=f"PMC{index:07d}.1",
+            pdf_sha256="a" * 64,
+            pdf_size_bytes=1,
+            xml_sha256="b" * 64,
+            xml_size_bytes=1,
+            licence="cc",
+            paragraphs=1,
+        )
+        for index in range(100)
+    )
+
+    selected = corpus._select(articles, 4)
+
+    assert [entry.article_id for entry in selected] == [
+        "PMC0000000.1",
+        "PMC0000025.1",
+        "PMC0000050.1",
+        "PMC0000075.1",
+    ]
+
+
+def test_limit_selection_is_deterministic_and_duplicate_free() -> None:
+    articles = tuple(corpus.ManifestArticle(f"PMC{i:07d}.1", "a" * 64, 1, "b" * 64, 1, "cc", 1) for i in range(37))
+
+    for size in range(1, 38):
+        selected = corpus._select(articles, size)
+        assert len(selected) == size
+        assert len({entry.article_id for entry in selected}) == size
+        assert selected == corpus._select(articles, size)
+
+
+def test_limit_none_returns_every_article() -> None:
+    articles = tuple(corpus.ManifestArticle(f"PMC{i:07d}.1", "a" * 64, 1, "b" * 64, 1, "cc", 1) for i in range(5))
+
+    assert corpus._select(articles, None) == articles
+
+
+@pytest.mark.parametrize("limit", [0, -1, 6, True])
+def test_limit_out_of_range_is_rejected(limit: Any) -> None:
+    articles = tuple(corpus.ManifestArticle(f"PMC{i:07d}.1", "a" * 64, 1, "b" * 64, 1, "cc", 1) for i in range(5))
+
+    with pytest.raises(ValueError, match="limit must be"):
+        corpus._select(articles, limit)
+
+
+# ---------------------------------------------------------------------------
+# Cache materialization
+# ---------------------------------------------------------------------------
+
+
+def test_load_corpus_downloads_and_validates_every_artifact(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    manifest_path = _write_manifest(tmp_path)
+    calls = _install_downloader(monkeypatch)
+
+    snapshot = corpus.load_corpus(tmp_path / "cache", manifest_path=manifest_path, workers=1)
+
+    assert snapshot.complete is True
+    assert len(snapshot.articles) == 3
+    assert len(calls) == 6
+    for article in snapshot.articles:
+        assert article.pdf_path.read_bytes() == _pdf_bytes(article.article_id)
+        assert article.xml_path.read_bytes() == _xml_bytes(article.article_id)
+    assert {a.pmcid for a in snapshot.articles} == {"PMC2000001", "PMC7000002", "PMC9000003"}
+    assert {a.version for a in snapshot.articles} == {1, 2}
+
+
+def test_a_warm_cache_downloads_nothing(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    manifest_path = _write_manifest(tmp_path)
+    calls = _install_downloader(monkeypatch)
+    corpus.load_corpus(tmp_path / "cache", manifest_path=manifest_path, workers=1)
+    calls.clear()
+
+    corpus.load_corpus(tmp_path / "cache", manifest_path=manifest_path, workers=1)
+
+    assert calls == []
+
+
+def test_a_corrupted_warm_file_is_replaced_rather_than_trusted(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    manifest_path = _write_manifest(tmp_path)
+    calls = _install_downloader(monkeypatch)
+    snapshot = corpus.load_corpus(tmp_path / "cache", manifest_path=manifest_path, workers=1)
+    victim = snapshot.articles[0].pdf_path
+    victim.write_bytes(b"%PDF-1.7 truncated")
+    calls.clear()
+
+    reloaded = corpus.load_corpus(tmp_path / "cache", manifest_path=manifest_path, workers=1)
+
+    assert calls == [corpus._object_url(snapshot.articles[0].article_id, "pdf")]
+    assert reloaded.articles[0].pdf_path.read_bytes() == _pdf_bytes(snapshot.articles[0].article_id)
+
+
+def test_a_download_that_disagrees_with_the_manifest_is_fatal(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    manifest_path = _write_manifest(tmp_path)
+
+    def download(url: str, destination: Path, *, label: str, retries: int = 0) -> None:
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        destination.write_bytes(b"%PDF-1.7 impostor\n")
+
+    monkeypatch.setattr(corpus, "_download", download)
+
+    with pytest.raises(corpus.CorpusIntegrityError, match="does not match the manifest"):
+        corpus.load_corpus(tmp_path / "cache", manifest_path=manifest_path, workers=1)
+
+
+def test_the_cache_directory_is_keyed_by_the_manifest_digest(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An edited manifest must not re-bless files selected under the old rules."""
+    _install_downloader(monkeypatch)
+    cache = tmp_path / "cache"
+    first = corpus.load_corpus(cache, manifest_path=_write_manifest(tmp_path), workers=1)
+
+    other = tmp_path / "other"
+    other.mkdir()
+    second_payload = _manifest_payload(["PMC2000001.1", "PMC7000002.1"])
+    second = corpus.load_corpus(cache, manifest_path=_write_manifest(other, second_payload), workers=1)
+
+    assert first.manifest_sha256 != second.manifest_sha256
+    assert first.articles[0].pdf_path != second.articles[0].pdf_path
+    assert {path.name for path in cache.iterdir()} == {
+        first.manifest_sha256[:16],
+        second.manifest_sha256[:16],
+    }
+
+
+def test_an_incomplete_load_is_marked_incomplete(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    manifest_path = _write_manifest(tmp_path)
+    _install_downloader(monkeypatch)
+
+    snapshot = corpus.load_corpus(tmp_path / "cache", manifest_path=manifest_path, limit=3, workers=1)
+
+    assert snapshot.complete is False
+    assert snapshot.expected_articles == 3
+    assert len(snapshot.articles) == 3
+
+
+@pytest.mark.parametrize("workers", [0, -1, True, "eight"])
+def test_invalid_worker_counts_are_rejected(tmp_path: Path, workers: Any) -> None:
+    with pytest.raises(ValueError, match="workers must be a positive integer"):
+        corpus.load_corpus(tmp_path / "cache", manifest_path=_write_manifest(tmp_path), workers=workers)
+
+
+def test_a_build_warms_the_load_cache(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Otherwise a fresh build leaves bytes on disk that the next load re-downloads."""
+    manifest_path = _write_manifest(tmp_path)
+    manifest = corpus.read_manifest(manifest_path)
+    workspace = tmp_path / "cache"
+    for entry in manifest.articles:
+        article_dir = workspace / "articles" / entry.article_id
+        article_dir.mkdir(parents=True)
+        (article_dir / f"{entry.article_id}.pdf").write_bytes(_pdf_bytes(entry.article_id))
+        (article_dir / f"{entry.article_id}.xml").write_bytes(_xml_bytes(entry.article_id))
+
+    corpus._promote_workspace(workspace, manifest_path, {e.article_id: e for e in manifest.articles})
+
+    calls = _install_downloader(monkeypatch)
+    snapshot = corpus.load_corpus(workspace, manifest_path=manifest_path, workers=1)
+    assert calls == []
+    assert len(snapshot.articles) == 3
+
+
+def test_promotion_never_invalidates_an_already_written_manifest(tmp_path: Path) -> None:
+    """A promotion failure costs a re-download; it must not raise."""
+    manifest_path = _write_manifest(tmp_path)
+    manifest = corpus.read_manifest(manifest_path)
+
+    corpus._promote_workspace(tmp_path / "absent", manifest_path, {e.article_id: e for e in manifest.articles})
+    corpus._promote_workspace(tmp_path / "cache", tmp_path / "absent.json", {})
+
+
+# ---------------------------------------------------------------------------
+# JATS handling
+# ---------------------------------------------------------------------------
+
+
+def test_undeclared_entities_do_not_reject_an_article() -> None:
+    """JATS references DTD-declared entities the bucket does not ship."""
+    payload = b"<article><body><p>alpha &mu; beta</p><p>gamma &emsp; delta</p></body></article>"
+
+    root, neutralized = corpus._parse_jats(payload)
+
+    assert neutralized is True
+    assert corpus._count_local(root, "p") == 2
+
+
+def test_a_well_formed_article_is_never_rewritten() -> None:
+    payload = b"<article><body><p>alpha &amp; beta &#181;</p></body></article>"
+
+    root, neutralized = corpus._parse_jats(payload)
+
+    assert neutralized is False
+    assert "alpha & beta µ" in "".join(root.itertext())
+
+
+def test_paragraph_counting_ignores_namespaces() -> None:
+    payload = b'<article xmlns="http://jats.nlm.nih.gov"><body><p>one</p><p>two</p></body></article>'
+
+    root, _ = corpus._parse_jats(payload)
+
+    assert corpus._count_local(root, "p") == 2
+    assert corpus._count_local(root, "sec") == 0
+
+
+@pytest.mark.parametrize(
+    ("payload", "expected"),
+    [
+        (
+            b'<article><ali:license_ref xmlns:ali="http://www.niso.org/schemas/ali/1.0/">'
+            b"https://creativecommons.org/licenses/by/4.0/</ali:license_ref></article>",
+            "https://creativecommons.org/licenses/by/4.0/",
+        ),
+        (
+            b'<article><license xmlns:xlink="http://www.w3.org/1999/xlink" '
+            b'xlink:href="http://creativecommons.org/licenses/by-nc-sa/3.0"/></article>',
+            "http://creativecommons.org/licenses/by-nc-sa/3.0",
+        ),
+        (b'<article><license license-type="OpenAccess"/></article>', "OpenAccess"),
+        (b"<article><body><p>no licence at all</p></body></article>", "unrecorded"),
+    ],
+)
+def test_licence_extraction_prefers_the_most_precise_source(payload: bytes, expected: str) -> None:
+    root, _ = corpus._parse_jats(payload)
+
+    assert corpus._extract_licence(root) == expected
+
+
+# ---------------------------------------------------------------------------
+# Bucket listing
+# ---------------------------------------------------------------------------
+
+
+def _listing(prefixes: list[str], *, truncated: bool = False, token: str = "next") -> bytes:
+    body = "".join(f"<CommonPrefixes><Prefix>{prefix}</Prefix></CommonPrefixes>" for prefix in prefixes)
+    continuation = f"<NextContinuationToken>{token}</NextContinuationToken>" if truncated else ""
+    return (
+        '<?xml version="1.0" encoding="UTF-8"?>'
+        '<ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/">'
+        f"<IsTruncated>{'true' if truncated else 'false'}</IsTruncated>"
+        f"{body}{continuation}</ListBucketResult>"
+    ).encode()
+
+
+def test_listing_keeps_only_versioned_article_prefixes() -> None:
+    payload = _listing(["PMC2000001.1/", "oa_comm/", "PMC2000002.3/", "PMC-not-an-id/", "PMC2000003/"])
+
+    prefixes, token = corpus._parse_listing(payload)
+
+    assert prefixes == ("PMC2000001.1", "PMC2000002.3")
+    assert token is None
+
+
+def test_listing_reports_a_continuation_token_only_when_truncated() -> None:
+    assert corpus._parse_listing(_listing(["PMC1.1/"], truncated=True))[1] == "next"
+    assert corpus._parse_listing(_listing(["PMC1.1/"], truncated=False))[1] is None
+
+
+def test_a_malformed_listing_is_a_selection_error() -> None:
+    with pytest.raises(corpus.CorpusSelectionError, match="not valid XML"):
+        corpus._parse_listing(b"<ListBucketResult>truncated...")
+
+
+# ---------------------------------------------------------------------------
+# The committed manifest itself
+# ---------------------------------------------------------------------------
+
+
+def test_the_committed_manifest_is_valid() -> None:
+    """The manifest is the corpus pin, so a hand edit that breaks it must fail here."""
+    manifest = corpus.read_manifest(corpus.DEFAULT_MANIFEST)
+
+    assert manifest.articles
+    assert all(entry.paragraphs > 0 for entry in manifest.articles)
+    assert all(entry.licence.strip() for entry in manifest.articles)
+
+
+def test_the_committed_manifest_spreads_across_the_id_range() -> None:
+    """Guards the trap this lane has now hit three times: a corpus drawn from one region.
+
+    The numerically-first PMCIDs are one journal's scanned back catalogue, so a manifest
+    clustered anywhere -- but especially at the front -- is not measuring born-digital
+    conversion.
+    """
+    manifest = corpus.read_manifest(corpus.DEFAULT_MANIFEST)
+    numbers = sorted(int(entry.article_id[3:].split(".")[0]) for entry in manifest.articles)
+
+    assert numbers[0] < 3_000_000, "corpus has no early-range articles"
+    assert numbers[-1] > 9_000_000, "corpus has no recent articles"
+    # No single million-wide band may hold more than a third of the corpus.
+    bands: dict[int, int] = {}
+    for number in numbers:
+        bands[number // 1_000_000] = bands.get(number // 1_000_000, 0) + 1
+    assert max(bands.values()) <= len(numbers) / 3

--- a/tests/unit/test_pmc_corpus.py
+++ b/tests/unit/test_pmc_corpus.py
@@ -461,3 +461,111 @@ def test_the_committed_manifest_spreads_across_the_id_range() -> None:
     for number in numbers:
         bands[number // 1_000_000] = bands.get(number // 1_000_000, 0) + 1
     assert max(bands.values()) <= len(numbers) / 3
+
+
+# ---------------------------------------------------------------------------
+# Corpus characterization (step 2)
+# ---------------------------------------------------------------------------
+
+
+def _make_pdf(path: Path, *, pages: int, drawings: int, text: bool, full_page_image: bool) -> None:
+    """Build a real PDF so the characterization is tested against its actual instrument."""
+    import fitz
+
+    document = fitz.open()
+    for _ in range(pages):
+        page = document.new_page()
+        if text:
+            page.insert_text((72, 72), "born digital")
+        for index in range(drawings):
+            page.draw_rect(fitz.Rect(10 + index, 10 + index, 40 + index, 40 + index), color=(0, 0, 0))
+        if full_page_image:
+            pixmap = fitz.Pixmap(fitz.csRGB, fitz.IRect(0, 0, 8, 8))
+            page.insert_image(page.rect, pixmap=pixmap)
+    document.save(path)
+    document.close()
+
+
+def _snapshot_of(paths: dict[str, Path]) -> Any:
+    articles = tuple(
+        corpus.CorpusArticle(
+            article_id=article_id,
+            pmcid=article_id.split(".")[0],
+            version=1,
+            pdf_path=path,
+            xml_path=path,
+            pdf_sha256="a" * 64,
+            pdf_size_bytes=1,
+            xml_sha256="b" * 64,
+            xml_size_bytes=1,
+            licence="cc",
+            paragraphs=10,
+        )
+        for article_id, path in paths.items()
+    )
+    return corpus.CorpusSnapshot(
+        manifest_path=Path("manifest.json"),
+        manifest_sha256="c" * 64,
+        bucket=corpus.BUCKET,
+        articles=articles,
+        expected_articles=len(articles),
+        complete=True,
+    )
+
+
+def test_characterization_separates_born_digital_from_a_scan(tmp_path: Path) -> None:
+    from benchmarks.pmc.characterize import characterize
+
+    born = tmp_path / "born.pdf"
+    scan = tmp_path / "scan.pdf"
+    _make_pdf(born, pages=3, drawings=5, text=True, full_page_image=False)
+    _make_pdf(scan, pages=2, drawings=0, text=False, full_page_image=True)
+
+    result = characterize(_snapshot_of({"PMC1000001.1": born, "PMC2000002.1": scan}))
+
+    assert result.pages == 5
+    assert result.text_layer_pages == 3
+    assert result.vector_drawing_pages == 3
+    # The vacuity check that matters: the scan-shape test must be able to fire.
+    assert result.scan_shape_pages == 2
+    assert result.pages_by_drawing_count == {"zero": 2, "one": 0, "two_or_more": 3}
+
+
+def test_the_scan_shape_test_is_not_vacuous(tmp_path: Path) -> None:
+    """A 0% scan-shape result is only evidence if a scan can produce a non-zero one."""
+    from benchmarks.pmc.characterize import characterize
+
+    scan = tmp_path / "scan.pdf"
+    _make_pdf(scan, pages=4, drawings=0, text=False, full_page_image=True)
+
+    result = characterize(_snapshot_of({"PMC1000001.1": scan}))
+
+    assert result.scan_shape_pages == 4
+    assert result.share(result.scan_shape_pages) == 1.0
+
+
+def test_characterization_reports_unreadable_articles_rather_than_crashing(tmp_path: Path) -> None:
+    from benchmarks.pmc.characterize import characterize
+
+    broken = tmp_path / "broken.pdf"
+    broken.write_bytes(b"not a pdf at all")
+
+    result = characterize(_snapshot_of({"PMC1000001.1": broken}))
+
+    assert result.unreadable == ("PMC1000001.1",)
+    assert result.pages == 0
+    assert result.share(0) == 0.0
+
+
+def test_a_single_embedded_font_is_visible_as_the_retypeset_signature(tmp_path: Path) -> None:
+    """Geometrically born-digital, but an OCR dump: the font count is the only tell."""
+    from benchmarks.pmc.characterize import characterize
+
+    dump = tmp_path / "dump.pdf"
+    _make_pdf(dump, pages=2, drawings=1, text=True, full_page_image=False)
+
+    result = characterize(_snapshot_of({"PMC1000001.1": dump}))
+
+    assert result.min_font_count == 1
+    assert result.scan_shape_pages == 0
+    assert result.vector_drawing_pages == 2

--- a/tests/unit/test_pmc_corpus.py
+++ b/tests/unit/test_pmc_corpus.py
@@ -725,3 +725,53 @@ def test_the_control_collapses_when_blocks_meet_the_wrong_article(tmp_path: Path
     assert report.placeable == report.scored
     assert report.control_false_placement == 0.0
     assert report.share(report.placeable) == 1.0
+
+
+def test_a_page_holding_the_whole_block_wins_over_an_echo_elsewhere() -> None:
+    """Completeness beats ambiguity, and the ordering is the point.
+
+    Checking the runner-up first was a real defect: body text restating a figure caption
+    made 71% of 'split' blocks -- and 88% of split figures -- read as ambiguous when their
+    top page already held 100% of them.
+    """
+    from benchmarks.pmc.alignment import place_block
+
+    caption = "figure eight tensile toughness of the hybrid biocomposite films under strain"
+    block = _grams(caption)
+    pages = [
+        _grams("introductory material with no bearing on the matter at hand whatsoever"),
+        _grams(caption),
+        _grams("unrelated filler"),
+        _grams("as discussed above the tensile toughness result demonstrates this clearly"),
+    ]
+
+    placement = place_block(block, pages)
+
+    assert placement.verdict == "clean"
+    assert placement.page == 1
+
+
+def test_a_genuine_page_break_still_reads_spans_under_the_completeness_rule() -> None:
+    """The completeness short-circuit must not swallow real page-break splits."""
+    from benchmarks.pmc.alignment import place_block
+
+    head = "the mitochondrial membrane potential was measured with a fluorescent probe and"
+    tail = "and the resulting signal was normalized against the untreated control samples"
+    block = _grams(f"{head} {tail}")
+
+    placement = place_block(block, [_grams(head), _grams(tail)])
+
+    assert placement.verdict == "spans"
+    assert placement.top_share < 0.95
+
+
+def test_equal_scoring_pages_break_toward_the_earliest() -> None:
+    """Without an explicit tie-break the sort silently preferred the *last* page."""
+    from benchmarks.pmc.alignment import place_block
+
+    text = "the mitochondrial membrane potential was measured with a fluorescent probe"
+    block = _grams(text)
+
+    placement = place_block(block, [_grams(text), _grams("filler"), _grams(text)])
+
+    assert placement.page == 0

--- a/tests/unit/test_pmc_corpus.py
+++ b/tests/unit/test_pmc_corpus.py
@@ -569,3 +569,159 @@ def test_a_single_embedded_font_is_visible_as_the_retypeset_signature(tmp_path: 
     assert result.min_font_count == 1
     assert result.scan_shape_pages == 0
     assert result.vector_drawing_pages == 2
+
+
+# ---------------------------------------------------------------------------
+# JATS-to-page alignment probe
+# ---------------------------------------------------------------------------
+
+
+def test_normalize_repairs_typesetter_hyphenation() -> None:
+    from benchmarks.pmc.alignment import normalize
+
+    assert normalize("hyphen-\nated word") == ["hyphenated", "word"]
+    assert normalize("soft­hyphen") == ["softhyphen"]
+    assert normalize("MiXeD Case!") == ["mixed", "case"]
+
+
+def test_jats_blocks_join_with_a_separator() -> None:
+    """The regression that made tables look unlocatable.
+
+    Concatenating element text fuses ``<label>Table 2</label>`` onto its caption into the
+    bogus token ``2obtained``, corrupting an n-gram at every element boundary. Tables have
+    the most boundaries, so they suffered most: 32.1% apparently missing against a real
+    1.4%.
+    """
+    from xml.etree import ElementTree
+
+    from benchmarks.pmc.alignment import jats_blocks, normalize
+
+    root = ElementTree.fromstring(
+        "<article><table-wrap><label>Table 2</label>" "<caption><p>Obtained values</p></caption></table-wrap></article>"
+    )
+    table = next(text for kind, text in jats_blocks(root) if kind == "table-wrap")
+
+    assert "2obtained" not in normalize(table)
+    assert "obtained" in normalize(table)
+
+
+def _grams(text: str) -> Any:
+    from benchmarks.pmc.alignment import ngrams, normalize
+
+    return ngrams(normalize(text))
+
+
+def test_a_block_wholly_on_one_page_reads_clean() -> None:
+    from benchmarks.pmc.alignment import place_block
+
+    block = _grams("the mitochondrial membrane potential was measured with a fluorescent probe")
+    pages = [_grams("unrelated introductory matter about something else entirely here"), block]
+
+    placement = place_block(block, pages)
+
+    assert placement.verdict == "clean"
+    assert placement.page == 1
+
+
+def test_a_block_broken_by_a_page_break_reads_spans() -> None:
+    from benchmarks.pmc.alignment import place_block
+
+    head = "the mitochondrial membrane potential was measured with a fluorescent probe and"
+    tail = "and the resulting signal was normalized against the untreated control samples"
+    block = _grams(f"{head} {tail}")
+    pages = [_grams(head), _grams(tail)]
+
+    placement = place_block(block, pages)
+
+    assert placement.verdict == "spans"
+    assert (placement.page, placement.runner_up_page) == (0, 1)
+
+
+def test_a_block_matching_two_distant_pages_reads_split() -> None:
+    from benchmarks.pmc.alignment import place_block
+
+    head = "the mitochondrial membrane potential was measured with a fluorescent probe and"
+    tail = "and the resulting signal was normalized against the untreated control samples"
+    block = _grams(f"{head} {tail}")
+    pages = [_grams(head), _grams("wholly unrelated filler text occupying the middle page"), _grams(tail)]
+
+    placement = place_block(block, pages)
+
+    assert placement.verdict == "split"
+    assert {placement.page, placement.runner_up_page} == {0, 2}
+
+
+def test_a_block_that_is_nowhere_reads_missing() -> None:
+    from benchmarks.pmc.alignment import place_block
+
+    block = _grams("the mitochondrial membrane potential was measured with a fluorescent probe")
+    pages = [_grams("entirely different words concerning agricultural policy in the region")]
+
+    placement = place_block(block, pages)
+
+    assert placement.verdict == "missing"
+
+
+def test_a_block_with_too_little_text_is_not_counted_as_a_failure() -> None:
+    from benchmarks.pmc.alignment import place_block
+
+    placement = place_block(_grams("three short words"), [_grams("three short words")])
+
+    assert placement.verdict == "too_short"
+
+
+def test_placement_never_uses_page_order() -> None:
+    """Order-free by construction: shuffling the pages must only move the index."""
+    from benchmarks.pmc.alignment import place_block
+
+    block = _grams("the mitochondrial membrane potential was measured with a fluorescent probe")
+    filler = _grams("entirely different words concerning agricultural policy in the region")
+
+    first = place_block(block, [block, filler])
+    second = place_block(block, [filler, block])
+
+    assert first.verdict == second.verdict == "clean"
+    assert (first.page, second.page) == (0, 1)
+
+
+def test_the_control_collapses_when_blocks_meet_the_wrong_article(tmp_path: Path) -> None:
+    """A placement rate is meaningless unless the same method fails on the wrong article."""
+    import fitz
+
+    from benchmarks.pmc.alignment import measure
+
+    sentences = {
+        "PMC1000001.1": "the mitochondrial membrane potential was measured with a fluorescent probe",
+        "PMC2000002.1": "agricultural policy in the region shifted after the subsidy was withdrawn",
+    }
+    articles = []
+    for article_id, sentence in sentences.items():
+        pdf_path = tmp_path / f"{article_id}.pdf"
+        xml_path = tmp_path / f"{article_id}.xml"
+        document = fitz.open()
+        page = document.new_page()
+        page.insert_text((40, 60), sentence)
+        document.save(pdf_path)
+        document.close()
+        xml_path.write_bytes(f"<article><body><p>{sentence}</p></body></article>".encode())
+        articles.append(
+            corpus.CorpusArticle(
+                article_id=article_id,
+                pmcid=article_id.split(".")[0],
+                version=1,
+                pdf_path=pdf_path,
+                xml_path=xml_path,
+                pdf_sha256="a" * 64,
+                pdf_size_bytes=1,
+                xml_sha256="b" * 64,
+                xml_size_bytes=1,
+                licence="cc",
+                paragraphs=1,
+            )
+        )
+
+    report = measure(articles)
+
+    assert report.placeable == report.scored
+    assert report.control_false_placement == 0.0
+    assert report.share(report.placeable) == 1.0


### PR DESCRIPTION
Steps 1 and 2 of the born-digital ground-truth lane: **the corpus fetcher and its characterization.** No oracle, no gate — those follow separately, deliberately not batched.

## Why

The external ground-truth lane we have is 981 rasters, so it measures the OCR path. Nothing external covers born-digital PDF conversion — text-layer extraction, vector table detection, layout-derived reading order — which is most real-world PDF conversion and what Theme 2 claims.

Articles come from the `pmc-oa-opendata` bucket, where each versioned prefix holds the publisher PDF beside its JATS XML. JATS is publisher-produced and already structured, which is why PMC beats arXiv here — LaTeX would mean macro expansion and moving floats, i.e. fighting the ground truth.

## The manifest is the pin

The bucket has no corpus-wide revision: article versions bump independently and decade-old articles carry recent reprocessing timestamps. A committed manifest of SHA-256 digests for **both** files of all 66 articles takes that role. `load_corpus` never lists the bucket, revalidates every byte, and keys its cache by the manifest digest so an edited manifest cannot re-bless files selected under different rules. Corpus bytes are never committed — only digests.

This needs **no cache index** — the manifest *is* the trusted digest record, which drops a whole layer the OmniDocBench adapter needs.

## Characterization (step 2)

Measured over 66 articles / **750 pages** with the sibling lane's own `_input_traits`, so the two corpora are comparable:

| trait | this corpus | OmniDocBench (OCR lane) |
| --- | --- | --- |
| text layer | **100.0%** | — |
| vector drawings | **81.1%** | ~2% |
| one ≥80%-area image (scan shape) | **0.0%** | ~100% |

The inverse of the raster lane, which is the point. Median 10 pages/article; drawings-per-page median 5.0.

**The `0.0%` was checked for vacuity before being believed.** A zero is evidence only if the instrument can produce a non-zero — run against a known raster scan, the scan-shape test fires on **11 of 11** pages.

## The filter finding — and a correction to my own first pass

The vector-drawing arm rejected **0 of 105** candidates. An arm that never fires deserves suspicion, so it was tested directly. My first read called the articles it would have accepted "scans"; that was wrong, and the truth is worse. The bucket holds **two** kinds of non-born-digital material:

| article | producer | fonts | pages | vector pages | ≥80%-area image pages |
| --- | --- | --- | --- | --- | --- |
| `PMC10000000.1` | ABBYY FineReader 14 | 2 | 11 | **0** | **11** |
| `PMC5000000.1` | iTextSharp 5.4.1 | **1** (`CourierStd`) | 28 | **28** | 0 |
| `PMC5000022.1` | iTextSharp 5.4.1 | **1** | 22 | **22** | 0 |

1. **Raster scans with an OCR text layer.** Both geometric tests catch these.
2. **OCR text dumps re-typeset into a PDF.** These contain no raster imagery at all, and geometrically they *are* born-digital — text layer everywhere, no large images, and their one "vector drawing" per page is a page-sized background rectangle that `bool(page.get_drawings())` reads as a figure.

So **no PDF-geometry test catches kind 2.** Calling it a tunable threshold, as I first did, understated it. Only the ground-truth side — does the JATS have paragraphs — reveals them: scanned back-catalogue articles deposit their body as a single `<preformat>` blob of raw OCR text and so have zero `<p>`.

**Neither kind survived into the corpus:** 0 of 750 pages have the scan shape, and the minimum embedded-font count across all 66 articles is **6** against the dump's 1.

One trap for anyone extending this: `"modified using iText"` in the producer string is **not** the dump signature — PMC post-processes ordinary publisher PDFs with iText, and 14 of the 66 carry it while having 6+ diverse subset fonts and 39–175 JATS paragraphs.

## Two more corrections to the plan

**Scanned material is not confined to the front of the ID range.** `PMC10000000.1`, a 2023-era identifier, is a scanned 1890s medical-society editorial — digitization projects get modern PMCIDs on deposit.

**Listing is lexicographic, not numeric.** `start-after=PMC1000000` lands on `PMC10000000`, since an 8-digit id sorts before a 7-digit one. This invalidated one of my own probes mid-session.

## Sampling and honesty

Selection walks from seeds every 500k across the ID range taking every 11th prefix. `limit` selects an **evenly spaced** subset, never the first N — the trap both sibling lanes shipped. Every rejected candidate is recorded in the manifest by reason.

Network failures are tracked **apart from** rejections and never enter the ledger: a rejection is a statement about an article, an unreachable host is a statement about the run. A build losing >10% of candidates aborts rather than committing a manifest a bad link quietly thinned out. A DNS blip killed the first trial run outright, which is how this got built.

## Result

66 articles from 105 candidates, 0 network losses. Rejections: 32 `no_paragraphs`, 7 `pdf_missing`. **13 distinct licences**, read from each article's own JATS — the OA subset is not uniformly licensed.

## Verification

- 52 unit tests, including PDFs built with PyMuPDF so the characterization is exercised against its real instrument, and an explicit non-vacuity test for the scan-shape check
- Full `tests/unit` suite green; `black` / `ruff` / `mypy` clean over `src/ tests/ benchmarks/`
- Root-markdown doc gate: `CHANGELOG.md` 100/100
- Full 66-article `load` verified warm, every byte revalidated

Also includes a fix where the manifest was written in text mode, so a Windows build computed a pin no other machine could reproduce from the same committed bytes (`4348465907b60685` vs `34cc7c503bba`).

## Reserved, not decided here

JATS describes a whole *article* with no page boundaries; OmniDocBench annotates *pages*. Whether this lane scores per-article or projects article truth onto pages is **open and reserved for you** — the fetcher is deliberately agnostic, exposing whole articles and no page structure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
