### PR TITLE
fix(pdf): dehyphenate text rescued from a rejected table region

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Text rescued from a rejected table region is dehyphenated like any other prose** (PDF).
+  When a detected table's grid turns out to be degenerate the region is emitted as a
+  paragraph instead, and its text is recovered with `page.get_textbox()` — raw extraction,
+  which returns the glyphs with their printed line breaks intact. Every other route into
+  the AST passes through `dehyphenate_blocks()` first and this one did not, so a word broken
+  across a line stayed broken: `Coroman-` and `del` never became `Coromandel`, and the word
+  appeared **nowhere in the output at all**, which no text-recall measure notices because
+  both fragments are still present. This is a growing path rather than an edge case — the
+  layout model over-predicts tables, and each over-prediction routes a whole region's prose
+  through it; on the page this was found on the predicted region covered the entire page
+  body. On that article, 32 line-break fragments become 0 and 8 words reappear. The join now
+  reads identically to ordinary prose, including where the two agree to leave a hyphen
+  alone: a capitalised continuation keeps it (`Anglo-Saxon`) and a digit continuation is
+  never merged.
+
 - **A bulleted or numbered list is no longer collapsed into a single item** (PDF). The
   vertical gap between two list items is the same gap that separates two paragraphs, so
   the paragraph-break rule is suspended once a list has started — otherwise every item

--- a/src/all2md/parsers/pdf.py
+++ b/src/all2md/parsers/pdf.py
@@ -3269,6 +3269,15 @@ class PdfToAstConverter(BaseParser):
         if not text or not text.strip():
             return None
 
+        # get_textbox is raw extraction: it returns the glyphs with their printed line
+        # breaks, and this is the only path into the AST that does not pass through
+        # dehyphenate_blocks(). Without this a word broken across a line survives as two
+        # fragments and the whole word is absent from the output -- "Coroman-" + "del" meant
+        # "Coromandel" appeared nowhere at all. The line break is consumed with the hyphen,
+        # so the join below does not put a space back between the halves.
+        if self.options.merge_hyphenated_words:
+            text = dehyphenate_text(text)
+
         lines = [line.strip() for line in text.strip().split("\n") if line.strip()]
         if not lines:
             return None

