### PR TITLE
fix(pdf): label lines, not just blocks, so headings inside a column survive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,35 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Section headings inside a multi-line block are no longer flattened to prose**
+  (PDF, requires `pymupdf-layout`). Layout labels were assigned per *block*, by IoU against
+  the model's predicted region. That is a fair test only when a block is one semantic unit,
+  and PyMuPDF returns a whole journal column as a single block — so a two-line heading
+  inside it scored an IoU near 0.03 against its own block and its `section-header` label was
+  discarded before anything could use it. Measured on the born-digital corpus, **54% of
+  `section-header` predictions never reached a block**, the median miss being a block 38x
+  the prediction's area; the same plumbing lost 52% of `list-item` and 51% of `page-header`
+  labels. Labels are now also stamped per line, by containment rather than IoU — a line
+  inside a correct region has a low IoU with it by construction — and the heading path
+  consults the line's own label before the block's. Against JATS section titles on 12
+  articles, the share emitted as headings rose from **0.420 to 0.729** (79 → 137 of 188)
+  for five additional headings not backed by a title. Two articles went from 0/32 and 3/33
+  to 24/32 and 26/33. Nothing else on the corpus moved: text recall is identical to the
+  digit in both arms (95.6% of attainable overall; `title` 94.2%, `text_block` 96.3%,
+  `table` 96.7%), reading order is unchanged at 0.779, and `block_structure_similarity`
+  rises 0.548 → 0.567 — a change in structure and nothing else, which is what was intended.
+  This is the same class of defect as the partial table region fixed above: a block is the
+  wrong unit to judge, and the fix is to judge the line.
+- **The structural half of heading detection is now measured.** The corpus lane scored
+  `title` as *text recall*, which cannot distinguish `## Materials and Methods` from a bare
+  paragraph carrying the same words — a parser that flattened every heading in the corpus
+  would have scored 1.00 on it. Note the ground truth for this is section titles
+  specifically: the oracle's `title` kind also maps `article-title`, which appears inside
+  every bibliography `<ref>`, so scoring headings against it rewards exactly the wrong
+  behaviour on a 60-reference article.
+
 ### Added
 
 - **`layout_feature_set`, choosing which layout classifier reads the page** (`--pdf-layout-feature-set`,

--- a/src/all2md/parsers/_pdf_layout.py
+++ b/src/all2md/parsers/_pdf_layout.py
@@ -37,6 +37,7 @@ __all__ = [
     "get_layout_model",
     "predict_page_layout",
     "match_predictions_to_blocks",
+    "annotate_lines_with_layout",
     "is_layout_available",
     "native_find_tables",
 ]
@@ -321,6 +322,74 @@ def match_predictions_to_blocks(
 
     logger.debug("Matched %d/%d blocks to layout labels", len(block_labels), len(blocks))
     return PageLayoutPredictions(predictions=predictions, block_labels=block_labels)
+
+
+def annotate_lines_with_layout(
+    blocks: list[dict],
+    predictions: list[LayoutPrediction],
+    coverage_threshold: float = 0.5,
+) -> int:
+    """Stamp ``_layout_label`` onto each *line* a prediction covers.
+
+    :func:`match_predictions_to_blocks` assigns labels per block, by IoU. That works when
+    a block is one semantic unit, and fails whenever it is not: PyMuPDF returns a whole
+    journal column as a single block, so a two-line section heading inside it has an IoU of
+    roughly 0.03 against its own block and the label is discarded. Measured on the PMC
+    corpus, 54% of ``section-header`` predictions never reached a block, the median offender
+    being a block 38x the area of the prediction.
+
+    Coverage of the *line* answers the question the matcher was really asking -- "did the
+    model draw a box around this text" -- without depending on how PyMuPDF happened to group
+    it. IoU is wrong at this granularity: a line inside a large correct region has a low IoU
+    with it, so containment is the test, in the same direction the table-region filter uses.
+
+    Parameters
+    ----------
+    blocks : list[dict]
+        Text blocks from ``page.get_text("dict")``; their lines are mutated in place.
+    predictions : list[LayoutPrediction]
+        Layout model predictions for the page.
+    coverage_threshold : float
+        Share of the line's area a prediction must cover to claim it.
+
+    Returns
+    -------
+    int
+        Number of lines stamped, for logging.
+
+    """
+    import fitz
+
+    if not predictions:
+        return 0
+
+    rects = [(pred, fitz.Rect(pred.bbox)) for pred in predictions]
+    stamped = 0
+    for block in blocks:
+        for line in block.get("lines", ()):
+            bbox = line.get("bbox")
+            if bbox is None:
+                continue
+            rect = fitz.Rect(bbox)
+            area = abs(rect)
+            if area <= 0:
+                continue
+            best_label: str | None = None
+            best_share = coverage_threshold
+            for pred, pred_rect in rects:
+                share = abs(rect & pred_rect) / area
+                # Strict improvement, so the first prediction wins a tie -- predictions
+                # arrive in the model's own order and a stable choice keeps the same page
+                # producing the same output across runs.
+                if share > best_share:
+                    best_share = share
+                    best_label = pred.label
+            if best_label is not None:
+                line["_layout_label"] = best_label
+                stamped += 1
+
+    logger.debug("Stamped %d line(s) with layout labels", stamped)
+    return stamped
 
 
 def annotate_blocks_with_layout(

--- a/src/all2md/parsers/pdf.py
+++ b/src/all2md/parsers/pdf.py
@@ -71,6 +71,7 @@ from all2md.parsers._pdf_images import extract_page_images
 from all2md.parsers._pdf_layout import (
     PageLayoutPredictions,
     annotate_blocks_with_layout,
+    annotate_lines_with_layout,
     is_layout_available,
     match_predictions_to_blocks,
     native_find_tables,
@@ -1739,6 +1740,10 @@ class PdfToAstConverter(BaseParser):
                 raw_predictions = predict_page_layout(page, self.options.layout_feature_set)
                 layout = match_predictions_to_blocks(raw_predictions, all_blocks, self.options.layout_iou_threshold)
                 annotate_blocks_with_layout(all_blocks, layout)
+                # Also label individual lines. A block-level label is only available when
+                # the block happens to be one semantic unit; on a journal page it is a whole
+                # column, and every heading inside it loses its label to the IoU test.
+                annotate_lines_with_layout(all_blocks, raw_predictions)
             except Exception as e:
                 logger.warning("Layout analysis failed for page %d: %s", page_num + 1, e)
                 layout = None
@@ -2643,11 +2648,13 @@ class PdfToAstConverter(BaseParser):
             if state.in_code_block:
                 self._finalize_code_block(state, page_num)
 
-            # Handle headers - layout label overrides font-size heuristics
-            if layout_label in ("title", "section-header"):
-                if self._handle_header_line_with_layout(
-                    spans, links, state, page_num, average_line_height, layout_label
-                ):
+            # Handle headers - layout label overrides font-size heuristics. A line carries
+            # its own label when the model drew a box around it, which is the only way a
+            # heading inside a full-column block is ever labelled; fall back to the block's
+            # label, which is all that exists when the block is one semantic unit.
+            line_label = line.get("_layout_label") or layout_label
+            if line_label in ("title", "section-header"):
+                if self._handle_header_line_with_layout(spans, links, state, page_num, average_line_height, line_label):
                     continue
             elif self._handle_header_line(spans, links, state, page_num, average_line_height):
                 continue

--- a/tests/unit/formats/pdf/test_pdf_layout_line_labels.py
+++ b/tests/unit/formats/pdf/test_pdf_layout_line_labels.py
@@ -1,0 +1,188 @@
+#  Copyright (c) 2025 Tom Villani, Ph.D.
+#
+# tests/unit/formats/pdf/test_pdf_layout_line_labels.py
+"""Layout labels have to reach the lines they describe, not just the blocks.
+
+``match_predictions_to_blocks`` assigns a label to a *block* when the two overlap by
+IoU >= 0.3. That is a reasonable test when a block is one semantic unit and a hopeless one
+when it is not: PyMuPDF hands back a whole journal column as a single block, so a two-line
+section heading inside it scores an IoU near 0.03 against its own block and its label is
+thrown away. Measured on the PMC born-digital corpus, 54% of ``section-header`` predictions
+never reached any block, and the median miss was a block 38x the prediction's area.
+
+``annotate_lines_with_layout`` asks the question the matcher meant to ask -- did the model
+draw a box around *this text* -- by containment rather than IoU, because a line inside a
+correct region has a low IoU with it by construction.
+
+These tests drive the annotator directly rather than through the model, so they run on the
+unit lane, which installs without the ``pdf_layout`` extra.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from all2md.parsers._pdf_layout import LayoutPrediction, annotate_lines_with_layout
+
+pytestmark = [pytest.mark.unit, pytest.mark.pdf]
+
+
+def _line(y0: float, y1: float, text: str, x0: float = 50.0, x1: float = 300.0) -> dict:
+    return {"bbox": (x0, y0, x1, y1), "spans": [{"text": text}]}
+
+
+def _block(*lines: dict) -> dict:
+    return {
+        "bbox": (
+            min(line["bbox"][0] for line in lines),
+            min(line["bbox"][1] for line in lines),
+            max(line["bbox"][2] for line in lines),
+            max(line["bbox"][3] for line in lines),
+        ),
+        "lines": list(lines),
+        "type": 0,
+    }
+
+
+def _pred(y0: float, y1: float, label: str, x0: float = 45.0, x1: float = 305.0) -> LayoutPrediction:
+    return LayoutPrediction(x0=x0, y0=y0, x1=x1, y1=y1, label=label)
+
+
+class TestLinesInsideAColumnKeepTheirLabel:
+    def test_a_heading_inside_a_full_column_block_is_labelled(self):
+        # The case the block matcher cannot serve: one block spanning the column, with a
+        # heading two lines tall inside it.
+        block = _block(
+            _line(100, 110, "Materials and Methods"),
+            *[_line(y, y + 10, f"body line at {y}") for y in range(120, 700, 10)],
+        )
+
+        stamped = annotate_lines_with_layout([block], [_pred(98, 112, "section-header")])
+
+        assert stamped == 1
+        assert block["lines"][0]["_layout_label"] == "section-header"
+        assert "_layout_label" not in block["lines"][1]
+
+    def test_body_lines_under_a_text_prediction_are_labelled_text(self):
+        block = _block(_line(100, 110, "Results"), _line(120, 130, "prose"), _line(130, 140, "more prose"))
+        predictions = [_pred(98, 112, "section-header"), _pred(118, 142, "text")]
+
+        annotate_lines_with_layout([block], predictions)
+
+        labels = [line.get("_layout_label") for line in block["lines"]]
+        assert labels == ["section-header", "text", "text"]
+
+    def test_a_line_the_model_did_not_cover_is_left_alone(self):
+        block = _block(_line(100, 110, "labelled"), _line(400, 410, "untouched"))
+
+        annotate_lines_with_layout([block], [_pred(98, 112, "section-header")])
+
+        assert "_layout_label" not in block["lines"][1]
+
+    def test_majority_coverage_is_required(self):
+        # A prediction clipping the top 20% of a line has not identified that line.
+        block = _block(_line(100, 110, "mostly outside"))
+
+        stamped = annotate_lines_with_layout([block], [_pred(98, 102, "section-header")])
+
+        assert stamped == 0
+        assert "_layout_label" not in block["lines"][0]
+
+    def test_the_prediction_covering_most_of_the_line_wins(self):
+        block = _block(_line(100, 110, "contested"))
+        # 'text' covers 60%, 'section-header' covers 90% -- the larger share decides, not
+        # the order predictions happen to arrive in.
+        predictions = [_pred(94, 106, "text"), _pred(99, 110, "section-header")]
+
+        annotate_lines_with_layout([block], predictions)
+
+        assert block["lines"][0]["_layout_label"] == "section-header"
+
+    def test_no_predictions_is_a_no_op(self):
+        block = _block(_line(100, 110, "unlabelled"))
+
+        assert annotate_lines_with_layout([block], []) == 0
+        assert "_layout_label" not in block["lines"][0]
+
+    def test_blocks_without_lines_are_skipped(self):
+        image_block = {"bbox": (0, 0, 10, 10), "type": 1}
+
+        assert annotate_lines_with_layout([image_block], [_pred(0, 10, "picture")]) == 0
+
+    def test_a_degenerate_line_bbox_is_not_divided_by(self):
+        block = {"bbox": (50, 100, 300, 100), "lines": [{"bbox": (50, 100, 300, 100), "spans": []}], "type": 0}
+
+        assert annotate_lines_with_layout([block], [_pred(90, 110, "section-header")]) == 0
+
+
+class TestPageEmitsAHeadingInsideAColumn:
+    """The same defect through the page pipeline, with predictions injected by hand.
+
+    The layout model is not run: the unit lane installs without ``pymupdf-layout``, and a
+    test that depended on what the model predicts this release would be measuring the model
+    rather than the plumbing.
+    """
+
+    @staticmethod
+    def _column_page(tmp_path):
+        import fitz
+
+        doc = fitz.open()
+        page = doc.new_page(width=300, height=500)
+        writer = fitz.TextWriter(page.rect)
+        font = fitz.Font("helv")
+        # A uniform cadence and one font size throughout, so the font heuristic has nothing
+        # to go on and only the layout label can promote the heading. A larger heading font
+        # would let the existing heuristic pass the test without the fix.
+        writer.append((50, 60), "Materials and Methods", font=font, fontsize=9)
+        for idx in range(30):
+            writer.append((50, 70 + idx * 10), f"body line {idx} of this column", font=font, fontsize=9)
+        writer.write_text(page)
+        path = tmp_path / "column.pdf"
+        doc.save(str(path))
+        doc.close()
+        return str(path)
+
+    def test_the_heading_line_becomes_a_heading(self, tmp_path, monkeypatch):
+        import fitz
+
+        from all2md.ast.nodes import Heading
+        from all2md.ast.transforms import NodeCollector
+        from all2md.ast.utils import extract_text
+        from all2md.options.pdf import PdfOptions
+        from all2md.parsers import pdf as pdf_module
+        from all2md.parsers.pdf import PdfToAstConverter
+
+        path = self._column_page(tmp_path)
+        doc = fitz.open(path)
+        page = doc[0]
+
+        blocks = [b for b in page.get_text("dict")["blocks"] if b.get("type") == 0]
+        # Precondition: one block holding heading and body alike. If PyMuPDF ever splits
+        # them the fixture stops testing this at all and should be rebuilt, not loosened.
+        assert len(blocks) == 1
+
+        heading_rect = blocks[0]["lines"][0]["bbox"]
+        monkeypatch.setattr(
+            pdf_module,
+            "predict_page_layout",
+            lambda page, feature_set: [
+                LayoutPrediction(
+                    x0=heading_rect[0] - 2,
+                    y0=heading_rect[1] - 1,
+                    x1=heading_rect[2] + 2,
+                    y1=heading_rect[3] + 1,
+                    label="section-header",
+                )
+            ],
+        )
+
+        converter = PdfToAstConverter(options=PdfOptions(layout_analysis_mode="enabled"))
+        converter._use_layout = True
+        nodes = converter._process_page_to_ast(page, 0, "doc", lambda a, b: (a, 0), doc.page_count)
+        doc.close()
+
+        collector = NodeCollector(lambda n: isinstance(n, Heading))
+        for node in nodes:
+            node.accept(collector)
+        assert [extract_text(h).strip() for h in collector.collected] == ["Materials and Methods"]


### PR DESCRIPTION
## The defect

Layout labels were assigned per **block**, by IoU against the model's predicted region. That is a fair test only when a block is one semantic unit — and PyMuPDF returns a whole journal column as a single block. A two-line section heading inside it scores an IoU near **0.03** against its own block, so its `section-header` label was discarded before anything could use it.

This is the same class of defect as #288: a block is the wrong unit to judge, and the fix is to judge the line.

## What was being lost

Measured across 111 pages of the PMC born-digital corpus:

| label | consumed today | predicted | reached a block |
|---|---|---|---|
| `list-item` | yes | 518 | 47.5% |
| `section-header` | yes | 190 | 46.3% |
| `page-header` | yes | 181 | 48.6% |
| `page-footer` | yes | 74 | 58.1% |
| `table` | yes | 23 | 39.1% |

The median unmatched `section-header` sits inside a block **38× its own area**. The labels were right; the unit they were matched against was wrong.

Of 120 section titles the parser failed to emit as headings, **41 were labelled correctly and lost by the matcher**, 33 had the label arrive and the heading guards still declined, and 46 the model never called a heading. This PR addresses the first group.

## The change

`annotate_lines_with_layout` stamps `_layout_label` onto lines by **containment** rather than IoU — a line inside a correct region has a low IoU with it by construction — and the heading path consults the line's own label before the block's. Where a block really is one semantic unit the previous behaviour is unchanged, since the block label remains the fallback.

## Measurement

The lane's `title` oracle scores *text recall*, so it cannot distinguish `## Materials and Methods` from a paragraph holding those words — a parser that flattened every heading in the corpus would still score 1.00 on it. Title recall sat at 99.2% of attainable while only 42% of section titles were emitted as headings.

Ground truth for the new question is section titles specifically, extracted by parent element. Note for anyone extending this: the oracle's `title` kind also maps `article-title`, which appears inside every bibliography `<ref>`, so scoring headings against it rewards turning citations into headings.

**Section titles emitted as headings, 12 articles: 79/188 → 137/188 (0.420 → 0.729)**, for five additional headings not backed by a title. Two articles go from 0/32 and 3/33 to 24/32 and 26/33.

Nothing else on the corpus moved, same 12 articles:

| dimension | baseline | branch |
|---|---|---|
| `block_structure_similarity` | 0.548 | **0.567** |
| `reading_order_similarity` | 0.779 | 0.779 |
| `text_content_similarity` | 0.570 | 0.570 |
| `table_content` / `table_structure` | 0.241 / 0.235 | 0.241 / 0.235 |
| recall of attainable | 95.6% | 95.6% |

Per-kind recall is identical to the digit in both arms: `title` 94.2%, `text_block` 96.3%, `table` 96.7%. A change in structure and nothing else, which is what was intended.

## Verification

- 9 new unit tests; the end-to-end fixture fails pre-fix with the right symptom (no heading emitted at all).
- The fixture uses a single font size throughout, so the font heuristic cannot pass it without the layout label.
- Output on both fixture PDFs is **byte-identical** pre/post, checked by neutralising the new call in-process — the golden snapshots cannot make this check here since they skip on Windows, which is how #288's regression escaped.
- `tests/unit`, `tests/golden`, `tests/integration`, `tests/e2e` all green locally.

## Not addressed here

The 51 remaining misses break down into three distinct defects, each filed separately and none reachable by a per-line label:

- **#295 — a heading that wraps is emitted as one `Heading` per printed line.** `PMC4000001`'s article title comes out as three sibling `# ` headings, none holding the title. ~11 of the 51, mostly article titles since they are the longest headings in a paper.
- **#296 — run-in headings stay prose.** `**Background:** To determine factors...` — the line is both heading and body, so no label can separate them. 9 of the 51 visibly, plus much of the 10 counted `heading_reused` (the same label run-in in the abstract and a real heading in the body, where only one occurrence is credited).
- The rest are genuinely flat: the model labelled them `text` and the font heuristic had nothing to say.

Separately, #294 is a **precision** defect this measurement surfaced: `classify_line_style` never requires a heading to contain a letter, so 122 of one article's 179 headings are a single Private Use Area math glyph (∑, ∫, large parentheses).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

