### PR TITLE
Recover borderless tables from layout-predicted regions

### DIFF
--- a/.github/workflows/pmc-borndigital.yml
+++ b/.github/workflows/pmc-borndigital.yml
@@ -11,11 +11,13 @@ name: PMC Born-Digital Fidelity
 # Tesseract would report drift instead of fidelity. The lockfile and the image are part of
 # the measurement.
 #
-# NOT gated yet, deliberately. The first full run reports a median of 0.000 on both table
-# dimensions -- all2md finds born-digital tables and rejects them, logging 76 table_rejected
-# events while recovering their cell text at 96.5%. Recording a baseline now would ratchet
-# that floor in as accepted. This lane publishes evidence until that is fixed or explicitly
-# accepted; gating is a separate change.
+# NOT gated yet, deliberately. The first full run reported a median of 0.000 on both table
+# dimensions: the default find_tables() strategy needs ruling lines on both axes, and journal
+# tables are booktabs-style, so it recovered 0 of 31 layout-predicted table regions. Text-
+# alignment detection now recovers a share of them, but the fix is deliberately conservative
+# -- it refuses any grid whose columns cut through words -- and the medians are still 0.000.
+# Recording a baseline now would ratchet that floor in as accepted. This lane publishes
+# evidence until that improves or is explicitly accepted; gating is a separate change.
 #
 # Also not on per-PR CI: a full run is over an hour of CPU, most of it OCR, and it downloads
 # ~146 MB from the PMC Open Access bucket.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Borderless tables in layout-predicted regions are recovered instead of being emitted as
+  prose.** With layout analysis on (`pdf_layout`), a region the layout model predicts to be a
+  table was searched with PyMuPDF's default `find_tables()` strategy, which requires ruling
+  lines on both axes. Journal tables are typically booktabs-style — horizontal rules only, or
+  none — so the search found nothing and the region was demoted to a paragraph. On the PMC
+  born-digital corpus that was **0 of 31** such regions recovered. The parser's own
+  `layout_region_not_tabular` telemetry made this look like guards rejecting tables they had
+  found; instrumenting the branch showed no grid was ever found to reject, and that the event
+  also fired a second time on regions whose specific rejection reason had already been
+  recorded, double-charging the confidence score. Text-alignment detection is now tried as a
+  fallback, and the duplicate event is gone.
+  Because that fallback has no ruling lines corroborating it and the layout model over-fires,
+  it is held to one extra test the line strategies are not: its columns must not cut through
+  words. Without it, a mis-predicted region rendered a page of abstract prose as a
+  seven-column table of half-words (`study was condu | cted to explore`) — every table metric
+  improved while whole-article recall fell from 92.6% to 83.8%. Grid shape, reading-order
+  preservation and region corroboration (ruling lines, a `Table N` caption) were each measured
+  as guards and each failed to separate real tables from gridded prose; whole-word integrity,
+  measured against the page's own unclipped word segmentation, separates them cleanly. Net
+  effect on a 12-article subset: tables emitted 4 → 12 of 32 expected,
+  `table_content_similarity` mean 0.075 → 0.241, `table_structure_similarity` 0.091 → 0.235,
+  with whole-article recall unchanged at baseline.
 - **Scanned PDFs now keep their block structure instead of collapsing to one paragraph.**
   Every OCR'd page previously projected as exactly one `Paragraph` — no `Heading`, no
   `Table`, no list structure — because the OCR result was returned as a flat string and

--- a/benchmarks/pmc/README.md
+++ b/benchmarks/pmc/README.md
@@ -346,11 +346,21 @@ at 94.4%, so that gap is the parser's.
 12-article spot check: **32 ground-truth tables against 4 emitted `Table` nodes**, 28 pages
 with a table against 4.
 
