### PR TITLE
fix(pdf): keep the space where a styled run wraps onto the next line

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Words no longer run together where a bold or italic run wraps onto the next line.** Lines
+  of a paragraph are joined with a separator space unless the text already ends with
+  whitespace there, and the check that decides this walks back to the last text leaf, which
+  may sit inside a `Strong`/`Emphasis`/`Link`. It conflated two different answers from a
+  wrapper — "its text does not end in whitespace" and "it holds no text at all" — and treated
+  both as *keep looking*. A line ending in a styled run therefore fell through to whatever
+  preceded that run, and if *that* ended with a space the separator was suppressed and the
+  two halves were concatenated: `negotiating Roang on` + `Lamotrek Atoll` came back as
+  `Roang onLamotrek`. The two runs then looked adjacent to the inline consolidator, which
+  merged them into a single node, so the space could not be recovered downstream either.
+  The walk now distinguishes "no text here" from a definite verdict about the join point.
+  This affects any wrapped styled run, not one document kind, but it surfaced through
+  bibliography entries on the PMC born-digital corpus: a wrapped reference title is short
+  enough that one bad join costs it more n-grams than a recall threshold allows, while a long
+  paragraph absorbs the same damage unnoticed. Over a 20-article subset it recovers **16 of
+  the 33** unrecoverable titles with **none newly lost**, taking `title` recall of attainable
+  from **95.4% to 97.6%**; one review article with a large reference list goes from 22 lost to
+  6. The remaining losses are a separate defect — text genuinely absent from the output rather
+  than reflowed — and are still open.
 - **Borderless tables in layout-predicted regions are recovered instead of being emitted as
   prose.** With layout analysis on (`pdf_layout`), a region the layout model predicts to be a
   table was searched with PyMuPDF's default `find_tables()` strategy, which requires ruling

--- a/src/all2md/parsers/pdf.py
+++ b/src/all2md/parsers/pdf.py
@@ -291,6 +291,29 @@ def _strip_leading_whitespace_in_place(nodes: list[Node]) -> None:
             return  # Code preserves whitespace; don't trim.
 
 
+def _trailing_whitespace_verdict(nodes: list[Node]) -> bool | None:
+    """Report whether the last Text-bearing leaf in ``nodes`` ends with whitespace.
+
+    Returns ``None`` — meaning "no text here, keep looking" — rather than ``False``
+    when there is no Text leaf to judge. The distinction matters: a wrapper whose
+    text does *not* end in whitespace is a definite answer about the join point, and
+    collapsing it into "keep looking" makes the walk fall through to an earlier
+    sibling and answer about the wrong position entirely.
+    """
+    for node in reversed(nodes):
+        if isinstance(node, Text):
+            return bool(node.content) and node.content[-1] in (" ", "\t")
+        if isinstance(node, (Strong, Emphasis, Link)):
+            verdict = _trailing_whitespace_verdict(node.content) if node.content else None
+            if verdict is not None:
+                return verdict
+            # This wrapper really had no Text leaves — keep walking outward.
+            continue
+        if isinstance(node, Code):
+            return False
+    return None
+
+
 def _trailing_text_is_whitespace(nodes: list[Node]) -> bool:
     """Return True if the last Text-bearing leaf in ``nodes`` ends with whitespace.
 
@@ -298,17 +321,7 @@ def _trailing_text_is_whitespace(nodes: list[Node]) -> bool:
     Used to decide whether an inter-line separator space would create a
     redundant whitespace run.
     """
-    for node in reversed(nodes):
-        if isinstance(node, Text):
-            return bool(node.content) and node.content[-1] in (" ", "\t")
-        if isinstance(node, (Strong, Emphasis, Link)):
-            if node.content and _trailing_text_is_whitespace(node.content):
-                return True
-            # Wrapper had no Text leaves — keep walking outward.
-            continue
-        if isinstance(node, Code):
-            return False
-    return False
+    return _trailing_whitespace_verdict(nodes) is True
 
 
 @dataclass

