### PR TITLE
fix(pdf): join a heading that wraps onto a second printed line

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **A heading that wraps onto a second printed line is now one heading** (PDF). A PDF has
+  no notion of a wrapped heading — it has two lines of type — and each line reached the
+  emitter on its own, so a long section heading became two sibling headings and an article
+  title set on three lines became three `#`s. None of them matched the real title, so the
+  text was there and the structure was not. A heading line now continues the heading
+  directly above it when the two are at the same level, nothing was emitted between them,
+  and the second sits within `HEADING_WRAP_GAP_RATIO` line heights of the first — the gap
+  is a ratio rather than a point count so it means the same thing for a 24pt title and a
+  9pt subheading. Two headings that genuinely follow one another are separated by the
+  space above a new section, which is what puts them beyond it, and a second line opening
+  with its own numbering starts a new heading however tightly it is set. Measured on the
+  born-digital corpus, section-title recall rises **0.729 → 0.766** and precision
+  **0.507 → 0.623** — 231 headings emitted for 188 real titles, down from 270, so the
+  join removes 39 duplicate headings as well as recovering 7 real ones.
 - **A lone math glyph is no longer promoted to a heading** (PDF). Heading classification
   validated a candidate by font size, bold/all-caps requirement, maximum length and an
   internal-sentence-boundary check, and never asked whether the text contained a letter.

--- a/src/all2md/parsers/pdf.py
+++ b/src/all2md/parsers/pdf.py
@@ -141,6 +141,30 @@ RUNNING_POSITION_TOLERANCE = 5.0
 #: because it is running furniture.
 _RUNNING_DIGITS = re.compile(r"\d+")
 
+#: How far apart, as a multiple of the line's own height, two heading lines may sit and
+#: still be the same heading wrapped onto a second printed line. Set as a ratio rather
+#: than in points so it means the same thing for a 24pt article title and a 9pt
+#: subheading. Consecutive *distinct* headings are separated by the space above a new
+#: section, which is what puts them beyond this.
+HEADING_WRAP_GAP_RATIO = 1.6
+
+
+def _span_union_bbox(spans: list) -> tuple[float, float, float, float] | None:
+    """Bounding box covering every span on a line, or None if none carry one.
+
+    The line's own bbox is not in scope where headings are emitted, and a span union is
+    the same rectangle for this purpose: spans partition the line.
+    """
+    boxes = [s["bbox"] for s in spans if s.get("bbox")]
+    if not boxes:
+        return None
+    return (
+        min(b[0] for b in boxes),
+        min(b[1] for b in boxes),
+        max(b[2] for b in boxes),
+        max(b[3] for b in boxes),
+    )
+
 
 def _running_text_key(text: str) -> str:
     """Key a header/footer candidate by what stays the same from page to page.
@@ -426,6 +450,13 @@ class _BlockProcessingState:
     pending_heading_prefix_content: list[Node] | None = None
     pending_heading_prefix_level: int = 0
     pending_heading_prefix_page: int = 0
+    # Bottom edge of the line the most recent heading was emitted from, and the index it
+    # occupies in `nodes`. Together these say "the previous node is a heading and it came
+    # from the line directly above this one", which is how a heading that wrapped onto a
+    # second printed line is recognised and joined instead of emitted twice.
+    last_heading_slot: int = -1
+    last_heading_bottom: float = 0.0
+    last_heading_height: float = 0.0
 
     def reset_paragraph(self) -> None:
         """Reset paragraph accumulation state."""
@@ -1942,7 +1973,7 @@ class PdfToAstConverter(BaseParser):
 
         if header_level > 0:
             line_text = "".join(s.get("text", "") for s in spans).strip()
-            self._emit_heading(state, header_level, line_text, inline_content, page_num)
+            self._emit_heading(state, header_level, line_text, inline_content, page_num, _span_union_bbox(spans))
         else:
             # Paragraph emission orphans any buffered numbering prefix —
             # flush it as its own heading so the marker isn't lost.
@@ -2288,6 +2319,7 @@ class PdfToAstConverter(BaseParser):
         line_text: str,
         inline_content: list[Node],
         page_num: int,
+        line_bbox: tuple[float, float, float, float] | None = None,
     ) -> None:
         """Emit a heading or buffer a numbering-only prefix for merging.
 
