### PR TITLE
fix(api): stop blaming the caller for options all2md injected itself

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **A dropped keyword argument is now diagnosed by which mistake it was.** A name that is an
+  option of no format still reports as `Unrecognized keyword arguments were ignored` — the
+  typo case #273 was about. A name that is a real all2md option the conversion's formats
+  simply have no field for (`pages` on a markdown parse, `flavor` on an HTML render) now
+  says so instead of telling the caller to check for a misspelling they did not make. Both
+  can arrive from one call, as two warnings. `to_ast` and `from_ast` previously stayed silent
+  for the second case while `to_markdown` warned; they now agree, which closes the last gap
+  #273 left open. Callers who pass a real-but-inapplicable option to `to_ast` will see a
+  warning where they saw none — it is telling them the option did nothing.
+
 ### Fixed
 
+- **Packaging no longer warns the user about an `attachment_mode` it injected itself.**
+  `create_package_from_conversions` forces `attachment_mode="base64"` so attachments stay in
+  memory, then passed it to `convert()`; for a source format with no such option (markdown,
+  txt) it was dropped and reported as an unrecognized keyword argument. The user never typed
+  it. An ordinary `all2md *.md --package out.zip` said "Check the API documentation for valid
+  parameter names" about a command line that was entirely valid. Library-internal call sites
+  can now mark an option as their own, and the three that inject one — the CLI packager, the
+  MCP server's `attachment_mode` from server config, and `convert`'s `flavor` shorthand — do.
+  An `attachment_mode` the caller passed explicitly is still theirs and still warns.
 - **Text rescued from a rejected table region is dehyphenated like any other prose** (PDF).
   When a detected table's grid turns out to be degenerate the region is emitted as a
   paragraph instead, and its text is recovered with `page.get_textbox()` — raw extraction,

--- a/src/all2md/api.py
+++ b/src/all2md/api.py
@@ -4,6 +4,9 @@
 # src/all2md/api.py
 import logging
 import warnings
+from collections.abc import Iterator
+from contextlib import contextmanager
+from contextvars import ContextVar
 from dataclasses import fields, is_dataclass
 from pathlib import Path
 from typing import IO, TYPE_CHECKING, Any, Optional, TypeVar, Union, cast, get_type_hints