--- a/tests/unit/formats/pdf/test_pdf_line_join_spacing.py
+++ b/tests/unit/formats/pdf/test_pdf_line_join_spacing.py
@@ -1,0 +1,140 @@
+"""Spacing at the join between two lines of one paragraph.
+
+Lines of a paragraph are joined with an explicit separator space, unless the text already
+ends with whitespace there. Deciding "already ends with whitespace" means finding the last
+Text leaf, which may sit inside a Strong/Emphasis/Link wrapper.
+
+The walk used to conflate two different answers from a wrapper — "its text does not end in
+whitespace" and "it holds no text at all" — and treat both as "keep looking". So a line
+ending in a bold run fell through to whatever came *before* the bold run, and if that ended
+with a space the separator was suppressed: `negotiating Roang on` + `Lamotrek Atoll` came
+back as `Roang onLamotrek`.
+
+Found on the PMC born-digital corpus, where it cost whole reference-list entries: a wrapped
+bibliography title loses several n-grams to one such join, which is enough to fail a recall
+threshold that a long paragraph would have absorbed.
+"""
+
+import re
+
+import fitz
+import pytest
+
+from all2md import to_markdown
+from all2md.ast.nodes import Code, Emphasis, Link, Strong, Text
+from all2md.parsers.pdf import _trailing_text_is_whitespace
+
+
+@pytest.mark.unit
+@pytest.mark.pdf
+class TestTrailingWhitespaceDetection:
+    """The predicate that decides whether a line join needs a separator space."""
+
+    def test_bold_run_not_ending_in_space_after_spaced_text(self) -> None:
+        """The bold run is the join point, so the space before it is irrelevant.
+
+        This is the regression: answering about `'167. Metzgar E: '` instead of about the
+        bold run that actually ends the line suppressed the separator.
+        """
+        nodes = [Text(content="167. Metzgar E: "), Strong(content=[Text(content="Roang on")])]
+        assert _trailing_text_is_whitespace(nodes) is False
+
+    def test_bold_run_ending_in_space(self) -> None:
+        """A wrapper whose own text ends in whitespace still answers True."""
+        nodes = [Text(content="a "), Strong(content=[Text(content="bold ")])]
+        assert _trailing_text_is_whitespace(nodes) is True
+
+    def test_plain_text(self) -> None:
+        """Unwrapped text is judged directly."""
+        assert _trailing_text_is_whitespace([Text(content="hello ")]) is True
+        assert _trailing_text_is_whitespace([Text(content="hello")]) is False
+
+    def test_empty_wrapper_falls_through(self) -> None:
+        """A wrapper holding no text really does mean "keep looking"."""
+        nodes = [Text(content="a "), Strong(content=[])]
+        assert _trailing_text_is_whitespace(nodes) is True
+
+    def test_nested_wrapper_is_judged_by_its_innermost_text(self) -> None:
+        """Bold-inside-italic answers about the text, not about the nesting."""
+        nodes = [Text(content="a "), Strong(content=[Emphasis(content=[Text(content="x")])])]
+        assert _trailing_text_is_whitespace(nodes) is False
+
+    def test_link_is_walked_like_other_wrappers(self) -> None:
+        """A link ending a line is a join point too."""
+        nodes = [Text(content="a "), Link(content=[Text(content="here")], url="https://example.com")]
+        assert _trailing_text_is_whitespace(nodes) is False
+
+    def test_code_stops_the_walk(self) -> None:
+        """Code is text-bearing, so it answers rather than deferring."""
+        assert _trailing_text_is_whitespace([Text(content="a "), Code(content="x")]) is False
+
+    def test_no_nodes(self) -> None:
+        """Nothing to judge is not whitespace."""
+        assert _trailing_text_is_whitespace([]) is False
+
+
+@pytest.mark.unit
+@pytest.mark.pdf
+class TestBoldRunAcrossLineBreak:
+    """The same defect through the parser, on a real PDF."""
+
+    @staticmethod
+    def _prose(markdown: str) -> str:
+        """Drop emphasis markers, so the assertion is about words rather than markup.
+
+        The two halves render as separate runs (`**...on** **Lamotrek...**`), which is
+        correct — what matters is that a space separates them in the text.
+        """
+        return re.sub(r"\*+", "", markdown)
+
+    @staticmethod
+    def _reference_entry(tmp_path, name: str, first_line: list[tuple[str, bool]], second_line: str) -> str:
+        """Write one numbered reference entry whose bold title wraps onto a second line.
+
+        Shaped after the real thing rather than invented: the spans reproduce a PMC
+        reference line (`'167.'`, `' '`, `'Metzgar E: '`, then the bold title), laid out
+        contiguously so PyMuPDF reports them as spans of one line. The leading ordinal
+        matters — it marks the block as a list item, which is what keeps both lines in a
+        single paragraph and therefore makes the inter-line join happen at all.
+        """
+        size = 8.0
+        doc = fitz.open()
+        page = doc.new_page()
+        writer = fitz.TextWriter(page.rect)
+        fonts = {False: fitz.Font("helv"), True: fitz.Font("hebo")}
+
+        x = 60.0
+        for text, is_bold in first_line:
+            writer.append((x, 100), text, font=fonts[is_bold], fontsize=size)
+            x += fonts[is_bold].text_length(text, size)
+        writer.append((60, 109), second_line, font=fonts[True], fontsize=size)
+        writer.write_text(page)
+
+        path = tmp_path / name
+        doc.save(str(path))
+        doc.close()
+        return str(path)
+
+    def test_space_survives_the_join(self, tmp_path) -> None:
+        """`on` and `Lamotrek` are separate words and must stay separate."""
+        path = self._reference_entry(
+            tmp_path,
+            "wrapped_bold.pdf",
+            [("167.", False), (" ", False), ("Metzgar E: ", False), ("negotiating Roang on", True)],
+            "Lamotrek Atoll, Micronesia.",
+        )
+        result = self._prose(to_markdown(path))
+        assert "onLamotrek" not in result, "the inter-line separator was dropped after a bold run"
+        assert "on Lamotrek" in result
+
+    def test_no_doubled_space_where_one_already_exists(self, tmp_path) -> None:
+        """A line whose bold run already ends in a space must not gain a second one."""
+        path = self._reference_entry(
+            tmp_path,
+            "already_spaced.pdf",
+            [("167.", False), (" ", False), ("Metzgar E: ", False), ("negotiating Roang on ", True)],
+            "Lamotrek Atoll, Micronesia.",
+        )
+        result = self._prose(to_markdown(path))
+        assert "on  Lamotrek" not in result
+        assert "on Lamotrek" in result