-Two other numbers say precisely what is lost. Table **cell text** is recovered at **96.5% of
-attainable** — the words reach the output. And the run records **76 `table_rejected` degraded
-events**, so the parser *finds* table candidates and rejects them. The failure is not blindness
-and not text loss: it finds a table, rejects it, and emits the cells as prose. That is a
-different defect from "cannot see born-digital tables", and it has a different fix.
+Table **cell text** is recovered at **96.5% of attainable** — the words reach the output, so
+this is a structure failure and not text loss.
+
+The run also records **76 `table_rejected` degraded events**, which first read as "the parser
+finds table candidates and rejects them" — a guard-tuning problem. **That reading was wrong,
+and the counter is what misled it.** 31 of those events are `layout_region_not_tabular`, which
+the code recorded whenever a layout-predicted region failed to *become* a table — including
+when nothing tabular was found there at all. Instrumenting the branch separately showed
+`find_tables()` recovering a grid in **0 of 31** such regions. No guard rejected anything; the
+detector saw nothing to reject. (The event also double-counted: a region whose grid *was*
+found and then rejected recorded both the specific reason and this vaguer one.)
+
+The cause is that PyMuPDF's default strategy needs ruling lines on both axes and journal
+tables are booktabs-style — horizontal rules only, or none. `strategy="text"` recovers a ≥2×2
+grid in **all 31**. See the "Fixing it" section below for why that alone is not the fix.
 
 This is also the gap the raster lane structurally cannot report: every OmniDocBench page is an
 image, so its PDF table path never runs and the whole table dimension is erased as
@@ -364,6 +374,43 @@ left enabled rather than switched off: it is a measurement that could fail, and 
 
 **Cost:** the full run takes over an hour of CPU on one core, most of it OCR. Use `--limit`
 for a spread subset; a per-PR gate over all 66 articles is not practical as it stands.
+
+### Fixing it, and what the fix needed that no table metric could supply
+
+Adding `strategy="text"` as a fallback moved every table number sharply the right way, on a
+12-article subset: `table_content_similarity` median **0.000 → 0.824**, `table_structure`
+**0.000 → 0.440**, tables emitted 4 → 40 against 32 expected, and both wrong-page gaps widened.
+Read on the table dimensions alone, it was an unambiguous win.
+
+**It was a serious regression.** Whole-article recall fell from **92.6% to 83.8%** of
+attainable, `title` from 87.5% to 71.2%. Reading the rendered output said why: the layout model
+over-fires, and on a mis-predicted region the text strategy turned a page of abstract prose
+into a seven-column table whose columns cut *through words* — `study was condu | cted to
+explore`, `micronutr | ients in the`. Emitted character count went **up**; nothing was deleted,
+it was shredded. This is the case for pairing a sharp instrument with a noisy one: every table
+metric approved, and only whole-article recall objected.
+
+Finding a guard took five measured attempts, four of them refuted. Grid **shape** (rows,
+columns, fill ratio, words per cell) does not separate the two — the text strategy chops prose
+into one-word cells, so gridded prose looks exactly as tabular as a table (mean words per cell
+1.54 vs 1.56). **Reading-order preservation** does not (0.812 vs 0.827). Region
+**corroboration** does not, and inverts: mis-predicted regions carried *more* ruling lines
+(median 2 vs 0) and 13 of 19 carried a `Table N` caption. A first **word-splitting** measure
+appeared to fail too, until the probe itself turned out to be at fault — it built its
+vocabulary with `get_text("words", clip=region)`, and clipping truncates words at the boundary,
+manufacturing the fragments it was counting.
+
+Measured unclipped, it separates cleanly: clean regions **0.000–0.022**, damaged ones
+**0.128–0.333**, with the threshold in an empty gap. On the known-bad article the mis-predicted
+abstract scores 0.2415 and its four real tables score exactly 0.0000. The guard is also right
+independent of the metric — a grid whose columns split words has corrupted cell text, so it
+should be refused whether or not a table is really there.
+
+With the guard, on the same subset: tables emitted **4 → 12**, `table_content_similarity` mean
+**0.075 → 0.241**, `table_structure` **0.091 → 0.235**, and recall back at baseline (92.5% vs
+92.6%; `title` and `text_block` exactly unchanged). Conservative on purpose — it still refuses
+real tables whose extraction splits words, and the medians remain 0.000 — but it buys the table
+gain for nothing.
 
 ## Licences
 

