### PR TITLE
fix(pdf): trigger auto OCR on the scan shape, not on total image area

### DIFF
--- a/.github/workflows/pmc-borndigital.yml
+++ b/.github/workflows/pmc-borndigital.yml
@@ -62,8 +62,10 @@ jobs:
 
       # OCR is left enabled in auto mode rather than switched off: on a corpus characterized
       # as 0.0% scan-shaped it should never fire, and "never fired" is only worth having as a
-      # measurement that could have failed. It fires on 11 of 66 articles, so Tesseract is a
-      # real dependency here and not a formality.
+      # measurement that could have failed. It did fail -- auto mode was OCR'ing figure-heavy
+      # born-digital pages and discarding their text layers, on 11 of 66 articles. With the
+      # trigger narrowed to the scan shape it reaches 2, on near-empty pages, so Tesseract is
+      # still a real dependency here and the measurement can still fire.
       - name: Install OCR language data
         run: |
           sudo apt-get update

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Auto-mode OCR no longer discards a good text layer because the page has figures on it.**
+  In `mode="auto"` the decision to OCR a page was made by summing the area of every image on
+  it and comparing that to `image_area_threshold` (then 0.5) — *regardless of how much text
+  the page already had*. Since `preserve_existing_text` defaults to `False`, a page that
+  tripped this had its publisher-supplied text thrown away and re-read from a picture. On the
+  PMC born-digital corpus, characterized as **0.0% scan-shaped**, this fired on 20 pages
+  across **11 of 66 articles**; every one of those pages had real extracted text (median 536
+  characters, up to 1998).
+  Two separate faults. Summing image areas does not measure whether a page is a scan: one
+  affected page carried six figure panels covering a tenth of the page each, which summed
+  past the threshold while nothing on the page was remotely page-sized. And the threshold sat
+  far below where scans actually live. The trigger now measures the **largest single image**,
+  and the default is **0.8**. That boundary is calibrated rather than picked: across 101
+  scanned pages the largest image covers exactly 100% of every one, while across 851
+  born-digital pages it never passes 64% (median 13% of pages carrying any image at all).
+  Note the threshold's meaning changed with its default, so an explicit
+  `image_area_threshold` is now read against the largest image rather than the summed area.
+  The narrowing was checked in both directions: a real scan raster carrying a thin text layer
+  — a running header, which clears `text_threshold` so only this branch can reach it — still
+  triggers OCR, and reverting the measure makes the born-digital pages fire again. Measured
+  over the 11 affected articles: `text_content_similarity` median 0.515 → 0.599,
+  `block_structure_similarity` mean 0.530 → 0.563, whole-article recall of attainable 94.6% →
+  95.1%, and 9 of the 11 articles stop OCR'ing entirely. Table scores and `title` recall are
+  unchanged, and the 55 unaffected articles are untouched by construction — exactly 16 of the
+  corpus's 750 page decisions change, all of them from OCR to no-OCR.
 - **Borderless tables in layout-predicted regions are recovered instead of being emitted as
   prose.** With layout analysis on (`pdf_layout`), a region the layout model predicts to be a
   table was searched with PyMuPDF's default `find_tables()` strategy, which requires ruling

--- a/benchmarks/pmc/README.md
+++ b/benchmarks/pmc/README.md
@@ -366,11 +366,11 @@ This is also the gap the raster lane structurally cannot report: every OmniDocBe
 image, so its PDF table path never runs and the whole table dimension is erased as
 unsupported.
 
-**OCR fired on 11 of 66 articles** — on a corpus characterized as 0.0% scan-shaped. Auto mode
-triggers on **≥50% image area regardless of how much text a page has**, and
+**OCR fired on 11 of 66 articles** — on a corpus characterized as 0.0% scan-shaped. This is
+why OCR was left enabled rather than switched off: it is a measurement that could fail, and it
+did. Auto mode triggered on **≥50% image area regardless of how much text a page had**, and
 `preserve_existing_text` defaults to `False`, so on a figure-heavy born-digital page the
