### PR TITLE
fix(pdf): keep PyMuPDF's layout advisory out of the converted document

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **PyMuPDF's layout advisory no longer lands inside the converted document** (PDF).
+  PyMuPDF prints `Consider using the pymupdf_layout package for a greatly improved page
+  layout analysis.` with a bare `print()` — not a warning, not a log record — the first
+  time `find_tables()` runs in a process where `pymupdf.layout` is not installed. all2md
+  writes converted documents to stdout, so the advisory arrived *inside the document*:
+  `all2md report.pdf > report.md` made it line one of the markdown, and any pipeline
+  reading all2md's stdout got it as content. This was the common case rather than an
+  exotic one — `pymupdf-layout` is deliberately excluded from the `all` extra over its
+  Polyform Noncommercial license, so the plain and `[all]` installs both hit it. all2md
+  now opts out through PyMuPDF's own entry point when it opens a PDF; it ships that
+  package as the `pdf_layout` extra and already reports its absence through its own
+  dependency machinery, which writes to stderr.
 - **`--zip` projects its namespaced options like every other path.** The CLI carries
   options fully qualified — `pdf.pages`, `markdown.flavor`, and the subcommand sections'
   own settings such as `view.dark` — and flattens them against the format that will

--- a/src/all2md/parsers/pdf.py
+++ b/src/all2md/parsers/pdf.py
@@ -630,6 +630,35 @@ def _check_pymupdf_version() -> None:
         )
 
 
+def _silence_pymupdf_layout_advisory() -> None:
+    """Stop PyMuPDF writing its layout-package advisory to stdout.
+
+    PyMuPDF emits::
+
+        Consider using the pymupdf_layout package for a greatly improved page layout analysis.
+
+    with a bare ``print()`` -- not a warning, not a log record -- the first time
+    ``find_tables()`` runs in a process where ``pymupdf.layout`` is not
+    installed. all2md writes converted documents to stdout, so the advisory
+    landed *inside the document*: ``all2md report.pdf > report.md`` made it line
+    one of the markdown. It is not a rare configuration either, since
+    ``pymupdf-layout`` is deliberately excluded from the ``all`` extra over its
+    Polyform Noncommercial license, so the plain and ``[all]`` installs both hit
+    it.
+
+    Suppressing it costs the user nothing: all2md ships that package as the
+    ``pdf_layout`` extra and already reports its absence through its own
+    dependency machinery, which writes to stderr.
+    """
+    import fitz
+
+    # Guarded: the entry point is PyMuPDF's own, but it is not load-bearing, and
+    # a version without it should convert rather than crash.
+    suppress = getattr(fitz, "no_recommend_layout", None)
+    if suppress is not None:
+        suppress()
+
+
 # Note: Column detection, table detection, image extraction, header identification,
 # OCR utilities, and text processing functions have been moved to private submodules:
 # - _pdf_columns.py: detect_columns and helpers
@@ -689,6 +718,7 @@ class PdfToAstConverter(BaseParser):
         import fitz
 
         _check_pymupdf_version()
+        _silence_pymupdf_layout_advisory()
 
         # Determine if layout analysis should be used
         if self.options.layout_analysis_mode == "enabled":

