### PR TITLE
fix(cli): match multi-part extensions so .tar.gz is accepted as input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **`.tar.gz`, `.tar.bz2` and `.tar.xz` are accepted on the command line again.** Every
+  read-side command collects inputs through one extension filter, and that filter compared
+  `Path.suffix` — which returns only the last dot-separated component — against the set of
+  registered extensions. `Path("bundle.tar.gz").suffix` is `".gz"`, which no converter
+  declares, so the file was dropped before any converter saw it and the CLI reported
+  `No valid input files found` about a file that was present, correctly named, and readable:
+  `to_markdown("bundle.tar.gz")` had opened it all along. The split was exact — every
+  single-part spelling (`.tar`, `.tgz`, `.tbz2`, `.txz`) worked and every two-part one
+  failed. Matching now walks the tails of `Path.suffixes` longest-first, so `.tar.gz` wins
+  where it applies while `report.2024.pdf` still resolves to `.pdf`. This reached `all2md`,
+  `grep`, `search`, `view` and `watch` alike. The same rule now backs the interactive
+  `batch` type table, so the extension it offers is the one its filter accepts.
 - **Packaging no longer warns the user about an `attachment_mode` it injected itself.**
   `create_package_from_conversions` forces `attachment_mode="base64"` so attachments stay in
   memory, then passed it to `convert()`; for a source format with no such option (markdown,

--- a/docs/source/quickstart.rst
+++ b/docs/source/quickstart.rst
@@ -295,12 +295,8 @@ This pairs with ``--zip``, which packages a batch conversion into an archive
 (see :doc:`batch`) — the result is searchable the same way, so a converted bundle
 remains queryable without being unpacked.
 
-.. note::
-
-   Archives named with a two-part extension (``.tar.gz``, ``.tar.bz2``, ``.tar.xz``) are
-   currently rejected by the CLI, though the Python API reads them normally
-   (`#306 <https://github.com/thomas-villani/all2md/issues/306>`_). Single-extension
-   spellings — ``.zip``, ``.tar``, ``.tgz``, ``.tbz2``, ``.txz`` — work everywhere.
+Every archive spelling works the same way — ``.zip``, ``.tar``, ``.tgz``, ``.tbz2``,
+``.txz``, and the two-part forms ``.tar.gz``, ``.tar.bz2`` and ``.tar.xz``.
 
 5. Progress Monitoring
 ~~~~~~~~~~~~~~~~~~~~~~

--- a/src/all2md/cli/_processors_detect.py
+++ b/src/all2md/cli/_processors_detect.py
@@ -16,7 +16,7 @@ from typing import Any, Dict, List, Optional
 
 from all2md.cli.builder import EXIT_DEPENDENCY_ERROR
 from all2md.cli.input_items import CLIInputItem
-from all2md.converter_registry import check_package_installed, registry
+from all2md.converter_registry import check_package_installed, match_extension, registry
 from all2md.utils.packages import check_version_requirement
 
 __all__ = [
@@ -57,8 +57,8 @@ def _detect_format_for_item(item: CLIInputItem, format_arg: str) -> tuple[str, s
     # Determine detection method
     metadata_list = registry.get_format_info(detected_format)
     metadata = metadata_list[0] if metadata_list else None
-    suffix = item.suffix.lower() if item.suffix else ""
-    if metadata and suffix in metadata.extensions:
+    name = item.path_hint.name if item.path_hint else item.display_name
+    if metadata and match_extension(name, metadata.extensions) is not None:
         return detected_format, "file extension"
 
     # Check MIME type
@@ -298,8 +298,8 @@ def _collect_file_info_for_dry_run(items: List[CLIInputItem], format_arg: str) -
                     for fmt_info in fmt_info_list:
                         all_extensions.extend(fmt_info.extensions)
 
-            suffix = item.suffix.lower() if item.suffix else ""
-            detection_method = "extension" if suffix in all_extensions else "content analysis"
+            name = item.path_hint.name if item.path_hint else item.display_name
+            detection_method = "extension" if match_extension(name, all_extensions) else "content analysis"
 
         converter_metadata_list = registry.get_format_info(detected_format)
         converter_metadata = converter_metadata_list[0] if converter_metadata_list else None

--- a/src/all2md/cli/commands/batch.py
+++ b/src/all2md/cli/commands/batch.py
@@ -20,7 +20,7 @@ from typing import Optional, Sequence
 from all2md.cli.builder import EXIT_ERROR, EXIT_SUCCESS
 from all2md.cli.commands.shared import collect_input_files
 from all2md.cli.input_items import CLIInputItem
-from all2md.converter_registry import registry
+from all2md.converter_registry import match_extension, registry
 
 logger = logging.getLogger(__name__)
 
@@ -174,7 +174,7 @@ def _step_inputs(p: _Prompter) -> Optional[tuple[list[str], list[CLIInputItem], 
             default=",".join(available),
         )
         chosen_exts = [_normalize_ext(e) for e in wanted.split(",") if e.strip()]
-        items = [it for it in items if (it.suffix.lower() in chosen_exts)]
+        items = [it for it in items if _registered_suffix(it) in chosen_exts]
         if not items:
             p.print("[yellow]No files left after filtering.[/yellow]")
             return None
@@ -276,10 +276,21 @@ def _step_advanced(p: _Prompter) -> dict:
 # ---------------------------------------------------------------------------
 
 
+def _registered_suffix(item: CLIInputItem) -> str:
+    """Return the extension the registry recognises, else plain ``Path`` semantics.
+
+    ``item.suffix`` reports ``.gz`` for ``bundle.tar.gz``; the registry declares
+    ``.tar.gz``. Grouping and filtering both go through here so the extension the
+    table offers is the one the filter accepts.
+    """
+    name = item.path_hint.name if item.path_hint else item.display_name
+    return match_extension(name, registry.get_all_extensions()) or item.suffix.lower()
+
+
 def _counts_by_suffix(items: list[CLIInputItem]) -> Counter:
     counter: Counter = Counter()
     for item in items:
-        suffix = item.suffix.lower() or "(no extension)"
+        suffix = _registered_suffix(item) or "(no extension)"
         counter[suffix] += 1
     return counter
 

--- a/src/all2md/cli/commands/shared.py
+++ b/src/all2md/cli/commands/shared.py
@@ -20,7 +20,7 @@ from typing import Any, Dict, Iterator, List, Optional
 from urllib.parse import unquote, urlparse
 
 from all2md.cli.input_items import CLIInputItem
-from all2md.converter_registry import registry
+from all2md.converter_registry import match_extension, registry
 from all2md.utils.packages import check_version_requirement, get_package_version
 
 _GLOB_CHARS = "*?["
@@ -324,7 +324,7 @@ def collect_input_files(
     def extension_allowed(path: Path) -> bool:
         if normalized_exts is None:
             return True
-        return path.suffix.lower() in normalized_exts
+        return match_extension(path, normalized_exts) is not None
 
     local_candidates: List[Path] = []
     remote_items: Dict[str, CLIInputItem] = {}

--- a/src/all2md/cli/watch.py
+++ b/src/all2md/cli/watch.py
@@ -17,7 +17,7 @@ from all2md.api import convert
 from all2md.cli.builder import EXIT_DEPENDENCY_ERROR
 from all2md.cli.processors import generate_output_path
 from all2md.constants import IMAGE_EXTENSIONS, DocumentFormat
-from all2md.converter_registry import registry
+from all2md.converter_registry import match_extension, registry
 from all2md.exceptions import All2MdError
 
 try:
@@ -133,7 +133,7 @@ class ConversionEventHandler(FileSystemEventHandler):
         # Add IMAGE_EXTENSIONS for watch mode (images can be converted)
         all_extensions = supported_extensions | set(IMAGE_EXTENSIONS)
 
-        if path.suffix.lower() not in all_extensions:
+        if match_extension(path, all_extensions) is None:
             logger.debug(f"Skipping {file_path}: unsupported extension")
             return False
 

--- a/src/all2md/converter_registry.py
+++ b/src/all2md/converter_registry.py
@@ -14,6 +14,7 @@ import importlib.metadata
 import io
 import logging
 import mimetypes
+from collections.abc import Iterable
 from pathlib import Path
 from typing import IO, Dict, List, NoReturn, Optional, Tuple, Union
 
@@ -184,6 +185,55 @@ def _load_renderer_class(renderer_class_spec: Union[str, type, None], format_nam
 
     """
     return _load_class(renderer_class_spec, f"all2md.renderers.{format_name}", "renderer")
+
+
+def match_extension(name: Union[str, Path], known_extensions: Iterable[str]) -> Optional[str]:
+    """Return the longest extension in ``known_extensions`` that ``name`` ends with.
+
+    ``Path.suffix`` returns only the final dot-separated component, so testing it
+    for membership cannot see a multi-part extension: ``Path("a.tar.gz").suffix``
+    is ``".gz"``, which no converter declares, while ``.tar.gz`` is declared and
+    parseable. Use this wherever a file name is checked against a set of
+    extensions.
+
+    Tails are tried longest-first so that a genuine two-part extension wins, and
+    shorter tails are still tried so that a dotted stem does not mask a real
+    extension: ``report.2024.pdf`` resolves to ``.pdf``.
+
+    Parameters
+    ----------
+    name : str or Path
+        File name or path to inspect. Only the final path component matters.
+    known_extensions : Iterable[str]
+        Extensions to match against, each dot-prefixed. Compared
+        case-insensitively.
+
+    Returns
+    -------
+    str or None
+        The matched extension in the spelling carried by ``name`` (lowercased),
+        or ``None`` when no tail matches.
+
+    Examples
+    --------
+        >>> match_extension("bundle.tar.gz", {".tar.gz", ".pdf"})
+        '.tar.gz'
+        >>> match_extension("report.2024.pdf", {".tar.gz", ".pdf"})
+        '.pdf'
+        >>> match_extension("notes.txt", {".pdf"}) is None
+        True
+
+    """
+    known = {ext.lower() for ext in known_extensions}
+    if not known:
+        return None
+
+    suffixes = [suffix.lower() for suffix in Path(name).suffixes]
+    for start in range(len(suffixes)):
+        candidate = "".join(suffixes[start:])
+        if candidate in known:
+            return candidate
+    return None
 
 
 class ConverterRegistry:
@@ -767,7 +817,11 @@ class ConverterRegistry:
         Get all supported extensions for file filtering:
             >>> from pathlib import Path
             >>> supported = registry.get_all_extensions()
-            >>> files = [f for f in Path('.').glob('*') if f.suffix in supported]
+            >>> files = [f for f in Path('.').glob('*') if match_extension(f, supported)]
+
+        Match with :func:`match_extension` rather than ``f.suffix in supported``:
+        ``Path.suffix`` returns only the last component, so two-part extensions
+        such as ``.tar.gz`` never compare equal to anything registered.
 
         """
         all_extensions: set[str] = set()
@@ -778,6 +832,33 @@ class ConverterRegistry:
                     if metadata.extensions:
                         all_extensions.update(metadata.extensions)
         return all_extensions
+
+    def match_extension(self, name: Union[str, Path]) -> Optional[str]:
+        """Return the registered extension ``name`` carries, or ``None``.
+
+        Convenience wrapper over :func:`match_extension` using every extension
+        the registry knows about.
+
+        Parameters
+        ----------
+        name : str or Path
+            File name or path to inspect. Only the final path component matters.
+
+        Returns
+        -------
+        str or None
+            The matched extension, lowercase and dot-prefixed, or ``None`` when
+            the name carries no registered extension.
+
+        Examples
+        --------
+            >>> registry.match_extension("bundle.tar.gz")
+            '.tar.gz'
+            >>> registry.match_extension("report.2024.pdf")
+            '.pdf'
+
+        """
+        return match_extension(name, self.get_all_extensions())
 
     def check_dependencies(
         self,

--- a/tests/unit/cli/commands/test_shared_helpers.py
+++ b/tests/unit/cli/commands/test_shared_helpers.py
@@ -13,6 +13,7 @@ from all2md.cli.commands.shared import (
     has_hidden_component,
     split_glob_pattern,
 )
+from all2md.converter_registry import registry
 
 
 @pytest.mark.unit
@@ -95,3 +96,49 @@ class TestCollectInputFilesHidden:
         items = collect_input_files([str(hidden)], extensions=[".md"])
         names = [Path(i.display_name).name for i in items]
         assert names == [".hidden.md"]
+
+
+@pytest.mark.unit
+class TestCollectInputFilesMultiPartExtensions:
+    """Two-part extensions must survive collection (#306).
+
+    ``Path("a.tar.gz").suffix`` is ``".gz"``, which no converter declares, so the
+    default extension filter used to drop every ``.tar.gz`` before any converter
+    saw it -- while the Python API opened the same file fine.
+    """
+
+    def test_every_registered_extension_is_accepted(self, tmp_path):
+        # Parity with the registry rather than a hand-listed set: if a format
+        # declares an extension, naming a file with it must be collectable.
+        known = sorted(registry.get_all_extensions())
+        for ext in known:
+            (tmp_path / f"sample{ext}").write_bytes(b"x")
+
+        items = collect_input_files([str(tmp_path)])
+        collected = {Path(i.display_name).name for i in items}
+        missing = sorted(f"sample{ext}" for ext in known if f"sample{ext}" not in collected)
+        assert missing == []
+
+    @pytest.mark.parametrize("name", ["bundle.tar.gz", "bundle.tar.bz2", "bundle.tar.xz"])
+    def test_explicitly_named_archive_is_collected(self, tmp_path, name):
+        archive = tmp_path / name
+        archive.write_bytes(b"x")
+        items = collect_input_files([str(archive)])
+        assert [Path(i.display_name).name for i in items] == [name]
+
+    def test_explicit_multi_part_extension_filter(self, tmp_path):
+        (tmp_path / "a.tar.gz").write_bytes(b"x")
+        (tmp_path / "b.md").write_text("# b")
+        items = collect_input_files([str(tmp_path)], extensions=[".tar.gz"])
+        assert [Path(i.display_name).name for i in items] == ["a.tar.gz"]
+
+    def test_dotted_stem_still_resolves_to_its_real_extension(self, tmp_path):
+        # Trying shorter tails is what keeps this working: the suffixes of
+        # "report.2024.md" are ['.2024', '.md'] and only the last is an extension.
+        (tmp_path / "report.2024.md").write_text("# r")
+        items = collect_input_files([str(tmp_path)], extensions=[".md"])
+        assert [Path(i.display_name).name for i in items] == ["report.2024.md"]
+
+    def test_unknown_double_extension_is_still_rejected(self, tmp_path):
+        (tmp_path / "a.tar.gz.bak").write_bytes(b"x")
+        assert collect_input_files([str(tmp_path)], extensions=[".tar.gz"]) == []

--- a/tests/unit/core/test_extension_matching.py
+++ b/tests/unit/core/test_extension_matching.py
@@ -1,0 +1,98 @@
+"""Tests for :func:`all2md.converter_registry.match_extension`.
+
+``Path.suffix`` sees only the last dot-separated component, so a plain
+membership test cannot recognise ``.tar.gz`` -- the CLI rejected every
+two-part archive extension as a result (#306). These cover the matcher that
+replaced it.
+"""
+
+import pytest
+
+from all2md.converter_registry import match_extension, registry
+
+KNOWN = {".pdf", ".md", ".tar", ".tar.gz", ".tar.bz2", ".tar.xz", ".gz"}
+
+
+@pytest.mark.unit
+class TestMultiPartExtensionsMatch:
+    """A two-part extension is found even though ``Path.suffix`` cannot see it."""
+
+    @pytest.mark.parametrize("name", ["a.tar.gz", "a.tar.bz2", "a.tar.xz"])
+    def test_two_part_extension_is_matched(self, name):
+        expected = "." + name.split(".", 1)[1]
+        assert match_extension(name, KNOWN) == expected
+
+    def test_the_longest_match_wins(self):
+        # Both ".gz" and ".tar.gz" are declared here; the specific one must win,
+        # otherwise the file routes to the wrong converter.
+        assert match_extension("a.tar.gz", KNOWN) == ".tar.gz"
+
+    def test_single_part_extension_still_matches(self):
+        assert match_extension("report.pdf", KNOWN) == ".pdf"
+
+
+@pytest.mark.unit
+class TestShorterTailsAreStillTried:
+    """A dotted stem must not mask the real extension."""
+
+    def test_dotted_stem(self):
+        assert match_extension("report.2024.pdf", KNOWN) == ".pdf"
+
+    def test_many_dots(self):
+        assert match_extension("my.long.file.name.pdf", KNOWN) == ".pdf"
+
+    def test_version_like_stem_on_an_archive(self):
+        assert match_extension("release.1.2.tar.gz", KNOWN) == ".tar.gz"
+
+
+@pytest.mark.unit
+class TestNonMatches:
+    """Names carrying no known extension return ``None``."""
+
+    @pytest.mark.parametrize("name", ["notes.xyz", "noextension", "a.tar.gz.bak"])
+    def test_unknown_returns_none(self, name):
+        assert match_extension(name, KNOWN) is None
+
+    def test_empty_candidate_set(self):
+        assert match_extension("report.pdf", set()) is None
+
+    def test_dotfile_has_no_extension(self):
+        # Path semantics: ".gitignore" is a name, not an extension. Matching it
+        # would make every dot-file look like a document.
+        assert match_extension(".pdf", KNOWN) is None
+
+
+@pytest.mark.unit
+class TestCaseAndPathHandling:
+    """Case folding, and only the final path component is considered."""
+
+    def test_case_insensitive(self):
+        assert match_extension("A.TAR.GZ", KNOWN) == ".tar.gz"
+
+    def test_uppercase_candidates(self):
+        assert match_extension("a.tar.gz", {".TAR.GZ"}) == ".tar.gz"
+
+    def test_dots_in_parent_directories_are_ignored(self):
+        assert match_extension("/some.dir/v1.0/report.pdf", KNOWN) == ".pdf"
+
+
+@pytest.mark.unit
+class TestEveryRegisteredExtensionIsMatchable:
+    """Parity with the registry, so a future multi-part extension cannot regress.
+
+    The bug was not that ``.tar.gz`` was special; it was that the matcher could
+    only see one-part extensions. Asserting over the live registry means any
+    newly declared multi-part extension is covered without editing this test.
+    """
+
+    def test_all_declared_extensions_round_trip(self):
+        known = registry.get_all_extensions()
+        unmatched = [ext for ext in sorted(known) if match_extension(f"sample{ext}", known) != ext.lower()]
+        assert unmatched == []
+
+    def test_registry_convenience_wrapper(self):
+        multi_part = sorted(e for e in registry.get_all_extensions() if e.count(".") > 1)
+        # Guard the guard: if this is ever empty the parity test above proves nothing.
+        assert multi_part, "registry declares no multi-part extensions"
+        for ext in multi_part:
+            assert registry.match_extension(f"bundle{ext}") == ext


### PR DESCRIPTION
Closes #306.

## The bug

```
$ all2md bundle.tar.gz
Error: No valid input files found

>>> to_markdown('bundle.tar.gz')      # same file
'## one.md\n\n# Alpha\n...'
```

`collect_input_files` filtered candidates with `path.suffix.lower() in extensions`.
`Path.suffix` returns only the last dot-separated component, so
`Path("bundle.tar.gz").suffix` is `".gz"` — which no converter declares, while `.tar.gz`
is declared and parseable. The file was dropped before any converter saw it, and the
error named the one thing that wasn't wrong: the file was present, correctly spelled and
readable.

Measured across the archive extensions the registry declares:

| file | before | after |
|---|---|---|
| `a.tar`, `a.tgz`, `a.tbz2`, `a.txz` | ok | ok |
| `a.tar.gz` | **no valid input files** | ok |
| `a.tar.bz2` | **no valid input files** | ok |
| `a.tar.xz` | **no valid input files** | ok |

Every single-part spelling worked and every two-part one failed. The split being exact is
what pointed at the matcher rather than at the archive parsers.

## The fix

`converter_registry.match_extension()` walks the tails of `Path.suffixes` longest-first.

- **Longest-first** is what makes `.tar.gz` beat a bare `.gz`.
- **Still trying shorter tails** is what keeps `report.2024.pdf` resolving to `.pdf` — its
  suffixes are `['.2024', '.pdf']` and only the last is a real extension.

Applied to every site that made the same assumption:

- input collection — reaches `all2md`, `grep`, `search`, `view`
- `watch`'s event filter
- the interactive `batch` command, where the type table and the filter now share one rule,
  so the extension it offers is the extension it accepts
- the two detection-reporting sites in `_processors_detect`, which had been labelling a
  tarball "content analysis" when the extension is what identified it

`CLIInputItem.suffix` is deliberately left alone — it is `Path` semantics and is used for
output naming.

## Verification

Tests assert **parity with the live registry** rather than a hand-listed set, so a future
multi-part extension is covered without editing them.

Confirmed the tests can fail: reverting `src/` leaves 5 failing. The two that assert
non-matches (`report.2024.md` resolves, `a.tar.gz.bak` is still rejected) pass either way
— that is what makes them controls on over-matching rather than restatements of the fix.

Also verified end-to-end on real tarballs: all five spellings convert, and
`all2md grep "Peregrine" a.tar.gz` finds the match inside a `.tar.gz` member.

Drops the `.tar.gz` caveat added to the quickstart in #307, which described this bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)