### PR TITLE
fix(pdf): read a list marker from the start of the line, not the first Text node

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,42 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **A list marker set in a symbol font now starts a list** (PDF). Whether a line opened
+  with a marker was decided by finding the first top-level `Text` node, which is the wrong
+  question in both directions. A bullet set in a symbol font carries that font's flags, so
+  it arrives wrapped — italic flags make `Emphasis(Text("-"))` — and the line has no
+  top-level `Text` at all: it read as empty and never started a list, so one born-digital
+  article's bullets came out as plain paragraphs each beginning with a literal `- `. In the
+  other direction, reading past the first node to find *some* `Text` answers for the middle
+  of the line, so a citation opening with a styled journal name, `Nature 12. 45-67`,
+  reported a numbered marker and became a list item. Detection now descends into inline
+  wrappers, and the marker is removed by character count so that it comes off even when it
+  sits inside a wrapper or straddles two nodes. Reading the raw spans instead would not
+  work, which is worth recording because it looks like the obvious fix: the parser rewrites
+  four bullet glyphs (`U+F0B7`, `U+00B7`, `U+2022`, `U+25CF`) to `-`, and three of those
+  four are not markers in their printed form, so detection has to run after that conversion
+  rather than before it.
+
+  A marker and the space that disambiguates it are also routinely *separate* spans, which
+  is why **Word's second-level Courier `o` bullets** never became list items at all — the
+  rule that an `o` must be followed by a space (so that "office" is not a bullet) could
+  never fire, because the space was in the next node. Those bullets now nest under the
+  item above them instead of landing as loose paragraphs between the items they belong to.
+
+  That look-ahead is allowed **only for a bullet**, never for a number, and the restriction
+  is the load-bearing part rather than a tidiness. A numbered marker arrives split exactly
+  the same way — `Text("44.")` then `Text(" Konema, Nigeria …")` — and nothing in a PDF
+  distinguishes the 44th bibliography entry from the 44th item of a list. Reading across
+  that boundary turned reference lists into ordered lists, and since nothing carries a start
+  number through, the renderer printed them from 1: reference 44 came out as item 1 and no
+  citation in the body could be matched to its reference. A numbered marker must therefore
+  be complete within one span, as it always was.
+
+  Measured on the born-digital corpus over the twelve list-bearing articles that complete
+  locally, list-item recall rises **0.231 → 0.269** and precision **0.116 → 0.141**; only
+  three articles change at all. The items still missed are overwhelmingly ones the PDF
+  prints with **no marker of any kind**, which no marker rule can reach.
+
 - **A bulleted or numbered list is no longer collapsed into a single item** (PDF). The
   vertical gap between two list items is the same gap that separates two paragraphs, so
   the paragraph-break rule is suspended once a list has started — otherwise every item

--- a/src/all2md/parsers/pdf.py
+++ b/src/all2md/parsers/pdf.py
@@ -26,7 +26,7 @@ if TYPE_CHECKING:
 
     from all2md.parsers._ocr import OcrParagraph
 
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, replace
 
 from all2md.ast import (
     Code,
@@ -166,14 +166,133 @@ def _span_union_bbox(spans: list) -> tuple[float, float, float, float] | None:
     )
 
 