--- a/src/all2md/parsers/_pdf_tables.py
+++ b/src/all2md/parsers/_pdf_tables.py
@@ -23,11 +23,14 @@ __all__ = [
     "MIN_TABLE_ROWS",
     "MAX_TABLE_EMPTY_RATIO",
     "MAX_TABLE_ROWS",
+    "MAX_SPLIT_WORD_RATIO",
     "MIN_FILLED_FOR_UNIFORMITY_CHECK",
+    "TABLE_REGION_STRATEGIES",
     "TABLE_SIGNAL_RULING_THRESHOLD",
     "detect_tables_by_ruling_lines",
     "is_dot_leader_cell",
     "page_has_table_signals",
+    "split_word_ratio",
 ]
 
 # Hard caps and guards applied to detected tables. Real prose tables rarely
@@ -52,6 +55,37 @@ MIN_FILLED_FOR_UNIFORMITY_CHECK = 5
 # visual row), the table is treated as a TOC region and rejected.
 MAX_DOT_LEADER_CELL_RATIO = 0.30
 
+# ``find_tables()`` strategies tried inside a region the layout model predicted to be a
+# table, in order. PyMuPDF's default wants ruling lines on both axes, and journal tables
+# are typically booktabs-style: horizontal rules only, or none at all. On the PMC
+# born-digital corpus the line strategies recovered 0 of 31 such regions and ``"text"``,
+# which infers columns from glyph alignment, recovered a >=2x2 grid in all 31.
+#
+# ``"lines"`` (looser than ``"lines_strict"``: it also accepts thin filled rectangles as
+# rules) is deliberately absent -- it found nothing the strict pass had not, on every one
+# of those 31 regions, and each strategy costs a full detection pass.
+#
+# Text alignment is trusted *only* inside a layout-predicted region. Run page-wide it
+# reads any vertically aligned prose as a grid; the predicted region is the prior that
+# makes it safe, and the guards in ``_process_table_to_ast`` still filter what it returns.
+TABLE_REGION_STRATEGIES = ("lines_strict", "text")
+
+# Maximum share of a text-aligned grid's word tokens that may be fragments -- pieces that are
+# not a whole word anywhere on the page. A real table's columns sit in the whitespace gutters
+# between cells, so its cells hold whole words. A column boundary invented over prose cuts
+# through them: on a mis-predicted abstract region it produced "condu"/"cted",
+# "micronutr"/"ients", "coronaviru", and rendered a page of prose as a seven-column table.
+#
+# Measured on the PMC born-digital corpus, this is the only signal found that separates the
+# two. Grid shape (rows, columns, fill ratio, words per cell), reading-order preservation, and
+# region corroboration (ruling lines, a "Table N" caption) were each measured and each failed:
+# every one of them had near-identical distributions for real tables and for gridded prose.
+#
+# Clean regions measured 0.000-0.022 and damaged ones 0.128-0.333, so the threshold sits in an
+# empty gap rather than on a slope. The residue in clean regions is ligature and encoding
+# noise, not splitting.
+MAX_SPLIT_WORD_RATIO = 0.05
+
 # Ruling-line length threshold (as a fraction of page width/height) used by
 # the cheap pre-flight gate that decides whether to call ``page.find_tables()``.
 # Smaller than the fallback threshold (0.5) on purpose: the gate just needs to
@@ -66,6 +100,57 @@ TABLE_SIGNAL_RULING_THRESHOLD = 0.15
 # alone.
 _DOT_ONLY = re.compile(r"^[.…\s]+$")
 _DOT_LEADER_TAIL = re.compile(r"\n\s*[.…](?:\s*[.…]){2,}\s*$")