@@ -2297,7 +2329,20 @@ class PdfToAstConverter(BaseParser):
         heading. PDFs often visually break Roman-numeral section markers
         onto their own line above the actual heading text, and emitting
         them as separate headings produced obviously-wrong output before.
+
+        A heading too long for one printed line is set on two, and each line
+        reaches here separately. When ``line_bbox`` shows this line sits
+        directly under the heading just emitted, at the same level, the text
+        is appended to that heading rather than starting a new one.
         """
+        if line_bbox is not None and self._continues_wrapped_heading(state, level, line_text, line_bbox):
+            heading = state.nodes[-1]
+            assert isinstance(heading, Heading)  # guaranteed by _continues_wrapped_heading
+            heading.content.extend([Text(content=" "), *inline_content])
+            state.last_heading_bottom = line_bbox[3]
+            state.last_heading_height = max(line_bbox[3] - line_bbox[1], state.last_heading_height)
+            return
+
         if parse_numbering_prefix(line_text) is not None:
             # If we *already* have a buffered prefix and this is also one,
             # flush the older one first so neither gets lost (rare in real
@@ -2326,6 +2371,7 @@ class PdfToAstConverter(BaseParser):
                 )
             )
             self._last_heading_level = merged_level
+            self._mark_heading_line(state, line_bbox)
             return
 
         _strip_leading_whitespace_in_place(inline_content)
@@ -2337,6 +2383,50 @@ class PdfToAstConverter(BaseParser):
             )
         )
         self._last_heading_level = level
+        self._mark_heading_line(state, line_bbox)
+
+    @staticmethod
+    def _mark_heading_line(state: _BlockProcessingState, line_bbox: tuple[float, float, float, float] | None) -> None:
+        """Record where the heading just appended to ``state.nodes`` was printed."""
+        if line_bbox is None:
+            state.last_heading_slot = -1
+            return
+        state.last_heading_slot = len(state.nodes) - 1
+        state.last_heading_bottom = line_bbox[3]
+        state.last_heading_height = line_bbox[3] - line_bbox[1]
+
+    @staticmethod
+    def _continues_wrapped_heading(
+        state: _BlockProcessingState,
+        level: int,
+        line_text: str,
+        line_bbox: tuple[float, float, float, float],
+    ) -> bool:
+        """Report whether this line is the rest of the heading emitted immediately above it.
+
+        Four things have to hold, and each rules out a way two heading lines can be
+        adjacent without being one heading: the previous node is a heading and nothing
+        came between them; it is at this line's level, since a subheading under a
+        heading is two headings; the line sits within a line's height of it, which is
+        what a wrap looks like and what the space above a new section does not; and it
+        does not open with its own numbering, which announces a new section however
+        tightly it is set.
+        """
+        if not state.nodes or state.last_heading_slot != len(state.nodes) - 1:
+            return False
+        previous = state.nodes[-1]
+        if not isinstance(previous, Heading) or previous.level != level:
+            return False
+        if parse_numbering_prefix(line_text.split(" ", 1)[0]) is not None:
+            return False
+
+        height = max(line_bbox[3] - line_bbox[1], state.last_heading_height)
+        if height <= 0:
+            return False
+        gap = line_bbox[3] - state.last_heading_bottom
+        # Strictly below: a line at or above the previous one is a different column or a
+        # reading-order artefact, not a continuation.
+        return 0 < gap <= height * HEADING_WRAP_GAP_RATIO
 
     def _flush_pending_heading_prefix(self, state: _BlockProcessingState) -> None:
         """Emit any buffered numbering-prefix heading as a standalone heading."""
@@ -2454,7 +2544,7 @@ class PdfToAstConverter(BaseParser):
 
         self._flush_state_paragraph(state, page_num)
         line_text = "".join(s.get("text", "") for s in spans).strip()
-        self._emit_heading(state, header_level, line_text, inline_content, page_num)
+        self._emit_heading(state, header_level, line_text, inline_content, page_num, _span_union_bbox(spans))
         return True
 
     def _handle_header_line_with_layout(
@@ -2545,7 +2635,7 @@ class PdfToAstConverter(BaseParser):
             return True
 
         self._flush_state_paragraph(state, page_num)
-        self._emit_heading(state, level, line_style.text, inline_content, page_num)
+        self._emit_heading(state, level, line_style.text, inline_content, page_num, _span_union_bbox(spans))
         return True
 
     def _accumulate_paragraph_line(

--- a/tests/unit/formats/pdf/test_pdf_wrapped_headings.py
+++ b/tests/unit/formats/pdf/test_pdf_wrapped_headings.py
@@ -1,0 +1,219 @@
+#  Copyright (c) 2025 Tom Villani, Ph.D.
+#
+# tests/unit/formats/pdf/test_pdf_wrapped_headings.py
+"""A heading too long for one printed line is still one heading.
+
+Issue #295. A PDF has no notion of a heading that wraps -- it has two lines of type, and
+each reaches the emitter separately, so an article title set on three lines came out as
+three sibling ``#`` headings. The join asks whether this line sits directly under the
+heading just emitted, at the same level, with nothing between them.
+
+The interesting tests are the ones that must *not* join: two headings of the same level
+can legitimately follow one another, and the only thing separating that case from a wrap
+is the space above a new section, so these pin the boundary from both sides.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from all2md.ast.nodes import Heading, Text
+from all2md.ast.utils import extract_text
+from all2md.options.pdf import PdfOptions
+from all2md.parsers.pdf import HEADING_WRAP_GAP_RATIO, PdfToAstConverter, _BlockProcessingState
+
+pytestmark = [pytest.mark.unit, pytest.mark.pdf]
+
+LINE_HEIGHT = 12.0
+
+
+@pytest.fixture
+def converter():
+    return PdfToAstConverter(options=PdfOptions())
+
+
+def _bbox(bottom: float, x0: float = 50.0, x1: float = 300.0) -> tuple[float, float, float, float]:
+    return (x0, bottom - LINE_HEIGHT, x1, bottom)
+
+
+def _emit(converter, state, text: str, *, level: int = 2, bottom: float, bbox=None) -> None:
+    converter._emit_heading(state, level, text, [Text(content=text)], 0, bbox or _bbox(bottom))
+
+
+def _headings(state) -> list[str]:
+    # joiner="" because the separator between the two halves has to come from the join
+    # itself. `extract_text`'s default inserts a space between every sibling node, which
+    # would make a heading that lost its space look correct here.
+    return [extract_text(n, joiner="") for n in state.nodes if isinstance(n, Heading)]
+
+
+class TestAWrappedHeadingBecomesOneHeading:
+    def test_two_lines_a_line_apart_join(self, converter):
+        state = _BlockProcessingState()
+
+        _emit(converter, state, "Effects of long-term exposure on", bottom=100)
+        _emit(converter, state, "cardiovascular outcomes", bottom=100 + LINE_HEIGHT)
+
+        assert _headings(state) == ["Effects of long-term exposure on cardiovascular outcomes"]
+
+    def test_three_lines_join_into_one(self, converter):
+        state = _BlockProcessingState()
+
+        for index, text in enumerate(["A very long", "article title set", "across three lines"]):
+            _emit(converter, state, text, level=1, bottom=100 + index * LINE_HEIGHT)
+
+        assert _headings(state) == ["A very long article title set across three lines"]
+
+    def test_the_joined_heading_keeps_the_first_line_s_level(self, converter):
+        state = _BlockProcessingState()
+
+        _emit(converter, state, "First half", level=3, bottom=100)
+        _emit(converter, state, "second half", level=3, bottom=100 + LINE_HEIGHT)
+
+        headings = [n for n in state.nodes if isinstance(n, Heading)]
+        assert len(headings) == 1
+        assert headings[0].level == 3
+
+    def test_a_gap_at_the_limit_still_joins(self, converter):
+        state = _BlockProcessingState()
+
+        _emit(converter, state, "First half", bottom=100)
+        _emit(converter, state, "second half", bottom=100 + LINE_HEIGHT * HEADING_WRAP_GAP_RATIO)
+
+        assert _headings(state) == ["First half second half"]
+
+
+class TestAdjacentHeadingsStayApart:
+    def test_a_wider_gap_starts_a_new_heading(self, converter):
+        # The space above a new section, not the leading inside one heading.
+        state = _BlockProcessingState()
+
+        _emit(converter, state, "Methods", bottom=100)
+        _emit(converter, state, "Results", bottom=100 + LINE_HEIGHT * (HEADING_WRAP_GAP_RATIO + 0.5))
+
+        assert _headings(state) == ["Methods", "Results"]
+
+    def test_a_different_level_starts_a_new_heading(self, converter):
+        state = _BlockProcessingState()
+
+        _emit(converter, state, "Results", level=2, bottom=100)
+        _emit(converter, state, "Gene expression", level=3, bottom=100 + LINE_HEIGHT)
+
+        assert _headings(state) == ["Results", "Gene expression"]
+
+    def test_a_numbered_second_line_starts_a_new_heading(self, converter):
+        # Tightly set numbered sections are common, and the number announces a new one
+        # however little space is above it.
+        state = _BlockProcessingState()
+
+        _emit(converter, state, "1. Introduction", bottom=100)
+        _emit(converter, state, "2. Methods", bottom=100 + LINE_HEIGHT)
+
+        assert _headings(state) == ["1. Introduction", "2. Methods"]
+
+    def test_a_paragraph_between_two_headings_stops_the_join(self, converter):
+        state = _BlockProcessingState()
+
+        _emit(converter, state, "Methods", bottom=100)
+        state.paragraph_content = [Text(content="Body text.")]
+        converter._flush_state_paragraph(state, 0)
+        _emit(converter, state, "Results", bottom=100 + LINE_HEIGHT)
+
+        assert _headings(state) == ["Methods", "Results"]
+
+    def test_a_line_above_the_previous_one_does_not_join(self, converter):
+        # A second column read after the first: same level, small distance, wrong direction.
+        state = _BlockProcessingState()
+
+        _emit(converter, state, "Discussion", bottom=400)
+        _emit(converter, state, "Conclusion", bottom=400 - LINE_HEIGHT)
+
+        assert _headings(state) == ["Discussion", "Conclusion"]
+
+    def test_headings_in_different_blocks_do_not_join(self, converter):
+        # State is per block, so this is really a guard against the bookkeeping leaking.
+        first, second = _BlockProcessingState(), _BlockProcessingState()
+
+        _emit(converter, first, "Methods", bottom=100)
+        _emit(converter, second, "Results", bottom=100 + LINE_HEIGHT)
+
+        assert _headings(first) == ["Methods"]
+        assert _headings(second) == ["Results"]
+
+
+class TestTheJoinNeedsGeometry:
+    def test_without_a_bbox_nothing_joins(self, converter):
+        # Callers that cannot supply a line box keep the old behaviour rather than
+        # joining on level alone.
+        state = _BlockProcessingState()
+
+        converter._emit_heading(state, 2, "First half", [Text(content="First half")], 0)
+        converter._emit_heading(state, 2, "second half", [Text(content="second half")], 0)
+
+        assert _headings(state) == ["First half", "second half"]
+
+    def test_a_degenerate_bbox_does_not_join(self, converter):
+        state = _BlockProcessingState()
+
+        _emit(converter, state, "First half", bottom=100, bbox=(50.0, 100.0, 300.0, 100.0))
+        _emit(converter, state, "second half", bottom=100, bbox=(50.0, 100.0, 300.0, 100.0))
+
+        assert _headings(state) == ["First half", "second half"]
+
+    def test_a_numbering_prefix_line_still_merges_into_the_next_heading(self, converter):
+        # The pre-existing prefix buffer has to keep working: "II." on its own line is
+        # absorbed by the heading below it rather than being treated as a wrap anchor.
+        state = _BlockProcessingState()
+
+        _emit(converter, state, "II.", bottom=100)
+        _emit(converter, state, "Background", bottom=100 + LINE_HEIGHT)
+
+        assert _headings(state) == ["II. Background"]
+
+
+class TestWrappedHeadingOnAPage:
+    """End to end, so the geometry really comes from a rendered page."""
+
+    @staticmethod
+    def _page_with_a_wrapped_title(tmp_path):
+        import fitz
+
+        doc = fitz.open()
+        page = doc.new_page(width=300, height=400)
+        writer = fitz.TextWriter(page.rect)
+        font = fitz.Font("helv")
+        # A two-line title at a size the font heuristic promotes, over body text that it
+        # does not.
+        writer.append((40, 60), "Long-term outcomes of an", font=font, fontsize=20)
+        writer.append((40, 84), "intervention in older adults", font=font, fontsize=20)
+        for idx in range(12):
+            writer.append((40, 120 + idx * 12), f"body line {idx} of the article", font=font, fontsize=9)
+        writer.write_text(page)
+        path = tmp_path / "wrapped.pdf"
+        doc.save(str(path))
+        doc.close()
+        return str(path)
+
+    def test_the_title_is_one_heading(self, tmp_path):
+        import fitz
+
+        from all2md.ast.transforms import NodeCollector
+        from all2md.parsers._pdf_headers import IdentifyHeaders
+
+        path = self._page_with_a_wrapped_title(tmp_path)
+        doc = fitz.open(path)
+        page = doc[0]
+
+        options = PdfOptions()
+        converter = PdfToAstConverter(options=options)
+        converter._hdr_identifier = IdentifyHeaders(doc, options=options)
+        nodes = converter._process_page_to_ast(page, 0, "doc", lambda a, b: (a, 0), doc.page_count)
+        doc.close()
+
+        collector = NodeCollector(lambda n: isinstance(n, Heading))
+        for node in nodes:
+            node.accept(collector)
+
+        assert [extract_text(h, joiner="").strip() for h in collector.collected] == [
+            "Long-term outcomes of an intervention in older adults"
+        ]