--- a/tests/unit/formats/pdf/test_pdf_stdout_advisory.py
+++ b/tests/unit/formats/pdf/test_pdf_stdout_advisory.py
@@ -1,0 +1,101 @@
+"""PyMuPDF's layout advisory must not land in the converted document.
+
+PyMuPDF prints::
+
+    Consider using the pymupdf_layout package for a greatly improved page layout analysis.
+
+with a bare ``print()`` the first time ``find_tables()`` runs in a process where
+``pymupdf.layout`` is not installed. all2md writes documents to stdout, so it
+arrived as line one of the markdown -- ``all2md report.pdf > report.md`` produced
+a corrupt file. See #284.
+
+``pymupdf-layout`` is excluded from the ``all`` extra over its license, so the
+plain and ``[all]`` installs are both affected; this is the common case, not an
+exotic one.
+"""
+
+import importlib.util
+
+import fitz
+import pytest
+
+from all2md import to_markdown
+from all2md.parsers import pdf as pdf_module
+
+ADVISORY = "pymupdf_layout package"
+
+
+def _one_page_pdf(tmp_path) -> str:
+    """A page carrying ruling lines, so ``find_tables()`` actually runs.
+
+    The default table mode gates ``find_tables()`` behind a cheap drawings scan,
+    so a prose-only page never reaches the call that emits the advisory. Drawing
+    a grid is what arms it.
+    """
+    doc = fitz.open()
+    page = doc.new_page()
+    page.insert_text((72, 72), "Peregrine falcons nest nearby.")
+    for offset in (0, 20, 40):
+        page.draw_line(fitz.Point(72, 120 + offset), fitz.Point(300, 120 + offset))
+    for offset in (0, 114, 228):
+        page.draw_line(fitz.Point(72 + offset, 120), fitz.Point(72 + offset, 160))
+    path = tmp_path / "advisory.pdf"
+    doc.save(str(path))
+    doc.close()
+    return str(path)
+
+
+@pytest.fixture
+def pymupdf_without_layout(monkeypatch):
+    """Make PyMuPDF believe ``pymupdf.layout`` is absent, as a plain install is.
+
+    Also rearms the once-per-process latch, so the advisory is genuinely due to
+    fire during the test rather than having been spent by an earlier one.
+    """
+    import pymupdf
+
+    real_find_spec = importlib.util.find_spec
+
+    def fake_find_spec(name, package=None):
+        if name == "pymupdf.layout":
+            return None
+        return real_find_spec(name, package)
+
+    monkeypatch.setattr(importlib.util, "find_spec", fake_find_spec)
+    monkeypatch.setattr(pymupdf, "_get_layout", None, raising=False)
+    monkeypatch.setattr(pymupdf, "_recommend_layout", True, raising=False)
+
+
+@pytest.mark.unit
+@pytest.mark.pdf
+class TestLayoutAdvisoryStaysOutOfStdout:
+    """The advisory is suppressed, and the suppression is what does it."""
+
+    def test_advisory_does_not_reach_stdout(self, tmp_path, capsys, pymupdf_without_layout):
+        to_markdown(_one_page_pdf(tmp_path))
+        assert ADVISORY not in capsys.readouterr().out
+
+    def test_the_harness_can_actually_catch_it(self, tmp_path, capsys, monkeypatch, pymupdf_without_layout):
+        """Control: with the suppression disabled, the advisory does print.
+
+        Without this, the test above would pass just as happily on a fixture that
+        never arms the advisory in the first place.
+        """
+        monkeypatch.setattr(pdf_module, "_silence_pymupdf_layout_advisory", lambda: None)
+        to_markdown(_one_page_pdf(tmp_path))
+        assert ADVISORY in capsys.readouterr().out
+
+    def test_document_text_is_unaffected(self, tmp_path, capsys, pymupdf_without_layout):
+        markdown = to_markdown(_one_page_pdf(tmp_path))
+        assert "Peregrine falcons nest nearby." in markdown
+        assert ADVISORY not in markdown
+
+
+@pytest.mark.unit
+@pytest.mark.pdf
+class TestSuppressionIsNotLoadBearing:
+    """A PyMuPDF without the entry point must convert, not crash."""
+
+    def test_missing_entry_point_is_tolerated(self, tmp_path, monkeypatch):
+        monkeypatch.delattr(fitz, "no_recommend_layout", raising=False)
+        assert "Peregrine" in to_markdown(_one_page_pdf(tmp_path))


### PR DESCRIPTION
Covers the stdout half of #284.

## The bug

PyMuPDF prints

```
Consider using the pymupdf_layout package for a greatly improved page layout analysis.
```

with a bare `print()` — not a warning, not a log record — the first time `find_tables()`
runs in a process where `pymupdf.layout` is not installed.

all2md writes converted documents to stdout, so it arrived **inside the document**:

```console
$ all2md report.pdf > report.md
$ head -1 report.md
Consider using the pymupdf_layout package for a greatly improved page layout analysis.
```

Measured on `tests/fixtures/documents/complex.pdf` with `pymupdf.layout` hidden: the
advisory is line one, and the rest of the file is **byte-identical** to a clean run. So
it is purely corruption of the output contract, and it silently poisons any pipeline
reading all2md's stdout.

**This is the common configuration.** `pymupdf-layout` is deliberately excluded from the
`all` extra over its Polyform Noncommercial license, so `pip install all2md[pdf]` and
`pip install all2md[all]` are both affected. Only someone who installed the `pdf_layout`
extra escapes it — which is why it went unnoticed here.

## The fix

Opt out through PyMuPDF's own `no_recommend_layout()` when the parser opens a PDF,
guarded with `getattr` so a build without the entry point converts rather than crashes.
The advice is redundant in our context: all2md ships that package as the `pdf_layout`
extra and already reports its absence through its own dependency machinery, which writes
to stderr.

**One thing worth your call:** this is process-global once a PDF has been parsed. I put it
in the parser rather than the CLI on purpose — a library caller doing
`python -c "print(to_markdown('x.pdf'))" > out.md` is corrupted exactly the same way — but
it does mean all2md silences another library's advice for the whole process. Easy to move
to CLI-only if you'd rather.

## Verification

The fixture draws ruling lines deliberately: the default table mode gates `find_tables()`
behind a cheap drawings scan, so a prose-only page never reaches the call that emits the
advisory.

A **control test** disables the suppression and asserts the advisory *does* print, so the
passing test cannot pass vacuously on a fixture that never armed it — the first version of
that fixture did exactly that, and the control is what caught it.

Reverting `src/` leaves the main test failing.

## Not covered here

The other half of #284 — `The `fitz` API is deprecated and will be removed in future` — does
not reproduce on the pinned pymupdf 1.28.0; the string is not in the installed package and
`import fitz` is silent. all2md imports `fitz` in 11 modules (168 references), so renaming
to the `pymupdf` spelling is a separate mechanical change worth its own PR. Leaving #284
open for that half.

🤖 Generated with [Claude Code](https://claude.com/claude-code)