+
+# Letters only. Digits are never "split words" -- a column boundary falling inside a number
+# yields two numbers, both plausible, and counting those would flag real numeric tables.
+_WORD_TOKEN = re.compile(r"[^\W\d_]+", re.UNICODE)
+
+
+def split_word_ratio(page: "fitz.Page", table_data: list[list[str | None]]) -> float:
+    """Share of a grid's word tokens that are not whole words of the page.
+
+    A grid whose columns fall in the whitespace gutters between cells holds whole words. One
+    whose column boundaries were invented over running prose cuts through them, leaving
+    fragments (``"condu"``, ``"cted"``) that appear nowhere on the page as words. That is the
+    difference between adding structure to a table and shredding a paragraph into one.
+
+    The page's own word segmentation is the reference, taken **unclipped**: clipping to the
+    region truncates any word straddling its boundary, which manufactures the very fragments
+    this is meant to detect.
+
+    Parameters
+    ----------
+    page : PyMuPDF Page
+        Page the grid was extracted from.
+    table_data : list of list of (str or None)
+        Extracted cell text, as returned by ``Table.extract()``.
+
+    Returns
+    -------
+    float
+        Fragment share in ``0.0..1.0``. ``0.0`` when the grid holds no word tokens, and on
+        error, so an unreadable page falls back to the other guards rather than dropping a
+        table nothing has shown to be bad.
+
+    """
+    tokens: list[str] = []
+    for row in table_data:
+        for cell in row:
+            if cell is not None:
+                tokens.extend(token.lower() for token in _WORD_TOKEN.findall(str(cell)))
+    if not tokens:
+        return 0.0
+
+    try:
+        vocabulary: set[str] = set()
+        for word in page.get_text("words"):
+            vocabulary.update(token.lower() for token in _WORD_TOKEN.findall(word[4]))
+    except Exception:
+        return 0.0
+    if not vocabulary:
+        return 0.0
+
+    return sum(1 for token in tokens if token not in vocabulary) / len(tokens)
 
 
 def is_dot_leader_cell(text: str) -> bool:

--- a/src/all2md/parsers/pdf.py
+++ b/src/all2md/parsers/pdf.py
@@ -86,15 +86,18 @@ from all2md.parsers._pdf_ocr import (
 )
 from all2md.parsers._pdf_tables import (
     MAX_DOT_LEADER_CELL_RATIO,
+    MAX_SPLIT_WORD_RATIO,
     MAX_TABLE_COLS,
     MAX_TABLE_EMPTY_RATIO,
     MAX_TABLE_ROWS,
     MIN_FILLED_FOR_UNIFORMITY_CHECK,
     MIN_TABLE_COLS,
     MIN_TABLE_ROWS,
+    TABLE_REGION_STRATEGIES,
     detect_tables_by_ruling_lines,
     is_dot_leader_cell,
     page_has_table_signals,
+    split_word_ratio,
 )
 from all2md.parsers._pdf_text import (
     classify_line_rotation,
@@ -2955,8 +2958,9 @@ class PdfToAstConverter(BaseParser):
     ) -> Node | None:
         """Extract the content of a region the layout model predicted to be a table.
 
-        Uses ``page.find_tables()`` scoped to the predicted region. When no structured
-        table can be recovered there, the region's text is returned as a **paragraph**.
+        Uses ``page.find_tables()`` scoped to the predicted region, trying ruling lines
+        first and then text alignment. When no structured table can be recovered there,
+        the region's text is returned as a **paragraph**.
 
         It used to be returned as a single-column table -- one row per line of text --
         and that was wrong twice over. A one-column table is not a table: it is prose
@@ -2988,23 +2992,51 @@ class PdfToAstConverter(BaseParser):
             its text. ``None`` only when the region is empty.
 
         """
