### PR TITLE
Score all2md against the PMC born-digital corpus

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   reading order, so it cannot quietly grade the reading-order metric against itself — and
   it ships with a control that scores every block against a different article's pages,
   where the false-placement rate is 0.8%.
+- **A born-digital scoring lane over that corpus** (`benchmarks.pmc score`). Each article is
+  converted once and every page scored against the JATS truth projected onto it, through the
+  *same* oracle the raster lane uses, so a number here means what a number there means. Page
+  boundaries come from the parser's own per-page separators, which keeps cross-page context
+  intact — splitting the PDF into single-page files would hide exactly the defects this lane
+  exists to find — and a dropped page raises rather than silently shifting every later page's
+  ground truth. Blocks that will not resolve to a page are excluded **and reported** as an
+  error budget printed with every run. Three controls ship inside the run: each page is
+  scored again against the *next page of the same article*, against deliberately reversed,
+  scrambled and halved output, and with OCR left enabled in auto mode so "no page needed OCR"
+  stays a measurement that could fail rather than a configuration. Two dimensions are
+  reported but flagged unusable as gates, with the measurement that disqualified them —
+  `block_structure_similarity` separates own-page from wrong-page output by only ~0.06 and
+  *rises* when half the content is deleted. Whole-article content recall ships with its
+  attainable ceiling: only 61.1% of JATS blocks are recoverable from the PDF text layer by
+  any parser, because structured citations and bylines record words in an order the page
+  never prints, so raw recall on its own reads as parser loss that is not there.
 
 ### Fixed
 

--- a/benchmarks/pmc/README.md
+++ b/benchmarks/pmc/README.md
@@ -213,23 +213,106 @@ not answer. That is where the residual risk sits.
 **The ~4.3% `split` + `missing` is the error budget.** Those blocks must be excluded *and
 reported*, never quietly dropped.
 
-### Score whole articles too, not instead
+## The oracle: `benchmarks.pmc score`
 
-Per-page and per-article scoring fail differently, so the lane should carry both:
+`score` converts each article once and scores every page of it against the JATS truth
+projected onto that page, through the **same oracle the OmniDocBench lane uses**. The metric
+definitions are not duplicated: each carries a calibration story that took a corpus to
+settle, and reusing them is what makes a number here mean the same thing as a number there.
 
-- **Per-page is blind to cross-page reading order.** It resets at every page boundary, so
-  emitting pages out of order, duplicating one, or dropping one can still score well.
-- **Per-article pays no alignment tax.** It does not need to know which page a block is
-  on, so it scores **100% of blocks rather than 95.7%** — including the `split`/`missing`
-  bucket. It is not a weaker per-page; it has a larger denominator.
-- They **audit each other**: a sharp disagreement on one document is evidence the
-  *alignment* failed there, not the parser.
-- Per-article cannot localize, and dilutes — a mangled page 7 of 20 barely moves it.
+```bash
+.venv/Scripts/python.exe -m benchmarks.pmc score --limit 8
+.venv/Scripts/python.exe -m benchmarks.pmc score --out result.json
+```
 
-Two things to measure before trusting an article-level number, rather than assume: whether
-the `_locate`-based order metric stays sensitive over a whole-article sequence instead of
-saturating, and whether article scores actually spread across the corpus. If everything
-lands at 0.98 it is a gate that cannot fail.
+### The plan said "score whole articles too". Measurement said no, and why
+
+The intent was a second, article-level endpoint for overall layout and reading order,
+carrying a larger denominator because it pays no alignment tax. Two measurements killed
+that design and one killed its motivation.
+
+**The shared oracle's block-locating threshold does not survive an article-length haystack.**
+`_IDENTIFIED_MATCH` counts a ground-truth block as *found* once half its characters align
+monotonically. Over one page that is sound. Over a whole article, **77–86% of one article's
+blocks "locate" inside a completely different article's output**, at a median alignment of
+0.62–0.72 against 0.93–1.00 for their own. The safeguard that stops absent content from
+earning reading-order credit is inoperative at that length. Reading order is therefore
+scored **per page only**, where the calibration holds.
+
+**Page order cannot fail, so it is not scored.** Page attribution comes from the parser's own
+per-page loop, which emits a separator per PDF page, so content cannot migrate between page
+groups and a dropped page raises `PageBoundaryError` rather than scoring. A page-sequence
+metric would report a perfect score by construction — which is the definition of a
+measurement not worth having. The cross-page blindness that motivated an article-level
+endpoint is handled structurally instead.
+
+What survives at article level is a narrower question — **did this block's text survive
+anywhere in the output?** — measured with n-gram containment, the one instrument on this
+corpus with a published false-positive rate.
+
+### Raw recall is unreadable without its ceiling
+
+Much of a JATS article cannot be recovered from the PDF by **any** parser, because the markup
+does not record words in the order the page prints them: `<element-citation>` lists the
+journal before the authors, `<surname>` precedes `<given-names>` against the rendered byline.
+Measured against the PDF's **own text layer**, only **61.1%** of blocks are recoverable at
+all. So a raw 54.6% recall is **88.9% of what was available**, not a parser losing half the
+document. The ceiling is computed every run, because it is a property of the corpus and the
+extraction rather than a constant.
+
+### Projection rules, and what each one cost
+
+| rule | why | measured |
+| --- | --- | --- |
+| a `spans` block is **split** across its two pages | it belongs to both, but scoring it *whole* against both guarantees a mismatch on both | split point comes from the same n-gram evidence as the placement; when the token stream cannot be mapped back onto raw text the block counts whole on both, and that is counted |
+| short blocks try an **exact phrase**, then inherit | a three-word heading has no five-grams | headings are kept with the text they introduce, so the next placed block's page is the heading's page |
+| structured blocks fall back to **token containment** | see below | recovers 89.1% of n-gram misses at 0.6% false placement |
+| `split` and `missing` blocks are **excluded and reported** | they are the alignment's failures, not the parser's | ~2–5% error budget, printed with every run |
+
+**The token fallback is the one addition that changed the numbers, and it was calibrated
+rather than chosen.** N-gram containment assumes the page renders a block's words in the
+order JATS declares them, which structured markup breaks without changing a single word — a
+citation fully present on its page scores *zero* n-gram containment. At a 0.65 token-share
+threshold the fallback recovers **89.1%** of the blocks n-gram containment calls missing,
+agrees with n-gram placement on **99.0%** of blocks where that method already gives a
+confident answer, and places only **0.6%** of blocks onto a *different article's* pages.
+Raising it to 0.85 buys nothing and gives up half the recoveries. It is kept as a separate
+rule from `place_block` so the feasibility numbers above still describe what they measured.
+
+### Three findings from building it
+
+**A nested `<table-wrap>` inside a `<p>` corrupted three things at once.** JATS puts floats
+inside the prose that introduces them. Taking the paragraph's full text fused the paragraph,
+the caption and every cell into one string — so the table vanished from the ground truth, the
+caption stopped being its own page object, and the fused block straddled the paragraph's page
+and the table's page and was placed on the wrong one. Found by reading a single page's truth
+beside its output, not by any aggregate.
+
+**Ordering ground truth by position on the page is worse than JATS order — tested, refuted.**
+Within a page, JATS document order puts a floated table where the prose cites it rather than
+where it renders, which costs real score on float-heavy pages. The obvious fix is to order
+blocks by where their text appears in the page's own token stream. Measured, that ordering
+disagrees with JATS on **25% of block pairs** and makes **every dimension worse**
+(reading order 0.748 → 0.663). PyMuPDF's extraction order is not rendered reading order, and
+grading against it would punish correct column handling. JATS order stays; the float cost is
+a documented bias, not a bug.
+
+**`block_structure_similarity` must not be gated on here.** It separates own-page from
+wrong-page output by only ~0.06, and it *rises* when half the emitted content is deleted —
+so gating on it would reward dropping blocks. It stays in the payload as evidence, flagged
+`ungateable` with the measurement that disqualified it.
+
+### Controls that ship inside every run
+
+- **Mismatch.** Every page is scored again against the *next page of the same article* — a
+  harder confounder than a different article, sharing the running head, the vocabulary and a
+  sentence that continues across the break. A dimension that does not clearly beat that is
+  not measuring the page.
+- **Mutation.** Every page is scored against output that has been reversed, scrambled and
+  halved. A dimension that does not move cannot detect that class of defect.
+- **Input shape.** OCR is left **enabled in auto mode** rather than switched off. Disabling
+  it would make "no page needed OCR" true by construction; leaving it on makes it a
+  measurement that can fail, and the run names any article where it fired.
 
 **Decided 2026-08-05:** a `spans` block **counts on both** of its pages. `<fig>` needs no
 special handling — the case for excluding it rested on a 14.5% split rate that was a

--- a/benchmarks/pmc/README.md
+++ b/benchmarks/pmc/README.md
@@ -318,6 +318,53 @@ so gating on it would reward dropping blocks. It stays in the payload as evidenc
 special handling — the case for excluding it rested on a 14.5% split rate that was a
 classifier artifact; the real figure is 1.8%.
 
+### First full-corpus run, 2026-08-05
+
+66 of 66 articles converted, **720 pages scored**, coverage median 0.98 ground-truth words
+per PDF word, **error budget 4.1%** (325 `missing`, 105 `split`, 44 trailing `too_short`).
+No gate is recorded from this — it is the first reading, not a baseline.
+
+| dimension | mean | median | wrong page | gap | sd | n |
+| --- | --- | --- | --- | --- | --- | --- |
+| `reading_order_similarity` | 0.757 | 0.786 | 0.294 | **0.463** | 0.222 | 720 |
+| `text_content_similarity` | 0.558 | 0.531 | 0.231 | **0.327** | 0.234 | 720 |
+| `table_structure_similarity` | 0.106 | **0.000** | 0.033 | 0.074 | 0.277 | 111 |
+| `table_content_similarity` | 0.097 | **0.000** | 0.017 | 0.080 | 0.256 | 111 |
+| `block_structure_similarity` | 0.494 | 0.500 | 0.424 | 0.070 | 0.212 | 720 | *(ungateable)* |
+
+**The scores spread, which was the second thing worth checking before trusting any of this.**
+Standard deviations of 0.21–0.28 with minima near 0 and maxima at 1.0 — these are not gates
+pinned at 0.98 that cannot fail.
+
+Whole-article recall: **94.2% of what is attainable** (raw 59.3%, ceiling 62.2%), against a
+mismatched-article control of **0.4%**. Per kind, of what was attainable: `text_block` 97.0%,
+`table` 96.5%, **`title` 90.2%** — headings are the weakest, and their ceiling is the highest
+at 94.4%, so that gap is the parser's.
+
+**Born-digital tables are the headline, and the parser's own telemetry sharpens it.** Median
+0.000 on both table dimensions across the 111 pages carrying table ground truth. On a
+12-article spot check: **32 ground-truth tables against 4 emitted `Table` nodes**, 28 pages
+with a table against 4.
+
+Two other numbers say precisely what is lost. Table **cell text** is recovered at **96.5% of
+attainable** — the words reach the output. And the run records **76 `table_rejected` degraded
+events**, so the parser *finds* table candidates and rejects them. The failure is not blindness
+and not text loss: it finds a table, rejects it, and emits the cells as prose. That is a
+different defect from "cannot see born-digital tables", and it has a different fix.
+
+This is also the gap the raster lane structurally cannot report: every OmniDocBench page is an
+image, so its PDF table path never runs and the whole table dimension is erased as
+unsupported.
+
+**OCR fired on 11 of 66 articles** — on a corpus characterized as 0.0% scan-shaped. Auto mode
+triggers on **≥50% image area regardless of how much text a page has**, and
+`preserve_existing_text` defaults to `False`, so on a figure-heavy born-digital page the
+publisher's real text layer is discarded and replaced with OCR output. This is why OCR was
+left enabled rather than switched off: it is a measurement that could fail, and it did.
+
+**Cost:** the full run takes over an hour of CPU on one core, most of it OCR. Use `--limit`
+for a spread subset; a per-PR gate over all 66 articles is not practical as it stands.
+
 ## Licences
 
 The OA subset is not uniformly licensed. Each article's licence is read out of its own

--- a/benchmarks/pmc/__main__.py
+++ b/benchmarks/pmc/__main__.py
@@ -183,7 +183,11 @@ def _score(args: argparse.Namespace) -> int:
     # words in an order the page never prints. Raw recall against that is unreadable.
     print(f"    attainable        {recall['ceiling']:6.1%}  (the PDF's own text layer reproduces this much)")
     print(f"    of what's attainable {recall['attainable_recall']:6.1%}  <- the number worth reading")
