### PR TITLE
fix(cli): project namespaced options per item on the --zip path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **`--zip` projects its namespaced options like every other path.** The CLI carries
+  options fully qualified — `pdf.pages`, `markdown.flavor`, and the subcommand sections'
+  own settings such as `view.dark` — and flattens them against the format that will
+  actually handle each file. Every path that writes to disk does that per input file;
+  `--zip` handed the whole namespaced dict to `convert()`, which matched none of it and
+  reported the leftovers as the user's typos: `Unrecognized keyword arguments were
+  ignored: ['view.no_wait', 'view.dark']`. Nobody typed those — they are the `[view]`
+  section's settings, and the function that exists to drop them was never called on this
+  path. Projection is now per item, so a mixed batch applies `pdf.*` to the PDFs and
+  `html.*` to the HTML rather than to everything, matching what the same files get when
+  converted to disk.
 - **Text rescued from a rejected table region is dehyphenated like any other prose** (PDF).
   When a detected table's grid turns out to be degenerate the region is emitted as a
   paragraph instead, and its text is recovered with `page.get_textbox()` — raw extraction,

--- a/src/all2md/cli/packaging.py
+++ b/src/all2md/cli/packaging.py
@@ -6,6 +6,7 @@ directly from memory without intermediate disk I/O.
 
 import logging
 import zipfile
+from collections.abc import Callable
 from io import BytesIO
 from pathlib import Path
 from typing import Any, Dict, List, Optional, cast
@@ -25,6 +26,7 @@ def create_package_from_conversions(
     transforms: Optional[list] = None,
     source_format: str = "auto",
     progress_callback: Optional[Any] = None,
+    option_resolver: Optional[Callable[[CLIInputItem], Dict[str, Any]]] = None,
 ) -> Path:
     """Create zip package by converting files directly to memory without disk I/O.
 
@@ -48,6 +50,13 @@ def create_package_from_conversions(
         Source format (auto-detect if "auto")
     progress_callback : ProgressCallback, optional
         Optional callback for progress updates
+    option_resolver : Callable[[CLIInputItem], dict], optional
+        Projects ``options`` onto the kwargs one item's formats actually accept,
+        called once per item. The CLI's options dict is namespaced
+        (``pdf.pages``, ``view.dark``) and has to be flattened against the format
+        that will handle each file; without this every key is forwarded verbatim
+        and the API reports the unusable ones as the caller's typos (#303). When
+        omitted, ``options`` is passed through unchanged.
 
     Returns
     -------
@@ -73,11 +82,7 @@ def create_package_from_conversions(
     # Get target extension
     extension = registry.get_default_extension_for_format(target_format)
 
-    # Prepare options with base64 embedding for attachments
-    conversion_options = options.copy() if options else {}
-    # Force base64 embedding to keep everything in memory
-    if "attachment_mode" not in conversion_options:
-        conversion_options["attachment_mode"] = "base64"
+    base_options = options.copy() if options else {}
 
     total_size = 0
     file_count = 0
@@ -88,6 +93,13 @@ def create_package_from_conversions(
             try:
                 # Generate output name
                 output_name = f"{item.derive_output_stem(index)}{extension}"
+
+                # Each item may be a different format, so the namespaced options are
+                # projected per item rather than once for the batch.
+                conversion_options = dict(option_resolver(item)) if option_resolver else dict(base_options)
+                # Force base64 embedding to keep everything in memory.
+                if "attachment_mode" not in conversion_options:
+                    conversion_options["attachment_mode"] = "base64"
 
                 # Convert to BytesIO buffer (always binary)
                 buffer = BytesIO()

--- a/src/all2md/cli/packaging.py
+++ b/src/all2md/cli/packaging.py
@@ -83,15 +83,6 @@ def create_package_from_conversions(
     extension = registry.get_default_extension_for_format(target_format)
 
     base_options = options.copy() if options else {}
-    # Prepare options with base64 embedding for attachments
-    conversion_options = options.copy() if options else {}
-    # Force base64 embedding to keep everything in memory. Formats without attachment
-    # handling (markdown, txt) have no such option and drop it; mark it as ours so the
-    # drop does not warn the user about a parameter we added, not them (#275).
-    injected: tuple[str, ...] = ()
-    if "attachment_mode" not in conversion_options:
-        conversion_options["attachment_mode"] = "base64"
-        injected = ("attachment_mode",)
 
     total_size = 0
     file_count = 0
@@ -106,9 +97,16 @@ def create_package_from_conversions(
                 # Each item may be a different format, so the namespaced options are
                 # projected per item rather than once for the batch.
                 conversion_options = dict(option_resolver(item)) if option_resolver else dict(base_options)
-                # Force base64 embedding to keep everything in memory.
+                # Force base64 embedding to keep everything in memory. Formats without
+                # attachment handling (markdown, txt) have no such option and drop it;
+                # mark it as ours so the drop does not warn the user about a parameter we
+                # added, not them (#275). This has to be decided per item, since whether
+                # the caller's own attachment_mode survives projection depends on the
+                # item's format.
+                injected: tuple[str, ...] = ()
                 if "attachment_mode" not in conversion_options:
                     conversion_options["attachment_mode"] = "base64"
+                    injected = ("attachment_mode",)
 
                 # Convert to BytesIO buffer (always binary)
                 buffer = BytesIO()

--- a/src/all2md/cli/processors.py
+++ b/src/all2md/cli/processors.py
@@ -1515,6 +1515,9 @@ def _create_output_package(
     try:
         # Determine target format
         target_format = getattr(parsed_args, "output_format", "markdown")
+        # For projecting renderer options, "auto" resolves the way the to-stdout path
+        # resolves it; the extension and convert() call keep the caller's spelling.
+        render_target = target_format if target_format != "auto" else "markdown"
 
         # Determine zip path
         if parsed_args.zip == "auto":
@@ -1528,7 +1531,11 @@ def _create_output_package(
             zip_path = Path(parsed_args.zip)
 
         # Create the zip package directly from conversions
-        # Pass user-specified options and transforms
+        # Pass user-specified options and transforms. The options dict is namespaced
+        # (``pdf.pages``, and the subcommand sections' own settings such as
+        # ``view.dark``), so it is projected per item exactly as the to-disk paths
+        # project per input file -- otherwise every key is forwarded to convert()
+        # verbatim and the unusable ones are reported to the user as their typos.
         created_zip = create_package_from_conversions(
             input_items=input_items,
             zip_path=zip_path,
@@ -1536,6 +1543,9 @@ def _create_output_package(
             options=options,
             transforms=transforms,
             source_format=format_arg,
+            option_resolver=lambda item: prepare_options_for_execution(
+                options, item.best_path(), format_arg, render_target
+            ),
         )
 
         print(f"Created package: {created_zip}", file=sys.stderr)

--- a/tests/unit/cli/test_cli_zip_option_projection.py
+++ b/tests/unit/cli/test_cli_zip_option_projection.py
@@ -1,0 +1,184 @@
+#  Copyright (c) 2025 Tom Villani, Ph.D.
+#
+# tests/unit/cli/test_cli_zip_option_projection.py
+"""The ``--zip`` path projects its namespaced options like every other path.
+
+The CLI carries options fully qualified -- ``pdf.pages``, ``markdown.flavor``, and
+the subcommand sections' own settings such as ``view.dark`` -- and flattens them
+against the formats that will actually handle each file. Every path that writes to
+disk does that per input file through ``prepare_options_for_execution``.
+
+``--zip`` did not. It handed the whole namespaced dict to ``convert()``, which
+matched none of it and told the user their parameter names were wrong:
+
+    UserWarning: Unrecognized keyword arguments were ignored:
+    ['view.no_wait', 'view.dark'].
+
+Those are the ``[view]`` section's own settings. Nobody typed them (#303).
+"""
+
+from __future__ import annotations
+
+import zipfile
+from pathlib import Path
+
+import pytest
+
+from all2md.cli.input_items import CLIInputItem
+from all2md.cli.packaging import create_package_from_conversions
+from all2md.cli.processors import prepare_options_for_execution
+
+pytestmark = [pytest.mark.unit, pytest.mark.cli]
+
+
+def _item(path: Path) -> CLIInputItem:
+    return CLIInputItem(raw_input=path, kind="local_file", display_name=path.name, path_hint=path)
+
+
+def _sources(tmp_path: Path) -> tuple[Path, Path]:
+    """One markdown file and one HTML file -- deliberately different formats."""
+    md = tmp_path / "note.md"
+    md.write_text("# Alpha\n\nBody text.\n", encoding="utf-8")
+    html = tmp_path / "page.html"
+    html.write_text("<h1>Beta</h1><p>Other text.</p>", encoding="utf-8")
+    return md, html
+
+
+class _ConvertSpy:
+    """Records the kwargs each conversion was given, and writes plausible output."""
+
+    def __init__(self):
+        self.calls: list[dict] = []
+
+    def __call__(self, *, source, output, **kwargs):
+        self.calls.append(kwargs)
+        output.write(b"# stub\n")
+
+    def kwargs_for(self, index: int) -> dict:
+        """The kwargs of one call, minus the ones packaging always sets."""
+        recorded = dict(self.calls[index])
+        for always_present in ("source_format", "target_format", "transforms", "progress_callback"):
+            recorded.pop(always_present, None)
+        recorded.pop("attachment_mode", None)  # packaging forces this one; see #275
+        return recorded
+
+
+@pytest.fixture
+def spy(monkeypatch):
+    replacement = _ConvertSpy()
+    monkeypatch.setattr("all2md.cli.packaging.convert", replacement)
+    return replacement
+
+
+def _resolver(options, format_arg="auto", target_format="markdown"):
+    return lambda item: prepare_options_for_execution(options, item.best_path(), format_arg, target_format)
+
+
+class TestASubcommandsOwnSettingsNeverReachTheConverter:
+    """The bug as reported: ``[view]`` settings arriving as conversion kwargs."""
+
+    @pytest.mark.parametrize("leaked_key", ["view.dark", "view.no_wait", "serve.host", "rich.theme"])
+    def test_a_namespaced_non_format_key_is_dropped(self, tmp_path, spy, leaked_key):
+        md, _ = _sources(tmp_path)
+        options = {leaked_key: True}
+
+        create_package_from_conversions(
+            [_item(md)], tmp_path / "out.zip", options=options, option_resolver=_resolver(options)
+        )
+
+        assert spy.kwargs_for(0) == {}, f"{leaked_key} reached convert()"
+
+    def test_without_a_resolver_the_dict_is_passed_through(self, tmp_path, spy):
+        """The unprojected behaviour is still available to a library caller.
+
+        Guards the fix from the other direction: the resolver is what filters, so a
+        caller that does its own projection is not silently second-guessed.
+        """
+        md, _ = _sources(tmp_path)
+
+        create_package_from_conversions([_item(md)], tmp_path / "out.zip", options={"view.dark": True})
+
+        assert spy.kwargs_for(0) == {"view.dark": True}
+
+
+class TestProjectionMatchesTheToDiskPath:
+    """The requirement is parity, not an ideal set of kwargs.
+
+    Asserting what the projected dict "should" contain would encode a spec the
+    to-disk paths do not follow either; the actual requirement is that packaging a
+    file and converting it to disk hand ``convert()`` the same options.
+    """
+
+    @pytest.mark.parametrize(
+        "options",
+        [
+            pytest.param({"view.dark": True}, id="non-format-namespace"),
+            pytest.param({"pdf.pages": [1]}, id="another-formats-option"),
+            pytest.param({"markdown.flavor": "commonmark"}, id="this-formats-option"),
+            pytest.param({"attachment_base_url": "/img"}, id="unqualified-applies-everywhere"),
+            pytest.param({"html.strip_dangerous_elements": True}, id="qualified-for-the-other-item"),
+            pytest.param({}, id="nothing-at-all"),
+        ],
+    )
+    def test_each_item_gets_what_the_to_disk_path_would_give_it(self, tmp_path, spy, options):
+        md, html = _sources(tmp_path)
+        items = [_item(md), _item(html)]
+
+        create_package_from_conversions(
+            items, tmp_path / "out.zip", options=options, option_resolver=_resolver(options)
+        )
+
+        for index, item in enumerate(items):
+            expected = prepare_options_for_execution(options, item.best_path(), "auto", "markdown")
+            assert spy.kwargs_for(index) == expected, f"{item.display_name} diverged from the to-disk path"
+
+    def test_the_two_items_are_projected_separately(self, tmp_path, spy):
+        """A batch is mixed-format, so one dict for the whole batch cannot be right."""
+        md, html = _sources(tmp_path)
+        options = {"html.strip_dangerous_elements": True}
+
+        create_package_from_conversions(
+            [_item(md), _item(html)], tmp_path / "out.zip", options=options, option_resolver=_resolver(options)
+        )
+
+        assert spy.kwargs_for(0) == {}, "an html-qualified option was applied to the markdown item"
+        assert spy.kwargs_for(1) == {"strip_dangerous_elements": True}
+
+
+class TestTheArchiveIsStillBuilt:
+    """Projection must not cost us the conversion it was filtering options for."""
+
+    def test_every_item_is_written(self, tmp_path):
+        md, html = _sources(tmp_path)
+        zip_path = tmp_path / "out.zip"
+        options = {"view.dark": True}
+
+        create_package_from_conversions(
+            [_item(md), _item(html)], zip_path, options=options, option_resolver=_resolver(options)
+        )
+
+        with zipfile.ZipFile(zip_path) as archive:
+            assert sorted(archive.namelist()) == ["note.md", "page.md"]
+            assert b"Alpha" in archive.read("note.md")
+            assert b"Beta" in archive.read("page.md")
+
+    def test_attachment_mode_is_still_forced_to_base64(self, tmp_path, spy):
+        """Projection replaced the options dict, so the base64 injection must survive."""
+        md, _ = _sources(tmp_path)
+        options = {"view.dark": True}
+
+        create_package_from_conversions(
+            [_item(md)], tmp_path / "out.zip", options=options, option_resolver=_resolver(options)
+        )
+
+        assert spy.calls[0]["attachment_mode"] == "base64"
+
+    def test_an_explicit_attachment_mode_still_wins(self, tmp_path, spy):
+        md, _ = _sources(tmp_path)
+        options = {"attachment_mode": "skip"}
+
+        create_package_from_conversions(
+            [_item(md)], tmp_path / "out.zip", options=options, option_resolver=_resolver(options)
+        )
+
+        assert spy.calls[0]["attachment_mode"] == "skip"


### PR DESCRIPTION
Closes #303. Found while verifying #275 — the fix for that issue did **not** silence the
issue's own repro command, and this is why.

## The leak

The CLI carries options fully qualified (`pdf.pages`, `markdown.flavor`, and the
subcommand sections' own settings such as `view.dark`) and flattens them against the
format that will handle each file. `_filter_options_for_formats` exists for exactly
that; its comment says non-format sections "(e.g. `[view]`, `[serve]`, `[diff]`,
`[search]`) never have their terminals injected as parser kwargs".

`--zip` never called it, so `convert()` received the namespaced dict verbatim, matched
none of it, and reported the leftovers as the user's typos:

```
UserWarning: Unrecognized keyword arguments were ignored: ['view.no_wait', 'view.dark'].
Check the API documentation for valid parameter names.
```

## Measured, not assumed

A spy on the packaging call, running `all2md --zip out.zip one.md three.html`:

| | |
|---|---|
| keys reaching packaging | `['view.dark', 'view.no_wait']` — both from `[view]` |
| correct projection for either file | `[]` — no converter options at all |
| plain / multi-file / `--output-dir` | silent |
| `--zip` | the only leaking path |

## The fix

Project **per item**, not once for the batch: a batch is mixed-format, so `pdf.*` should
reach the PDFs and `html.*` the HTML, which one projection cannot express.

`cli/packaging.py` cannot import `cli/processors.py` (processors imports packaging at
module scope), so the projection arrives as an `option_resolver` callable. Omitting it
keeps the old pass-through, so a library caller doing its own projection is not silently
second-guessed — there's a test for that direction too.

The resolver mirrors the closest existing analogue, `processors.py:3569`, including its
`auto` → `markdown` normalisation for the renderer hint.

## Tests assert parity, not an ideal

The requirement is that packaging a file and converting it to disk hand `convert()` the
same options. Asserting a hand-written "correct" dict would encode a spec the to-disk
paths don't follow either, so the parametrised test compares the two paths directly,
with concrete assertions alongside so it can't pass vacuously.

14 of the 15 new tests fail against pre-fix source.

## Merge note for whoever lands this second

This conflicts with #304 in `cli/packaging.py` and `CHANGELOG.md`. I resolved it locally
and verified the result; the correct resolution keeps **both** changes — the
`attachment_mode` injection moves *inside* the per-item loop and tracks `injected` there:

```python
conversion_options = dict(option_resolver(item)) if option_resolver else dict(base_options)
injected: tuple[str, ...] = ()
if "attachment_mode" not in conversion_options:
    conversion_options["attachment_mode"] = "base64"
    injected = ("attachment_mode",)

buffer = BytesIO()
with library_injected_options(*injected):
    convert(...)
```

With both merged, the command from #275 is fully silent, the archive is correct, and it
still round-trips into `all2md grep`. Verified locally on a throwaway merge; all 42 tests
from the two branches pass together.

🤖 Generated with [Claude Code](https://claude.com/claude-code)