### PR TITLE
feat(pdf): expose the layout classifier as a searchable option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **`layout_feature_set`, choosing which layout classifier reads the page** (`--pdf-layout-feature-set`,
+  requires `pymupdf-layout`; inert otherwise). The package bundles three: `imf+rf` (the
+  default, image and text-geometry features), `imf` (image only) and `rf` (text geometry
+  only). Which one is right depends on the document, so it is now a searchable option and
+  is registered as an `optimize` knob rather than decided globally. The difference is not
+  subtle: on a two-column reference page the image-feature models read the dense left column
+  as a table — deleting nine reference entries before the fix elsewhere in this release, and
+  splitting one table into two on three further pages — while `rf` labels all 41 entries
+  correctly and predicts no table at all. Across 20 born-digital articles `rf` led on every
+  axis measured (title recall 0.9916 → 0.9972, identical table content recall, three fewer
+  spurious table nodes on the same 16 pages, 29% faster for skipping image inference).
+  **The default is deliberately unchanged**: that is one corpus of one document kind, and
+  image features plausibly earn their place on scanned pages, of which it contains none.
+  Models are now cached per feature set instead of in a single global — an unkeyed cache
+  returned whichever model loaded first, which would have made every arm of a search over
+  this knob identical and the setting look inert.
 - **A pinned PMC Open Access corpus for born-digital PDF benchmarking**
   (`benchmarks/pmc`). The existing external ground-truth lane is 981 rasters, so it
   measures the OCR path; nothing external covered text-layer extraction, vector table

--- a/docs/source/options.rst
+++ b/docs/source/options.rst
@@ -8539,6 +8539,16 @@ supported via ``engine``: Tesseract (default) and EasyOCR.
    :Default: ``0.3``
    :Importance: advanced
 
+**layout_feature_set**
+
+   Which layout classifier to run: 'imf+rf' (image and text-geometry features), 'rf' (text geometry only), 'imf' (image only). Ignored unless layout analysis runs
+
+   :Type: ``Literal['imf+rf', 'rf', 'imf']``
+   :CLI flag: ``--pdf-layout-feature-set``
+   :Default: ``'imf+rf'``
+   :Choices: ``imf+rf``, ``rf``, ``imf``
+   :Importance: advanced
+
 PDF Renderer Options
 ^^^^^^^^^^^^^^^^^^^^
 

--- a/src/all2md/constants.py
+++ b/src/all2md/constants.py
@@ -78,6 +78,12 @@ ImageFormat = Literal["png", "jpeg"]
 OCRMode = Literal["auto", "force", "off"]
 OCREngine = Literal["tesseract", "easyocr"]
 LayoutAnalysisMode = Literal["auto", "enabled", "disabled"]
+#: Which pymupdf-layout classifier to run. The names are the upstream feature sets: ``rf``
+#: reads text geometry ("rule features"), ``imf`` reads a raster of the page ("image
+#: features"), and ``imf+rf`` combines them. Each selects a different bundled ONNX model.
+#: Upstream also accepts ``imf+rf+yf`` and ``rf+jf``, which are omitted because they pass
+#: validation and then fail on a missing config file.
+LayoutFeatureSet = Literal["imf+rf", "rf", "imf"]
 
 # Email-specific types
 DateFormatMode = Literal["iso8601", "locale", "strftime"]
@@ -777,6 +783,12 @@ DEFAULT_FOOTER_HEIGHT = 0  # Height in points to trim from bottom
 # Layout analysis defaults (requires pymupdf-layout)
 DEFAULT_LAYOUT_ANALYSIS_MODE: LayoutAnalysisMode = "auto"
 DEFAULT_LAYOUT_IOU_THRESHOLD = 0.3  # Min IoU to match a prediction to a text block