-    print(f"    wrong article     {recall['control_recall']:6.1%}  (want ~0%)")
+    if recall["control_scored"]:
+        print(f"    wrong article     {recall['control_recall']:6.1%}  (want ~0%)")
+    else:
+        # A 0.0% with no denominator behind it would read exactly like a passing control.
+        print("    wrong article        n/a  (needs more than one article to have a control)")
     for kind, counts in recall["by_kind"].items():
         print(
             f"      {kind:12s} attainable {counts['attainable']:5d}/{counts['scored']:<5d}"

--- a/benchmarks/pmc/__main__.py
+++ b/benchmarks/pmc/__main__.py
@@ -156,6 +156,11 @@ def _score(args: argparse.Namespace) -> int:
     print(f"articles   : {corpus_facts['articles_converted']} of {corpus_facts['articles_scored']} converted")
     print(f"pages      : {corpus_facts['pages_scored']} scored")
     print(f"coverage   : {corpus_facts['coverage']['median']:.2f} median ground-truth words per PDF word")
+    print(
+        f"tables     : {corpus_facts['tables_emitted']} emitted against "
+        f"{corpus_facts['tables_expected']} expected, on "
+        f"{corpus_facts['pages_with_emitted_table']} of {corpus_facts['pages_with_expected_table']} page(s)"
+    )
     print()
     print("projection : how each ground-truth block reached a page")
     for name, count in projection["assignments"].items():

--- a/benchmarks/pmc/__main__.py
+++ b/benchmarks/pmc/__main__.py
@@ -137,6 +137,67 @@ def _align(args: argparse.Namespace) -> int:
     return 0
 
 
+def _score(args: argparse.Namespace) -> int:
+    from benchmarks.pmc.benchmark import run, write_result
+
+    snapshot = corpus.load_corpus(
+        Path(args.cache),
+        manifest_path=None if args.manifest is None else Path(args.manifest),
+        limit=args.limit,
+        workers=args.workers,
+    )
+    payload = run(snapshot, all2md_commit=args.commit)
+    if args.out:
+        print(f"written    : {write_result(payload, Path(args.out))}")
+
+    corpus_facts = payload["corpus"]
+    projection = payload["projection"]
+    print(f"pin        : {payload['provenance']['corpus_pin']}")
+    print(f"articles   : {corpus_facts['articles_converted']} of {corpus_facts['articles_scored']} converted")
+    print(f"pages      : {corpus_facts['pages_scored']} scored")
+    print(f"coverage   : {corpus_facts['coverage']['median']:.2f} median ground-truth words per PDF word")
+    print()
+    print("projection : how each ground-truth block reached a page")
+    for name, count in projection["assignments"].items():
+        print(f"    {name:11s} {count:6d}")
+    print(f"  error budget (excluded from every page score): {projection['error_budget']:.1%}")
+    if projection["excluded_reasons"]:
+        print(f"  excluded because: {projection['excluded_reasons']}")
+    print()
+    print("dimensions : own score, then the same truth against the WRONG page, then the gap")
+    header = f"    {'dimension':34s} {'mean':>7s} {'median':>7s} {'wrong':>7s} {'gap':>7s}"
+    print(f"{header}  {'reversed':>9s} {'halved':>7s}")
+    for name, summary in payload["dimensions"].items():
+        drop = summary.get("mutation_drop", {})
+        flag = "  <- ungateable" if "ungateable" in summary else ""
+        print(
+            f"    {name:34s} {summary['mean']:7.3f} {summary['median']:7.3f} "
+            f"{summary.get('control_mean', 0.0):7.3f} {summary.get('discrimination', 0.0):7.3f}  "
+            f"{drop.get('reversed', 0.0):9.3f} {drop.get('halved', 0.0):7.3f}{flag}"
+        )
+    print()
+    recall = payload["article_recall"]
+    print("whole-article recall: did the text survive anywhere in the output")
+    print(f"    raw recall        {recall['recall']:6.1%} of {recall['scored']} blocks")
+    # Much of a JATS article cannot be recovered by any parser, because the markup records
+    # words in an order the page never prints. Raw recall against that is unreadable.
+    print(f"    attainable        {recall['ceiling']:6.1%}  (the PDF's own text layer reproduces this much)")
+    print(f"    of what's attainable {recall['attainable_recall']:6.1%}  <- the number worth reading")
+    print(f"    wrong article     {recall['control_recall']:6.1%}  (want ~0%)")
+    for kind, counts in recall["by_kind"].items():
+        print(
+            f"      {kind:12s} attainable {counts['attainable']:5d}/{counts['scored']:<5d}"
+            f"   recovered {counts['attainable_recall']:6.1%} of those"
+        )
+    if payload["ocr_articles"]:
+        print()
+        print(f"OCR fired on {len(payload['ocr_articles'])} article(s): {payload['ocr_articles']}")
+    if payload["conversion_failures"]:
+        print()
+        print(f"failures   : {payload['conversion_failures']}")
+    return 0
+
+
 def main(argv: list[str] | None = None) -> int:
     """Run the PMC corpus command line.
 
@@ -189,6 +250,18 @@ def main(argv: list[str] | None = None) -> int:
     align.add_argument("--limit", type=int, default=None, help="evenly spaced subset size")
     align.add_argument("--workers", type=int, default=8, help="concurrent download workers")
     align.set_defaults(handler=_align)
+
+    score = subparsers.add_parser(
+        "score",
+        help="score all2md against the corpus page by page, with the mismatch and mutation controls",
+    )
+    score.add_argument("--manifest", default=None, help="manifest path (default: the committed one)")
+    score.add_argument("--cache", default=str(DEFAULT_CACHE), help="cache directory")
+    score.add_argument("--limit", type=int, default=None, help="evenly spaced subset size")
+    score.add_argument("--workers", type=int, default=8, help="concurrent download workers")
+    score.add_argument("--out", default=None, help="write the evidence payload here")
+    score.add_argument("--commit", default="unknown", help="all2md commit being scored")
+    score.set_defaults(handler=_score)
 
     show = subparsers.add_parser("show", help="summarize the committed manifest without any network access")
     show.add_argument("--manifest", default=None, help="manifest path (default: the committed one)")

--- a/benchmarks/pmc/alignment.py
+++ b/benchmarks/pmc/alignment.py
@@ -58,6 +58,24 @@ COMPLETE_MIN = 0.95
 #: separately rather than counted as failures.
 MIN_NGRAMS = 4
 
+#: Share of a block's distinct tokens a page must hold for `place_by_tokens` to place it.
+#: N-gram containment assumes the page renders a block's words in the order JATS declares
+#: them, and structured markup breaks that assumption without changing a single word: an
+#: ``<element-citation>`` lists source before authors while the page prints authors first,
+#: and ``<surname>``/``<given-names>`` invert against the rendered byline. Those blocks are
+#: fully present on their page and score zero n-gram containment.
+#:
+#: Calibrated on 8 articles, not chosen: at 0.65 the fallback recovers 89.1% of the blocks
+#: n-gram containment reports as missing, agrees with n-gram placement on 99.0% of the
+#: blocks where that method already gives a confident answer, and places only 0.6% of blocks
+#: onto a *different article's* pages. Raising it to 0.85 buys nothing -- false placement is
+#: already under 1% -- and gives up half the recovered blocks.
+TOKEN_PLACEMENT_MIN = 0.65
+
+#: Below this many distinct tokens a bag of words is not distinctive enough to identify a
+#: page, whatever share of it matches.
+TOKEN_MIN_DISTINCT = 5
+
 #: JATS elements worth placing on a page.
 PLACEABLE_TAGS = ("p", "table-wrap", "fig")
 
@@ -278,6 +296,35 @@ def place_block(block: set[tuple[str, ...]], pages: Sequence[set[tuple[str, ...]
             return BlockPlacement("", "spans", min(top_page, second_page), max(top_page, second_page), top_share)
         return BlockPlacement("", "split", top_page, second_page, top_share)
     return BlockPlacement("", "clean", top_page, None, top_share)
+
+
+def place_by_tokens(tokens: Sequence[str], pages: Sequence[set[str]]) -> int | None:
+    """Place a block by unordered token containment, for blocks whose word order is not the page's.
+
+    Deliberately kept apart from `place_block` rather than folded into it as a fallback: the
+    published feasibility numbers describe n-gram containment, and quietly widening the rule
+    they were measured with would leave them describing something else. Callers compose the
+    two and report which rule placed what.
+
+    Parameters
+    ----------
+    tokens : Sequence[str]
+        The block's normalized tokens.
+    pages : Sequence[set[str]]
+        Per-page distinct token sets, in page order.
+
+    Returns
+    -------
+    int or None
+        Zero-based page index, or ``None`` when no page holds enough of the block. Ties
+        break toward the earliest page, as in `place_block`.
+
+    """
+    distinct = set(tokens)
+    if len(distinct) < TOKEN_MIN_DISTINCT or not pages:
+        return None
+    share, negated_index = max((len(distinct & page) / len(distinct), -index) for index, page in enumerate(pages))
+    return -negated_index if share >= TOKEN_PLACEMENT_MIN else None
 
 
 def measure(articles: Iterable[Any]) -> AlignmentReport:

--- a/benchmarks/pmc/article.py
+++ b/benchmarks/pmc/article.py
@@ -1,0 +1,230 @@
+"""Measure whether anything was lost, over the whole article rather than page by page.
+
+The per-page instrument excludes the blocks that will not resolve to a page -- about 5% --
+and those are not a random 5%: they are structured citations, bylines and float captions,
+the material most likely to be mishandled. An instrument that silently drops the hard cases
+and reports on the rest is flattering itself. This one pays no alignment tax, so its
+denominator is every ground-truth block.
+
+**It asks a narrower question than the page instrument, on purpose: did this block's text
+survive anywhere in the output?** Not "in the right place" -- that is the page instrument's
+job, and at article scale it is not answerable with these tools. Two measurements settled
+that.
+
+*The shared oracle's block-locating threshold does not survive an article-length haystack.*
+``_IDENTIFIED_MATCH`` admits a block once half its characters align monotonically, which is
+sound over one page. Over a whole article, 77-86% of one article's ground-truth blocks
+"locate" inside a **completely different article's** output, at a median alignment of
+0.62-0.72. The safeguard that is supposed to stop absent content from earning order credit
+is inoperative at this length, so reading order is scored per page, where its calibration
+holds.
+
+*Page order cannot fail here, so it is not scored.* Page attribution comes from the parser's
+own per-page loop, which emits a separator per PDF page. Content cannot migrate between page
+groups, and a dropped page raises `benchmarks.pmc.convert.PageBoundaryError` instead of
+scoring. A page-sequence metric would report a perfect score by construction.
+
+What remains is recall, measured with n-gram containment -- the one instrument on this
+corpus with a published false-positive rate, 0.8% against a mismatched article.
+
+**Raw recall is not readable on its own, so the ceiling ships with it.** Much of a JATS
+article cannot be recovered from the PDF by *any* parser, because the markup does not record
+the words in the order the page prints them: ``<element-citation>`` lists the journal before
+the authors, ``<surname>`` precedes ``<given-names>`` against the rendered byline. Measured
+against the PDF's own text layer, only 61.1% of blocks are recoverable at all -- so a raw
+54.6% is 89% of what was available, not a parser losing half the document. The ceiling is
+computed per run rather than pinned, because it is a property of the corpus and the
+extraction, both of which can change.
+"""
+
+from __future__ import annotations
+
+import statistics
+from collections import Counter
+from dataclasses import dataclass
+from typing import Iterable, Mapping, Sequence
+
+from benchmarks.pmc.alignment import MIN_NGRAMS, ngrams, normalize
+
+#: Share of a block's n-grams that must appear in the output for the block to count as
+#: recovered. Not 1.0: de-hyphenation, ligature folding and a dropped soft hyphen each cost
+#: an n-gram or two on text that is otherwise reproduced exactly.
+RECALL_MIN = 0.80
+
+
+@dataclass(frozen=True, slots=True)
+class RecallReport:
+    """Whole-article content recall with its mismatch control.
+
+    Attributes
+    ----------
+    recovered : int
+        Blocks whose text was found in the article's own output.
+    attainable : int
+        Blocks recoverable at all, measured against the PDF's own text layer. The honest
+        denominator: everything above this is unreachable for any parser.
+    recovered_attainable : int
+        Blocks that were both attainable and recovered.
+    scored : int
+        Blocks long enough to look for.
+    too_short : int
+        Blocks with too few n-grams to test, reported rather than counted either way.
+    by_kind : Mapping[str, KindRecall]
+        The same counts per block kind.
+    control_recovered : int
+        Blocks "recovered" from a *different* article's output. The instrument's noise
+        floor: a recall figure means nothing without it.
+    control_scored : int
+        Blocks scored against the mismatched article.
+
+    """
+
+    recovered: int
+    attainable: int
+    recovered_attainable: int
+    scored: int
+    too_short: int
+    by_kind: Mapping[str, "KindRecall"]
+    control_recovered: int
+    control_scored: int
+
+    @property
+    def recall(self) -> float:
+        """Share of testable blocks whose text survived into the output."""
+        return self.recovered / self.scored if self.scored else 0.0
+
+    @property
+    def ceiling(self) -> float:
+        """Share of blocks the PDF's own text layer reproduces -- the best any parser could do."""
+        return self.attainable / self.scored if self.scored else 0.0
+
+    @property
+    def attainable_recall(self) -> float:
+        """Share of the *recoverable* blocks that were recovered. The number worth reading."""
+        return self.recovered_attainable / self.attainable if self.attainable else 0.0
+
+    @property
+    def control_recall(self) -> float:
+        """Share of blocks 'recovered' from the wrong article."""
+        return self.control_recovered / self.control_scored if self.control_scored else 0.0
+
+
+@dataclass(frozen=True, slots=True)
+class KindRecall:
+    """Recall counts for one block kind.
+
+    Attributes
+    ----------
+    recovered, attainable, recovered_attainable, scored : int
+        As on `RecallReport`, restricted to this kind.
+
+    """
+
+    recovered: int
+    attainable: int
+    recovered_attainable: int
+    scored: int
+
+    @property
+    def attainable_recall(self) -> float:
+        """Share of this kind's recoverable blocks that were recovered."""
+        return self.recovered_attainable / self.attainable if self.attainable else 0.0
+
+
+def _contained(block: set[tuple[str, ...]], haystack: set[tuple[str, ...]]) -> bool:
+    return len(block & haystack) / len(block) >= RECALL_MIN
+
+
+def measure_recall(
+    articles: Iterable[tuple[str, Sequence[tuple[str, str]], str, str]],
+) -> RecallReport:
+    """Measure article-level content recall against both the output and the attainable ceiling.
+
+    Parameters
+    ----------
+    articles : Iterable
+        ``(article_id, blocks, emitted_text, pdf_text)`` tuples, where ``blocks`` are
+        ``(kind, text)`` ground-truth pairs, ``emitted_text`` is all2md's whole output and
+        ``pdf_text`` is the PDF's own text layer.
+
+    Returns
+    -------
+    RecallReport
+        Recall, ceiling and the mismatched-article control, overall and per kind.
+
+    """
+    indexed = [
+        (
+            article_id,
+            [(kind, ngrams(normalize(text))) for kind, text in blocks],
+            ngrams(normalize(emitted)),
+            ngrams(normalize(pdf_text)),
+        )
+        for article_id, blocks, emitted, pdf_text in articles
+    ]
+
+    totals = [0, 0, 0, 0]  # recovered, attainable, both, scored
+    too_short = control_recovered = control_scored = 0
+    by_kind: dict[str, list[int]] = {}
+    for position, (_article_id, blocks, haystack, ceiling) in enumerate(indexed):
+        # Pair with the neighbour rather than a random article, so the control reproduces
+        # exactly on a re-run.
+        other = indexed[(position + 1) % len(indexed)][2]
+        for kind, block in blocks:
+            if len(block) < MIN_NGRAMS:
+                too_short += 1
+                continue
+            found = _contained(block, haystack)
+            reachable = _contained(block, ceiling)
+            counts = by_kind.setdefault(kind, [0, 0, 0, 0])
+            for bucket in (totals, counts):
+                bucket[0] += found
+                bucket[1] += reachable
+                bucket[2] += found and reachable
+                bucket[3] += 1
+            if other is not haystack:
+                control_scored += 1
+                control_recovered += _contained(block, other)
+
+    return RecallReport(
+        recovered=totals[0],
+        attainable=totals[1],
+        recovered_attainable=totals[2],
+        scored=totals[3],
+        too_short=too_short,
+        by_kind={kind: KindRecall(*counts) for kind, counts in sorted(by_kind.items())},
+        control_recovered=control_recovered,
+        control_scored=control_scored,
+    )
+
+
+def summarize(values: Sequence[float]) -> dict[str, float]:
+    """Summarize a dimension's distribution, so a gate can see whether it discriminates.
+
+    Parameters
+    ----------
+    values : Sequence[float]
+        Per-item scores.
+
+    Returns
+    -------
+    dict[str, float]
+        ``count``, ``mean``, ``median``, ``minimum``, ``maximum`` and ``stdev``. A dimension
+        whose minimum, median and maximum coincide cannot fail, whatever its value.
+
+    """
+    if not values:
+        return {"count": 0.0}
+    return {
+        "count": float(len(values)),
+        "mean": statistics.fmean(values),
+        "median": statistics.median(values),
+        "minimum": min(values),
+        "maximum": max(values),
+        "stdev": statistics.stdev(values) if len(values) > 1 else 0.0,
+    }
+
+
+def tally(counter: Counter[str], names: Sequence[str]) -> dict[str, int]:
+    """Return a counter as a dict with every expected name present, zero-filled."""
+    return {name: counter.get(name, 0) for name in names}

--- a/benchmarks/pmc/benchmark.py
+++ b/benchmarks/pmc/benchmark.py
@@ -386,6 +386,10 @@ def normalize_results(
                 for kind, counts in recall.by_kind.items()
             },
             "control_recall": recall.control_recall,
+            # Reported so a zero cannot be read as a passing control: with one article there
+            # is no other article to score against, and the rate is 0.0% for want of a
+            # denominator rather than because nothing false was placed.
+            "control_scored": recall.control_scored,
             "discrimination": recall.recall - recall.control_recall,
         },
         "dimensions": dimensions,

