### PR TITLE
docs: show that archives are searchable without unpacking

### DIFF
--- a/docs/source/cli.rst
+++ b/docs/source/cli.rst
@@ -172,6 +172,9 @@ faster follow-up queries.
    # Reuse an existing index without reprocessing inputs
    all2md search "incident response" --index-dir ./index
 
+   # Index an archive directly; its members are converted first, binaries included
+   all2md search "termination clause" contracts.zip --keyword
+
 Common grep-style flags are supported:
 
 * ``-A/-B/-C`` to control trailing/leading context lines (e.g. ``-C 1`` for one line around each match)
@@ -211,6 +214,9 @@ overhead of building persistent indexes.
 
    # Limit line width and enable rich output
    all2md grep -M 100 --rich "keyword" report.docx
+
+   # Archives are searched without unpacking; each member becomes a section
+   all2md grep "clause 4" contracts.zip
 
 Common grep-style options:
 

--- a/docs/source/quickstart.rst
+++ b/docs/source/quickstart.rst
@@ -266,6 +266,42 @@ Extract and convert multiple files from ZIP archives:
    # Flatten directory structure (disable directory preservation)
    all2md archive.zip --zip-no-preserve-directory --out combined.md
 
+Searching inside an archive
+^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+An archive converts to a single document, with each member under a heading of its own
+name. That means it is an ordinary target for the read-side commands — no unpacking
+step, and no separate handling for the members that are binary:
+
+.. code-block:: bash
+
+   # Search a bundle without extracting it
+   all2md grep "Peregrine falcons" bundle.zip
+
+   # Members are converted first, so this searches the PDF's text too
+   all2md search --keyword "termination clause" contracts.zip
+
+   # Read the whole bundle in the browser
+   all2md view bundle.zip
+
+Output identifies the match by its heading, so the member a hit came from stays visible:
+
+.. code-block:: text
+
+   bundle.zip
+     Gamma:Peregrine falcons nest nearby.
+
+This pairs with ``--zip``, which packages a batch conversion into an archive
+(see :doc:`batch`) — the result is searchable the same way, so a converted bundle
+remains queryable without being unpacked.
+
+.. note::
+
+   Archives named with a two-part extension (``.tar.gz``, ``.tar.bz2``, ``.tar.xz``) are
+   currently rejected by the CLI, though the Python API reads them normally
+   (`#306 <https://github.com/thomas-villani/all2md/issues/306>`_). Single-extension
+   spellings — ``.zip``, ``.tar``, ``.tgz``, ``.tbz2``, ``.txz`` — work everywhere.
+
 5. Progress Monitoring
 ~~~~~~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
An archive converts to a single document with each member under a heading of its own
name, so `grep`, `search` and `view` take one as an ordinary target — including members
that are binary, which get converted before the search runs.

Nothing in the docs said so. The quickstart's ZIP section covered conversion only, and
the read-side command docs never mentioned archives at all.

```bash
$ all2md grep "Peregrine falcons" bundle.zip
bundle.zip
  Gamma:Peregrine falcons nest nearby.
```

It also closes the loop on `--zip`: a batch conversion packaged into an archive stays
queryable without being unpacked, which is worth knowing *before* choosing that output
form.

## Changes

- `quickstart.rst` — new "Searching inside an archive" subsection under the existing
  ZIP section, covering `grep`, `search` and `view`, plus how output identifies which
  member a hit came from.
- `cli.rst` — one example each in the Grep and Search sections.

## Verified

Every command shown was **run**, and the sample output is transcribed from a real
invocation rather than written by hand. Confirmed a zip holding `one.md` + `doc.pdf`
converts both, PDF text included, and that `search --keyword` ranks across members.

`sphinx -b html` builds clean with no warnings against either file.

## One caveat documented in place

The CLI rejects two-part archive extensions (`.tar.gz`, `.tar.bz2`, `.tar.xz`) while the
Python API reads them fine — `Path.suffix` returns only `.gz`, which the registry never
declares. Filed as #306; noted here as a `.. note::` so a reader hits the warning at the
point they'd otherwise hit the bug, and told which spellings work today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)