-        # Try PyMuPDF's find_tables within the predicted region. Only a real table is
-        # accepted here: a rejected detection may hand back a paragraph covering just
-        # the grid's bbox, which can be narrower than the region the layout model
-        # predicted. Falling through instead keeps the whole region's text.
-        try:
-            tabs = page.find_tables(clip=table_rect)
-            if tabs.tables:
-                table = self._process_table_to_ast(tabs.tables[0], page, page_num)
-                if isinstance(table, AstTable):
-                    return table
-        except Exception:
-            # PyMuPDF table detection is best-effort; fall through to the text path.
-            pass
+        # Try PyMuPDF's find_tables within the predicted region, line-based detection
+        # first and text alignment second (see TABLE_REGION_STRATEGIES: the default
+        # strategy needs ruling lines on both axes, which borderless journal tables do
+        # not have). Only a real table is accepted here: a rejected detection may hand
+        # back a paragraph covering just the grid's bbox, which can be narrower than the
+        # region the layout model predicted. Falling through instead keeps the whole
+        # region's text.
+        found_grid = False
+        for strategy in TABLE_REGION_STRATEGIES:
+            try:
+                tabs = page.find_tables(clip=table_rect, strategy=strategy)
+            except Exception:
+                # PyMuPDF table detection is best-effort; try the next strategy.
+                continue
+            if not tabs.tables:
+                continue
+            # Text alignment has no ruling lines corroborating it, so it is held to one
+            # extra test the line strategies are not: its columns must not cut through
+            # words. See MAX_SPLIT_WORD_RATIO -- without this, a mis-predicted region
+            # renders a page of prose as a multi-column table of half-words.
+            if strategy == "text":
+                try:
+                    fragments = split_word_ratio(page, tabs.tables[0].extract())
+                except Exception:
+                    fragments = 0.0
+                if fragments > MAX_SPLIT_WORD_RATIO:
+                    logger.debug(
+                        f"Rejecting text-aligned grid on page {page_num + 1}: "
+                        f"{fragments:.0%} of its word tokens are fragments, so its columns "
+                        f"cut through words rather than falling between them"
+                    )
+                    self._record_table_rejection("text_grid_splits_words")
+                    continue
+            found_grid = True
+            table = self._process_table_to_ast(tabs.tables[0], page, page_num)
+            if isinstance(table, AstTable):
+                return table
 
         # No table here -- the layout model was wrong. Keep the text, drop the pipes.
         paragraph = self._region_text_as_paragraph(page, table_rect, page_num)
-        if paragraph is not None:
+        if paragraph is not None and not found_grid:
+            # Only when nothing tabular was found at all. If a grid *was* found and then
+            # rejected, that guard has already recorded its own, more specific reason --
+            # adding this vaguer one on top counts the same region twice and takes a
+            # second bite out of the confidence score.
             self._record_table_rejection("layout_region_not_tabular")
         return paragraph
 