--- a/benchmarks/pmc/benchmark.py
+++ b/benchmarks/pmc/benchmark.py
@@ -433,7 +433,10 @@ def run(snapshot: Any, *, all2md_commit: str = "unknown", worktree_dirty: bool =
         recall=recall,
         all2md_commit=all2md_commit,
         worktree_dirty=worktree_dirty,
-        parser_runtime={"pymupdf": getattr(fitz, "__doc__", "") or "", "python": sys.version.split()[0]},
+        parser_runtime={
+            "pymupdf": str(getattr(fitz, "__version__", "unknown")),
+            "python": sys.version.split()[0],
+        },
     )
 
 

--- a/benchmarks/pmc/benchmark.py
+++ b/benchmarks/pmc/benchmark.py
@@ -1,0 +1,444 @@
+"""Score all2md against PMC born-digital articles, page by page, with the controls attached.
+
+This is the born-digital counterpart to `benchmarks.omnidocbench.benchmark`, and it scores
+the same dimensions through the same oracle so the two are comparable. What differs is the
+ground truth: JATS describes an *article*, so every page's truth is projected onto it by
+`benchmarks.pmc.pages`, and the projection's failures are reported as an error budget rather
+than folded into the parser's score.
+
+Three controls ship inside the run, because each of them has already caught something:
+
+* **Mismatch.** Every page is scored a second time against the *next page of the same
+  article* -- the hardest confounder available, sharing running heads, vocabulary and
+  sentences that continue across the break. A dimension whose own-page score does not
+  clearly beat that is not measuring the page.
+* **Mutation.** Every page is scored against deliberately damaged output. A dimension that
+  does not move when the output is reversed, scrambled, or halved cannot detect that class
+  of defect and must not be gated on. This is how `block_structure_similarity` was found to
+  *rise* when half the content is deleted.
+* **Input shape.** OCR is left enabled in auto mode. On a born-digital corpus it should
+  never fire, and "never fired" is worth having as a measurement that could have failed.
+"""
+
+from __future__ import annotations
+
+import json
+import random
+import statistics
+import sys
+import time
+from collections import Counter
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Callable, Mapping, Sequence
+
+from benchmarks.omnidocbench.oracles import PageProjection, project_ast, score_page
+from benchmarks.pmc.alignment import TOKEN_PLACEMENT_MIN
+from benchmarks.pmc.article import RECALL_MIN, RecallReport, measure_recall, summarize
+from benchmarks.pmc.convert import convert_article, pdf_options
+from benchmarks.pmc.oracles import coverage, project_jats, to_projection
+from benchmarks.pmc.pages import ASSIGNMENTS, assign_pages, index_pages
+
+SCHEMA_VERSION = 1
+ORACLE_SCHEMA_VERSION = 1
+
+#: Fixed seed: a control that scrambles differently every run cannot be compared across
+#: runs, and a resolution change would be indistinguishable from a parser change.
+SHUFFLE_SEED = 20260805
+
+#: Dimensions this lane records but must not gate on, with the measurement that disqualified
+#: each. Kept in the payload because a dimension nobody may gate on is still evidence.
+UNGATEABLE: Mapping[str, str] = {
+    "block_structure_similarity": (
+        "cannot fail usefully: separates own-page from wrong-page output by only ~0.06, and "
+        "rises when half the emitted content is deleted, so it rewards dropping blocks"
+    ),
+}
+
+
+def _reorder(projection: PageProjection, order: Sequence[int]) -> PageProjection:
+    return PageProjection(
+        text_blocks=tuple(projection.text_blocks[index] for index in order),
+        block_kinds=tuple(projection.block_kinds[index] for index in order),
+        tables=projection.tables,
+        formulas=projection.formulas,
+    )
+
+
+def _reversed(projection: PageProjection) -> PageProjection:
+    return _reorder(projection, list(reversed(range(len(projection.text_blocks)))))
+
+
+def _shuffled(projection: PageProjection) -> PageProjection:
+    order = list(range(len(projection.text_blocks)))
+    random.Random(SHUFFLE_SEED).shuffle(order)
+    return _reorder(projection, order)
+
+
+def _halved(projection: PageProjection) -> PageProjection:
+    keep = list(range(0, len(projection.text_blocks), 2))
+    return PageProjection(
+        text_blocks=tuple(projection.text_blocks[index] for index in keep),
+        block_kinds=tuple(projection.block_kinds[index] for index in keep),
+        tables=projection.tables[: len(projection.tables) // 2],
+        formulas=projection.formulas,
+    )
+
+
+#: Damage applied to emitted output, each asking a different question of the score.
+MUTATIONS: Mapping[str, Callable[[PageProjection], PageProjection]] = {
+    "reversed": _reversed,
+    "shuffled": _shuffled,
+    "halved": _halved,
+}
+
+
+@dataclass(frozen=True, slots=True)
+class PageEvaluation:
+    """One page scored against its projected ground truth."""
+
+    article_id: str
+    page: int
+    scores: Mapping[str, float]
+    control_scores: Mapping[str, float]
+    mutated: Mapping[str, Mapping[str, float]]
+    truth_blocks: int
+    truth_tables: int
+    emitted_blocks: int
+    emitted_tables: int
+
+
+@dataclass(frozen=True, slots=True)
+class ArticleEvaluation:
+    """One article's pages, its projection accounting, and its conversion evidence."""
+
+    article_id: str
+    pages: tuple[PageEvaluation, ...]
+    assignments: Mapping[str, int]
+    unsplit_spans: int
+    excluded: Mapping[str, int]
+    coverage: float
+    ocr_page_fraction: float
+    degraded_kinds: tuple[str, ...]
+    duration_seconds: float
+    ground_truth_blocks: int
+    emitted_text: str = ""
+    #: The PDF's own text layer, which bounds what any parser could recover.
+    pdf_text: str = ""
+    truth_blocks: tuple[tuple[str, str], ...] = field(default_factory=tuple)
+    error: str | None = None
+
+
+def _pdf_facts(pdf_path: Path) -> tuple[int, int, str]:
+    """Return the PDF's page count, word count, and its own text layer."""
+    import fitz
+
+    with fitz.open(pdf_path) as document:
+        pages = [page.get_text() for page in document]
+    text = " ".join(pages)
+    return len(pages), len(text.split()), text
+
+
+def evaluate_article(article: Any, *, options: Any = None) -> ArticleEvaluation:
+    """Convert one article and score every page of it.
+
+    Parameters
+    ----------
+    article : benchmarks.pmc.corpus.CorpusArticle
+        Article with validated PDF and XML paths.
+    options : PdfOptions or None
+        Parser policy; defaults to `benchmarks.pmc.convert.pdf_options`.
+
+    Returns
+    -------
+    ArticleEvaluation
+        Page scores with the projection accounting that qualifies them.
+
+    """
+    from benchmarks.pmc.corpus import _parse_jats
+
+    started = time.perf_counter()
+    root, _ = _parse_jats(article.xml_path.read_bytes())
+    blocks, whole = project_jats(root)
+    page_count, pdf_words, pdf_text = _pdf_facts(article.pdf_path)
+    indexed = index_pages(article.pdf_path)
+    assignment = assign_pages(blocks, indexed)
+    truth_pairs = tuple((block.kind, block.text) for block in blocks if block.text)
+
+    try:
+        converted = convert_article(article.pdf_path, page_count, options=options or pdf_options())
+    except Exception as exc:  # noqa: BLE001 - a failed article stays in every denominator
+        return ArticleEvaluation(
+            article_id=article.article_id,
+            pages=(),
+            assignments=dict(assignment.assignments),
+            unsplit_spans=assignment.unsplit_spans,
+            excluded=dict(Counter(assignment.excluded)),
+            coverage=coverage(whole, pdf_words),
+            ocr_page_fraction=0.0,
+            degraded_kinds=(),
+            duration_seconds=time.perf_counter() - started,
+            ground_truth_blocks=len(blocks),
+            truth_blocks=truth_pairs,
+            error=f"{type(exc).__name__}: {exc}",
+        )
+
+    emitted = [project_ast(page) for page in converted.pages]
+    evaluations: list[PageEvaluation] = []
+    for index, placed in enumerate(assignment.pages):
+        truth = to_projection(tuple(item.block for item in placed))
+        if not truth.text_blocks:
+            # A page with no projected ground truth cannot be scored without inventing a
+            # verdict. Counted in the payload's page accounting instead.
+            continue
+        actual = emitted[index]
+        # The next page of the same article: a harder control than a different article,
+        # because it shares the running head, the vocabulary, and a continuing sentence.
+        control = emitted[(index + 1) % len(emitted)] if len(emitted) > 1 else PageProjection((), (), (), ())
+        evaluations.append(
+            PageEvaluation(
+                article_id=article.article_id,
+                page=index,
+                scores=score_page(truth, actual),
+                control_scores=score_page(truth, control),
+                mutated={name: score_page(truth, mutate(actual)) for name, mutate in MUTATIONS.items()},
+                truth_blocks=len(truth.text_blocks),
+                truth_tables=len(truth.tables),
+                emitted_blocks=len(actual.text_blocks),
+                emitted_tables=len(actual.tables),
+            )
+        )
+
+    return ArticleEvaluation(
+        article_id=article.article_id,
+        pages=tuple(evaluations),
+        assignments=dict(assignment.assignments),
+        unsplit_spans=assignment.unsplit_spans,
+        excluded=dict(Counter(assignment.excluded)),
+        coverage=coverage(whole, pdf_words),
+        ocr_page_fraction=converted.ocr_page_fraction,
+        degraded_kinds=converted.degraded_kinds,
+        duration_seconds=time.perf_counter() - started,
+        ground_truth_blocks=len(blocks),
+        emitted_text=" ".join(block for page in emitted for block in page.text_blocks),
+        pdf_text=pdf_text,
+        truth_blocks=truth_pairs,
+    )
+
+
+def evaluate_corpus(articles: Sequence[Any], *, options: Any = None) -> list[ArticleEvaluation]:
+    """Score every article in a corpus snapshot.
+
+    Parameters
+    ----------
+    articles : Sequence
+        `benchmarks.pmc.corpus.CorpusArticle` values.
+    options : PdfOptions or None
+        Parser policy.
+
+    Returns
+    -------
+    list[ArticleEvaluation]
+        One evaluation per article, in article-id order.
+
+    """
+    results = [evaluate_article(article, options=options) for article in articles]
+    results.sort(key=lambda result: result.article_id)
+    return results
+
+
+def _dimension(pages: Sequence[PageEvaluation], name: str) -> dict[str, Any] | None:
+    values = [page.scores[name] for page in pages if name in page.scores]
+    if not values:
+        return None
+    control = [page.control_scores[name] for page in pages if name in page.control_scores]
+    summary: dict[str, Any] = dict(summarize(values))
+    summary["direction"] = "higher"
+    if control:
+        summary["control_mean"] = statistics.fmean(control)
+        # The whole point of the control: how far the real score sits above scoring the
+        # same ground truth against the wrong page.
+        summary["discrimination"] = statistics.fmean(values) - statistics.fmean(control)
+    drops: dict[str, float] = {}
+    for mutation in MUTATIONS:
+        deltas = [
+            page.scores[name] - page.mutated[mutation][name]
+            for page in pages
+            if name in page.scores and mutation in page.mutated and name in page.mutated[mutation]
+        ]
+        if deltas:
+            drops[mutation] = statistics.fmean(deltas)
+    summary["mutation_drop"] = drops
+    if name in UNGATEABLE:
+        summary["ungateable"] = UNGATEABLE[name]
+    return summary
+
+
+def normalize_results(
+    *,
+    snapshot: Any,
+    evaluations: Sequence[ArticleEvaluation],
+    recall: RecallReport,
+    all2md_commit: str,
+    worktree_dirty: bool = False,
+    parser_runtime: Mapping[str, str],
+) -> dict[str, Any]:
+    """Build the deterministic evidence payload for this lane.
+
+    Parameters
+    ----------
+    snapshot : benchmarks.pmc.corpus.CorpusSnapshot
+        The pinned corpus that was scored.
+    evaluations : Sequence[ArticleEvaluation]
+        Per-article results.
+    recall : RecallReport
+        Whole-article content recall with its control.
+    all2md_commit : str
+        Commit the parser was scored at.
+    worktree_dirty : bool
+        Whether the worktree had uncommitted changes.
+    parser_runtime : Mapping[str, str]
+        Versions of the libraries the parser used.
+
+    Returns
+    -------
+    dict
+        JSON-ready payload.
+
+    """
+    pages = [page for evaluation in evaluations for page in evaluation.pages]
+    names = sorted({name for page in pages for name in page.scores})
+    dimensions = {name: summary for name in names if (summary := _dimension(pages, name)) is not None}
+
+    assignments: Counter[str] = Counter()
+    excluded: Counter[str] = Counter()
+    for evaluation in evaluations:
+        assignments.update(evaluation.assignments)
+        excluded.update(evaluation.excluded)
+    placed = sum(count for name, count in assignments.items() if name != "excluded")
+    total_blocks = placed + assignments.get("excluded", 0)
+
+    failures = {result.article_id: result.error for result in evaluations if result.error is not None}
+    ocr_articles = [result.article_id for result in evaluations if result.ocr_page_fraction > 0]
+    coverages = [result.coverage for result in evaluations]
+
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "provenance": {
+            "corpus_pin": snapshot.manifest_sha256,
+            "bucket": snapshot.bucket,
+            "complete_corpus": snapshot.complete,
+            "oracle_schema_version": ORACLE_SCHEMA_VERSION,
+            "all2md_commit": all2md_commit,
+            "worktree_dirty": worktree_dirty,
+            "created_at": datetime.now(timezone.utc).isoformat(),
+            "python": sys.version,
+            "platform": sys.platform,
+            "parser_runtime": dict(sorted(parser_runtime.items())),
+            "parser_config": {
+                "layout_analysis_mode": "enabled",
+                "include_page_numbers": True,
+                "ocr": {"enabled": True, "mode": "auto", "engine": "tesseract", "dpi": 200},
+            },
+            "placement_config": {
+                "token_placement_min": TOKEN_PLACEMENT_MIN,
+                "recall_min": RECALL_MIN,
+            },
+        },
+        "corpus": {
+            "articles_expected": snapshot.expected_articles,
+            "articles_scored": len(evaluations),
+            "articles_converted": sum(1 for result in evaluations if result.error is None),
+            "pages_scored": len(pages),
+            "ground_truth_blocks": total_blocks,
+            # Ground-truth words over PDF words. Far from 1 in either direction means the
+            # ground truth does not describe what the page renders, and every content score
+            # carries an unearned penalty.
+            "coverage": summarize(coverages),
+        },
+        # The error budget, stated rather than absorbed. These blocks are excluded from every
+        # per-page score; article-level recall still counts them.
+        "projection": {
+            "assignments": {name: assignments.get(name, 0) for name in ASSIGNMENTS},
+            "excluded_reasons": dict(sorted(excluded.items())),
+            "error_budget": assignments.get("excluded", 0) / total_blocks if total_blocks else 0.0,
+            "unsplit_spans": sum(result.unsplit_spans for result in evaluations),
+        },
+        "article_recall": {
+            "recall": recall.recall,
+            "recovered": recall.recovered,
+            "scored": recall.scored,
+            "too_short": recall.too_short,
+            # The share of blocks the PDF's own text layer reproduces. Everything above it
+            # is unreachable for any parser, so raw recall alone reads as parser loss when
+            # it is mostly JATS recording words in an order the page never prints.
+            "ceiling": recall.ceiling,
+            "attainable": recall.attainable,
+            "attainable_recall": recall.attainable_recall,
+            "by_kind": {
+                kind: {
+                    "recovered": counts.recovered,
+                    "attainable": counts.attainable,
+                    "scored": counts.scored,
+                    "attainable_recall": counts.attainable_recall,
+                }
+                for kind, counts in recall.by_kind.items()
+            },
+            "control_recall": recall.control_recall,
+            "discrimination": recall.recall - recall.control_recall,
+        },
+        "dimensions": dimensions,
+        "conversion_failures": failures,
+        # Expected to be empty: this corpus was characterized as 0.0% scan-shaped. A
+        # non-empty list means the corpus is not what the characterization says it is.
+        "ocr_articles": ocr_articles,
+        "degraded_events": dict(
+            sorted(Counter(kind for result in evaluations for kind in result.degraded_kinds).items())
+        ),
+    }
+
+
+def run(snapshot: Any, *, all2md_commit: str = "unknown", worktree_dirty: bool = False) -> dict[str, Any]:
+    """Score a corpus snapshot end to end.
+
+    Parameters
+    ----------
+    snapshot : benchmarks.pmc.corpus.CorpusSnapshot
+        Pinned corpus to score.
+    all2md_commit : str
+        Commit the parser is being scored at.
+    worktree_dirty : bool
+        Whether the worktree had uncommitted changes.
+
+    Returns
+    -------
+    dict
+        JSON-ready payload.
+
+    """
+    import fitz
+
+    evaluations = evaluate_corpus(snapshot.articles)
+    recall = measure_recall(
+        [
+            (result.article_id, result.truth_blocks, result.emitted_text, result.pdf_text)
+            for result in evaluations
+            if result.error is None
+        ]
+    )
+    return normalize_results(
+        snapshot=snapshot,
+        evaluations=evaluations,
+        recall=recall,
+        all2md_commit=all2md_commit,
+        worktree_dirty=worktree_dirty,
+        parser_runtime={"pymupdf": getattr(fitz, "__doc__", "") or "", "python": sys.version.split()[0]},
+    )
+
+
+def write_result(payload: Mapping[str, Any], path: Path) -> Path:
+    """Write the evidence payload as strict JSON."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2, ensure_ascii=False, allow_nan=False), encoding="utf-8")
+    return path

--- a/benchmarks/pmc/benchmark.py
+++ b/benchmarks/pmc/benchmark.py
@@ -356,6 +356,13 @@ def normalize_results(
             # ground truth does not describe what the page renders, and every content score
             # carries an unearned penalty.
             "coverage": summarize(coverages),
+            # Both sides of the table count, because the score alone cannot tell "found
+            # nothing" from "found something wrong" -- and the parser's own
+            # `table_rejected` events say it often finds a candidate and then rejects it.
+            "tables_expected": sum(page.truth_tables for page in pages),
+            "tables_emitted": sum(page.emitted_tables for page in pages),
+            "pages_with_expected_table": sum(1 for page in pages if page.truth_tables),
+            "pages_with_emitted_table": sum(1 for page in pages if page.emitted_tables),
         },
         # The error budget, stated rather than absorbed. These blocks are excluded from every
         # per-page score; article-level recall still counts them.

--- a/benchmarks/pmc/convert.py
+++ b/benchmarks/pmc/convert.py
@@ -1,0 +1,191 @@
+"""Convert an article PDF once, and recover its page boundaries from that one conversion.
+
+Both instruments in this lane need the same conversion, and the per-page one needs to know
+which emitted nodes belong to which page. The alternative -- splitting the PDF and calling
+the parser once per page -- was rejected: it hides every cross-page defect this lane exists
+to find, because a parser that mangles a paragraph continuing across a page break would
+never be shown the break.
+
+Page attribution comes from the parser's own page-separator nodes, which is close to free
+of judgement: the separator is emitted per PyMuPDF page, so the boundaries are the file's,
+not a decision the parser could shade in its favour. What the parser *can* do is drop a
+page, and the separators carry their page numbers precisely so that shows up as a mismatch
+instead of silently shifting every later page's ground truth by one.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from all2md.ast.nodes import Document
+    from all2md.options.pdf import PdfOptions
+
+#: Separator template carrying the number of the page that just ended. The parser's default
+#: is a bare rule, which would leave page identity to be inferred from position -- and
+#: inference is exactly what fails when a page is dropped.
+PAGE_SEPARATOR_TEMPLATE = "--- all2md page {page_num} of {total_pages} ---"
+_SEPARATOR = re.compile(r"^--- all2md page (\d+) of (\d+) ---$")
+
+
+class PageBoundaryError(RuntimeError):
+    """Emitted page separators do not describe the PDF's pages."""
+
+
+@dataclass(frozen=True, slots=True)
+class ConvertedArticle:
+    """One article's AST, whole and split by page.
+
+    Attributes
+    ----------
+    document : Document
+        The article's AST exactly as the parser produced it.
+    pages : tuple[Document, ...]
+        One synthetic `Document` per PDF page, holding that page's nodes in emitted order.
+    ocr_page_fraction : float
+        Share of pages the parser OCR'd. Expected to be zero on a born-digital corpus, and
+        reported rather than assumed so a non-zero is visible.
+    degraded_kinds : tuple[str, ...]
+        Degraded-conversion event kinds the parser recorded.
+
+    """
+
+    document: Document
+    pages: tuple[Document, ...]
+    ocr_page_fraction: float
+    degraded_kinds: tuple[str, ...]
+
+
+def pdf_options(**overrides: Any) -> PdfOptions:
+    """Build this lane's fixed parser policy.
+
+    OCR is left **enabled in auto mode** rather than switched off. Disabling it would make
+    "no page needed OCR" true by construction; leaving it on means the reported OCR fraction
+    is a measurement that can fail, and a corpus that is not born-digital would say so.
+
+    Parameters
+    ----------
+    **overrides
+        Field overrides, for tests that need a narrower policy.
+
+    Returns
+    -------
+    PdfOptions
+        Parser options.
+
+    """
+    from all2md.options.common import OCROptions
+    from all2md.options.pdf import PdfOptions
+
+    settings: dict[str, Any] = {
+        "layout_analysis_mode": "enabled",
+        "include_page_numbers": True,
+        "page_separator_template": PAGE_SEPARATOR_TEMPLATE,
+        "ocr": OCROptions(enabled=True, mode="auto", engine="tesseract", languages="eng", dpi=200),
+    }
+    settings.update(overrides)
+    return PdfOptions(**settings)
+
+
+def _is_separator(node: Any) -> str | None:
+    from all2md.ast.nodes import Comment
+
+    if not isinstance(node, Comment):
+        return None
+    metadata = node.metadata if isinstance(node.metadata, dict) else {}
+    if metadata.get("comment_type") != "page_separator":
+        return None
+    return node.content if isinstance(node.content, str) else ""
+
+
+def split_pages(document: Any, expected_pages: int) -> tuple[Document, ...]:
+    """Split a converted article into one `Document` per PDF page.
+
+    Parameters
+    ----------
+    document : Document
+        Converted article.
+    expected_pages : int
+        Page count read from the PDF itself.
+
+    Returns
+    -------
+    tuple[Document, ...]
+        One document per page, in page order.
+
+    Raises
+    ------
+    PageBoundaryError
+        If the separators do not describe exactly ``expected_pages`` consecutive pages.
+        Silently accepting a mismatch would shift every later page's ground truth.
+
+    """
+    from all2md.ast.nodes import Document
+
+    groups: list[list[Any]] = [[]]
+    numbers: list[int] = []
+    for node in document.children:
+        content = _is_separator(node)
+        if content is None:
+            groups[-1].append(node)
+            continue
+        match = _SEPARATOR.match(content.strip())
+        if match is None:
+            raise PageBoundaryError(f"unparsable page separator: {content!r}")
+        numbers.append(int(match.group(1)))
+        groups.append([])
+
+    if len(groups) != expected_pages:
+        raise PageBoundaryError(
+            f"parser emitted {len(groups)} page group(s) for a {expected_pages}-page PDF; "
+            f"separators name pages {numbers}"
+        )
+    if numbers != list(range(1, expected_pages)):
+        raise PageBoundaryError(f"page separators are not consecutive from 1: {numbers}")
+    return tuple(Document(children=nodes) for nodes in groups)
+
+
+def convert_article(pdf_path: Path, expected_pages: int, *, options: PdfOptions | None = None) -> ConvertedArticle:
+    """Convert one article PDF and recover its page boundaries.
+
+    Parameters
+    ----------
+    pdf_path : pathlib.Path
+        Article PDF.
+    expected_pages : int
+        Page count read from the PDF itself, used to validate the separators.
+    options : PdfOptions or None
+        Parser policy; defaults to `pdf_options`.
+
+    Returns
+    -------
+    ConvertedArticle
+        Whole and per-page ASTs with conversion evidence.
+
+    """
+    from typing import Mapping
+
+    from all2md import to_ast
+
+    document = to_ast(pdf_path, source_format="pdf", parser_options=options or pdf_options())
+    metadata = document.metadata if isinstance(document.metadata, Mapping) else {}
+    confidence = metadata.get("confidence")
+    signals = confidence.get("signals") if isinstance(confidence, Mapping) else None
+    raw_fraction = signals.get("ocr_page_fraction") if isinstance(signals, Mapping) else None
+    numeric = isinstance(raw_fraction, (int, float)) and not isinstance(raw_fraction, bool)
+    fraction = float(raw_fraction) if numeric else 0.0
+    events = confidence.get("degraded_events") if isinstance(confidence, Mapping) else None
+    kinds = (
+        tuple(sorted(str(event["kind"]) for event in events if isinstance(event, Mapping) and "kind" in event))
+        if isinstance(events, list)
+        else ()
+    )
+    return ConvertedArticle(
+        document=document,
+        pages=split_pages(document, expected_pages),
+        ocr_page_fraction=fraction,
+        degraded_kinds=kinds,
+    )

