### PR TITLE
fix(pdf): require a heading to contain at least one alphanumeric character

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **A lone math glyph is no longer promoted to a heading** (PDF). Heading classification
+  validated a candidate by font size, bold/all-caps requirement, maximum length and an
+  internal-sentence-boundary check, and never asked whether the text contained a letter.
+  Large delimiters are set in a symbol font well above body size, so they cleared the size
+  gate and passed every remaining one — short, non-empty, no sentence boundary — and were
+  emitted as headings from inside displayed equations. One chemistry paper in the
+  born-digital corpus produced **179 headings for its 9 sections, 122 of them a single
+  Private Use Area glyph** (∑, ∫, large parentheses and brackets); it now emits 55, with
+  its real headings untouched and its text content byte-identical once heading markers are
+  stripped. The gate is `str.isalnum`, not an ASCII character class, precisely so that
+  headings in CJK, Cyrillic, Arabic, Devanagari, Greek and Hangul still qualify — an ASCII
+  test would have deleted every one of them while fixing this.
+
 ### Added
 
 - **`layout_feature_set`, choosing which layout classifier reads the page** (`--pdf-layout-feature-set`,

--- a/src/all2md/parsers/_pdf_headers.py
+++ b/src/all2md/parsers/_pdf_headers.py
@@ -570,6 +570,18 @@ class IdentifyHeaders:
             return 0
         if len(text) > self.options.header_max_line_length:
             return 0
+        # A heading names something, so it contains at least one alphanumeric character.
+        # Without this, a large math delimiter set in a symbol font passes every other gate
+        # -- it is short, non-empty and holds no sentence boundary -- and its size alone
+        # promotes it. One chemistry paper emitted 179 headings for its 9 sections, 122 of
+        # them a single Private Use Area glyph (large parentheses, sigma, integral signs)
+        # sitting inside displayed equations.
+        #
+        # `str.isalnum` rather than an ASCII class on purpose: it is Unicode-aware, so
+        # headings in CJK, Cyrillic, Arabic and Devanagari still qualify, while PUA
+        # codepoints (category Co, where symbol fonts put their glyphs) do not.
+        if not any(char.isalnum() for char in text):
+            return 0
         # Multi-sentence body text isn't a heading. Detected via lowercase
         # letter immediately preceding `.`/`!`/`?`, then whitespace, then a
         # capital letter — sidesteps acronyms like "U.S. Department".

--- a/tests/unit/formats/pdf/test_pdf_heading_content_gate.py
+++ b/tests/unit/formats/pdf/test_pdf_heading_content_gate.py
@@ -1,0 +1,110 @@
+#  Copyright (c) 2025 Tom Villani, Ph.D.
+#
+# tests/unit/formats/pdf/test_pdf_heading_content_gate.py
+"""A heading names something, so it has to contain at least one alphanumeric character.
+
+``IdentifyHeaders.classify_line_style`` validated a candidate by font size, bold/all-caps
+requirements, maximum length and an internal-sentence-boundary check -- and never asked
+whether the text held a letter. Large math delimiters are set in a symbol font at a size
+well above body text, so they cleared the size gate and passed every remaining one: short,
+non-empty, no sentence boundary.
+
+On one chemistry paper in the born-digital corpus that produced **179 headings for 9
+sections**, 122 of them a single Private Use Area glyph -- sigma, integral, large
+parentheses -- lifted out of displayed equations and emitted as `### `.
+
+The gate uses ``str.isalnum`` rather than an ASCII character class, which is the whole
+point: it is Unicode-aware, so a heading in any script still qualifies, while PUA
+codepoints (category Co, where symbol fonts keep their glyphs) do not. An ASCII test would
+have rejected every CJK, Cyrillic, Arabic and Devanagari heading in the process of fixing
+this.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from all2md.options.pdf import PdfOptions
+from all2md.parsers._pdf_headers import IdentifyHeaders
+
+pytestmark = [pytest.mark.unit, pytest.mark.pdf]
+
+
+@pytest.fixture
+def identifier() -> IdentifyHeaders:
+    """A classifier with one heading size registered, and no style requirement on it."""
+    ident = IdentifyHeaders.__new__(IdentifyHeaders)
+    ident.header_id = {20: 1, 16: 2}
+    ident.bold_header_sizes = set()
+    ident.allcaps_header_sizes = set()
+    ident.options = PdfOptions()
+    ident.debug_info = None
+    return ident
+
+
+def _classify(ident: IdentifyHeaders, text: str, size: int = 20) -> int:
+    return ident.classify_line_style(size=size, text=text, is_bold=False, is_allcaps=False)
+
+
+class TestGlyphOnlyLinesAreNotHeadings:
+    @pytest.mark.parametrize(
+        "glyph,name",
+        [
+            ("", "summation"),
+            ("", "large opening parenthesis"),
+            ("", "large closing parenthesis"),
+            ("", "integral"),
+            ("", "large bracket"),
+        ],
+    )
+    def test_a_lone_symbol_font_glyph_is_rejected(self, identifier, glyph, name):
+        assert _classify(identifier, glyph) == 0, name
+
+    def test_a_run_of_glyphs_is_rejected(self, identifier):
+        assert _classify(identifier, "") == 0
+
+    def test_punctuation_alone_is_rejected(self, identifier):
+        assert _classify(identifier, "— :") == 0
+
+    def test_whitespace_around_a_glyph_does_not_rescue_it(self, identifier):
+        assert _classify(identifier, "    ") == 0
+
+
+class TestRealHeadingsStillQualify:
+    def test_ordinary_text(self, identifier):
+        assert _classify(identifier, "Introduction") == 1
+
+    def test_a_numbered_heading(self, identifier):
+        assert _classify(identifier, "3.1. Non-Relativistic Bondons") == 1
+
+    def test_a_number_alone(self, identifier):
+        # A chapter number is a legitimate heading; the gate asks for alphanumeric, not
+        # alphabetic, so digits carry it.
+        assert _classify(identifier, "7") == 1
+
+    @pytest.mark.parametrize(
+        "text,script",
+        [
+            ("第一章", "CJK"),
+            ("Введение", "Cyrillic"),
+            ("المقدمة", "Arabic"),
+            ("परिचय", "Devanagari"),
+            ("Εισαγωγή", "Greek"),
+            ("서론", "Hangul"),
+        ],
+    )
+    def test_non_latin_headings_are_kept(self, identifier, text, script):
+        # The reason the gate is `str.isalnum` and not `[A-Za-z0-9]`. An ASCII test would
+        # silently delete every heading in these scripts.
+        assert _classify(identifier, text) == 1, script
+
+    def test_a_heading_mixing_text_and_a_glyph_is_kept(self, identifier):
+        assert _classify(identifier, "Method: Identification of Bondons (B)") == 1
+
+
+class TestTheGateRunsAfterTheOtherChecks:
+    def test_a_size_that_is_not_a_heading_size_is_still_rejected(self, identifier):
+        assert _classify(identifier, "Introduction", size=11) == 0
+
+    def test_an_overlong_line_is_still_rejected(self, identifier):
+        assert _classify(identifier, "word " * 200) == 0


### PR DESCRIPTION
Closes #294.

## The defect

`IdentifyHeaders.classify_line_style` validated a candidate heading by font size, bold/all-caps requirement, maximum length, and an internal-sentence-boundary check. It never asked whether the text contained a **letter**.

Large math delimiters are set in a symbol font well above body size, so they cleared the size gate and then passed every remaining one — short, non-empty, no sentence boundary — and were emitted as headings from inside displayed equations.

## Evidence

`PMC3000079`, a chemistry paper in the born-digital corpus, emitted **179 headings for its 9 section titles**. 122 were a single Private Use Area glyph:

| glyph | count | what it is |
|---|---|---|
| U+F0E5 | 29 | ∑ |
| U+F028 / U+F029 | 24 / 24 | large parentheses |
| U+F075 | 9 | ν |
| U+F0F2 | 5 | ∫ |
| U+F05B | 5 | large bracket |

Full set: `f028 f029 f02b f02d f050 f057 f05b f05d f064 f068 f070 f075 f0e5 f0f2` — every one in the PUA block, which is where symbol fonts keep their glyphs.

## Why `str.isalnum` and not `[A-Za-z0-9]`

This is the substance of the fix rather than a detail. `isalnum` is Unicode-aware, so headings in CJK, Cyrillic, Arabic, Devanagari, Greek and Hangul still qualify, while PUA codepoints (category Co) do not.

An ASCII character class would have fixed the reported bug and silently deleted **every non-Latin heading in the library**. The corpus that surfaced this is entirely English, so no measurement available here would have caught that regression — it is covered by parametrised tests over six scripts instead.

## Measurement

Over 12 corpus articles:

| | baseline | branch |
|---|---|---|
| section titles emitted as headings | 79/188 | **79/188** |
| headings emitted | 329 | **207** |
| heading precision vs JATS | 0.240 | **0.382** |

Recall is bit-identical **per article** as well as in total — no real heading was touched. On the affected paper, 179 → 55 headings, and its text content is byte-identical once heading markers are stripped, so nothing was demoted out of existence.

## Verification

- 20 new unit tests: five real PUA glyphs, glyph runs, punctuation-only and whitespace-padded glyphs rejected; ordinary, numbered, digit-only, mixed and six non-Latin-script headings kept; plus two checks that the earlier gates still fire.
- Removing the gate fails 8 of them, with the right symptom.
- Output on both fixture PDFs is byte-identical, checked by neutralising the gate in-process — the golden snapshots skip on Windows and cannot make this check here.
- `tests/unit`, `tests/golden`, `tests/integration`, `tests/e2e` all green locally; ruff, black and mypy clean.

## Relationship to #293

Independent and touches a different file. #293 raises heading **recall** by fixing which labels reach a line; this raises heading **precision** by rejecting lines that were never headings. Both were surfaced by the same new heading-structure measurement, since the corpus lane's `title` oracle scores text recall and is blind to whether anything became a heading at all.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