--- a/tests/unit/formats/pdf/test_pdf_layout_region_tables.py
+++ b/tests/unit/formats/pdf/test_pdf_layout_region_tables.py
@@ -1,0 +1,184 @@
+#  Copyright (c) 2025 Tom Villani, Ph.D.
+#
+# tests/unit/formats/pdf/test_pdf_layout_region_tables.py
+"""Recovering borderless tables from layout-predicted regions, without shredding prose.
+
+PyMuPDF's default ``find_tables()`` strategy wants ruling lines on both axes. Journal tables
+are typically booktabs-style -- horizontal rules only, or none -- so the default finds nothing
+in them. Measured on the PMC born-digital corpus, it recovered **0 of 31** regions the layout
+model predicted to be tables, and every one of those became a ``layout_region_not_tabular``
+event. The diagnosis that matters: those events were a *detection* failure, not guards
+rejecting grids they had found.
+
+``strategy="text"``, which infers columns from glyph alignment, recovered a >=2x2 grid in all
+31. But it has no ruling lines corroborating it, and the layout model over-fires: on a
+mis-predicted region it turned a page of abstract prose into a seven-column table whose
+columns cut through words ("study was condu | cted to explore", "micronutr | ients in the").
+That is far worse output than the paragraph it replaced, and no table-shaped metric catches
+it -- the table scores went *up* while whole-article recall fell from 92.6% to 83.8%.
+
+Grid shape (rows, columns, fill ratio, words per cell), reading-order preservation, and region
+corroboration (ruling lines, a "Table N" caption) were each measured as candidate guards and
+each failed, with near-identical distributions for real tables and gridded prose. What
+separates them is whether the columns cut through words, which is what these tests pin.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from all2md.ast import Paragraph as AstParagraph
+from all2md.ast import Table as AstTable
+from all2md.parsers._pdf_tables import MAX_SPLIT_WORD_RATIO, TABLE_REGION_STRATEGIES, split_word_ratio
+from all2md.parsers.pdf import PdfToAstConverter
+
+pytestmark = [pytest.mark.unit, pytest.mark.pdf, pytest.mark.table]
+
+
+class _FakeTable:
+    def __init__(self, grid: list[list[str | None]], bbox: tuple[float, float, float, float]) -> None:
+        self._grid = grid
+        self.bbox = bbox
+
+    def extract(self) -> list[list[str | None]]:
+        return self._grid
+
+
+class _FakeTables:
+    def __init__(self, tables: list[_FakeTable]) -> None:
+        self.tables = tables
+
+
+class _FakePage:
+    """A page whose ``find_tables`` answers per strategy, as PyMuPDF's does."""
+
+    def __init__(self, text: str, by_strategy: dict[str, list[_FakeTable]] | None = None) -> None:
+        self._text = text
+        self._by_strategy = by_strategy or {}
+        self.strategies_tried: list[str] = []
+
+    def get_textbox(self, rect) -> str:
+        return self._text
+
+    def get_text(self, kind: str, **kwargs):
+        assert kind == "words", "the split-word guard reads word segmentation"
+        assert "clip" not in kwargs, "clipping truncates boundary words and fabricates fragments"
+        return [(0.0, 0.0, 1.0, 1.0, word, 0, 0, 0) for word in self._text.split()]
+
+    def find_tables(self, clip=None, strategy: str = "lines_strict"):
+        self.strategies_tried.append(strategy)
+        return _FakeTables(self._by_strategy.get(strategy, []))
+
+
+@pytest.fixture
+def converter() -> PdfToAstConverter:
+    conv = PdfToAstConverter()
+    conv._tables_rejected = 0
+    return conv
+
+
+def _rect(*values: float):
+    import fitz
+
+    return fitz.Rect(*values)
+
+
+# A booktabs table: real columns, whole words in every cell.
+BORDERLESS_TABLE = [["Variables", "AUC", "Sensitivity"], ["25(OH)D3", "0.901", "0.88"], ["Mg", "0.774", "0.71"]]
+BORDERLESS_TEXT = "Variables AUC Sensitivity 25(OH)D3 0.901 0.88 Mg 0.774 0.71"
+
+# The abstract that the layout model mis-predicted, gridded by text alignment. Its column
+# boundary falls inside words, which is the thing that distinguishes it.
+SHREDDED_PROSE = [
+    ["Keywords:", "Objectives: The present", "study was condu", "cted to explore"],
+    ["COVID-19", "prediction and prevent", "ion of coronaviru", "s disease"],
+]
+PROSE_TEXT = "Keywords: Objectives: The present study was conducted to explore prediction and prevention of coronavirus disease COVID-19"
+
+
+class TestSplitWordRatio:
+    def test_a_faithful_grid_holds_whole_words(self):
+        page = _FakePage(BORDERLESS_TEXT)
+        assert split_word_ratio(page, BORDERLESS_TABLE) == 0.0
+
+    def test_columns_cutting_through_words_leave_fragments(self):
+        """Fragments like condu/cted are words nowhere on the page; that is the signal."""
+        page = _FakePage(PROSE_TEXT)
+        assert split_word_ratio(page, SHREDDED_PROSE) > MAX_SPLIT_WORD_RATIO
+
+    def test_digits_are_never_counted_as_split_words(self):
+        """A boundary inside a number yields two plausible numbers, so numeric tables must not trip."""
+        page = _FakePage("Total 1234 5678")
+        assert split_word_ratio(page, [["Total", "12", "34"], ["", "56", "78"]]) == 0.0
+
+    def test_an_unreadable_page_does_not_reject_the_table(self):
+        """On error the guard must abstain, not drop a table nothing has shown to be bad."""
+
+        class _Broken(_FakePage):
+            def get_text(self, kind: str, **kwargs):
+                raise RuntimeError("no text layer")
+
+        assert split_word_ratio(_Broken(BORDERLESS_TEXT), BORDERLESS_TABLE) == 0.0
+
+    def test_a_grid_of_pure_punctuation_has_no_opinion(self):
+        assert split_word_ratio(_FakePage("a b c"), [["-", "-"], ["", "."]]) == 0.0
+
+
+class TestLayoutRegionExtraction:
+    def test_text_alignment_recovers_a_table_the_line_strategies_miss(self, converter):
+        """The headline fix: a borderless journal table stops being emitted as prose."""
+        page = _FakePage(BORDERLESS_TEXT, {"text": [_FakeTable(BORDERLESS_TABLE, (0, 0, 100, 50))]})
+        node = converter._extract_table_from_layout_region(page, _rect(0, 0, 100, 50), page_num=0)
+
+        assert isinstance(node, AstTable), "a booktabs table has no ruling lines but is still a table"
+        assert page.strategies_tried == ["lines_strict", "text"], "lines are tried first, text only as fallback"
+
+    def test_a_grid_whose_columns_split_words_is_refused(self, converter):
+        """Gridding prose is worse than leaving it alone, however tabular the result looks."""
+        page = _FakePage(PROSE_TEXT, {"text": [_FakeTable(SHREDDED_PROSE, (0, 0, 100, 50))]})
+        node = converter._extract_table_from_layout_region(page, _rect(0, 0, 100, 50), page_num=0)
+
+        assert not isinstance(node, AstTable)
+        assert isinstance(node, AstParagraph), "the region's text must survive as prose"
+
+    def test_refusing_a_shredded_grid_keeps_every_word(self, converter):
+        """Region text is already excluded from the ordinary blocks, so a refusal must demote, not delete."""
+        page = _FakePage(PROSE_TEXT, {"text": [_FakeTable(SHREDDED_PROSE, (0, 0, 100, 50))]})
+        node = converter._extract_table_from_layout_region(page, _rect(0, 0, 100, 50), page_num=0)
+
+        assert isinstance(node, AstParagraph), f"the shredded grid was emitted as {type(node).__name__}"
+        rendered = " ".join(text.content for text in node.content)
+        for word in ("conducted", "coronavirus", "Objectives:"):
+            assert word in rendered, f"refusing the shredded grid lost {word!r}"
+
+    def test_the_split_word_guard_applies_only_to_text_alignment(self, converter):
+        """Ruling lines are corroboration the text strategy lacks; a line-detected grid is not second-guessed.
+
+        Its fragments come from hyphenation and ligatures, not from invented columns.
+        """
+        page = _FakePage(PROSE_TEXT, {"lines_strict": [_FakeTable(SHREDDED_PROSE, (0, 0, 100, 50))]})
+        node = converter._extract_table_from_layout_region(page, _rect(0, 0, 100, 50), page_num=0)
+
+        assert isinstance(node, AstTable)
+        assert page.strategies_tried == ["lines_strict"], "a line-detected table stops the search"
+
+    def test_a_region_with_no_grid_at_all_is_still_reported(self, converter):
+        """The genuine detection failure keeps its own event, which is how the corpus was diagnosed."""
+        page = _FakePage("just some prose here")
+        node = converter._extract_table_from_layout_region(page, _rect(0, 0, 100, 50), page_num=0)
+
+        assert isinstance(node, AstParagraph)
+        assert converter._tables_rejected == 1
+        assert page.strategies_tried == list(TABLE_REGION_STRATEGIES), "every strategy is tried before giving up"
+
+    def test_a_guard_rejection_is_not_counted_twice(self, converter):
+        """A grid found and then rejected has already recorded its specific reason.
+
+        Adding ``layout_region_not_tabular`` on top counts the same region twice and takes a
+        second bite out of the confidence score.
+        """
+        degenerate = [["one column"], ["still one column"]]
+        page = _FakePage("one column still one column", {"lines_strict": [_FakeTable(degenerate, (0, 0, 100, 50))]})
+        converter._extract_table_from_layout_region(page, _rect(0, 0, 100, 50), page_num=0)
+
+        assert converter._tables_rejected == 1, "the degenerate-grid guard already recorded this region"