--- a/benchmarks/pmc/convert.py
+++ b/benchmarks/pmc/convert.py
@@ -175,8 +175,9 @@ def convert_article(pdf_path: Path, expected_pages: int, *, options: PdfOptions 
     confidence = metadata.get("confidence")
     signals = confidence.get("signals") if isinstance(confidence, Mapping) else None
     raw_fraction = signals.get("ocr_page_fraction") if isinstance(signals, Mapping) else None
-    numeric = isinstance(raw_fraction, (int, float)) and not isinstance(raw_fraction, bool)
-    fraction = float(raw_fraction) if numeric else 0.0
+    fraction = 0.0
+    if isinstance(raw_fraction, (int, float)) and not isinstance(raw_fraction, bool):
+        fraction = float(raw_fraction)
     events = confidence.get("degraded_events") if isinstance(confidence, Mapping) else None
     kinds = (
         tuple(sorted(str(event["kind"]) for event in events if isinstance(event, Mapping) and "kind" in event))

--- a/benchmarks/pmc/oracles.py
+++ b/benchmarks/pmc/oracles.py
@@ -1,0 +1,397 @@
+"""Project JATS article ground truth into the shape the OmniDocBench oracle already scores.
+
+The metric definitions are **not** duplicated here. `benchmarks.omnidocbench.oracles` owns
+them, and every one carries a calibration story that took a corpus to settle -- what counts
+as text, why block kinds are scored apart from reading order, why locating blocks beats
+pairing them. Reusing `score_page` means the two lanes are directly comparable: the same
+number means the same thing on a raster page and on a born-digital one.
+
+What is new here is only the ground-truth side. JATS is publisher markup, not page
+annotation, so this module answers two questions the raster lane never had to ask.
+
+**What does the PDF actually render?** JATS holds material that never reaches the page
+(processing metadata, structured bibliographic scalars) and omits material the page carries
+(running heads, folios). Neither can be fixed, so `coverage` reports the ratio of projected
+ground-truth words to PDF words per article, and a caller that does not look at it is
+scoring against an unknown denominator.
+
+**Structured citations do not round-trip.** Two thirds of this corpus's references are
+``<element-citation>``: surname, year, source and page range as separate fields with no
+rendered punctuation between them. Their text is projected in field order, which is close
+to the rendered string but never equal to it. Reference-heavy articles therefore carry a
+noise floor that is a property of JATS, not of the parser.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Iterator
+
+from benchmarks.omnidocbench.oracles import PageProjection, TableProjection, normalize_text
+
+#: Elements whose subtree never reaches the rendered page. Skipped whole, so nothing inside
+#: can leak into the text stream through a descendant rule.
+SKIPPED = frozenset(
+    {
+        "processing-meta",
+        "custom-meta-group",
+        "journal-meta",
+        "article-id",
+        "article-categories",
+        "history",
+        "pub-date",
+        "volume",
+        "issue",
+        "fpage",
+        "lpage",
+        "elocation-id",
+        "object-id",
+        "counts",
+        "funding-group",
+        "graphic",
+        "media",
+        "inline-graphic",
+        "alt-text",
+        "long-desc",
+    }
+)
+
+#: Elements that become one ground-truth block, mapped to the block kind the shared oracle
+#: scores. Encountering one ends the walk of that subtree: its whole text is the block.
+BLOCKS: dict[str, str] = {
+    "article-title": "title",
+    "subtitle": "title",
+    "trans-title": "title",
+    "title": "title",
+    "contrib-group": "text_block",
+    "aff": "text_block",
+    "author-notes": "text_block",
+    "kwd-group": "text_block",
+    "copyright-statement": "text_block",
+    "license": "text_block",
+    "p": "text_block",
+    "disp-formula": "text_block",
+    "disp-quote": "text_block",
+    "def-item": "text_block",
+    "speech": "text_block",
+    "verse-group": "text_block",
+    "statement": "text_block",
+    "fn": "text_block",
+    "supplementary-material": "text_block",
+    "ref": "text_block",
+    "fig": "text_block",
+    "table-wrap": "table",
+}
+
+#: Containers walked through rather than emitted, listed so that an unrecognized element is
+#: a visible gap rather than silent text loss. Anything not skipped, not a block, and not
+#: here still recurses -- this set only documents the expected ones.
+_CONTAINERS = frozenset(
+    {
+        "article",
+        "front",
+        "article-meta",
+        "title-group",
+        "abstract",
+        "trans-abstract",
+        "permissions",
+        "body",
+        "sec",
+        "back",
+        "ack",
+        "app",
+        "app-group",
+        "glossary",
+        "def-list",
+        "ref-list",
+        "fn-group",
+        "notes",
+        "boxed-text",
+        "list",
+        "list-item",
+        "floats-group",
+        "sub-article",
+        "response",
+    }
+)
+
+
+@dataclass(frozen=True, slots=True)
+class JatsBlock:
+    """One rendered block of an article, in document order.
+
+    Attributes
+    ----------
+    kind : str
+        Block kind in the shared oracle's vocabulary: ``title``, ``text_block``, ``table``.
+    text : str
+        Rendered text of the block. For a table this is its cell text, matching how the
+        shared oracle puts table content into the text stream on both sides.
+    caption : str
+        Table or figure caption, emitted as its own block by `to_projection`. Empty
+        elsewhere.
+    table : TableProjection or None
+        Structure and content of a ``<table-wrap>``'s table, when it has one.
+
+    """
+
+    kind: str
+    text: str
+    caption: str = ""
+    table: TableProjection | None = None
+
+
+def _tag(element: Any) -> str:
+    return element.tag.rsplit("}", 1)[-1] if isinstance(element.tag, str) else ""
+
+
+def _all_text(element: Any) -> str:
+    """Return every rendered character under an element, joined by spaces.
+
+    Joined, never concatenated: concatenation fuses ``<label>Table 2</label>`` onto the
+    caption that follows it into a single bogus token, corrupting a token boundary at every
+    element boundary. Tables have the most boundaries, so an earlier version of the
+    alignment probe made them look unlocatable when they are not.
+    """
+    parts: list[str] = []
+
+    def visit(node: Any) -> None:
+        if _tag(node) in SKIPPED:
+            return
+        if node.text and node.text.strip():
+            parts.append(node.text.strip())
+        for child in node:
+            visit(child)
+            if child.tail and child.tail.strip():
+                parts.append(child.tail.strip())
+
+    visit(element)
+    return " ".join(parts)
+
+
+def _own_text(element: Any) -> str:
+    """Return an element's text *excluding* nested elements that are blocks in their own right.
+
+    JATS nests block material inside prose: a ``<table-wrap>`` or ``<disp-formula>`` sits
+    inside the ``<p>`` that introduces it. Taking the paragraph's full text swallowed the
+    table's caption and every cell into the paragraph, which fused three page objects into
+    one string, deleted the table from the ground truth entirely, and -- because the fused
+    block straddled the paragraph's page and the table's page -- placed it on the wrong one.
+    """
+    parts: list[str] = []
+
+    def visit(node: Any, *, root: bool) -> None:
+        tag = _tag(node)
+        if tag in SKIPPED or (not root and tag in BLOCKS):
+            return
+        if node.text and node.text.strip():
+            parts.append(node.text.strip())
+        for child in node:
+            visit(child, root=False)
+            if child.tail and child.tail.strip():
+                parts.append(child.tail.strip())
+
+    visit(element, root=True)
+    return " ".join(parts)
+
+
+def _nested_blocks(element: Any) -> list[Any]:
+    """Return block elements nested inside another block, in document order."""
+    found: list[Any] = []
+
+    def visit(node: Any) -> None:
+        for child in node:
+            tag = _tag(child)
+            if tag in SKIPPED:
+                continue
+            if tag in BLOCKS:
+                found.append(child)
+            else:
+                visit(child)
+
+    visit(element)
+    return found
+
+
+def _positive_span(value: str | None) -> int:
+    try:
+        span = int(value) if value is not None else 1
+    except ValueError:
+        return 1
+    return max(1, span)
+
+
+def _jats_table(table: Any) -> TableProjection:
+    """Project a JATS ``<table>`` with the same counting rules the HTML side uses.
+
+    Deliberately mirrors `benchmarks.omnidocbench.oracles._TableHTMLParser` rather than
+    inventing a second convention: a row count, the widest row by colspan, total occupied
+    slots, and cell text in row-major order. A test pins the two against each other, because
+    two table metrics that disagree would make the lanes incomparable in exactly the
+    dimension this one exists to exercise.
+    """
+    rows = 0
+    columns = 0
+    cell_slots = 0
+    cells: list[str] = []
+    for row in table.iter():
+        if _tag(row) != "tr":
+            continue
+        rows += 1
+        row_columns = 0
+        for cell in row:
+            if _tag(cell) not in {"td", "th"}:
+                continue
+            colspan = _positive_span(cell.get("colspan"))
+            row_columns += colspan
+            cell_slots += colspan * _positive_span(cell.get("rowspan"))
+            cells.append(_all_text(cell))
+        columns = max(columns, row_columns)
+    return TableProjection(rows=rows, columns=columns, cell_slots=cell_slots, text=" ".join(cells))
+
+
+def _caption_of(element: Any) -> str:
+    """Return a figure or table's label and caption as the page renders them together."""
+    parts = [_all_text(child) for child in element if _tag(child) in {"label", "caption"} and _all_text(child)]
+    return " ".join(parts)
+
+
+def _table_wrap(element: Any) -> JatsBlock:
+    table = next((child for child in element.iter() if _tag(child) == "table"), None)
+    projection = _jats_table(table) if table is not None else None
+    # Footnotes under the table are rendered beneath it, so they belong to the caption
+    # stream rather than to the cell text, which is compared against Table nodes.
+    foot = " ".join(_all_text(child) for child in element if _tag(child) == "table-wrap-foot")
+    caption = " ".join(part for part in (_caption_of(element), foot) if part)
+    if projection is None:
+        # A table-wrap with no table renders as a graphic plus its caption: real page
+        # content, but nothing a Table node could match. Scoring it as an empty table would
+        # punish a parser for the absence of something that was never there.
+        return JatsBlock(kind="text_block", text=caption, caption="")
+    return JatsBlock(kind="table", text=projection.text, caption=caption, table=projection)
+
+
+def walk(root: Any) -> Iterator[JatsBlock]:
+    """Yield every rendered block of a parsed JATS article in document order.
+
+    Parameters
+    ----------
+    root : xml.etree.ElementTree.Element
+        Parsed JATS article element.
+
+    Yields
+    ------
+    JatsBlock
+        Blocks in the order the article declares them.
+
+    """
+    tag = _tag(root)
+    if tag in SKIPPED:
+        return
+    kind = BLOCKS.get(tag)
+    if kind == "table":
+        yield _table_wrap(root)
+        return
+    if tag == "fig":
+        caption = _caption_of(root)
+        if caption:
+            yield JatsBlock(kind="text_block", text=caption)
+        return
+    if kind is not None:
+        # The element's own prose first, then whatever block material it contains. A page
+        # renders a floated table after the sentence that introduces it, so this is also
+        # the order the page shows them in.
+        text = _own_text(root)
+        if text:
+            yield JatsBlock(kind=kind, text=text)
+        for nested in _nested_blocks(root):
+            yield from walk(nested)
+        return
+    for child in root:
+        yield from walk(child)
+
+
+def to_projection(blocks: tuple[JatsBlock, ...]) -> PageProjection:
+    """Convert ground-truth blocks into the projection the shared oracle scores.
+
+    A table contributes two entries to the text stream -- its caption and its cell text --
+    matching the raster lane, where a caption is its own annotated detection and cell text
+    is appended beside the table. Formulas are deliberately empty: this corpus records
+    equations as MathML rather than LaTeX for 246 of 284 cases, and scoring MathML against
+    an AST's LaTeX representation would measure a notation gap rather than the parser.
+
+    Parameters
+    ----------
+    blocks : tuple[JatsBlock, ...]
+        Ground-truth blocks in document order.
+
+    Returns
+    -------
+    PageProjection
+        Comparable facts for `benchmarks.omnidocbench.oracles.score_page`.
+
+    """
+    text_blocks: list[str] = []
+    block_kinds: list[str] = []
+    tables: list[TableProjection] = []
+    for block in blocks:
+        if block.caption:
+            text_blocks.append(block.caption)
+            block_kinds.append("text_block")
+        if block.table is not None:
+            tables.append(block.table)
+            block_kinds.append("table")
+            text_blocks.append(block.table.text)
+        elif block.text:
+            text_blocks.append(block.text)
+            block_kinds.append(block.kind)
+    return PageProjection(
+        text_blocks=tuple(text_blocks),
+        block_kinds=tuple(block_kinds),
+        tables=tuple(tables),
+        formulas=(),
+    )
+
+
+def project_jats(root: Any) -> tuple[tuple[JatsBlock, ...], PageProjection]:
+    """Project a whole article, returning its blocks and their comparable projection.
+
+    Parameters
+    ----------
+    root : xml.etree.ElementTree.Element
+        Parsed JATS article element.
+
+    Returns
+    -------
+    tuple[tuple[JatsBlock, ...], PageProjection]
+        Blocks in document order, and the projection scored against an AST.
+
+    """
+    blocks = tuple(walk(root))
+    return blocks, to_projection(blocks)
+
+
+def coverage(projection: PageProjection, pdf_words: int) -> float:
+    """Return projected ground-truth words as a share of the PDF's own word count.
+
+    A ratio near 1 means the ground truth accounts for the page. Far below it, the article
+    renders text JATS never recorded and every content score carries an unearned penalty;
+    far above it, the projection is claiming text the page does not show. Reported rather
+    than asserted, because both directions are properties of the source.
+
+    Parameters
+    ----------
+    projection : PageProjection
+        Projected ground truth.
+    pdf_words : int
+        Whitespace-separated word count of the PDF's own text layer.
+
+    Returns
+    -------
+    float
+        Ground-truth words over PDF words, or ``0.0`` when the PDF has no text.
+
+    """
+    if pdf_words <= 0:
+        return 0.0
+    return len(normalize_text(" ".join(projection.text_blocks)).split()) / pdf_words

--- a/benchmarks/pmc/pages.py
+++ b/benchmarks/pmc/pages.py
@@ -1,0 +1,303 @@
+"""Project article-level JATS ground truth onto the PDF pages that render it.
+
+`benchmarks.pmc.alignment` established that this is possible -- 95.7% of blocks resolve to
+a page or an adjacent pair, measured with a mismatch control that puts false placement below
+1%. This module does the projection for real, and handles the three cases the probe only
+counted.
+
+**Blocks that cross a page break are split, not double-counted.** The decided policy is that
+a spanning block belongs to both its pages, but *belonging* to a page and *being scored
+whole against* it are different things: a paragraph broken across a break has half its text
+on each side, so scoring the whole paragraph against both pages would guarantee a mismatch
+on both. The split point comes from the same n-gram evidence as the placement -- the last
+token whose n-gram is still on the earlier page -- and when the token stream cannot be
+mapped back onto the raw text the block falls back to counting whole on both pages, which
+is counted rather than hidden.
+
+**Blocks too short to place inherit a page.** A section heading is three words; it has no
+five-grams, so containment cannot place it. It is first looked for as an exact phrase, which
+resolves the distinctive ones, and otherwise takes the page of the next block that *was*
+placed. Typesetting supports that fallback: a heading is kept with the text it introduces,
+so the next block's page is the heading's page except in the rare orphan.
+
+**Blocks that do not resolve are excluded and counted.** They are the lane's error budget.
+Dropping them silently would let the alignment's failures read as the parser's.
+"""
+
+from __future__ import annotations
+
+import re
+from collections import Counter
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Mapping, Sequence
+
+from benchmarks.pmc.alignment import NGRAM, ngrams, normalize, place_block, place_by_tokens
+from benchmarks.pmc.oracles import JatsBlock
+
+#: Word pattern used to map a token index back to a character offset in the raw text. It
+#: must agree with `benchmarks.pmc.alignment.normalize` on token *count*; when it does not,
+#: the split is abandoned rather than applied at the wrong place.
+_RAW_WORD = re.compile(r"[A-Za-z0-9]+")
+
+#: How a block came to sit on a page, plus the bucket for those that never did.
+ASSIGNMENTS = ("clean", "spans", "tokens", "phrase", "inherited", "excluded")
+
+
+@dataclass(frozen=True, slots=True)
+class PageText:
+    """One PDF page indexed both ways placement needs it.
+
+    Attributes
+    ----------
+    grams : set[tuple[str, ...]]
+        The page's token n-grams, for containment scoring.
+    phrase : str
+        The page's tokens joined by spaces, for exact-phrase search of blocks too short to
+        have n-grams.
+    tokens : set[str]
+        The page's distinct tokens, for the order-free fallback.
+
+    """
+
+    grams: set[tuple[str, ...]]
+    phrase: str
+    tokens: set[str]
+
+
+@dataclass(frozen=True, slots=True)
+class PlacedBlock:
+    """One ground-truth block assigned to one page.
+
+    Attributes
+    ----------
+    block : JatsBlock
+        The block, with ``text`` narrowed to the portion this page renders when it was split
+        across a page break.
+    order : int
+        Index in JATS document order, so a page's blocks can be restored to article order.
+    assignment : str
+        One of `ASSIGNMENTS`, never ``excluded``.
+
+    """
+
+    block: JatsBlock
+    order: int
+    assignment: str
+
+
+@dataclass(frozen=True, slots=True)
+class PageAssignment:
+    """Ground truth projected onto a PDF's pages.
+
+    Attributes
+    ----------
+    pages : tuple[tuple[PlacedBlock, ...], ...]
+        Blocks per page in JATS document order, one entry per PDF page.
+    assignments : Mapping[str, int]
+        Counts per `ASSIGNMENTS` category.
+    excluded : tuple[str, ...]
+        Placement verdicts of the blocks that could not be placed, in document order.
+    unsplit_spans : int
+        Spanning blocks counted whole on both pages because the split point could not be
+        mapped back onto the raw text.
+
+    """
+
+    pages: tuple[tuple[PlacedBlock, ...], ...]
+    assignments: Mapping[str, int]
+    excluded: tuple[str, ...]
+    unsplit_spans: int
+
+    @property
+    def placed(self) -> int:
+        """Blocks that reached at least one page."""
+        return sum(count for name, count in self.assignments.items() if name != "excluded")
+
+    @property
+    def error_budget(self) -> float:
+        """Share of blocks excluded because they would not resolve to a page."""
+        total = self.placed + self.assignments.get("excluded", 0)
+        return self.assignments.get("excluded", 0) / total if total else 0.0
+
+
+def index_pages(pdf_path: Path) -> tuple[PageText, ...]:
+    """Index every page of a PDF for placement.
+
+    Read with PyMuPDF directly rather than through all2md, so that what a page is held to
+    contain can never be changed by a parser change.
+
+    Parameters
+    ----------
+    pdf_path : pathlib.Path
+        PDF to index.
+
+    Returns
+    -------
+    tuple[PageText, ...]
+        One entry per page, in page order.
+
+    """
+    import fitz
+
+    with fitz.open(pdf_path) as document:
+        indexed = []
+        for page in document:
+            tokens = normalize(page.get_text())
+            indexed.append(PageText(grams=ngrams(tokens), phrase=" ".join(tokens), tokens=set(tokens)))
+        return tuple(indexed)
+
+
+def _split_at_token(text: str, token_index: int) -> tuple[str, str] | None:
+    """Split raw text after its ``token_index``-th word, or ``None`` if that cannot be found.
+
+    Parameters
+    ----------
+    text : str
+        Raw block text.
+    token_index : int
+        Number of leading tokens that belong to the earlier page.
+
+    Returns
+    -------
+    tuple[str, str] or None
+        Earlier and later portions, or ``None`` when the raw word count disagrees with the
+        normalized token count, which would put the offset in the wrong place.
+
+    """
+    matches = list(_RAW_WORD.finditer(text))
+    if len(matches) != len(normalize(text)) or not 0 < token_index < len(matches):
+        return None
+    cut = matches[token_index - 1].end()
+    return text[:cut].strip(), text[cut:].strip()
+
+
+def _spanning_split(block: JatsBlock, early: set[tuple[str, ...]]) -> tuple[str, str] | None:
+    """Find where a spanning block leaves the earlier page.
+
+    Parameters
+    ----------
+    block : JatsBlock
+        Block whose placement verdict was ``spans``.
+    early : set[tuple[str, ...]]
+        N-grams of the earlier of its two pages.
+
+    Returns
+    -------
+    tuple[str, str] or None
+        Text rendered on the earlier and on the later page, or ``None`` if the block cannot
+        be split reliably.
+
+    """
+    tokens = normalize(block.text)
+    last_on_early = -1
+    for index in range(len(tokens) - NGRAM + 1):
+        if tuple(tokens[index : index + NGRAM]) in early:
+            last_on_early = index
+    if last_on_early < 0:
+        return None
+    return _split_at_token(block.text, min(last_on_early + NGRAM, len(tokens)))
+
+
+def _phrase_page(block: JatsBlock, pages: Sequence[PageText]) -> int | None:
+    """Return the only page containing a short block verbatim, if exactly one does."""
+    phrase = " ".join(normalize(block.text))
+    if not phrase:
+        return None
+    hits = [index for index, page in enumerate(pages) if phrase in page.phrase]
+    return hits[0] if len(hits) == 1 else None
+
+
+def assign_pages(blocks: Sequence[JatsBlock], pages: Sequence[PageText]) -> PageAssignment:
+    """Project ground-truth blocks onto the pages that render them.
+
+    Parameters
+    ----------
+    blocks : Sequence[JatsBlock]
+        Ground-truth blocks in JATS document order.
+    pages : Sequence[PageText]
+        Indexed pages from `index_pages`.
+
+    Returns
+    -------
+    PageAssignment
+        Blocks per page, with the accounting for everything that did not place.
+
+    """
+    grams = [page.grams for page in pages]
+    buckets: list[list[PlacedBlock]] = [[] for _ in pages]
+    counts: Counter[str] = Counter()
+    excluded: list[str] = []
+    unsplit = 0
+    #: Short blocks waiting for the next placed block to tell them which page they are on.
+    pending: list[tuple[int, JatsBlock]] = []
+
+    def flush(page: int | None) -> None:
+        nonlocal pending
+        for order, block in pending:
+            if page is None:
+                counts["excluded"] += 1
+                excluded.append("too_short")
+            else:
+                buckets[page].append(PlacedBlock(block, order, "inherited"))
+                counts["inherited"] += 1
+        pending = []
+
+    token_sets = [page.tokens for page in pages]
+    for order, block in enumerate(blocks):
+        tokens = normalize(block.text)
+        placement = place_block(ngrams(tokens), grams)
+        if placement.verdict == "too_short":
+            page = _phrase_page(block, pages)
+            if page is None:
+                pending.append((order, block))
+                continue
+            buckets[page].append(PlacedBlock(block, order, "phrase"))
+            counts["phrase"] += 1
+            continue
+        if placement.verdict == "missing":
+            # Word order, not presence: a structured citation lists its fields in an order
+            # the page does not print, so it holds no n-gram in common with a page that
+            # renders every one of its words.
+            page = place_by_tokens(tokens, token_sets)
+            if page is not None:
+                flush(page)
+                buckets[page].append(PlacedBlock(block, order, "tokens"))
+                counts["tokens"] += 1
+                continue
+        if placement.page is None or placement.verdict in {"missing", "split"}:
+            counts["excluded"] += 1
+            excluded.append(placement.verdict)
+            continue
+        if placement.verdict == "spans" and placement.runner_up_page is not None:
+            flush(placement.page)
+            early, late = placement.page, placement.runner_up_page
+            split = _spanning_split(block, grams[early])
+            if split is None:
+                unsplit += 1
+                buckets[early].append(PlacedBlock(block, order, "spans"))
+                buckets[late].append(PlacedBlock(block, order, "spans"))
+            else:
+                head, tail = split
+                # The table's structure stays with the earlier page: splitting a
+                # TableProjection would invent a shape that neither page renders.
+                buckets[early].append(
+                    PlacedBlock(JatsBlock(block.kind, head, block.caption, block.table), order, "spans")
+                )
+                buckets[late].append(PlacedBlock(JatsBlock("text_block", tail, "", None), order, "spans"))
+            counts["spans"] += 1
+            continue
+        flush(placement.page)
+        buckets[placement.page].append(PlacedBlock(block, order, "clean"))
+        counts["clean"] += 1
+
+    # Short blocks trailing the last placed block have no successor to inherit from.
+    flush(None)
+    for bucket in buckets:
+        bucket.sort(key=lambda placed: placed.order)
+    return PageAssignment(
+        pages=tuple(tuple(bucket) for bucket in buckets),
+        assignments={name: counts.get(name, 0) for name in ASSIGNMENTS},
+        excluded=tuple(excluded),
+        unsplit_spans=unsplit,
+    )

--- a/tests/unit/test_pmc_oracle.py
+++ b/tests/unit/test_pmc_oracle.py
@@ -309,6 +309,14 @@ def test_recall_falls_when_the_parser_loses_recoverable_text() -> None:
     assert report.attainable_recall == pytest.approx(0.0)
 
 
+def test_a_single_article_reports_no_control_rather_than_a_flattering_zero() -> None:
+    """With nothing to mismatch against, 0.0% would read exactly like a passing control."""
+    text = "the participants completed every session of the supervised training programme"
+    report = article.measure_recall([("A", [("text_block", text)], text, text)])
+    assert report.control_scored == 0
+    assert report.control_recall == 0.0
+
+
 def test_recall_collapses_against_a_different_article() -> None:
     """A recall figure means nothing unless the same method fails on the wrong document."""
     first = "the participants completed every session of the supervised training programme"

--- a/tests/unit/test_pmc_oracle.py
+++ b/tests/unit/test_pmc_oracle.py
@@ -1,0 +1,403 @@
+"""Tests for the PMC born-digital oracle: JATS projection, page assignment, and its controls.
+
+Several of these pin findings rather than code. Where a test's name states a measured fact,
+the fact was measured first and the behaviour written to match it -- not the other way round.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+from xml.etree import ElementTree
+
+import pytest
+
+from benchmarks.pmc import alignment, article, benchmark, convert, oracles, pages
+
+pytestmark = pytest.mark.unit
+
+
+def _jats(body: str) -> Any:
+    return ElementTree.fromstring(f"<article><body>{body}</body></article>")
+
+
+# ---------------------------------------------------------------------------
+# Ground-truth projection
+# ---------------------------------------------------------------------------
+
+
+def test_a_table_nested_in_a_paragraph_is_its_own_block() -> None:
+    """JATS nests floats inside prose, and swallowing them corrupted three things at once.
+
+    Taking a ``<p>``'s full text fused the paragraph, the caption and every cell into one
+    string: the table vanished from the ground truth, the caption stopped being its own
+    page object, and the fused block straddled the paragraph's page and the table's page so
+    it was placed on the wrong one.
+    """
+    root = _jats(
+        "<p>Results appear in <xref>Table 1</xref>."
+        "<table-wrap><label>Table 1</label><caption><p>Characteristics</p></caption>"
+        "<table><tr><th>Group</th><th>N</th></tr><tr><td>Control</td><td>15</td></tr></table>"
+        "</table-wrap></p>"
+    )
+    blocks, projection = oracles.project_jats(root)
+
+    prose = [block for block in blocks if block.kind == "text_block"]
+    tables = [block for block in blocks if block.kind == "table"]
+    assert len(tables) == 1
+    assert tables[0].table is not None
+    assert tables[0].table.rows == 2
+    # The paragraph keeps its own words and the cross-reference, and none of the table's.
+    assert prose[0].text == "Results appear in Table 1 ."
+    assert "Characteristics" not in prose[0].text
+    assert "Control" not in prose[0].text
+    # Caption and cell text reach the text stream as separate page objects.
+    assert "Table 1 Characteristics" in projection.text_blocks
+    assert any("Control" in block for block in projection.text_blocks)
+
+
+def test_cross_reference_text_is_kept_because_the_page_prints_it() -> None:
+    blocks, _ = oracles.project_jats(_jats("<p>See <xref ref-type='table'>Table 3</xref> for detail.</p>"))
+    assert blocks[0].text == "See Table 3 for detail."
+
+
+def test_unrendered_metadata_never_reaches_the_text_stream() -> None:
+    root = ElementTree.fromstring(
+        "<article><front><article-meta>"
+        "<article-id>10.1000/xyz</article-id><counts><page-count count='9'/></counts>"
+        "<title-group><article-title>Real Title</article-title></title-group>"
+        "</article-meta></front></article>"
+    )
+    _, projection = oracles.project_jats(root)
+    joined = " ".join(projection.text_blocks)
+    assert "Real Title" in joined
+    assert "10.1000/xyz" not in joined
+
+
+def test_jats_and_html_tables_are_counted_identically() -> None:
+    """The two lanes must not measure table shape differently, or they are incomparable."""
+    from benchmarks.omnidocbench.oracles import _html_table
+
+    markup = (
+        "<table><tr><th colspan='2'>Head</th></tr>"
+        "<tr><td rowspan='2'>A</td><td>B</td></tr><tr><td>C</td></tr></table>"
+    )
+    jats = oracles._jats_table(ElementTree.fromstring(markup))
+    html = _html_table(markup)
+    assert (jats.rows, jats.columns, jats.cell_slots) == (html.rows, html.columns, html.cell_slots)
+    assert jats.text == html.text
+
+
+def test_a_table_wrap_without_a_table_is_not_scored_as_an_empty_table() -> None:
+    """It renders as a graphic and a caption; an empty Table would punish a parser for nothing."""
+    blocks, projection = oracles.project_jats(
+        _jats("<table-wrap><label>Table 2</label><caption><p>Only an image</p></caption></table-wrap>")
+    )
+    assert projection.tables == ()
+    assert blocks[0].kind == "text_block"
+    assert "Only an image" in blocks[0].text
+
+
+def test_element_text_is_joined_not_concatenated() -> None:
+    """Concatenation fused ``<label>Table 2</label>`` onto its caption as one bogus token."""
+    blocks, _ = oracles.project_jats(_jats("<p><italic>Table 2</italic>obtained results</p>"))
+    assert "2obtained" not in blocks[0].text
+
+
+def test_coverage_reports_ground_truth_against_the_page_rather_than_assuming_it() -> None:
+    _, projection = oracles.project_jats(_jats("<p>one two three four</p>"))
+    assert oracles.coverage(projection, pdf_words=4) == pytest.approx(1.0)
+    assert oracles.coverage(projection, pdf_words=8) == pytest.approx(0.5)
+    assert oracles.coverage(projection, pdf_words=0) == 0.0
+
+
+# ---------------------------------------------------------------------------
+# Page boundaries
+# ---------------------------------------------------------------------------
+
+
+def _document(*children: Any) -> Any:
+    from all2md.ast.nodes import Document
+
+    return Document(children=list(children))
+
+
+def _separator(page_num: int, total: int) -> Any:
+    from all2md.ast.nodes import Comment
+
+    return Comment(
+        content=convert.PAGE_SEPARATOR_TEMPLATE.format(page_num=page_num, total_pages=total),
+        metadata={"comment_type": "page_separator"},
+    )
+
+
+def _paragraph(text: str) -> Any:
+    from all2md.ast.nodes import Paragraph, Text
+
+    return Paragraph(content=[Text(content=text)])
+
+
+def test_pages_are_recovered_from_one_conversion() -> None:
+    document = _document(_paragraph("one"), _separator(1, 3), _paragraph("two"), _separator(2, 3), _paragraph("three"))
+    recovered = convert.split_pages(document, 3)
+    assert [len(page.children) for page in recovered] == [1, 1, 1]
+
+
+def test_a_dropped_page_is_an_error_rather_than_a_silent_shift() -> None:
+    """Without this the parser's missing page would shift every later page's ground truth."""
+    document = _document(_paragraph("one"), _separator(1, 3), _paragraph("two"))
+    with pytest.raises(convert.PageBoundaryError, match="2 page group"):
+        convert.split_pages(document, 3)
+
+
+def test_out_of_order_separators_are_an_error() -> None:
+    document = _document(_paragraph("one"), _separator(2, 3), _paragraph("two"), _separator(1, 3), _paragraph("x"))
+    with pytest.raises(convert.PageBoundaryError, match="not consecutive"):
+        convert.split_pages(document, 3)
+
+
+def test_an_unrecognized_separator_is_an_error() -> None:
+    from all2md.ast.nodes import Comment
+
+    document = _document(
+        _paragraph("one"),
+        Comment(content="-----", metadata={"comment_type": "page_separator"}),
+        _paragraph("two"),
+    )
+    with pytest.raises(convert.PageBoundaryError, match="unparsable"):
+        convert.split_pages(document, 2)
+
+
+def test_the_lane_leaves_ocr_enabled_so_a_non_born_digital_corpus_would_say_so() -> None:
+    options = convert.pdf_options()
+    assert options.ocr.enabled is True
+    assert options.ocr.mode == "auto"
+    assert options.include_page_numbers is True
+
+
+# ---------------------------------------------------------------------------
+# Placement
+# ---------------------------------------------------------------------------
+
+
+def _page(text: str) -> pages.PageText:
+    tokens = alignment.normalize(text)
+    return pages.PageText(grams=alignment.ngrams(tokens), phrase=" ".join(tokens), tokens=set(tokens))
+
+
+def test_token_placement_finds_a_block_whose_word_order_the_page_does_not_print() -> None:
+    """A structured citation lists its fields in an order the rendered page never uses."""
+    citation = "Ferlay J Soerjomataram I Int J Cancer 2015 10.1002/ijc.29210"
+    rendered = _page("Ferlay J, Soerjomataram I, et al. Int J Cancer. 2015. doi:10.1002/ijc.29210")
+    tokens = alignment.normalize(citation)
+
+    assert alignment.place_block(alignment.ngrams(tokens), [rendered.grams]).verdict == "missing"
+    assert alignment.place_by_tokens(tokens, [rendered.tokens]) == 0
+
+
+def test_token_placement_refuses_a_page_that_holds_too_little() -> None:
+    tokens = alignment.normalize("alpha beta gamma delta epsilon zeta eta theta")
+    assert alignment.place_by_tokens(tokens, [_page("alpha beta unrelated words here").tokens]) is None
+
+
+def test_token_placement_refuses_a_block_with_too_few_distinct_words() -> None:
+    """Below a handful of words a bag is not distinctive enough to name a page."""
+    tokens = alignment.normalize("the the results")
+    assert alignment.place_by_tokens(tokens, [_page("the results section follows here").tokens]) is None
+
+
+def test_token_placement_breaks_ties_toward_the_earliest_page() -> None:
+    tokens = alignment.normalize("alpha beta gamma delta epsilon")
+    page = _page("alpha beta gamma delta epsilon")
+    assert alignment.place_by_tokens(tokens, [page.tokens, page.tokens, page.tokens]) == 0
+
+
+def test_a_block_crossing_a_page_break_is_split_rather_than_counted_whole_twice() -> None:
+    """Counting it whole on both pages would guarantee a mismatch on both."""
+    head = "the quick brown fox jumps over the lazy dog and keeps running onward"
+    tail = "through the tall wet grass until it reaches the far riverbank at dusk"
+    block = oracles.JatsBlock(kind="text_block", text=f"{head} {tail}")
+    assigned = pages.assign_pages([block], [_page(head), _page(tail)])
+
+    assert assigned.assignments["spans"] == 1
+    first, second = assigned.pages[0][0].block.text, assigned.pages[1][0].block.text
+    assert first.startswith("the quick brown fox")
+    assert second.endswith("far riverbank at dusk")
+    # The whole block appears on neither page on its own.
+    assert first != block.text and second != block.text
+
+
+def test_a_split_that_cannot_be_mapped_back_is_counted_rather_than_applied_wrongly() -> None:
+    """De-hyphenation makes one token out of two words, so the raw offset would be wrong."""
+    assert pages._split_at_token("run-\nning water", token_index=1) is None
+
+
+def test_a_short_block_is_placed_by_a_phrase_that_only_one_page_carries() -> None:
+    block = oracles.JatsBlock(kind="title", text="Statistical Analysis")
+    assigned = pages.assign_pages(
+        [block],
+        [_page("introduction and background material"), _page("statistical analysis was performed")],
+    )
+    assert assigned.assignments["phrase"] == 1
+    assert assigned.pages[1][0].assignment == "phrase"
+
+
+def test_a_short_block_on_no_unique_page_takes_the_page_of_what_it_introduces() -> None:
+    """A heading is kept with the text it introduces, so its successor's page is its own."""
+    heading = oracles.JatsBlock(kind="title", text="Results")
+    body = oracles.JatsBlock(
+        kind="text_block",
+        text="participants completed the protocol without any reported adverse events at all",
+    )
+    assigned = pages.assign_pages(
+        [heading, body],
+        [
+            # "Results" appears on both pages, so no phrase uniquely identifies one.
+            _page("results were mixed across every measured outcome results"),
+            _page("results participants completed the protocol without any reported adverse events at all"),
+        ],
+    )
+    assert [placed.assignment for placed in assigned.pages[1]] == ["inherited", "clean"]
+    assert assigned.pages[0] == ()
+
+
+def test_a_short_block_with_nothing_after_it_is_excluded_rather_than_guessed() -> None:
+    trailing = oracles.JatsBlock(kind="title", text="Results")
+    assigned = pages.assign_pages([trailing], [_page("results here"), _page("results there")])
+    assert assigned.assignments["excluded"] == 1
+    assert assigned.excluded == ("too_short",)
+
+
+def test_unplaceable_blocks_are_counted_as_an_error_budget_not_dropped() -> None:
+    present = oracles.JatsBlock(kind="text_block", text="alpha beta gamma delta epsilon zeta eta theta iota")
+    absent = oracles.JatsBlock(kind="text_block", text="wholly unrelated wording nowhere near this document at all")
+    assigned = pages.assign_pages([present, absent], [_page("alpha beta gamma delta epsilon zeta eta theta iota")])
+    assert assigned.assignments["excluded"] == 1
+    assert assigned.error_budget == pytest.approx(0.5)
+
+
+# ---------------------------------------------------------------------------
+# Article-level recall
+# ---------------------------------------------------------------------------
+
+
+def test_recall_is_reported_against_what_the_pdf_can_actually_yield() -> None:
+    """39% of this corpus's blocks are unreachable for any parser, so raw recall misleads."""
+    reachable = "the participants completed every session of the supervised training programme"
+    unreachable = "Ferlay J Soerjomataram I Int J Cancer 2015"
+    report = article.measure_recall(
+        [
+            (
+                "A",
+                [("text_block", reachable), ("text_block", unreachable)],
+                reachable,
+                reachable,
+            ),
+        ]
+    )
+    assert report.scored == 2
+    assert report.ceiling == pytest.approx(0.5)
+    assert report.recall == pytest.approx(0.5)
+    # All of what was available was recovered, even though raw recall reads as half.
+    assert report.attainable_recall == pytest.approx(1.0)
+
+
+def test_recall_falls_when_the_parser_loses_recoverable_text() -> None:
+    reachable = "the participants completed every session of the supervised training programme"
+    report = article.measure_recall([("A", [("text_block", reachable)], "nothing useful here", reachable)])
+    assert report.ceiling == pytest.approx(1.0)
+    assert report.attainable_recall == pytest.approx(0.0)
+
+
+def test_recall_collapses_against_a_different_article() -> None:
+    """A recall figure means nothing unless the same method fails on the wrong document."""
+    first = "the participants completed every session of the supervised training programme"
+    second = "vector drawings were counted on each page of the publisher issued document"
+    report = article.measure_recall(
+        [("A", [("text_block", first)], first, first), ("B", [("text_block", second)], second, second)]
+    )
+    assert report.recall == pytest.approx(1.0)
+    assert report.control_recall == pytest.approx(0.0)
+
+
+# ---------------------------------------------------------------------------
+# Controls that qualify the scores
+# ---------------------------------------------------------------------------
+
+
+def _projection(*blocks: str) -> Any:
+    from benchmarks.omnidocbench.oracles import PageProjection
+
+    return PageProjection(
+        text_blocks=tuple(blocks),
+        block_kinds=tuple("text_block" for _ in blocks),
+        tables=(),
+        formulas=(),
+    )
+
+
+def test_every_mutation_actually_damages_the_output_it_is_given() -> None:
+    """A control that does not change anything cannot show that a score can fail."""
+    original = _projection("alpha", "beta", "gamma", "delta")
+    assert benchmark.MUTATIONS["reversed"](original).text_blocks == ("delta", "gamma", "beta", "alpha")
+    assert benchmark.MUTATIONS["halved"](original).text_blocks == ("alpha", "gamma")
+    assert benchmark.MUTATIONS["shuffled"](original).text_blocks != original.text_blocks
+
+
+def test_shuffling_is_seeded_so_two_runs_are_comparable() -> None:
+    original = _projection(*(f"block {index}" for index in range(12)))
+    assert benchmark.MUTATIONS["shuffled"](original) == benchmark.MUTATIONS["shuffled"](original)
+
+
+def test_block_structure_is_recorded_but_marked_unusable_as_a_gate() -> None:
+    """It rises when half the content is deleted, so gating on it would reward dropping blocks."""
+    assert "block_structure_similarity" in benchmark.UNGATEABLE
+
+
+def test_a_dimension_carries_its_control_and_its_mutation_drops() -> None:
+    page = benchmark.PageEvaluation(
+        article_id="PMC1.1",
+        page=0,
+        scores={"text_content_similarity": 0.8},
+        control_scores={"text_content_similarity": 0.2},
+        mutated={name: {"text_content_similarity": 0.3} for name in benchmark.MUTATIONS},
+        truth_blocks=3,
+        truth_tables=0,
+        emitted_blocks=3,
+        emitted_tables=0,
+    )
+    summary = benchmark._dimension([page], "text_content_similarity")
+    assert summary is not None
+    assert summary["discrimination"] == pytest.approx(0.6)
+    assert summary["mutation_drop"]["reversed"] == pytest.approx(0.5)
+
+
+def test_page_scores_and_the_error_budget_come_from_the_same_run(tmp_path: Path) -> None:
+    """The excluded blocks must be reported beside the scores they were excluded from."""
+    payload = benchmark.normalize_results(
+        snapshot=type(
+            "Snapshot",
+            (),
+            {"manifest_sha256": "a" * 64, "bucket": "b", "complete": True, "expected_articles": 1},
+        )(),
+        evaluations=[
+            benchmark.ArticleEvaluation(
+                article_id="PMC1.1",
+                pages=(),
+                assignments={"clean": 9, "excluded": 1},
+                unsplit_spans=0,
+                excluded={"missing": 1},
+                coverage=1.0,
+                ocr_page_fraction=0.0,
+                degraded_kinds=(),
+                duration_seconds=0.1,
+                ground_truth_blocks=10,
+            )
+        ],
+        recall=article.measure_recall([]),
+        all2md_commit="deadbeef",
+        parser_runtime={},
+    )
+    assert payload["projection"]["error_budget"] == pytest.approx(0.1)
+    assert payload["projection"]["excluded_reasons"] == {"missing": 1}
+    assert payload["ocr_articles"] == []


### PR DESCRIPTION
Builds the step-3 oracle over the PMC corpus landed in #281. Each article is converted once and every page scored against the JATS truth projected onto it, **through the same oracle the OmniDocBench lane uses** — the metric definitions each carry a calibration story that took a corpus to settle, and reusing them is what makes a number here mean what a number there means.

```bash
.venv/Scripts/python.exe -m benchmarks.pmc score --limit 8
.venv/Scripts/python.exe -m benchmarks.pmc score --out result.json
```

## Three design decisions were reversed by measurement

**The plan called for a whole-article endpoint with a larger denominator. It cannot be built with these metrics.** The shared oracle counts a ground-truth block as *found* once half its characters align monotonically — sound over a page, inoperative over an article. **77–86% of one article's blocks "locate" inside a completely different article's output**, at median alignment 0.62–0.72 against 0.93–1.00 for their own. The safeguard that stops absent content from earning reading-order credit does not survive the length. Reading order is scored per page only.

**Page order is not scored, because it cannot fail.** Page attribution comes from the parser's own per-page loop, so content cannot migrate between page groups and a dropped page raises rather than scoring. A page-sequence metric would be perfect by construction. The cross-page blindness that motivated an article-level endpoint is handled structurally instead.

**Ordering ground truth by position on the page — the obvious fix for floats — is worse than JATS order.** Within a page, JATS puts a floated table where the prose cites it, not where it renders, which costs real score. Ordering blocks by where their text appears in the page's own token stream disagrees with JATS on **25% of block pairs** and makes **every dimension worse** (reading order 0.748 → 0.663). PyMuPDF's extraction order is not rendered reading order, and grading against it would punish correct column handling. JATS order stays; the float cost is a documented bias.

## One calibrated addition

N-gram containment assumes the page prints a block's words in the order JATS declares them. Structured markup breaks that without changing a single word — an `<element-citation>` lists the journal before the authors, so a citation *fully present on its page* scores zero containment. A token-containment fallback at a 0.65 share:

| | |
| --- | --- |
| recovers of the n-gram misses | **89.1%** |
| agrees with n-gram placement where that is already confident | **99.0%** |
| places onto a **different article's** pages | **0.6%** |

Raising the threshold to 0.85 buys nothing and gives up half the recoveries. Kept as a separate rule from `place_block` so the feasibility numbers in #281 still describe what they measured.

## A projection bug, found by reading one page

JATS nests `<table-wrap>` inside the `<p>` that introduces it. Taking the paragraph's full text fused the paragraph, the caption and every cell into one string — the table vanished from the ground truth, the caption stopped being its own page object, and the fused block straddled two pages and was placed on the wrong one. No aggregate showed this; reading a single page's truth beside its output did.

## Raw recall is unreadable without its ceiling

Only **61.1%** of JATS blocks are recoverable from the PDF's text layer **by any parser**, because structured citations and bylines record words in an order the page never prints. So a raw 54.6% recall is **88.9% of what was available**, not a parser losing half the document. The ceiling is recomputed every run.

## Controls that ship inside the run

- **Mismatch** — every page scored again against the *next page of the same article*, a harder confounder than a different article.
- **Mutation** — every page scored against reversed, scrambled and halved output. This is how `block_structure_similarity` was found to *rise* when half the content is deleted; it is reported but flagged `ungateable`.
- **Input shape** — OCR left enabled in auto mode, so "no page needed OCR" stays a measurement that could fail rather than a configuration.

Blocks that will not resolve to a page are **excluded and reported** as an error budget printed with every run.

No gate or baseline is recorded here — that follows once the full-corpus numbers are read.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