### PR DESCRIPTION
Third finding from the PMC born-digital lane. Independent of #285 and #286 — merges in any order.

## What this started as, and what it turned out to be

The roadmap item was "`title` recall gap": the weakest kind against the highest ceiling. Two hypotheses went in, both wrong.

1. **"It's the same defect as auto-OCR"** (OCR'd pages lose headings). **Refuted by measurement** — across #286's A/B, `title` recall is bit-identical at **377/394 in both arms** while text content and block structure both moved.
2. **"It's a heading-detection defect."** Also wrong. Every lost title is a **bibliography entry**, and nothing is missing or misordered.

## The actual defect

`_trailing_text_is_whitespace` decides whether a line join needs a separator space, by walking back to the last `Text` leaf — which may sit inside a `Strong`/`Emphasis`/`Link`. It conflated two different answers from a wrapper:

- *"its text does not end in whitespace"* → a definite answer about the join point
- *"it holds no text at all"* → genuinely means keep looking

Both returned `False`, and both were treated as *keep looking*. So a line ending in a styled run fell through to an earlier sibling, found **its** trailing space, and suppressed the separator:

```
167. Metzgar E: **negotiating Roang on**
**Lamotrek Atoll, Micronesia.**          ->  "Roang onLamotrek"
```

The two runs then looked adjacent to the inline consolidator, which merged them into a single node — so the space could not be recovered downstream either.

Fixed with a three-state verdict (`True` / `False` / `None`), so "no text here" is distinct from an answer about the join.

## Why it presented as a title problem, and isn't one

It hits **any wrapped styled run, document-wide**. It concentrated in `title` because of the *metric's* sensitivity, not the defect's location: a wrapped bibliography title is short, so one bad join costs it more n-grams than `RECALL_MIN = 0.80` allows, while a long paragraph absorbs identical damage unnoticed. `text_block` recall at 96.3% was quietly paying for the same bug.

## Measured (20-article subset)

| | before | after |
|---|---|---|
| lost titles (attainable but not recovered) | 33 | **17** |
| recovered by the fix | — | **16** |
| newly lost | — | **0** |
| `title` recall of attainable | 95.4% | **97.6%** |
| `PMC1500805.1` (review, large reference list) | 22 lost | **6 lost** |

## Tests

10 tests; **4 fail without the fix** (3 predicate + the end-to-end reproduction).

The end-to-end fixture is built from the real `get_text("dict")` span layout rather than invented, because **two earlier fixtures passed against the unfixed parser**. Without the leading `167.` ordinal the block is not a list item, so the second line starts a *new* paragraph and gets re-joined with a space anyway — the defect never fires. A fixture that cannot fail is not a fixture.

## Risk

PDF golden snapshots are Linux-only and skipped on Windows, so I could not run them locally. I inspected the committed snapshot for missing-space artifacts and found none, but that is inspection, not a run — CI is the real check here. If a golden does encode the old spacing, it should be regenerated.

## Still open

The residual **17** losses are a *different* cause: text genuinely absent from the output rather than reflowed (word-level share 0.67–0.92 against a PDF text layer that contains all of it), concentrated in `PMC7500012.1` (9) and `PMC1500805.1` (6). Not diagnosed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)