-def _leading_text(spans: list) -> str:
-    """Return a line's text as printed, for tests that only look at how it starts.
+#: Inline nodes that can wrap the text a line opens with. A span's font flags become
+#: ``Strong``/``Emphasis`` and a hyperlink becomes ``Link``, so a marker printed in bold, in
+#: italic, or inside a link arrives wrapped rather than as a bare ``Text``. ``Superscript``
+#: is deliberately absent: a superscript digit opening a line is a footnote or citation
+#: reference, and descending into one would read ``1. Smith et al.`` off a footnote.
+_INLINE_WRAPPERS = (Strong, Emphasis, Link)
 
-    Taken from the spans rather than from converted inline nodes: a line opening with a
-    link or a styled run puts something other than a Text node first, and picking the
-    first Text node anywhere on the line asks the question of the middle of the line.
+#: How much of a line's opening text the marker tests need. The longest marker they accept
+#: is a run of digits, a ``.`` or ``)`` and a space, so this is generous; it exists to stop
+#: the walk after a few nodes rather than to bound what counts as a marker.
+_LEADING_TEXT_CHARS = 16
+
+#: A bullet standing alone, with the space that follows it not yet read. The walk crosses a
+#: node boundary only while what it holds matches this -- see :func:`_leading_inline_text`.
+#: Numbers are deliberately not here, and that is the whole of what keeps a bibliography
+#: from becoming an ordered list.
+_BULLET_AWAITING_ITS_SPACE = re.compile("^[-–—*+•◦▪▫o]$")
+
+
+def _leading_inline_text(content: list[Node], limit: int = _LEADING_TEXT_CHARS) -> str:
+    """Return the text a paragraph or line *opens with*, descending into inline wrappers.
+
+    Reading the first top-level ``Text`` node instead gets the question wrong in both
+    directions. A bullet set in a symbol font is italic by its font flags, so it arrives as
+    ``Emphasis(Text("-"))`` and the line has no top-level ``Text`` at all -- it reads as
+    empty and never starts a list. A citation opening with a styled journal name has its
+    first top-level ``Text`` in the *middle* of the line, so ``Nature 12. 45-67`` reported
+    an ordered marker and became a list item.
+
+    Reading the raw spans instead is no better, and is the reason this is not simply a text
+    join over ``line["spans"]``: ``_process_text_spans_to_inline`` rewrites four bullet
+    glyphs (``U+F0B7``, ``U+00B7``, ``U+2022``, ``U+25CF``) to ``-``, and three of the four
+    are not markers in their printed form. The conversion is what makes a symbol-font bullet
+    recognisable, so detection has to run after it.
+
+    The walk crosses a node boundary **only while what it has read so far is a lone
+    bullet**, waiting on the space that follows it. A bullet is its own span by typographic
+    necessity -- it is set in a different font from the text -- and the letter ``o`` is only
+    a bullet when a space follows, so without that one step the rule that keeps "office"
+    from being a bullet could never fire and Word's second-level bullets could never be
+    recognised at all.
+
+    Numbers get no such step, and that restriction is the load-bearing part. A numbered
+    marker arrives split exactly the same way -- ``Text("44.")`` then ``Text(" Konema,
+    Nigeria ...")`` -- and nothing in the PDF distinguishes the 44th bibliography entry from
+    the 44th item of a list. Reading across that boundary turned reference lists into
+    ordered lists, whereupon the renderer renumbered them from 1 and destroyed every
+    citation number in the document. A numbered marker must therefore be complete within one
+    node, which is exactly what it was before.
+
+    ``Code`` and anything else that is not an inline wrapper stops the walk: a line opening
+    with inline code does not open with a list marker, and reporting the text past it would
+    reintroduce the middle-of-the-line reading.
     """
-    return "".join(span.get("text", "") for span in spans)
+    text = ""
+    for node in content:
+        if isinstance(node, Text):
+            piece = node.content
+        elif isinstance(node, _INLINE_WRAPPERS):
+            piece = _leading_inline_text(node.content, limit)
+        else:
+            break
+        if text and not _BULLET_AWAITING_ITS_SPACE.match(text.strip()):
+            break
+        text += piece
+        if len(text.lstrip()) >= limit:
+            break
+    return text
+
+
+def _opening_line_text(content: list[Node], limit: int = _LEADING_TEXT_CHARS) -> str:
+    """Everything a line opens with, wrappers descended and node boundaries ignored.
+
+    The liberal counterpart to :func:`_leading_inline_text`, and safe only where it is used.
+    The item-split test runs *inside* a paragraph already known to be a list, so reading
+    across node boundaries there can re-split a list that exists but can never create one --
+    and it has to read across them, because a numbered item's marker is routinely a span of
+    its own and every item after the first would otherwise run into its predecessor.
+
+    The tests that *create* lists cannot use this, which is the whole distinction between
+    the two readers: a bibliography entry is a numbered marker in its own span too, and
+    creating a list from one renumbers the references from 1.
+    """
+    text = ""
+    for node in content:
+        if isinstance(node, Text):
+            text += node.content
+        elif isinstance(node, _INLINE_WRAPPERS):
+            text += _opening_line_text(node.content, limit)
+        else:
+            break
+        if len(text.lstrip()) >= limit:
+            break
+    return text
+
+
+def _consume_leading_chars(content: list[Node], count: int) -> tuple[list[Node], int]:
+    """Drop the first ``count`` characters of ``content``, descending into inline wrappers.
+
+    Counts characters exactly as :func:`_leading_inline_text` reports them, so a marker
+    *located* by that function is *removed* by this one even when it sits inside a wrapper
+    or straddles two nodes -- ``Emphasis(Text("-"))`` followed by ``Text(" Body")`` keeps
+    the bullet in the first node and the space after it in the second. A wrapper left with
+    nothing inside it is dropped rather than emitted empty.
+
+    Returns the new content and however much of ``count`` went unconsumed.
+    """
+    out: list[Node] = []
+    remaining = count
+    for node in content:
+        if remaining <= 0:
+            out.append(node)
+        elif isinstance(node, Text):
+            if len(node.content) <= remaining:
+                remaining -= len(node.content)  # wholly marker; drop the node
+            else:
+                out.append(replace(node, content=node.content[remaining:]))
+                remaining = 0
+        elif isinstance(node, _INLINE_WRAPPERS):
+            inner, remaining = _consume_leading_chars(node.content, remaining)
+            if inner:
+                out.append(replace(node, content=inner))
+        else:
+            # Opaque to the reader above, so it cannot have been part of the marker.
+            out.append(node)
+            remaining = 0
+    return out, remaining
 
 
 def _running_text_key(text: str) -> str:
@@ -2660,18 +2779,29 @@ class PdfToAstConverter(BaseParser):
         average_line_height: float | None,
     ) -> None:
         """Accumulate regular text line into paragraph state."""
+        # Converted before the split test below rather than after it, because the conversion
+        # is what turns a symbol-font bullet into a recognisable marker -- see
+        # _leading_inline_text. The flush still has to happen before the empty-content
+        # return, so that a line which converts to nothing keeps ending a paragraph on gap.
+        inline_content = self._process_text_spans_to_inline(spans, links, page_num, average_line_height)
+
         # A list item runs on across the vertical gaps that separate paragraphs -- the space
         # between two bullets is the same space that ends a paragraph -- so the gap rule is
         # suspended once a list has started. Without a second rule to end an item, though,
         # every bullet in a list ran into its predecessor and the whole list arrived as a
         # single item: one born-digital article emitted 1 list item for its 16 bullets.
         # A line carrying its own marker is the next item, whatever the spacing says.
-        starts_new_item = state.paragraph_is_list and self._is_valid_list_marker(_leading_text(spans))[0]
+        #
+        # This asks with the liberal reader, unlike the paragraph-start test below. It is
+        # gated on the paragraph already being a list, so it can only ever re-split one;
+        # narrowing it to the conservative reader ran a whole ordered list back into a
+        # single item, because "2." is a span of its own and stops that reader dead.
+        opens_with_marker = self._is_valid_list_marker(_opening_line_text(inline_content))[0]
+        starts_new_item = state.paragraph_is_list and opens_with_marker
         breaks_paragraph = vertical_gap > paragraph_break_threshold and not state.paragraph_is_list
         if state.paragraph_content and (starts_new_item or breaks_paragraph):
             self._flush_state_paragraph(state, page_num)
 
-        inline_content = self._process_text_spans_to_inline(spans, links, page_num, average_line_height)
         if not inline_content:
             return
 
@@ -2684,8 +2814,9 @@ class PdfToAstConverter(BaseParser):
         else:
             # Starting new paragraph
             state.paragraph_bbox = line["bbox"]
-            first_text = next((n.content for n in inline_content if isinstance(n, Text)), "")
-            state.paragraph_is_list, state.paragraph_list_type = self._is_valid_list_marker(first_text)
+            state.paragraph_is_list, state.paragraph_list_type = self._is_valid_list_marker(
+                _leading_inline_text(inline_content)
+            )
 
         state.paragraph_content.extend(inline_content)
 
@@ -3456,18 +3587,11 @@ class PdfToAstConverter(BaseParser):
         if not paragraph.content:
             return False
 
-        def extract_text(nodes: list[Node]) -> str:
-            """Recursively extract text from nodes."""
-            text_parts = []
-            for node in nodes:
-                if isinstance(node, Text):
-                    text_parts.append(node.content)
-                elif hasattr(node, "content") and isinstance(node.content, list):
-                    text_parts.append(extract_text(node.content))
-            return "".join(text_parts)
-
-        full_text = extract_text(paragraph.content)
-        is_list, _ = self._is_valid_list_marker(full_text)
+        # The liberal reader, because this only ever *protects* a paragraph from being
+        # merged into its neighbour -- it creates nothing. Answering it conservatively let
+        # consecutive numbered items merge back into a single paragraph, which is how a
+        # whole ordered list came out on one line.
+        is_list, _ = self._is_valid_list_marker(_opening_line_text(paragraph.content))
         return is_list
 
     def _determine_list_level_from_x(self, x_coord: float, x_levels: dict[int, float]) -> int:
@@ -3809,13 +3933,7 @@ class PdfToAstConverter(BaseParser):
             "ordered", "unordered", or None
 
         """
-        full_text = ""
-        for node in para.content:
-            if isinstance(node, Text):
-                full_text = node.content
-                break
-
-        return self._is_valid_list_marker(full_text)
+        return self._is_valid_list_marker(_leading_inline_text(para.content))
 
     def _extract_list_item_x_coord(self, node: AstParagraph) -> float | None:
         """Extract x-coordinate from a paragraph's bbox metadata.
@@ -3851,11 +3969,7 @@ class PdfToAstConverter(BaseParser):
             Content nodes with the list marker removed
 
         """
-        full_text = ""
-        for node in para.content:
-            if isinstance(node, Text):
-                full_text = node.content
-                break
+        full_text = _leading_inline_text(para.content)
 
         # Use the robust marker detection to validate this is actually a list item
         is_list, list_type = self._is_valid_list_marker(full_text)
@@ -3880,20 +3994,12 @@ class PdfToAstConverter(BaseParser):
             if match:
                 marker_end = match.end()
 
-        # Create new content without the marker
-        new_content: list[Node] = []
-        if marker_end > 0:
-            # Remove marker from first text node
-            for i, node in enumerate(para.content):
-                if i == 0 and isinstance(node, Text):
-                    remaining_text = node.content[marker_end:]
-                    if remaining_text:
-                        new_content.append(Text(content=remaining_text))
-                else:
-                    new_content.append(node)
-        else:
-            new_content = list(para.content)
+        if marker_end <= 0:
+            return list(para.content)
 
+        # The marker may sit inside a wrapper and may straddle two nodes, so it is removed
+        # by character count rather than by rewriting whichever node happens to be first.
+        new_content, _ = _consume_leading_chars(para.content, marker_end)
         return new_content
 
     def _finalize_pending_lists(self, list_stack: list[tuple[str, int, list[ListItem]]], result: list[Node]) -> None:

--- a/tests/golden/__snapshots__/test_pdf_golden.ambr
+++ b/tests/golden/__snapshots__/test_pdf_golden.ambr
@@ -81,9 +81,9 @@
   
   Now for an unordered list: 
   
-  *  First item on unordered list 
-  *  Second item 
-  *  Third 
+  * First item on unordered list 
+  * Second item 
+  * Third 
   
   Let’s add some more stuff 
   
@@ -99,21 +99,15 @@
   
   And now a multilevel list: 
   
-  *  First level 
-  *  First level 2 
-  
-  o Second level 1 
-  
-  o Second level 2 
-  
-  *  First level 3 
-  *  First level 4 
-  
-  o Second level 3 
-  
-  o Second level 4 
-  
-  *  First level 5 
+  * First level 
+  * First level 2 
+    - Second level 1 
+    - Second level 2 
+  * First level 3 
+  * First level 4 
+    - Second level 3 
+    - Second level 4 
+  * First level 5 
   
    
   

--- a/tests/golden/__snapshots__/test_pdf_golden.ambr
+++ b/tests/golden/__snapshots__/test_pdf_golden.ambr
@@ -107,6 +107,7 @@
   * First level 4 
     - Second level 3 
     - Second level 4 
+  
   * First level 5 
   
    

--- a/tests/unit/formats/pdf/test_pdf_symbol_font_list_markers.py
+++ b/tests/unit/formats/pdf/test_pdf_symbol_font_list_markers.py
@@ -1,0 +1,258 @@
+#  Copyright (c) 2025 Tom Villani, Ph.D.
+#
+# tests/unit/formats/pdf/test_pdf_symbol_font_list_markers.py
+"""A list marker is whatever the line opens with, not whatever the first Text node holds.
+
+Three places asked "does this start with a marker?" and each answered by finding the first
+top-level ``Text`` node. That gets the question wrong in both directions:
+
+* A bullet set in a symbol font carries that font's flags, so it arrives wrapped -- italic
+  flags make ``Emphasis(Text("-"))`` -- and the line has no top-level ``Text`` at all. It
+  read as empty and never started a list. On the PMC corpus one article's sixteen bullets
+  came out as fourteen plain paragraphs each beginning with a literal "- ".
+* A marker and the space that disambiguates it are often *separate spans*. The rule that
+  the letter "o" must be followed by a space (so "office" is not a bullet) could therefore
+  never fire, because the space was in the next node. Word's second-level Courier "o"
+  bullets escaped list detection entirely and landed as loose paragraphs.
+* Reading past the first node to find a ``Text`` answers for the *middle* of the line. A
+  citation opening with a styled journal name -- ``Nature 12. 45-67`` -- reported an
+  ordered marker and became a list item.
+
+Reading the raw spans instead does not work either, and that is worth stating because it
+looks like the obvious fix: ``_process_text_spans_to_inline`` rewrites four bullet glyphs
+to "-", and three of those four are not markers in their printed form. The conversion is
+what makes a symbol-font bullet recognisable, so detection has to run after it.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from all2md.ast.nodes import Emphasis, Link, List, ListItem, Strong, Text
+from all2md.ast.nodes import Paragraph as AstParagraph
+from all2md.ast.utils import extract_text
+from all2md.options.pdf import PdfOptions
+from all2md.parsers.pdf import PdfToAstConverter
+
+pytestmark = [pytest.mark.unit, pytest.mark.pdf]
+
+LINE_HEIGHT = 10.0
+
+ITALIC, MONO, BOLD = 2, 8, 16
+
+
+@pytest.fixture
+def converter():
+    return PdfToAstConverter(options=PdfOptions())
+
+
+def _spans(*parts: tuple[str, int], x0: float = 50.0, top: float = 100.0) -> list[dict]:
+    """Build the spans of one line from (text, font-flags) pairs."""
+    spans = []
+    for text, flags in parts:
+        width = max(len(text) * 5.0, 3.0)
+        spans.append(
+            {
+                "text": text,
+                "size": 9.0,
+                "font": "Helvetica",
+                "flags": flags,
+                "bbox": (x0, top, x0 + width, top + LINE_HEIGHT),
+            }
+        )
+        x0 += width
+    return spans
+
+
+def _line(top: float, *parts: tuple[str, int]) -> dict:
+    spans = _spans(*parts, top=top)
+    return {
+        "bbox": (spans[0]["bbox"][0], top, spans[-1]["bbox"][2], top + LINE_HEIGHT),
+        "dir": (1.0, 0.0),
+        "spans": spans,
+    }
+
+
+def _items(converter, block) -> list[str]:
+    """Run a block through block processing and list grouping, returning item texts."""
+    nodes = converter._process_single_block_to_ast(block, [], 0)
+    grouped = converter._convert_paragraphs_to_lists(nodes)
+    found: list[str] = []
+
+    def visit(node) -> None:
+        if isinstance(node, ListItem):
+            found.append(" ".join(extract_text(node, joiner="").split()))
+            return
+        for child in getattr(node, "items", []) or []:
+            visit(child)
+
+    for node in grouped:
+        if isinstance(node, List):
+            for item in node.items:
+                visit(item)
+    return found
+
+
+def _block(*lines: dict) -> dict:
+    return {
+        "bbox": (
+            min(line["bbox"][0] for line in lines),
+            min(line["bbox"][1] for line in lines),
+            max(line["bbox"][2] for line in lines),
+            max(line["bbox"][3] for line in lines),
+        ),
+        "lines": list(lines),
+        "type": 0,
+    }
+
+
+class TestAMarkerPrintedInASymbolFontStartsAList:
+    def test_an_italic_flagged_bullet_is_still_a_bullet(self, converter):
+        # CMSY10 and friends mark their bullet italic, so it converts to Emphasis(Text("-"))
+        # and the line has no top-level Text node to find.
+        block = _block(
+            _line(100, ("•", ITALIC), (" ", 0), ("First point about the study", 0)),
+            _line(112, ("•", ITALIC), (" ", 0), ("Second point about the study", 0)),
+        )
+
+        assert _items(converter, block) == [
+            "First point about the study",
+            "Second point about the study",
+        ]
+
+    def test_a_numbered_marker_inside_a_wrapper_is_still_a_marker(self, converter):
+        # Wrapped, but complete within the one span -- which is the condition below.
+        block = _block(
+            _line(100, ("1. Prepare the sample", BOLD)),
+            _line(112, ("2. Measure the absorbance", BOLD)),
+        )
+
+        assert _items(converter, block) == ["Prepare the sample", "Measure the absorbance"]
+
+    def test_a_marker_inside_a_link_is_still_a_marker(self, converter):
+        para = AstParagraph(
+            content=[Link(url="https://example.com", content=[Text(content="- ")]), Text(content="Item")]
+        )
+
+        assert converter._detect_list_marker(para) == (True, "unordered")
+
+
+class TestAMarkerSplitAcrossSpans:
+    def test_the_letter_o_bullet_finds_the_space_in_the_next_span(self, converter):
+        # Word sets its second-level bullet as a Courier "o", and the space after it is a
+        # separate span in a different font. "o" only counts as a marker when a space
+        # follows, so a reader that stopped at the first node could never accept one.
+        block = _block(
+            _line(100, ("o", MONO), (" ", 0), ("Second level 1", 0)),
+            _line(112, ("o", MONO), (" ", 0), ("Second level 2", 0)),
+        )
+
+        assert _items(converter, block) == ["Second level 1", "Second level 2"]
+
+    def test_the_letter_o_still_needs_a_space_after_it(self, converter):
+        # The disambiguation the rule exists for: "office" is not a bullet. Now that the
+        # reader crosses spans, the word being split across two of them must not create one.
+        block = _block(_line(100, ("off", 0), ("ice hours are posted weekly", 0)))
+
+        assert _items(converter, block) == []
+
+    def test_the_markers_own_trailing_space_does_not_leak_into_the_item(self, converter):
+        # The bullet is its own span, so the space after it lived in the next node and
+        # survived stripping -- every item used to begin with a stray leading space.
+        block = _block(_line(100, ("•", 0), (" ", 0), ("First item", 0)))
+
+        nodes = converter._process_single_block_to_ast(block, [], 0)
+        grouped = converter._convert_paragraphs_to_lists(nodes)
+        item = next(n for n in grouped if isinstance(n, List)).items[0]
+
+        assert extract_text(item, joiner="") == "First item"
+
+
+class TestANumberedMarkerMustBeCompleteWithinOneSpan:
+    """The one place the walk deliberately stops short, and the reason it has to.
+
+    A reference number is typeset exactly like a list marker -- ``Text("44.")`` then
+    ``Text(" Konema, Nigeria ...")`` -- and nothing in the PDF says which is which. Reading
+    across that boundary turned a 60-entry bibliography into an ordered list, and because
+    nothing carries the start number through, the renderer printed it from 1: reference 44
+    came out as item 1, so no citation in the body could be matched to its reference.
+    """
+
+    def test_a_reference_number_in_its_own_span_does_not_start_a_list(self, converter):
+        block = _block(
+            _line(100, ("44.", 0), (" Konema. Nigeria - Youth literacy rate 2015. Available from", 0)),
+            _line(112, ("45.", 0), (" Denny L. Prevention of cervical cancer. Reprod Health Matters", 0)),
+        )
+
+        assert _items(converter, block) == []
+
+    def test_the_reference_keeps_its_printed_number(self, converter):
+        block = _block(_line(100, ("44.", 0), (" Konema. Nigeria - Youth literacy rate 2015", 0)))
+
+        nodes = converter._process_single_block_to_ast(block, [], 0)
+        grouped = converter._convert_paragraphs_to_lists(nodes)
+
+        assert "44." in extract_text(grouped[0], joiner="")
+
+    def test_a_bullet_in_its_own_span_still_reaches_across_for_its_space(self, converter):
+        # The asymmetry is the point: a bullet may look ahead one node, a number may not.
+        block = _block(_line(100, ("•", 0), (" ", 0), ("Konema. Nigeria - Youth literacy rate", 0)))
+
+        assert _items(converter, block) == ["Konema. Nigeria - Youth literacy rate"]
+
+
+class TestTheReaderDoesNotAnswerForTheMiddleOfTheLine:
+    @pytest.mark.parametrize(
+        "opening",
+        [
+            pytest.param(Emphasis(content=[Text(content="Nature ")]), id="styled-journal-name"),
+            pytest.param(Link(url="https://doi.org/x", content=[Text(content="Nature ")]), id="linked-journal-name"),
+            pytest.param(Strong(content=[Text(content="Nature ")]), id="bold-journal-name"),
+        ],
+    )
+    def test_a_citation_is_not_an_ordered_list_item(self, converter, opening):
+        # The first top-level Text node is "12. 45-67, 2019", which reads as a numbered
+        # marker only because the reader skipped the journal name in front of it.
+        para = AstParagraph(content=[opening, Text(content="12. 45-67, 2019")])
+
+        assert converter._detect_list_marker(para) == (False, None)
+        assert converter._strip_list_marker(para) == para.content
+
+    def test_a_dash_after_a_bold_lead_in_is_not_a_bullet(self, converter):
+        para = AstParagraph(content=[Strong(content=[Text(content="Note ")]), Text(content="- see appendix")])
+
+        assert converter._detect_list_marker(para) == (False, None)
+
+    def test_a_line_opening_with_inline_code_is_not_a_list_item(self, converter):
+        # Code stops the walk rather than being read through, so the prose after it cannot
+        # supply a marker. (A one-character "-" span is exempt from monospace treatment
+        # precisely so that a bullet in a Courier list survives as a bullet, which is why
+        # this needs a multi-character run to be inline code at all.)
+        block = _block(_line(100, ("--flag", MONO), (" enables the check", 0)))
+
+        assert _items(converter, block) == []
+
+
+class TestTheMarkerIsRemovedFromWhereverItSits:
+    def test_a_wrapper_emptied_by_stripping_is_dropped(self, converter):
+        para = AstParagraph(content=[Emphasis(content=[Text(content="-")]), Text(content=" Item body")])
+
+        stripped = converter._strip_list_marker(para)
+
+        assert extract_text(stripped, joiner="") == "Item body"
+        assert not any(isinstance(node, Emphasis) for node in stripped)
+
+    def test_a_wrapper_that_survives_keeps_its_formatting(self, converter):
+        # Only the marker comes off; the bold run it shared a node with stays bold.
+        para = AstParagraph(content=[Strong(content=[Text(content="- Background")]), Text(content=" of the study")])
+
+        stripped = converter._strip_list_marker(para)
+
+        assert extract_text(stripped, joiner="") == "Background of the study"
+        assert isinstance(stripped[0], Strong)
+
+    def test_a_marker_straddling_two_nodes_is_fully_removed(self, converter):
+        # Bullet in the first node, the space that follows it in the second.
+        para = AstParagraph(content=[Emphasis(content=[Text(content="-")]), Text(content=" Item body")])
+
+        assert extract_text(converter._strip_list_marker(para), joiner="").startswith("Item")


### PR DESCRIPTION
Closes #300.

## The bug

Whether a line opened with a list marker was decided by finding the first top-level `Text` node. That asks the wrong question in **both** directions:

- **Misses.** A bullet set in a symbol font carries that font's flags, so it arrives wrapped — italic flags make `Emphasis(Text("-"))` — and the line has no top-level `Text` at all. It read as empty and never started a list.
- **Inventions.** Reading *past* the first node to find some `Text` answers for the middle of the line. A citation opening with a styled journal name, `Nature 12. 45-67`, reported a numbered marker and became a list item. This half was not in the issue; it turned up while reproducing it.

Detection now descends into inline wrappers, and the marker is removed by character count so it comes off even when it sits inside a wrapper or straddles two nodes.

**Reading the raw spans instead does not work**, which is worth recording because it looks like the obvious fix. `_process_text_spans_to_inline` rewrites four bullet glyphs (`U+F0B7`, `U+00B7`, `U+2022`, `U+25CF`) to `-`, and **three of the four are not markers in their printed form** — the conversion is what makes a symbol-font bullet recognisable, so detection has to run after it.

## Word's `o` bullets, and the line this fix does not cross

A marker and the space that disambiguates it are routinely *separate spans*. That is why Word's second-level Courier `o` bullets never became list items: the rule that an `o` must be followed by a space (so "office" is not a bullet) could never fire, because the space was in the next node. They now nest under the item above instead of landing as loose paragraphs between the items they belong to.

That look-ahead is allowed **only for a bullet, never for a number**, and that restriction is the load-bearing part of this PR rather than a tidiness:

> A numbered marker arrives split exactly the same way — `Text("44.")` then `Text(" Konema, Nigeria …")` — and **nothing in a PDF distinguishes the 44th bibliography entry from the 44th item of a list.**

My first version did read across that boundary. It turned reference lists into ordered lists, and since nothing carries a start number through, the renderer printed them from 1 — **reference 44 came out as item 1**, so no citation in the body could be matched to its reference.

The oracle *did* flag this, as a precision drop from 0.113 to ~0.064, and it was easy to dismiss: JATS marks references as `<ref-list>`, which the list oracle cannot see, so "the metric is measuring the wrong thing" was a comfortable story. It was wrong. Reading the candidate's actual rendered output is what caught it.

## Two readers, deliberately different

| reader | used by | crosses node boundaries? |
|---|---|---|
| `_leading_inline_text` (conservative) | the tests that **create** lists | only for a lone bullet awaiting its space |
| `_opening_line_text` (liberal) | the two that only **re-split** or **protect** a list already found | yes |

Unifying these was my instinct and it was wrong. Narrowing the liberal two ran a whole ordered list back into a single item, because `"2."` is a span of its own and stops the conservative reader dead. Both are safe where they are used: neither of the liberal sites can create a list.

## Measurements

**Born-digital corpus**, over the twelve list-bearing articles that complete locally (`PMC9500000.1` does not converge and is excluded from *both* sides):

| | before | after |
|---|---|---|
| list-item recall | 0.231 | **0.269** |
| precision | 0.116 | **0.141** |
| F1 | 0.155 | **0.185** |

Three of twelve articles change at all. The remaining misses are overwhelmingly items the PDF prints with **no marker of any kind** — no marker rule can reach those, so #300's estimate of 16 recovered on one article was optimistic; the real figure there is 3.

**Golden fixtures** — 4 of 6 byte-identical to `main`; both changes are improvements:
- `*  First item` → `* First item` — the bullet's own trailing space no longer leaks into the item text
- the `o` bullets nest (`  - Second level 1`) instead of escaping as loose paragraphs
- **ordered lists are unchanged**

## Tests

17 new tests. 12 of the first 14 fail against `main` (the 2 that pass are negative controls); a new `TestANumberedMarkerMustBeCompleteWithinOneSpan` class pins the bibliography behaviour so it cannot regress silently.

## One thing for CI to adjudicate

The snapshot line `* First level 5` joining the list is a **prediction**. That line renders differently on Windows (it becomes a heading), so I could not observe its Linux form locally and transcribed the surrounding delta by hand. If CI disagrees, the fix is to transcribe its diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)