### PR DESCRIPTION
Closes #295.

## The defect

A PDF has no notion of a heading that wraps. It has two lines of type, and each one reached the emitter separately, so a long section heading came out as two sibling headings and an article title set on three lines came out as three `#`s.

Neither half matched the real title, which is the shape of the defect — the text survived and the structure did not. The lane's `title` oracle scores text recall, so it saw nothing wrong.

## The fix

A heading line continues the heading directly above it when four things hold, each ruling out a way two heading lines can be adjacent without being one heading:

- the previous node is a heading and **nothing was emitted between them**;
- it is at **this line's level**, since a subheading under a heading is two headings;
- the line sits within `HEADING_WRAP_GAP_RATIO` (1.6) **line heights** of it — a ratio rather than a point count, so it means the same thing for a 24pt title and a 9pt subheading, and so the space above a new section is what puts two real headings beyond it;
- the line **does not open with its own numbering**, which announces a new section however tightly it is set.

## Measurement

PMC born-digital corpus, 12 articles, baseline run on `main` rather than a remembered number:

| | main | branch |
|---|---|---|
| section-title recall | 0.729 | **0.766** |
| precision | 0.507 | **0.623** |
| headings emitted (188 real titles) | 270 | **231** |

The join removes 39 duplicate headings as well as recovering 7 real titles that neither half had matched.

## Tests

14 new tests in `tests/unit/formats/pdf/test_pdf_wrapped_headings.py`. Over half of them are cases that must **not** join — a wider gap, a different level, a numbered second line, a paragraph in between, a line above the previous one, a different block — because "consecutive and same level" also describes two genuinely distinct headings and that is the only thing the join can get wrong.

Verified the tests can fail: with `_continues_wrapped_heading` neutralised, 5 of the 14 fail, including the end-to-end page test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)