--- a/tests/unit/formats/pdf/test_pdf_rejected_region_text.py
+++ b/tests/unit/formats/pdf/test_pdf_rejected_region_text.py
@@ -1,0 +1,131 @@
+#  Copyright (c) 2025 Tom Villani, Ph.D.
+#
+# tests/unit/formats/pdf/test_pdf_rejected_region_text.py
+"""Text rescued from a rejected table region is prose, and has to be treated as prose.
+
+When a detected table's grid turns out to be degenerate, the region is emitted as a
+paragraph instead. Its text is recovered with ``page.get_textbox()``, which is raw
+extraction: the glyphs come back with their printed line breaks intact. Every other route
+into the AST passes through ``dehyphenate_blocks()`` first, and this one did not, so a word
+broken across a line stayed broken -- "Coroman-" and "del" never became "Coromandel", and
+the word appeared nowhere in the output at all.
+
+That matters more than a rejected grid sounds like it should: the layout model over-predicts
+tables, and each over-prediction routes a whole region's prose through here. On the page
+this was found on, the predicted region covered the entire page body.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from all2md.ast.utils import extract_text
+from all2md.options.pdf import PdfOptions
+from all2md.parsers.pdf import PdfToAstConverter
+
+pytestmark = [pytest.mark.unit, pytest.mark.pdf]
+
+fitz = pytest.importorskip("fitz")
+
+
+TOP = 100
+
+
+def _pdf_bytes(*lines: str) -> bytes:
+    """A one-page PDF holding ``lines``, one under the other."""
+    doc = fitz.open()
+    page = doc.new_page()
+    for offset, line in enumerate(lines):
+        page.insert_text((72, TOP + offset * 14), line, fontsize=11)
+    return doc.tobytes()
+
+
+def _page_with_lines(*lines: str):
+    """The same page, re-opened from bytes, plus a rect covering every line on it."""
+    page = fitz.open(stream=_pdf_bytes(*lines), filetype="pdf")[0]
+    region = fitz.Rect(60, TOP - 14, 400, TOP + len(lines) * 14 + 4)
+    return page, region
+
+
+def _region_text(page, region, **option_overrides) -> str:
+    converter = PdfToAstConverter(options=PdfOptions(**option_overrides))
+    paragraph = converter._region_text_as_paragraph(page, region, 0)
+    return extract_text(paragraph, joiner="") if paragraph is not None else ""
+
+
+class TestAWordBrokenAcrossALineComesBackWhole:
+    def test_the_two_halves_are_joined(self):
+        page, region = _page_with_lines("forests on the Coroman-", "del coast, south India.")
+
+        assert "Coromandel" in _region_text(page, region)
+
+    def test_the_broken_form_is_gone(self):
+        # The failure was not just a missing join: searching the output for the word found
+        # nothing, because neither fragment is the word.
+        page, region = _page_with_lines("forests on the Coroman-", "del coast, south India.")
+
+        text = _region_text(page, region)
+
+        assert "Coroman-" not in text
+        assert "Coroman del" not in text  # the line break must go with the hyphen
+
+    def test_the_rest_of_the_region_is_unharmed(self):
+        page, region = _page_with_lines("forests on the Coroman-", "del coast, south India.")
+
+        assert "south India." in _region_text(page, region)
+
+
+class TestTheJoinFollowsTheSameRulesAsEverywhereElse:
+    def test_a_capitalised_continuation_keeps_its_hyphen(self):
+        # "Anglo-Saxon" is a real compound that happens to break at its hyphen.
+        page, region = _page_with_lines("the history of Anglo-", "Saxon settlement")
+
+        assert "Anglo-Saxon" in _region_text(page, region)
+
+    @pytest.mark.parametrize(
+        ("first", "second"),
+        [
+            pytest.param("forests on the Coroman-", "del coast, south India.", id="merged"),
+            pytest.param("the history of Anglo-", "Saxon settlement", id="compound-keeps-hyphen"),
+            pytest.param("during the COVID-", "19 pandemic", id="digit-continuation-left-alone"),
+            pytest.param("Plant biodiversity and", "conservation of forests", id="no-hyphen"),
+        ],
+    )
+    def test_the_region_reads_the_same_as_ordinary_prose(self, first, second):
+        """The actual requirement: same text either way, not some ideal text.
+
+        Asserting an ideal outcome got this wrong once -- ``COVID-`` + ``19`` was expected
+        to come back as ``COVID-19`` and comes back as ``COVID- 19``, because a digit
+        continuation is deliberately not merged and the line join then puts a space in.
+        Ordinary prose does exactly the same thing, so that is a quirk of the line join
+        shared by both paths, not something this fallback does wrong.
+        """
+        from io import BytesIO
+
+        from all2md import to_markdown
+
+        page, region = _page_with_lines(first, second)
+        as_prose = to_markdown(BytesIO(_pdf_bytes(first, second)), source_format="pdf").strip()
+
+        assert _region_text(page, region) == as_prose
+
+    def test_the_option_is_respected(self):
+        # merge_hyphenated_words is off, so the region keeps what the page printed.
+        page, region = _page_with_lines("forests on the Coroman-", "del coast, south India.")
+
+        assert "Coroman-" in _region_text(page, region, merge_hyphenated_words=False)
+
+
+class TestTheRestOfTheFallbackIsUnchanged:
+    def test_separate_lines_are_still_joined_by_a_space(self):
+        page, region = _page_with_lines("Plant biodiversity and", "conservation of forests")
+
+        assert "biodiversity and conservation" in _region_text(page, region)
+
+    def test_a_region_with_no_text_still_yields_nothing(self):
+        page, region = _page_with_lines("text well below the region")
+        empty = fitz.Rect(0, 0, 20, 20)
+
+        converter = PdfToAstConverter(options=PdfOptions())
+
+        assert converter._region_text_as_paragraph(page, empty, 0) is None


### PR DESCRIPTION
Closes #291.

## The bug

When a detected table's grid turns out to be degenerate, the region is emitted as a paragraph instead of being dropped. Its text is recovered with `page.get_textbox()` — **raw extraction**, which returns the glyphs with their printed line breaks intact.

Every other route into the AST passes through `dehyphenate_blocks()` first. This one did not, so a word broken across a line stayed broken:

```
conservation of two tropical dry ev-ergreen forests on the Coroman-
del coast, south India.
```

`Coromandel` **appeared nowhere in the output at all**. Note what that does to measurement: no text-recall oracle notices, because `Coroman-` and `del` are both still present. Only searching for the word finds it missing.

This is a growing path rather than an edge case. The layout model over-predicts tables, and each over-prediction routes a whole region's prose through here — on the page this was found on, the predicted region covered the **entire page body**.

## The fix

Apply `dehyphenate_text()` to the recovered text before splitting it into lines, gated on `merge_hyphenated_words` like everywhere else. It consumes the line break along with the hyphen, so the join does not put a space back between the halves.

## Measurements

On `PMC1500805.1` (the article from the issue):

| | before | after |
|---|---|---|
| line-break hyphen fragments left in the output | 32 | **0** |
| whole words (>6 chars) present that were not before | — | **8** |

Recovered: `Conserving`, `Constable`, `Coromandel`, `Religions`, `Rituals`, `Science`, `Technological`, `resulting`.

All **6 golden fixtures byte-identical** to `main`.

## On the tests

They assert **parity with ordinary prose** rather than an ideal outcome, which is the actual requirement in the issue ("goes through the same dehyphenation and line-joining as ordinary prose") — and it caught an idealised expectation of my own. I first asserted that `COVID-` + `19` should come back as `COVID-19`. It comes back as `COVID- 19`, because a digit continuation is deliberately never merged and the line join then inserts a space. **Ordinary prose does exactly the same thing**, so that is a quirk of the line join shared by both paths, not something this fallback does wrong. Asserting parity states the requirement and cannot drift from it.

5 of the 11 tests fail against `main`; the rest are negative controls (option respected, no-hyphen case, empty region).

`ev-ergreen` in the same passage is deliberately left alone — the issue confirms it is present in the publisher's JATS and in the PDF alike, so it is not ours to fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)