@@ -221,26 +224,38 @@ def _collect_nested_dataclass_kwargs(
     return {"nested": nested_kwargs, "remaining": remaining_kwargs}
 
 
-def _warn_unrecognized_kwargs(unmatched: list[str], stacklevel: int) -> None:
-    """Warn that keyword arguments matched no options field and were dropped.
+_LIBRARY_INJECTED_OPTIONS: ContextVar[frozenset[str]] = ContextVar("all2md_library_injected_options")
 
-    Every public entry point that accepts ``**kwargs`` routes its leftovers here so
-    the warning stays identical across them. Silently discarding an option name is
-    the bad kind of failure: the call returns a plausible-looking result, so a typo
-    (or a parameter that simply doesn't exist, like ``filename``) reads as a library
-    bug rather than a caller mistake.
 
-    ``stacklevel`` is counted from the caller's frame, as if it had called
-    ``warnings.warn`` itself.
+@contextmanager
+def library_injected_options(*names: str) -> Iterator[None]:
+    """Mark option names as supplied by all2md rather than by the caller.
+
+    Several internal call sites add an option the caller never wrote: the CLI
+    packager forces ``attachment_mode="base64"`` so attachments stay in memory, the
+    MCP server sets it from server config, and ``convert``/``to_markdown`` push their
+    ``flavor`` shorthand into renderer kwargs. When the resolved format has no such
+    field the option is dropped, which is harmless -- a format with no attachment
+    handling has nothing to embed -- but the drop used to raise "Unrecognized keyword
+    arguments were ignored", telling the user to check parameter names they never
+    typed. An ordinary ``all2md *.md --package out.zip`` said exactly that (#275).
+
+    Wrapping the call marks those names as best-effort for its duration, so a drop
+    stays a debug-level detail. Names the caller *did* pass are unaffected: mark only
+    what was actually injected.
+
+    Nested and concurrent use is safe -- a :class:`~contextvars.ContextVar` is
+    per-thread and per-task, and the marks union rather than replace::
+
+        with library_injected_options("attachment_mode"):
+            convert(source, output=buffer, **conversion_options)
     """
-    if not unmatched:
-        return
-    warnings.warn(
-        f"Unrecognized keyword arguments were ignored: {unmatched}. "
-        "Check the API documentation for valid parameter names.",
-        UserWarning,
-        stacklevel=stacklevel + 1,
-    )
+    marked = _LIBRARY_INJECTED_OPTIONS.get(frozenset())
+    token = _LIBRARY_INJECTED_OPTIONS.set(marked | frozenset(names))
+    try:
+        yield
+    finally:
+        _LIBRARY_INJECTED_OPTIONS.reset(token)
 
 
 _ALL_OPTION_FIELD_NAMES: set[str] | None = None
@@ -280,19 +295,52 @@ def _all_option_field_names() -> set[str]:
     return _ALL_OPTION_FIELD_NAMES
 
 
-def _warn_unknown_option_names(dropped: list[str], stacklevel: int) -> None:
-    """Warn only for dropped kwargs that are not options anywhere in all2md.
+def _warn_dropped_kwargs(dropped: list[str], stacklevel: int) -> None:
+    """Warn that keyword arguments matched no options field and were dropped.
 
-    Unlike ``_split_kwargs_for_parser_and_renderer``, which sees both halves of a
-    conversion and can conclude a name is bogus, callers of this helper see only one
-    options class. A name like ``attachment_mode`` is a genuine option that this
-    particular format has no use for -- and the CLI packager, the MCP server and
-    ``convert``'s ``flavor`` shorthand all inject such options themselves. Warning
-    about those would blame the caller for something the library did, so they stay a
-    debug-level detail; only names that exist nowhere reach the user.
+    Every public entry point that accepts ``**kwargs`` routes its leftovers here, so
+    the same mistake reads the same way whichever one you called. Silently discarding
+    an option name is the bad kind of failure: the call returns a plausible-looking
+    result, so a typo (or a parameter that simply doesn't exist, like ``filename``)
+    reads as a library bug rather than a caller mistake.
+
+    Two different mistakes end up here and they get two different messages, because
+    telling someone to check for a typo in a name they spelled correctly sends them
+    hunting for nothing:
+
+    * a name that is an option of no format at all -- a typo, or an invented parameter;
+    * a name that is a real all2md option, just not one this conversion's formats have
+      (``pages`` on a markdown parse, ``flavor`` on an HTML render).
+
+    Options all2md injected itself are exempt from both -- see
+    ``library_injected_options``.
+
+    ``stacklevel`` is counted from the caller's frame, as if it had called
+    ``warnings.warn`` itself.
     """
-    unknown = [name for name in dropped if name not in _all_option_field_names()]
-    _warn_unrecognized_kwargs(unknown, stacklevel=stacklevel + 1)
+    injected = _LIBRARY_INJECTED_OPTIONS.get(frozenset())
+    names = [name for name in dropped if name not in injected]
+    if not names:
+        return
+
+    known_somewhere = _all_option_field_names()
+    unrecognized = [name for name in names if name not in known_somewhere]
+    wrong_format = [name for name in names if name in known_somewhere]
+
+    if unrecognized:
+        warnings.warn(
+            f"Unrecognized keyword arguments were ignored: {unrecognized}. "
+            "Check the API documentation for valid parameter names.",
+            UserWarning,
+            stacklevel=stacklevel + 1,
+        )
+    if wrong_format:
+        warnings.warn(
+            f"Keyword arguments were ignored: {wrong_format}. "
+            "They are valid all2md options, but not for the formats in this conversion.",
+            UserWarning,
+            stacklevel=stacklevel + 1,
+        )
 
 
 def _create_options_from_kwargs(
@@ -319,16 +367,18 @@ def _create_options_from_kwargs(
     Warns
     -----
     UserWarning
-        If a keyword argument is not an option of any format (a typo, or a parameter
-        that does not exist such as ``filename``). Callers that pre-split kwargs
-        through ``_split_kwargs_for_parser_and_renderer`` have already filtered
-        theirs, so this only fires for entry points that pass user kwargs through
-        unfiltered (``to_ast``, ``from_ast``).
+        If a keyword argument is dropped, either because it is an option of no format
+        (a typo, or a parameter that does not exist such as ``filename``) or because
+        it is a real option that ``options_class`` has no field for. Options all2md
+        injected itself are exempt; see ``library_injected_options``. Callers that
+        pre-split kwargs through ``_split_kwargs_for_parser_and_renderer`` have
+        already warned about theirs, so this fires for the entry points that pass
+        user kwargs through unfiltered (``to_ast``, ``from_ast``).
 
     """
     if not options_class:
         # No options class for this format, so every kwarg is dropped.
-        _warn_unknown_option_names(list(kwargs), stacklevel=4)
+        _warn_dropped_kwargs(list(kwargs), stacklevel=4)
         return None
 
     # Collect nested dataclass kwargs
@@ -367,7 +417,7 @@ def _create_options_from_kwargs(
     missing = [k for k in flat_kwargs if k not in valid_kwargs]
     if missing:
         logger.debug(f"Skipping unknown {options_type_name} options: {missing}")
-        _warn_unknown_option_names(missing, stacklevel=4)
+        _warn_dropped_kwargs(missing, stacklevel=4)
     return options_class(**valid_kwargs)
 
 
@@ -466,7 +516,7 @@ def _split_kwargs_for_parser_and_renderer(
         else:
             unmatched.append(k)
 
-    _warn_unrecognized_kwargs(unmatched, stacklevel=3)
+    _warn_dropped_kwargs(unmatched, stacklevel=3)
 
     return parser_kwargs, renderer_kwargs
 
@@ -1788,9 +1838,13 @@ def convert(
         remote_input_options=remote_input_options,
     )
 
-    # Prepare renderer options
+    # Prepare renderer options. ``flavor`` is a named parameter of this function that
+    # we push into renderer kwargs ourselves, so a target format without it (html,
+    # docx) must drop it quietly -- the caller did not pass a stray kwarg (#275).
+    injected_by_shorthand: tuple[str, ...] = ()
     if flavor:
         renderer_kwargs["flavor"] = flavor
+        injected_by_shorthand = ("flavor",)
 
     # Inject template_path / clear_template_body when preserve_formatting=True
     _maybe_apply_preserve_formatting(
@@ -1802,14 +1856,15 @@ def convert(
     )
 
     final_renderer_options: Optional[BaseRendererOptions]
-    if renderer_kwargs and renderer_options:
-        final_renderer_options = renderer_options.create_updated(**renderer_kwargs)
-    elif renderer_kwargs:
-        final_renderer_options = _create_renderer_options_from_kwargs(
-            cast(DocumentFormat, actual_target_format), **renderer_kwargs
-        )
-    else:
-        final_renderer_options = renderer_options
+    with library_injected_options(*injected_by_shorthand):
+        if renderer_kwargs and renderer_options:
+            final_renderer_options = renderer_options.create_updated(**renderer_kwargs)
+        elif renderer_kwargs:
+            final_renderer_options = _create_renderer_options_from_kwargs(
+                cast(DocumentFormat, actual_target_format), **renderer_kwargs
+            )
+        else:
+            final_renderer_options = renderer_options
 
     # Render AST to target format
     renderer_spec = renderer or actual_target_format

--- a/src/all2md/cli/packaging.py
+++ b/src/all2md/cli/packaging.py
@@ -10,7 +10,7 @@ from io import BytesIO
 from pathlib import Path
 from typing import Any, Dict, List, Optional, cast
 
-from all2md.api import convert
+from all2md.api import convert, library_injected_options
 from all2md.cli.input_items import CLIInputItem
 from all2md.converter_registry import registry
 
@@ -75,9 +75,13 @@ def create_package_from_conversions(
 
     # Prepare options with base64 embedding for attachments
     conversion_options = options.copy() if options else {}
-    # Force base64 embedding to keep everything in memory
+    # Force base64 embedding to keep everything in memory. Formats without attachment
+    # handling (markdown, txt) have no such option and drop it; mark it as ours so the
+    # drop does not warn the user about a parameter we added, not them (#275).
+    injected: tuple[str, ...] = ()
     if "attachment_mode" not in conversion_options:
         conversion_options["attachment_mode"] = "base64"
+        injected = ("attachment_mode",)
 
     total_size = 0
     file_count = 0
@@ -91,15 +95,16 @@ def create_package_from_conversions(
 
                 # Convert to BytesIO buffer (always binary)
                 buffer = BytesIO()
-                convert(
-                    source=item.raw_input,
-                    output=buffer,
-                    source_format=cast(Any, source_format),
-                    target_format=cast(Any, target_format),
-                    transforms=transforms,
-                    progress_callback=progress_callback,
-                    **conversion_options,
-                )
+                with library_injected_options(*injected):
+                    convert(
+                        source=item.raw_input,
+                        output=buffer,
+                        source_format=cast(Any, source_format),
+                        target_format=cast(Any, target_format),
+                        transforms=transforms,
+                        progress_callback=progress_callback,
+                        **conversion_options,
+                    )
 
                 # Write buffer contents to zip
                 content_bytes = buffer.getvalue()

--- a/src/all2md/mcp/tools.py
+++ b/src/all2md/mcp/tools.py
@@ -19,7 +19,7 @@ from pathlib import Path
 from typing import Any, cast, get_args
 from urllib.parse import unquote
 
-from all2md.api import from_ast, from_markdown, to_ast
+from all2md.api import from_ast, from_markdown, library_injected_options, to_ast
 from all2md.ast.nodes import Document, Image
 from all2md.ast.sections import extract_sections
 from all2md.ast.transforms import NodeCollector
@@ -297,7 +297,10 @@ def read_document_as_markdown_impl(input_data: ReadDocumentAsMarkdownInput, conf
     try:
         # Convert to AST first (allows us to extract images and sections)
         # format_hint has been validated above, safe to cast to DocumentFormat
-        doc = to_ast(source, source_format=cast(DocumentFormat, input_data.format_hint or "auto"), **kwargs)
+        # attachment_mode comes from server config, not from the caller, so a format
+        # without attachment handling must drop it quietly rather than warn (#275).
+        with library_injected_options("attachment_mode"):
+            doc = to_ast(source, source_format=cast(DocumentFormat, input_data.format_hint or "auto"), **kwargs)
 
         # Validate return type
         if not isinstance(doc, Document):

--- a/tests/unit/core/test_api_kwarg_validation.py
+++ b/tests/unit/core/test_api_kwarg_validation.py
@@ -1,8 +1,12 @@
-"""Unrecognized keyword arguments must warn from every public entry point.
+"""Dropped keyword arguments must warn from every public entry point.
 
 Regression tests for #273. ``to_markdown`` warned on unknown kwargs but ``to_ast``
 and ``from_ast`` dropped them silently, so a typo (or a plausible-but-nonexistent
 parameter such as ``filename``) produced a valid-looking result with no diagnostic.
+
+Extended for #275, which split the diagnosis three ways. A dropped name is either a
+typo, a real option that this conversion's formats have no field for, or something
+all2md injected itself -- and only the first two are the caller's business.
 """
 
 import warnings
@@ -13,13 +17,23 @@ from all2md import from_ast, to_ast, to_markdown
 
 MARKDOWN_SRC = "# Heading\n\nBody text.\n"
 
+# Both diagnoses open this way; the wording after it is what tells them apart.
+ANY_DROP = "were ignored"
+TYPO = "Unrecognized keyword"
+WRONG_FORMAT = "not for the formats in this conversion"
+
 
 def _warnings_from(func, *args, **kwargs):
     """Return the UserWarnings raised by a call, ignoring everything else."""
+    return _warnings_matching(ANY_DROP, func, *args, **kwargs)
+
+
+def _warnings_matching(fragment, func, *args, **kwargs):
+    """Return the UserWarnings whose message contains ``fragment``."""
     with warnings.catch_warnings(record=True) as caught:
         warnings.simplefilter("always")
         func(*args, **kwargs)
-    return [w for w in caught if issubclass(w.category, UserWarning) and "Unrecognized keyword" in str(w.message)]
+    return [w for w in caught if issubclass(w.category, UserWarning) and fragment in str(w.message)]
 
 
 @pytest.mark.unit
@@ -78,29 +92,137 @@ class TestValidKwargsStaySilent:
 
 
 @pytest.mark.unit
-class TestKnownOptionForAnotherFormatStaysQuiet:
-    """A real option that this format ignores is not a typo, and must not warn.
+class TestARealOptionForAnotherFormatIsDiagnosedDifferently:
+    """A misspelled name and a misplaced one are not the same mistake.
 
-    ``to_ast``/``from_ast`` see only one options class, so they cannot tell "bogus"
-    from "valid elsewhere". The library itself injects such options -- the CLI
-    packager forces ``attachment_mode``, the MCP server sets it from server config,
-    ``convert`` injects its ``flavor`` shorthand -- so warning here would blame the
-    caller for something they never passed.
+    Both end in a dropped kwarg, and #273 gave both the same message: check your
+    parameter names. For ``pages`` on a markdown parse that sends the caller hunting
+    for a typo they did not make, so the wording splits (#275).
     """
 
-    @pytest.mark.parametrize("option_name", ["attachment_mode", "flavor", "pages"])
-    def test_real_option_from_another_format_is_silent(self, option_name):
-        assert not _warnings_from(to_ast, MARKDOWN_SRC, source_format="markdown", **{option_name: "base64"})
+    @pytest.mark.parametrize("entry_point", [to_ast, to_markdown])
+    def test_it_warns_without_calling_the_name_unrecognized(self, entry_point):
+        found = _warnings_matching(WRONG_FORMAT, entry_point, MARKDOWN_SRC, source_format="markdown", pages="1-3")
 
-    def test_library_injected_flavor_does_not_blame_the_caller(self):
-        """from_markdown documents `flavor`; converting to HTML must not call it bogus."""
+        assert found, "a real option this format has no use for was dropped silently"
+        assert "pages" in str(found[0].message)
+        assert TYPO not in str(found[0].message)
+
+    def test_a_typo_is_still_called_unrecognized(self):
+        found = _warnings_matching(TYPO, to_ast, MARKDOWN_SRC, source_format="markdown", atachment_mode="base64")
+
+        assert found, "the case that motivated #273 must still warn"
+        assert WRONG_FORMAT not in str(found[0].message)
+
+    def test_both_diagnoses_can_arrive_from_one_call(self):
+        """One bad name and one misplaced name are two problems, reported as two."""
+        found = _warnings_from(to_ast, MARKDOWN_SRC, source_format="markdown", pages="1-3", bogus_xyz=1)
+
+        typo = [str(w.message) for w in found if TYPO in str(w.message)]
+        misplaced = [str(w.message) for w in found if WRONG_FORMAT in str(w.message)]
+
+        assert typo and "bogus_xyz" in typo[0] and "pages" not in typo[0]
+        assert misplaced and "pages" in misplaced[0] and "bogus_xyz" not in misplaced[0]
+
+    @pytest.mark.parametrize("entry_point", [to_ast, to_markdown])
+    def test_the_entry_points_agree(self, entry_point):
+        """#275's other half: to_ast used to stay silent here while to_markdown warned."""
+        assert _warnings_from(entry_point, MARKDOWN_SRC, source_format="markdown", attachment_mode="base64")
+
+
+@pytest.mark.unit
+class TestOptionsAll2mdInjectedItselfStayQuiet:
+    """A warning must not blame the caller for a kwarg the library added (#275).
+
+    ``all2md *.md --package out.zip`` warned that ``attachment_mode`` was
+    unrecognized. The user never passed it -- the packager forces it so attachments
+    stay in memory, and markdown has no such option, so it was dropped.
+    """
+
+    def test_packaging_does_not_warn_about_its_own_attachment_mode(self, tmp_path):
+        from all2md.cli.input_items import CLIInputItem
+        from all2md.cli.packaging import create_package_from_conversions
+
+        source = tmp_path / "note.md"
+        source.write_text(MARKDOWN_SRC, encoding="utf-8")
+        item = CLIInputItem(raw_input=source, kind="local_file", display_name="note.md", path_hint=source)
+
+        found = _warnings_from(create_package_from_conversions, [item], tmp_path / "out.zip")
+
+        assert not found, f"packaging blamed the caller: {[str(w.message) for w in found]}"
+
+    def test_the_package_is_still_written(self, tmp_path):
+        """Silencing the warning must not mean skipping the work it accompanied."""
+        import zipfile
+
+        from all2md.cli.input_items import CLIInputItem
+        from all2md.cli.packaging import create_package_from_conversions
+
+        source = tmp_path / "note.md"
+        source.write_text(MARKDOWN_SRC, encoding="utf-8")
+        item = CLIInputItem(raw_input=source, kind="local_file", display_name="note.md", path_hint=source)
+        zip_path = tmp_path / "out.zip"
+
+        create_package_from_conversions([item], zip_path)
+
+        with zipfile.ZipFile(zip_path) as archive:
+            assert archive.namelist() == ["note.md"]
+            assert b"Heading" in archive.read("note.md")
+
+    def test_a_caller_supplied_attachment_mode_is_still_the_callers(self, tmp_path):
+        """The packager only marks what it injected, so an explicit one still warns."""
+        from all2md.cli.input_items import CLIInputItem
+        from all2md.cli.packaging import create_package_from_conversions
+
+        source = tmp_path / "note.md"
+        source.write_text(MARKDOWN_SRC, encoding="utf-8")
+        item = CLIInputItem(raw_input=source, kind="local_file", display_name="note.md", path_hint=source)
+
+        found = _warnings_from(
+            create_package_from_conversions,
+            [item],
+            tmp_path / "out.zip",
+            options={"attachment_mode": "base64"},
+        )
+
+        assert found, "an attachment_mode the caller chose is theirs to hear about"
+
+    def test_the_flavor_shorthand_does_not_blame_the_caller(self):
+        """``flavor`` is a named parameter of convert(); we push it into renderer kwargs."""
         from all2md import from_markdown
 
         assert not _warnings_from(from_markdown, MARKDOWN_SRC, "html", flavor="gfm")
 
-    def test_typo_of_a_real_option_still_warns(self):
-        """The safety net still catches the case that motivated #273."""
-        assert _warnings_from(to_ast, MARKDOWN_SRC, source_format="markdown", atachment_mode="base64")
+    def test_the_mark_does_not_outlive_the_call(self):
+        """A ContextVar left set would silence the same name for everyone afterwards."""
+        from all2md.api import library_injected_options
+
+        with library_injected_options("attachment_mode"):
+            assert not _warnings_from(to_ast, MARKDOWN_SRC, source_format="markdown", attachment_mode="base64")
+
+        assert _warnings_from(to_ast, MARKDOWN_SRC, source_format="markdown", attachment_mode="base64")
+
+    def test_marks_nest_rather_than_replace(self):
+        from all2md.api import library_injected_options
+
+        with library_injected_options("attachment_mode"), library_injected_options("pages"):
+            assert not _warnings_from(
+                to_ast, MARKDOWN_SRC, source_format="markdown", attachment_mode="base64", pages="1-3"
+            )
+
+    def test_an_injected_mark_does_not_hide_a_typo(self):
+        """Marking one name best-effort must not silence the bad kwarg beside it."""
+        from all2md.api import library_injected_options
+
+        with library_injected_options("attachment_mode"):
+            found = _warnings_from(
+                to_ast, MARKDOWN_SRC, source_format="markdown", attachment_mode="base64", bogus_xyz=1
+            )
+
+        assert found
+        messages = " ".join(str(w.message) for w in found)
+        assert "bogus_xyz" in messages
+        assert "attachment_mode" not in messages
 
 
 @pytest.mark.unit


### PR DESCRIPTION
Closes #275.

## The complaint

`all2md *.md --zip out.zip` warned:

```
UserWarning: Unrecognized keyword arguments were ignored: ['attachment_mode'].
Check the API documentation for valid parameter names.
```

about a command line that was entirely valid. `create_package_from_conversions`
forces `attachment_mode="base64"` so attachments stay in memory; markdown has no
such option, so it was dropped and reported as the user's typo. Reproduced first,
attributed to `packaging.py:94` exactly as the issue describes.

## The mechanism

`library_injected_options()` — a context manager marking option names as the
library's own for the duration of a call. A `ContextVar` rather than a parameter
because the three sites that need it inject at different depths and none wants a
new signature:

| site | injects |
|---|---|
| `cli/packaging.py` | `attachment_mode="base64"` |
| `mcp/tools.py` | `attachment_mode` from server config |
| `api.convert` | the `flavor` shorthand |

The packager marks `attachment_mode` **only when it actually injected one**, so an
explicit `attachment_mode` from the caller is still theirs and still warns.

## Why the known-option rule goes with it

`_warn_unknown_option_names` suppressed any name that was an option *somewhere*.
Its docstring named these exact three sites as the reason. With the mark doing that
job properly, the rule is redundant — and dropping it closes the last gap #273 left
open: `to_ast`/`from_ast` stayed silent when a real option didn't apply to the
format, while `to_markdown` warned. They now agree.

## The wording splits

Warning about both cases with one message would re-create the same fault in
miniature — telling someone to check the spelling of a name they spelled correctly.
So:

- an option of **no** format → `Unrecognized keyword arguments were ignored` (the
  #273 typo case, unchanged)
- a **real** all2md option this conversion's formats have no field for (`pages` on a
  markdown parse) → says that instead

Both can arrive from one call, as two warnings.

## Behaviour change

Callers passing a real-but-inapplicable option to `to_ast`/`from_ast` will see a
warning where they saw none. That is the point — it tells them the option did
nothing. Noted in the CHANGELOG under Changed.

## Verification

- New tests confirmed to **fail against pre-fix source** (8 of them), not just pass against the new one.
- Rule removal measured before committing to it: unit + integration + e2e + golden green apart from the two tests encoding the old semantics.
- `mypy src/` clean apart from the known local-only `_pdf_layout.py:201`.

## What this does *not* fix

The issue's own repro command still warns, about different names:

| | `all2md --zip bundle.zip *.md *.html` |
|---|---|
| before | `['view.no_wait', 'view.dark', 'attachment_mode']` |
| after | `['view.no_wait', 'view.dark']` |

`view.*` are the `[view]` config section's own settings leaking through the one
conversion path that never projects namespaced options. Same symptom, different root
cause, different module — filed separately as #303.

🤖 Generated with [Claude Code](https://claude.com/claude-code)