### PR DESCRIPTION
The PMC born-digital lane's headline finding, diagnosed and fixed — with a correction to what the finding actually was.

## The finding was misread, and the parser's own telemetry did the misleading

The lane reported a median of **0.000** on both table dimensions and **76 `table_rejected`** events. That read as *guards rejecting tables the parser had found* — a tuning problem.

It wasn't. 31 of those events are `layout_region_not_tabular`, which was recorded whenever a layout-predicted region failed to *become* a table, **including when nothing tabular was found there at all**. Instrumenting the branch separately:

> `find_tables()` recovered a grid in **0 of 31** layout-predicted table regions.

Nothing was rejected — the detector saw nothing to reject. A degraded-event kind that names an *outcome* rather than a *cause* is what made a detection failure look like a guard failure. It also double-fired: a region whose grid *was* found and then rejected recorded both its specific reason and this vaguer one, taking two bites out of the confidence score.

**Real cause:** PyMuPDF's default strategy needs ruling lines on *both* axes. Journal tables are booktabs-style — horizontal rules only, or none. `strategy="text"` recovers a ≥2×2 grid in **all 31**.

## The obvious fix is a regression, and no table metric can see it

Adding the text strategy alone, on a 12-article subset:

| | baseline | text strategy |
|---|---|---|
| `table_content_similarity` median | 0.000 | **0.824** |
| `table_structure_similarity` median | 0.000 | **0.440** |
| tables emitted | 4 / 32 | 40 / 32 |
| **whole-article recall** | **92.6%** | **83.8%** |
| **`title` recall** | **87.5%** | **71.2%** |