+#: Upstream's own default, kept deliberately. Measured on 20 born-digital journal articles
+#: ``rf`` scored better on every axis -- title recall 0.9916 -> 0.9972, three fewer spurious
+#: table nodes on the same 16 pages, 29% faster -- but that is one corpus of one document
+#: kind, and image features plausibly earn their place on scanned pages, which that corpus
+#: contains none of. The value is exposed for per-document search rather than changed here.
+DEFAULT_LAYOUT_FEATURE_SET: LayoutFeatureSet = "imf+rf"
 
 # PDF rendering defaults (for Markdown to PDF conversion)
 DEFAULT_PDF_PAGE_SIZE: PageSize = "letter"

--- a/src/all2md/optimize.py
+++ b/src/all2md/optimize.py
@@ -234,6 +234,15 @@ KNOBS: dict[str, dict[str, list[Any]]] = {
         "trim_headers_footers": [True, False],
         "auto_trim_headers_footers": [True, False],
         "dedup_running_headings": [True, False],
+        # Which layout classifier reads the page. A genuine per-document trade-off: the
+        # image-feature models see a dense two-column reference list as a table and delete
+        # it, while the text-geometry model reads the same page correctly -- and the
+        # reverse is expected on scanned pages, where there is no text geometry to read.
+        # Inert when layout analysis does not run, which the search tolerates: the values
+        # simply tie. Measured on 20 born-digital articles, 'rf' beat the default on title
+        # recall, spurious table nodes and runtime; that is one document kind, which is
+        # why this is searched per document rather than changed as a default.
+        "layout_feature_set": ["imf+rf", "rf", "imf"],
     },
     "html": {
         "extract_readable": [True, False],

--- a/src/all2md/options/pdf.py
+++ b/src/all2md/options/pdf.py
@@ -34,6 +34,7 @@ from all2md.constants import (
     DEFAULT_INCLUDE_IMAGE_CAPTIONS,
     DEFAULT_INCLUDE_PAGE_NUMBERS,
     DEFAULT_LAYOUT_ANALYSIS_MODE,
+    DEFAULT_LAYOUT_FEATURE_SET,
     DEFAULT_LAYOUT_IOU_THRESHOLD,
     DEFAULT_LINK_OVERLAP_THRESHOLD,
     DEFAULT_MERGE_HYPHENATED_WORDS,
@@ -54,6 +55,7 @@ from all2md.constants import (
     ColumnDetectionMode,
     ImageFormat,
     LayoutAnalysisMode,
+    LayoutFeatureSet,
     PageSize,
     PdfCommentMode,
     TableDetectionMode,
@@ -589,6 +591,17 @@ class PdfOptions(PaginatedParserOptions):
         metadata={
             "help": "Minimum IoU overlap to match layout predictions to text blocks (0.0-1.0)",
             "type": float,
+            "importance": "advanced",
+        },
+    )
+    layout_feature_set: LayoutFeatureSet = field(
+        default=DEFAULT_LAYOUT_FEATURE_SET,
+        metadata={
+            "help": (
+                "Which layout classifier to run: 'imf+rf' (image and text-geometry features), "
+                "'rf' (text geometry only), 'imf' (image only). Ignored unless layout analysis runs"
+            ),
+            "choices": ["imf+rf", "rf", "imf"],
             "importance": "advanced",
         },
     )

--- a/src/all2md/parsers/_pdf_layout.py
+++ b/src/all2md/parsers/_pdf_layout.py
@@ -26,6 +26,8 @@ import sys
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any, Iterator
 
+from all2md.constants import DEFAULT_LAYOUT_FEATURE_SET
+
 if TYPE_CHECKING:
     import fitz
 
@@ -152,8 +154,11 @@ class PageLayoutPredictions:
         return [p for p in self.predictions if p.label == label]
 
 
-# Module-level model cache (singleton, loaded once per process)
-_layout_model: Any = None
+#: Loaded models, keyed by feature set. Keyed rather than a singleton because the feature
+#: set selects a *different* ONNX model, and a caller that switches sets mid-process -- the
+#: optimizer searching this knob does exactly that -- would otherwise silently keep getting
+#: whichever model was loaded first, making every arm of the search identical.
+_layout_models: dict[str, Any] = {}
 
 
 def is_layout_available() -> bool:
@@ -166,11 +171,17 @@ def is_layout_available() -> bool:
         return False
 
 
-def get_layout_model() -> Any:
-    """Get or create the cached layout analysis model.
+def get_layout_model(feature_set: str = DEFAULT_LAYOUT_FEATURE_SET) -> Any:
+    """Get or create the cached layout analysis model for a feature set.
 
-    Returns the DocumentLayoutAnalyzer model instance, caching it
-    for reuse across pages and documents.
+    Models are cached per feature set and reused across pages and documents; loading one
+    costs several MB of ONNX weights, and a search over this knob revisits each value many
+    times.
+
+    Parameters
+    ----------
+    feature_set : str
+        Which classifier to load -- see `LayoutFeatureSet`.
 
     Returns
     -------
@@ -183,22 +194,23 @@ def get_layout_model() -> Any:
         If pymupdf-layout is not installed.
 
     """
-    global _layout_model  # noqa: PLW0603
-    if _layout_model is None:
+    if feature_set not in _layout_models:
         from pymupdf.layout import DocumentLayoutAnalyzer
 
-        _layout_model = DocumentLayoutAnalyzer.get_model()
-        logger.debug("Loaded pymupdf-layout GNN model")
-    return _layout_model
+        _layout_models[feature_set] = DocumentLayoutAnalyzer.get_model(feature_set_name=feature_set)
+        logger.debug("Loaded pymupdf-layout GNN model (feature_set=%s)", feature_set)
+    return _layout_models[feature_set]
 
 
-def predict_page_layout(page: "fitz.Page") -> list[LayoutPrediction]:
+def predict_page_layout(page: "fitz.Page", feature_set: str = DEFAULT_LAYOUT_FEATURE_SET) -> list[LayoutPrediction]:
     """Run layout prediction on a single page.
 
     Parameters
     ----------
     page : fitz.Page
         PDF page to analyze.
+    feature_set : str
+        Which classifier to run -- see `LayoutFeatureSet`.
 
     Returns
     -------
@@ -206,7 +218,7 @@ def predict_page_layout(page: "fitz.Page") -> list[LayoutPrediction]:
         Predicted regions with semantic labels.
 
     """
-    model = get_layout_model()
+    model = get_layout_model(feature_set)
     raw_predictions = model.predict(page)
     # raw_predictions: list of [x0, y0, x1, y1, label_str]
 

--- a/src/all2md/parsers/pdf.py
+++ b/src/all2md/parsers/pdf.py
@@ -1736,7 +1736,7 @@ class PdfToAstConverter(BaseParser):
         layout: PageLayoutPredictions | None = None
         if self._use_layout:
             try:
-                raw_predictions = predict_page_layout(page)
+                raw_predictions = predict_page_layout(page, self.options.layout_feature_set)
                 layout = match_predictions_to_blocks(raw_predictions, all_blocks, self.options.layout_iou_threshold)
                 annotate_blocks_with_layout(all_blocks, layout)
             except Exception as e:

--- a/tests/unit/formats/pdf/test_pdf_layout_feature_set.py
+++ b/tests/unit/formats/pdf/test_pdf_layout_feature_set.py
@@ -1,0 +1,130 @@
+#  Copyright (c) 2025 Tom Villani, Ph.D.
+#
+# tests/unit/formats/pdf/test_pdf_layout_feature_set.py
+"""Choosing which layout classifier reads the page, and caching one model per choice.
+
+`pymupdf-layout` ships three bundled classifiers. `imf+rf` (the default) and `imf` read a
+raster of the page; `rf` reads text geometry alone. Which is better depends on the document,
+so the choice is exposed as a searchable option rather than decided globally: on born-digital
+journal articles the image-feature models read a dense two-column reference list as a table
+and delete it, while `rf` labels all 41 entries correctly -- and the opposite is expected on
+scanned pages, where there is no text geometry to read.
+
+The cache is what these tests mostly guard. Models were previously held in a single module
+global with no key, which is correct for one fixed choice and silently wrong the moment a
+caller switches: every arm of a search over this knob would get whichever model loaded first
+and the arms would tie, looking like "the setting does nothing".
+
+The real models are never loaded here. They are several MB of ONNX weights and the extra is
+absent from the unit lane's install, so `pymupdf.layout` is stubbed.
+"""
+
+from __future__ import annotations
+
+import sys
+
+import pytest
+
+from all2md.constants import DEFAULT_LAYOUT_FEATURE_SET
+from all2md.options.pdf import PdfOptions
+from all2md.parsers import _pdf_layout
+
+pytestmark = [pytest.mark.unit, pytest.mark.pdf]
+
+
+class _FakeAnalyzer:
+    """Stands in for `pymupdf.layout.DocumentLayoutAnalyzer`, recording what it was asked for."""
+
+    calls: list[str] = []
+
+    @staticmethod
+    def get_model(feature_set_name: str = "imf+rf", **kwargs):
+        _FakeAnalyzer.calls.append(feature_set_name)
+        return f"model:{feature_set_name}"
+
+
+@pytest.fixture
+def stub_layout(monkeypatch):
+    import types
+
+    module = types.ModuleType("pymupdf.layout")
+    module.DocumentLayoutAnalyzer = _FakeAnalyzer
+    monkeypatch.setitem(sys.modules, "pymupdf.layout", module)
+    monkeypatch.setattr(_pdf_layout, "_layout_models", {})
+    _FakeAnalyzer.calls = []
+    return _FakeAnalyzer
+
+
+class TestModelCacheIsKeyedByFeatureSet:
+    def test_different_feature_sets_load_different_models(self, stub_layout):
+        first = _pdf_layout.get_layout_model("imf+rf")
+        second = _pdf_layout.get_layout_model("rf")
+
+        assert first == "model:imf+rf"
+        assert second == "model:rf"
+        assert stub_layout.calls == ["imf+rf", "rf"]
+
+    def test_repeating_a_feature_set_reuses_its_model(self, stub_layout):
+        _pdf_layout.get_layout_model("rf")
+        _pdf_layout.get_layout_model("imf")
+        _pdf_layout.get_layout_model("rf")
+
+        # Three requests, two loads: the second 'rf' must come from the cache, or a search
+        # revisiting values pays several MB of ONNX load each time it changes its mind.
+        assert stub_layout.calls == ["rf", "imf"]
+
+    def test_switching_back_does_not_return_the_other_model(self, stub_layout):
+        first = _pdf_layout.get_layout_model("imf+rf")
+        _pdf_layout.get_layout_model("rf")
+        again = _pdf_layout.get_layout_model("imf+rf")
+
+        # The defect a single unkeyed global would produce: every arm silently identical.
+        assert again == first == "model:imf+rf"
+
+    def test_defaults_to_the_documented_feature_set(self, stub_layout):
+        _pdf_layout.get_layout_model()
+
+        assert stub_layout.calls == [DEFAULT_LAYOUT_FEATURE_SET]
+
+
+class TestPredictPassesTheFeatureSetThrough:
+    def test_prediction_uses_the_requested_classifier(self, monkeypatch, stub_layout):
+        requested: list[str] = []
+
+        class _Model:
+            def predict(self, page):
+                return []
+
+        def _fake_get_model(feature_set=DEFAULT_LAYOUT_FEATURE_SET):
+            requested.append(feature_set)
+            return _Model()
+
+        monkeypatch.setattr(_pdf_layout, "get_layout_model", _fake_get_model)
+        _pdf_layout.predict_page_layout(object(), "rf")
+
+        assert requested == ["rf"]
+
+
+class TestOptionAndKnob:
+    def test_option_default_matches_upstream(self):
+        # Deliberately upstream's default: 'rf' won on one born-digital corpus, which is not
+        # grounds for changing what every document gets.
+        assert PdfOptions().layout_feature_set == "imf+rf"
+
+    def test_option_is_settable(self):
+        assert PdfOptions(layout_feature_set="rf").layout_feature_set == "rf"
+
+    def test_registered_as_a_searchable_knob(self):
+        from all2md.optimize import FORBIDDEN_KNOBS, tunable_knobs
+
+        knobs = tunable_knobs("pdf")
+        assert knobs["layout_feature_set"] == ["imf+rf", "rf", "imf"]
+        assert "layout_feature_set" not in FORBIDDEN_KNOBS
+
+    def test_every_searched_value_is_accepted_by_the_options(self):
+        from all2md.optimize import tunable_knobs
+
+        # A knob whose values the options reject would fail only at search time, on a user's
+        # document, after the expensive part of the run.
+        for value in tunable_knobs("pdf")["layout_feature_set"]:
+            assert PdfOptions(layout_feature_set=value).layout_feature_set == value


### PR DESCRIPTION
## Why

`pymupdf-layout` bundles **three** classifiers, selected by `feature_set_name`, and all2md hardcoded upstream's default:

| value | model | reads |
|---|---|---|
| `imf+rf` | `layout_rf2.4.1+imf1.onnx` | image + text-geometry features (**default**) |
| `imf` | `layout_imf1.onnx` | image features only |
| `rf` | `layout_rf2.4.1.onnx` | text geometry only |

Which is right depends on the document, which is the stated bar for a `KNOBS` entry, so this exposes it and registers it for `optimize` rather than picking a winner.

The difference is not subtle. On page 16 of `PMC7500012.1` — a two-column reference page:

- `imf+rf` predicts 22 regions including **one spurious `table`** over the dense left column, which deleted nine reference entries (the loss fixed separately in #288)
- `imf` predicts 38 regions, still with a spurious table
- `rf` predicts 43 regions, labels **all 41 reference entries `list-item`**, and predicts no table at all

That is the shape of a genuine per-document trade-off: a page raster of a dense reference list *looks* like a table, and on a scanned page there is no text geometry to read.

## Measurement — 20 PMC born-digital articles

| | `imf+rf` | `rf` | `imf` |
|---|---|---|---|
| `title` recall | 706/712 = 0.9916 | **710/712 = 0.9972** | 708/712 = 0.9944 |
| `text_block` recall | 964/983 = 0.9807 | **965/983 = 0.9817** | 965/983 = 0.9817 |
| `table` content recall | 18/21 | 18/21 | 18/21 |
| `Table` nodes built | 22 | 19 | 22 |
| wall clock | 153s | **109s** | 140s |

Table content recall is *identical*, so `rf` gives up no table content. Its 3 fewer nodes were checked rather than assumed: both arms build tables on the **same 16 pages**, and the difference is three pages where `imf+rf` builds 2 nodes and `rf` builds 1 — over-segmentation, consistent with #256's finding that `block_structure_similarity` measures granularity.

## The default is deliberately unchanged

`rf` won on every axis here, and that is still not grounds for changing what every document gets. This is one corpus of one document kind, containing **no scanned pages** — precisely where image features would be expected to earn their place. Settling that needs the OmniDocBench raster lane, not this one.

## Cache correctness

Models were held in a single unkeyed global. That is fine for one fixed choice and silently wrong the moment a caller switches — every arm of a search over this knob would receive whichever model loaded first, tie, and make the setting look inert. Now keyed per feature set. Two tests fail against the old behaviour.

## Also established, and negative

`table_grid_model_ver` (14 variants across 11 bundled ONNX files) is **not** worth exposing: `V4`, `V1` and `V2` produce byte-identical predictions because the grid extractor only feeds `to_markdown()`/`to_html()`, which all2md never calls. `V3` additionally crashes on a missing `cv2`. Recording this so the sweep is not attempted again.

There is also **no confidence threshold** anywhere — predictions are `[x0, y0, x1, y1, label]` with no score — so the usual "raise the cutoff to curb over-prediction" lever does not exist.

## Notes

- Weights are bundled ONNX inside the wheel (~48 MB); nothing is downloaded, so no network or version-drift exposure.
- Upstream also accepts `imf+rf+yf` and `rf+jf`; both pass validation and then fail on a missing config file, so they are excluded from the Literal.
- Docs regenerated via `scripts/generate_options_doc.py`; CLI flag `--pdf-layout-feature-set` cross-checked against `create_parser()`.
- `tests/unit`, `tests/golden`, `tests/integration`, `tests/e2e` all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)