-publisher's real text layer is discarded and replaced with OCR output. This is why OCR was
-left enabled rather than switched off: it is a measurement that could fail, and it did.
+publisher's real text layer was discarded and replaced with OCR output. Fixed — see below.
 
 **Cost:** the full run takes over an hour of CPU on one core, most of it OCR. Use `--limit`
 for a spread subset; a per-PR gate over all 66 articles is not practical as it stands.
@@ -411,6 +411,33 @@ With the guard, on the same subset: tables emitted **4 → 12**, `table_content_
 92.6%; `title` and `text_block` exactly unchanged). Conservative on purpose — it still refuses
 real tables whose extraction splits words, and the medians remain 0.000 — but it buys the table
 gain for nothing.
+
+### Fixing the OCR trigger, and the arm that was silently not the baseline
+
+The trigger held two faults, both visible in one pass over all 750 pages. Summing image areas
+does not ask whether a page is a scan: one affected page carries six figure panels of a tenth
+of the page each, summing past the threshold with nothing page-sized on it. And 0.5 sits far
+below where scans live. Measuring the **largest single image** separates the two cleanly —
+born-digital pages never pass **0.634**, real scans sit at exactly **1.000** — and 0.8 is the
+same boundary `benchmarks/omnidocbench` already calibrated for `one_full_page_image`.
+
+Both directions were checked. The 12 mis-firing born-digital pages stop; a real OmniDocBench
+scan raster with a running header painted onto it — enough characters to clear `text_threshold`,
+so only this branch can reach the page — still fires 6 of 6. The gated raster lane cannot move
+either way: all 52 of its cached pages have **no text layer at all**, so they trigger on the
+text branch and never reach this one.
+
+Over the 11 affected articles: `text_content_similarity` median **0.515 → 0.599**,
+`block_structure` mean **0.530 → 0.563**, recall of attainable **94.6% → 95.1%**, and 9 of the
+11 stop OCR'ing. **`title` recall does not move** (377/394 in both arms) — so the title gap and
+the OCR trigger are separate defects, which is what this A/B was run to find out.
+
+**The first baseline arm was not a baseline, and its scores looked fine.** It was produced by
+reassigning the `image_area_threshold` dataclass field default, which does nothing — a
+dataclass bakes its defaults into the generated `__init__` — so the arm silently ran the
+candidate. What exposed it was the payload's own `ocr_articles` field listing 2 articles where
+a true baseline must list 11. Patch the *function* the option feeds, and confirm an arm is the
+arm from a field recording what the parser did, never from the score it produced.
 
 ## Licences
 

--- a/docs/source/options.rst
+++ b/docs/source/options.rst
@@ -8495,11 +8495,11 @@ supported via ``engine``: Tesseract (default) and EasyOCR.
 
 **image_area_threshold**
 
-   Image area ratio (0.0-1.0) to trigger OCR (for auto mode)
+   Share of the page (0.0-1.0) its largest image must cover to trigger OCR (auto mode)
 
    :Type: ``float``
    :CLI flag: ``--pdf-ocr-image-area-threshold``
-   :Default: ``0.5``
+   :Default: ``0.8``
    :Importance: advanced
 
 **preserve_existing_text**

--- a/src/all2md/constants.py
+++ b/src/all2md/constants.py
@@ -807,7 +807,12 @@ DEFAULT_OCR_AUTO_DETECT_LANGUAGE = False
 DEFAULT_OCR_DPI = 300
 DEFAULT_OCR_TEXT_THRESHOLD = 50  # Minimum characters to consider page as text-based
 DEFAULT_OCR_DOC_TEXT_THRESHOLD = 16  # Whole-doc meaningful-char floor below which auto OCR retries
-DEFAULT_OCR_IMAGE_AREA_THRESHOLD = 0.5  # Ratio of image area to page area to trigger OCR
+# Share of a page its largest image must cover for auto mode to read the page as a scan.
+# Calibrated, not guessed: across 49 pages of scanned journal back-catalogue and 52 raster
+# benchmark pages the largest image covered exactly 100% of every page, while across 851
+# pages of born-digital articles it never passed 64% (median 13% of the pages carrying any
+# image at all). 0.8 sits in that gap, and nothing measured lands near it from either side.
+DEFAULT_OCR_IMAGE_AREA_THRESHOLD = 0.8
 DEFAULT_OCR_PRESERVE_EXISTING_TEXT = False
 DEFAULT_OCR_TESSERACT_CONFIG = ""
 

--- a/src/all2md/options/common.py
+++ b/src/all2md/options/common.py
@@ -586,9 +586,13 @@ class OCROptions(CloneFrozenMixin):
         mode, if no page triggered OCR yet the rendered document has fewer
         meaningful characters than this, the PDF parser retries once with OCR
         forced. Catches scanned/image-only documents the per-page heuristic missed.
-    image_area_threshold : float, default 0.5
-        Minimum ratio of image area to total area (0.0-1.0) to consider
-        content as image-based. Used by parsers in "auto" mode.
+    image_area_threshold : float, default 0.8
+        Share of the page (0.0-1.0) that its **largest single image** must cover
+        for "auto" mode to read the page as a scan and OCR it. Measured on the
+        largest image rather than on every image's area added together, because a
+        born-digital page carrying several figures has a large total image area
+        while its publisher-supplied text layer is perfectly good — and OCR
+        replaces that text rather than adding to it (see ``preserve_existing_text``).
     preserve_existing_text : bool, default False
         Whether to preserve existing text when OCR is applied:
 
@@ -708,7 +712,7 @@ class OCROptions(CloneFrozenMixin):
     image_area_threshold: float = field(
         default=DEFAULT_OCR_IMAGE_AREA_THRESHOLD,
         metadata={
-            "help": "Image area ratio (0.0-1.0) to trigger OCR (for auto mode)",
+            "help": "Share of the page (0.0-1.0) its largest image must cover to trigger OCR (auto mode)",
             "type": float,
             "importance": "advanced",
         },

--- a/src/all2md/parsers/_pdf_ocr.py
+++ b/src/all2md/parsers/_pdf_ocr.py
@@ -27,6 +27,7 @@ __all__ = [
     "get_tesseract_lang",
     "detect_page_language",
     "calculate_image_coverage",
+    "largest_image_coverage",
     "dehyphenate_text",
     "dehyphenate_blocks",
 ]
@@ -179,8 +180,11 @@ def calculate_image_coverage(page: "fitz.Page") -> float:
 
     Notes
     -----
-    This function accounts for overlapping images by combining their bounding
-    boxes and calculating the total covered area.
+    Image areas are summed, so images that overlap are counted more than once and
+    the result is an upper bound on true coverage. It is therefore *not* the test
+    for "is this page a scan" -- several unrelated figures sum past any threshold
+    on a page that is plainly born-digital. Use :func:`largest_image_coverage` for
+    that; this remains available as a rough measure of how image-heavy a page is.
 
     """
     page_area = page.rect.width * page.rect.height
@@ -209,6 +213,44 @@ def calculate_image_coverage(page: "fitz.Page") -> float:
     # Calculate ratio
     coverage_ratio = min(1.0, total_image_area / page_area)
     return coverage_ratio
+
+
+def largest_image_coverage(page: "fitz.Page") -> float:
+    """Calculate the share of the page covered by its single largest image.
+
+    This is the scan test. A scanned page is one raster the size of the page, so the
+    question is whether *one* image dominates -- not how much image there is in total.
+    A page carrying several figures has plenty of image area while remaining entirely
+    born-digital, and summing those areas (:func:`calculate_image_coverage`) cannot
+    tell the two apart.
+
+    Parameters
+    ----------
+    page : fitz.Page
+        PDF page to analyze
+
+    Returns
+    -------
+    float
+        Area of the largest image placement divided by the page area (0.0 to 1.0)
+
+    Notes
+    -----
+    Every placement of every image is measured, not just the first, because a scan
+    may embed the page raster once and a small logo elsewhere; taking only the first
+    occurrence would score the logo.
+
+    """
+    page_area = page.rect.width * page.rect.height
+    if page_area == 0:
+        return 0.0
+
+    largest = 0.0
+    for img in page.get_images():
+        for bbox in page.get_image_rects(img[0]):
+            largest = max(largest, (bbox.width * bbox.height) / page_area)
+
+    return min(1.0, largest)
 
 
 def should_use_ocr(page: "fitz.Page", extracted_text: str, options: PdfOptions) -> bool:
@@ -262,11 +304,16 @@ def should_use_ocr(page: "fitz.Page", extracted_text: str, options: PdfOptions) 
             )
             return True
 
-        # Check image coverage threshold
-        image_coverage = calculate_image_coverage(page)
+        # The page has real text. It is still worth OCR'ing if that text is a thin
+        # layer over a scan -- a running header above a page-sized raster -- so ask
+        # whether one image covers the page, which is what a scan looks like. The
+        # summed area of every image is not that question: a born-digital page with
+        # five figure panels reaches any coverage threshold you like while its text
+        # layer is the publisher's own and replacing it destroys the page.
+        image_coverage = largest_image_coverage(page)
         if image_coverage >= ocr_opts.image_area_threshold:
             logger.debug(
-                f"Page has {image_coverage:.1%} image coverage "
+                f"Page's largest image covers {image_coverage:.1%} of it "
                 f"(threshold: {ocr_opts.image_area_threshold:.1%}), triggering OCR"
             )
             return True

--- a/tests/unit/parsers/test_pdf_ocr.py
+++ b/tests/unit/parsers/test_pdf_ocr.py
@@ -13,6 +13,7 @@ from all2md.options.pdf import PdfOptions
 from all2md.parsers._pdf_ocr import (
     calculate_image_coverage,
     dehyphenate_text,
+    largest_image_coverage,
 )
 from all2md.parsers._pdf_ocr import (
     detect_page_language as _detect_page_language,
@@ -36,7 +37,7 @@ class TestOCROptions:
         assert opts.dpi == 300
         assert opts.text_threshold == 50
         assert opts.doc_text_threshold == 16
-        assert opts.image_area_threshold == 0.5
+        assert opts.image_area_threshold == 0.8
         assert opts.preserve_existing_text is False
         assert opts.tesseract_config == ""
 
@@ -84,6 +85,29 @@ class TestOCROptions:
             OCROptions(languages=["eng", "   "])
 
 
+class _Box:
+    """A stand-in for ``fitz.Rect`` carrying only what the coverage helpers read."""
+
+    def __init__(self, width: float, height: float) -> None:
+        self.width = width
+        self.height = height
+
+
+def _page_with_images(*images: list[tuple[float, float]], width: float = 612.0, height: float = 792.0) -> Mock:
+    """Build a mock page carrying the given images.
+
+    Each argument is one image, given as the list of boxes it is placed at — so a single
+    image drawn twice on the page is one argument with two boxes.
+    """
+    page = Mock()
+    page.rect.width = width
+    page.rect.height = height
+    page.get_images.return_value = [(xref, 0, 0, 0, 0, 0, 0) for xref in range(1, len(images) + 1)]
+    placements = {xref: [_Box(w, h) for w, h in boxes] for xref, boxes in enumerate(images, start=1)}
+    page.get_image_rects.side_effect = lambda xref, **_: placements.get(xref, [])
+    return page
+
+
 class TestImageCoverage:
     """Test image coverage calculation."""
 
@@ -127,6 +151,50 @@ class TestImageCoverage:
 
         coverage = calculate_image_coverage(mock_page)
         assert coverage == 0.0
+
+
+class TestLargestImageCoverage:
+    """The scan test asks whether one image dominates the page."""
+
+    def test_no_images(self) -> None:
+        """A page with no images covers none of itself."""
+        assert largest_image_coverage(_page_with_images()) == 0.0
+
+    def test_zero_page_area(self) -> None:
+        """A degenerate page reports no coverage rather than dividing by zero."""
+        page = _page_with_images([(10.0, 10.0)], width=0.0, height=0.0)
+        assert largest_image_coverage(page) == 0.0
+
+    def test_single_image(self) -> None:
+        """One image covering half the page reports half."""
+        page = _page_with_images([(612.0, 396.0)])
+        assert 0.49 < largest_image_coverage(page) < 0.51
+
+    def test_figure_panels_are_not_a_scan(self) -> None:
+        """Six figure panels covering the page between them are still six figures.
+
+        This is the case that made auto mode discard publisher text layers: summing the
+        panels' areas reaches any threshold, while no single panel comes close.
+        """
+        panels = [[(300.0, 260.0)] for _ in range(6)]
+        page = _page_with_images(*panels)
+        assert calculate_image_coverage(page) > 0.9  # what the old trigger saw
+        assert largest_image_coverage(page) < 0.21  # what is actually on the page
+
+    def test_page_sized_scan(self) -> None:
+        """A page-sized raster reports ~1.0, whatever else sits beside it."""
+        page = _page_with_images([(612.0, 792.0)], [(40.0, 40.0)])
+        assert largest_image_coverage(page) > 0.99
+
+    def test_measures_every_placement_not_just_the_first(self) -> None:
+        """A logo placed before the page raster must not be the one that gets measured."""
+        page = _page_with_images([(40.0, 40.0), (612.0, 792.0)])
+        assert largest_image_coverage(page) > 0.99
+
+    def test_never_exceeds_one(self) -> None:
+        """An image drawn larger than the page is clamped."""
+        page = _page_with_images([(1224.0, 1584.0)])
+        assert largest_image_coverage(page) == 1.0
 
 
 class TestShouldUseOCR:
@@ -205,17 +273,40 @@ class TestShouldUseOCR:
         # 20 meaningful chars -> above threshold -> no OCR.
         assert _should_use_ocr(mock_page, "a" * 20 + "  ...", options) is False
 
-    @patch("all2md.parsers._pdf_ocr.calculate_image_coverage")
-    def test_should_use_ocr_auto_high_image_coverage(self, mock_coverage: Mock) -> None:
-        """Test OCR triggering in auto mode with high image coverage."""
-        mock_page = Mock()
-        mock_coverage.return_value = 0.8  # 80% image coverage
+    def test_should_use_ocr_auto_page_sized_image(self) -> None:
+        """A scan carrying a thin text layer must still be OCR'd.
 
-        options = PdfOptions(ocr=OCROptions(enabled=True, mode="auto", text_threshold=50, image_area_threshold=0.5))
+        The text branch cannot rescue this page — a running header clears
+        ``text_threshold`` — so the image branch is the only thing that reaches it. This
+        is what that branch exists for, and narrowing it must not disable it.
+        """
+        page = _page_with_images([(612.0, 792.0)])
+        options = PdfOptions(ocr=OCROptions(enabled=True, mode="auto", text_threshold=50))
 
-        # High image coverage should trigger OCR even with some text
-        result = _should_use_ocr(mock_page, "A" * 100, options)
-        assert result is True
+        assert _should_use_ocr(page, "JOURNAL OF THE CHICAGO MEDICAL SOCIETY, VOL XXIV, No 3, page 118", options)
+
+    def test_should_use_ocr_auto_leaves_a_figure_heavy_page_alone(self) -> None:
+        """A born-digital page of figures keeps its publisher text layer.
+
+        OCR *replaces* the extracted text by default, so firing here is not a harmless
+        second opinion — it discards the real text and re-reads it from a picture.
+        """
+        panels = [[(300.0, 260.0)] for _ in range(6)]
+        page = _page_with_images(*panels)
+        options = PdfOptions(ocr=OCROptions(enabled=True, mode="auto", text_threshold=50))
+
+        assert _should_use_ocr(page, "A" * 500, options) is False
+
+    def test_should_use_ocr_auto_image_threshold_is_configurable(self) -> None:
+        """The caller can still lower the bar back down to a figure-sized image."""
+        page = _page_with_images([(612.0, 396.0)])  # half the page
+        text = "A" * 100
+
+        conservative = PdfOptions(ocr=OCROptions(enabled=True, mode="auto", image_area_threshold=0.8))
+        assert _should_use_ocr(page, text, conservative) is False
+
+        eager = PdfOptions(ocr=OCROptions(enabled=True, mode="auto", image_area_threshold=0.4))
+        assert _should_use_ocr(page, text, eager) is True
 
 
 class TestDetectPageLanguage:


### PR DESCRIPTION
Second finding from the PMC born-digital lane's first full run. The first was #285.

## The defect

In `mode="auto"`, the decision to OCR a page summed the area of **every** image on it and compared that to `image_area_threshold` (then 0.5) — **regardless of how much text the page already had**. Since `preserve_existing_text` defaults to `False`, a page that tripped this had its publisher-supplied text layer discarded and re-read from a picture.

On the PMC corpus, characterized as **0.0% scan-shaped**, this fired on 20 pages across **11 of 66 articles**. Every one had real extracted text — median 536 characters, up to 1998.

## Two faults, both visible in one pass over 750 pages

| page | summed | largest | chars |
|---|---|---|---|
| `PMC11500014.1` p4 | 0.507 | 0.507 | 1998 |
| `PMC8500002.2` p4 | 0.500 | **0.100** | 706 |
| a real scan (OmniDocBench) | 1.000 | **1.000** | 0 |

1. **Summing image areas does not ask whether a page is a scan.** `PMC8500002.2` p4 carries six figure panels covering a tenth of the page each; they sum past the threshold with nothing page-sized on the page.
2. **0.5 sits far below where scans live.**

## The fix

Measure the **largest single image**; default **0.8**.

That boundary is calibrated, not picked. It is the one `benchmarks/omnidocbench` already uses for `one_full_page_image` (49 scanned pages at exactly 100%, 101 born-digital topping out at 61%), and this corpus reproduces it independently: across 851 born-digital pages the largest image never passes **0.634**, while 52 raster pages sit at exactly **1.000**. Nothing measured lands near 0.8 from either side.

## Controls

- **Negative:** the 12 mis-firing born-digital pages → 0/12.
- **Positive:** a real OmniDocBench scan raster with a running header painted on — enough characters to clear `text_threshold`, so *only* this branch can reach it — still fires **6/6**. The branch is narrowed, not disabled.
- **The probe can fail:** reverted to the old measure, the negative control fires 12/12 again.
- **The gated raster lane cannot move:** all 52 of its cached pages have *no text layer at all*, so they trigger on the text branch and never reach this one.

## Measured effect (the 11 affected articles)

| | before | after |
|---|---|---|
| `text_content_similarity` (median) | 0.5147 | **0.5985** |
| `block_structure_similarity` (mean) | 0.5296 | **0.5629** |
| `reading_order_similarity` (mean) | 0.7391 | **0.7477** |
| recall of attainable | 94.6% | **95.1%** |
| `text_block` recall | 0.9542 | **0.9630** |
| `title` recall | 0.9391 | 0.9391 |
| table content / structure | 0.2816 / 0.2955 | unchanged |

9 of the 11 stop OCR'ing entirely. Exactly **16 of the corpus's 750** page decisions change, all from OCR to no-OCR, so the other 55 articles are untouched by construction — which is why this scores the affected articles rather than a spread subset that would only pick 3 of the 11.

**`title` recall does not move.** The roadmap hypothesis that the title gap and the auto-OCR trigger were one defect is refuted; they are separate, and the title gap is still open.

## Note for users

The option's meaning changed with its default: an explicit `image_area_threshold` is now read against the largest image rather than the summed area — stricter at the same number.

## Also worth recording

The first baseline arm **was not a baseline**, and its scores looked entirely plausible. It was produced by reassigning the `image_area_threshold` dataclass field default, which does nothing — a dataclass bakes defaults into the generated `__init__` — so the arm silently ran the candidate. What exposed it was the payload's own `ocr_articles` field listing 2 articles where a true baseline must list 11. The benchmark README now records this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)