Every table metric approved. Reading the rendered output said why they were wrong: the layout model over-fires, and on a mis-predicted region the text strategy turned a page of abstract prose into a seven-column table whose columns cut **through words**:

```
| Keywords: | Objectives: The present | study was condu | cted to explore |
| COVID-19  | prediction and prevent  | ion of coronaviru | s disease     |
```

Emitted character count went *up*. Nothing was deleted — it was shredded.

## Finding a guard: four refuted, one works

| candidate | real tables | gridded prose | verdict |
|---|---|---|---|
| grid shape (mean words/cell) | 1.54 | 1.56 | refuted |
| reading-order preservation | 0.812 | 0.827 | refuted |
| ruling lines in region (median) | 0 | **2** | refuted, inverted |
| `Table N` caption present | 20/22 | 13/19 | refuted |
| word splitting, `clip=region` | 0.138 | 0.122 | **the probe was the bug** |
| **word splitting, unclipped** | **0.000–0.022** | **0.128–0.333** | **separates** |

The fifth attempt appeared to fail until the probe itself turned out to be at fault: it built its vocabulary with `get_text("words", clip=region)`, and clipping truncates words at the region boundary — manufacturing exactly the fragments it was counting.

Measured unclipped it separates with an empty gap. On the known-bad article the mis-predicted abstract scores **0.2415** while its four real tables score **exactly 0.0000**.

The guard is also right independent of the metric: **a grid whose columns split words has corrupted cell text**, so it should be refused whether or not a table is really there. It applies to the text strategy only — ruling lines are corroboration the line strategies already have.

## Result

| | baseline | **guarded** |
|---|---|---|
| tables emitted | 4 / 32 | **12 / 32** |
| `table_content_similarity` mean | 0.075 | **0.241** |
| `table_structure_similarity` mean | 0.091 | **0.235** |
| whole-article recall | 92.6% | **92.5%** |
| `title` / `text_block` recall | 87.5% / 95.0% | **87.5% / 95.0%** |

The table gain, bought for nothing. Conservative on purpose — it still refuses real tables whose extraction splits words, and both medians remain 0.000, so **the PMC lane stays ungated**.

## Testing

New `tests/unit/formats/pdf/test_pdf_layout_region_tables.py` (11 tests), each verified to fail without the change it pins — with the threshold disabled 3 fail, with the text strategy removed the recovery test fails.

⚠️ **CI cannot cover this path.** `[all,dev]` excludes `pymupdf-layout` under its Polyform Noncommercial licence, so only the monthly PMC lane exercises it. The new unit tests use fakes and need no extra. PDF golden snapshots are unaffected for the same reason.

🤖 Generated with [Claude Code](https://claude.com/claude-code)