### PR TITLE
Run the PMC born-digital lane on a monthly schedule

### DIFF
--- a/.github/workflows/pmc-borndigital.yml
+++ b/.github/workflows/pmc-borndigital.yml
@@ -1,0 +1,109 @@
+name: PMC Born-Digital Fidelity
+
+# Scores all2md against publisher PDFs with JATS ground truth, page by page. This is the
+# born-digital counterpart to the OmniDocBench lane: that corpus is 981 rasters, so it
+# measures the OCR path and its PDF table path never runs at all.
+#
+# Modelled on omnidocbench-gate.yml rather than on the Corpus Benchmark, because the two
+# external-ground-truth lanes share a corpus that is pinned rather than resolved live, the
+# same oracle, and the same runtime-identity problem: the ratchet compares against a recorded
+# baseline, so a resolver free to move PyMuPDF or a runner image free to change the system
+# Tesseract would report drift instead of fidelity. The lockfile and the image are part of
+# the measurement.
+#
+# NOT gated yet, deliberately. The first full run reports a median of 0.000 on both table
+# dimensions -- all2md finds born-digital tables and rejects them, logging 76 table_rejected
+# events while recovering their cell text at 96.5%. Recording a baseline now would ratchet
+# that floor in as accepted. This lane publishes evidence until that is fixed or explicitly
+# accepted; gating is a separate change.
+#
+# Also not on per-PR CI: a full run is over an hour of CPU, most of it OCR, and it downloads
+# ~146 MB from the PMC Open Access bucket.
+
+on:
+  schedule:
+    # 06:00 UTC on the 15th. Monthly for the same reason as the OmniDocBench lane -- the
+    # corpus is pinned by a committed manifest, so the only thing that changes between runs
+    # is our code -- and mid-month rather than on the 1st so the two external lanes report a
+    # fortnight apart instead of on the same morning.
+    - cron: "0 6 15 * *"
+  workflow_dispatch:
+    inputs:
+      limit:
+        description: "Score an evenly spaced subset of this many articles (blank = all 66)"
+        required: false
+        default: ""
+        type: string
+
+concurrency:
+  group: pmc-borndigital-${{ github.ref }}-${{ github.event_name }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  fidelity:
+    name: PMC Born-Digital Fidelity
+    runs-on: ubuntu-24.04
+    timeout-minutes: 180
+
+    steps:
+      - name: Check out all2md
+        uses: actions/checkout@v7
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          python-version: "3.12"
+          enable-cache: true
+
+      # OCR is left enabled in auto mode rather than switched off: on a corpus characterized
+      # as 0.0% scan-shaped it should never fire, and "never fired" is only worth having as a
+      # measurement that could have failed. It fires on 11 of 66 articles, so Tesseract is a
+      # real dependency here and not a formality.
+      - name: Install OCR language data
+        run: |
+          sudo apt-get update
+          sudo apt-get install --yes tesseract-ocr tesseract-ocr-eng
+
+      - name: Install all2md from the lockfile
+        run: uv sync --frozen --extra pdf_layout --extra ocr
+
+      - name: Score the corpus
+        run: |
+          ARGS=(--out benchmarks/pmc/.cache/results/current.json --commit "${GITHUB_SHA}")
+          if [ -n "${LIMIT}" ]; then
+            ARGS+=(--limit "${LIMIT}")
+          fi
+          uv run --frozen --extra pdf_layout --extra ocr python -m benchmarks.pmc score "${ARGS[@]}" \
+            | tee "${RUNNER_TEMP}/pmc-summary.txt"
+        env:
+          LIMIT: ${{ inputs.limit }}
+
+      # The artifact alone is easy to ignore, and this lane's whole point is that somebody
+      # reads the numbers beside their controls.
+      - name: Append the reading to the job summary
+        if: always()
+        run: |
+          {
+            echo '### PMC born-digital fidelity'
+            echo
+            echo '```'
+            cat "${RUNNER_TEMP}/pmc-summary.txt" || echo "no summary produced"
+            echo '```'
+          } >> "${GITHUB_STEP_SUMMARY}"
+
+      - name: Upload derived scores
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: pmc-borndigital-scores-${{ github.run_number }}
+          # Results live under the gitignored `.cache/` directory, and this action skips
+          # anything inside a dot-directory unless hidden files are opted in. Without this the
+          # upload silently produces an empty artifact. Only derived score JSON is matched;
+          # the article PDFs sit in the digest-keyed corpus directory beside it.
+          include-hidden-files: true
+          path: benchmarks/pmc/.cache/results/*.json
+          if-no-files-found: error
+          retention-days: 14


### PR DESCRIPTION
Gives the born-digital lane from #282 a home. Not on per-PR CI: a full run is **over an hour of CPU**, most of it OCR, plus a ~146 MB download from the PMC Open Access bucket.

## Why beside the OmniDocBench gate rather than the Corpus Benchmark

The two external-ground-truth lanes have the same shape and the same failure mode. Both score against a corpus **pinned** rather than resolved live, both go through the same oracle, and both compare against a recorded baseline — so a resolver free to move PyMuPDF, or a runner image free to change the system Tesseract, would report runtime drift instead of a fidelity result. That is why this copies `omnidocbench-gate.yml`'s `uv sync --frozen` and pinned `ubuntu-24.04` image rather than `ubuntu-latest` and pip.

The Corpus Benchmark (`benchmark.yml`) is `workflow_dispatch`-only and reports rather than ratchets, and the Corpus Fidelity Gate deliberately excludes its non-reproducible sources and budgets 90 minutes — tight against a run this long that also has to install Tesseract.

**Mid-month rather than the 1st**, so the two external lanes report a fortnight apart instead of on the same morning.

## Deliberately not gated

The first full run reports a **median of 0.000 on both table dimensions**. Recording a baseline now would ratchet that floor in as accepted. This publishes the reading to the job summary and an artifact until the table rejection is fixed or explicitly accepted.

Gating is a separate change and needs work first: `benchmarks/omnidocbench/gate.py` is not corpus-agnostic — `_IDENTITY_FIELDS` hardcodes `provenance.dataset_revision` and `provenance.annotation_sha256` (this lane has `corpus_pin`), and `_PAGE_FIELDS` requires a `pages` mapping with `annotations`/`pdfs`/`unique_ids`, which are annotation-shaped fields that do not mean anything for articles.

## Notes

- OCR stays **enabled in auto mode**, so Tesseract is a real dependency here rather than a formality — it fires on 11 of 66 articles.
- `workflow_dispatch` takes a `limit` input for a quick evenly spaced subset, which matters given the runtime.
- `include-hidden-files: true` on the upload, because results land under the gitignored `.cache/` and the action otherwise produces a silently empty artifact — the same trap the OmniDocBench lane hit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
