### PR TITLE
fix(markdown,html): fold del/s/sup/sub/mark instead of escaping or dropping them

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **`<del>`, `<s>`, `<sup>`, `<sub>` and `<mark>` survive a Markdown round trip.** mistune
+  hands raw inline HTML through untouched, so the Markdown parser produced loose
+  `HTMLInline` nodes rather than the AST node that already existed for the meaning; the
+  default `html_passthrough_mode="escape"` then escaped them on the way back out and
+  `a <del>x</del> b` returned as `a &lt;del&gt;x&lt;/del&gt; b`. They now fold into
+  `Strikethrough`, `Superscript`, `Subscript` and `Mark` the way `<u>`/`<ins>` already
+  folded into `Underline`, and render as `~~x~~`, `^x^`, `~x~` and `==x==`. The existing
+  constraints are unchanged: a tag carrying attributes stays raw HTML, because the
+  attributes hold information the node cannot, and an unmatched opener or stray closer
+  stays raw rather than being guessed at.
+- **`<mark>` no longer disappears when parsing HTML.** It was listed as an inline element
+  but had no handler, so it fell through to the generic unwrap and the highlight was
+  dropped outright — `<mark>x</mark>` became a bare `x`. Unlike the Markdown side this was
+  silent loss rather than escaping, so no round-trip text comparison would have noticed
+  it; a golden snapshot had captured the damaged output as expected. Same gap `<ins>` had.
 - **`.tar.gz`, `.tar.bz2` and `.tar.xz` are accepted on the command line again.** Every
   read-side command collects inputs through one extension filter, and that filter compared
   `Path.suffix` — which returns only the last dot-separated component — against the set of

--- a/src/all2md/parsers/html.py
+++ b/src/all2md/parsers/html.py
@@ -39,6 +39,7 @@ from all2md.ast import (
     Link,
     List,
     ListItem,
+    Mark,
     Node,
     Paragraph,
     Strikethrough,
@@ -871,6 +872,7 @@ class HtmlToAstConverter(BaseParser):
         "img": "_process_image_to_ast",
         "u": "_process_underline_to_ast",
         "ins": "_process_insert_to_ast",
+        "mark": "_process_mark_to_ast",
     }
 
     def _process_node_to_ast(self, node: Any) -> Node | list[Node] | None:
@@ -1705,6 +1707,27 @@ class HtmlToAstConverter(BaseParser):
         """
         content = self._process_children_to_inline(node)
         return Subscript(content=content)
+
+    def _process_mark_to_ast(self, node: Any) -> Mark:
+        """Process mark element to Mark node.
+
+        ``mark`` was listed as an inline element but had no handler, so it fell
+        through to the generic unwrap and the highlight was dropped outright --
+        ``<mark>x</mark>`` became a bare ``x``. Same gap ``<ins>`` had (#113).
+
+        Parameters
+        ----------
+        node : Any
+            Mark element
+
+        Returns
+        -------
+        Mark
+            Mark node
+
+        """
+        content = self._process_children_to_inline(node)
+        return Mark(content=content)
 
     def _process_link_to_ast(self, node: Any) -> Link:
         """Process a element to Link node.

--- a/src/all2md/parsers/markdown.py
+++ b/src/all2md/parsers/markdown.py
@@ -15,6 +15,7 @@ import json
 import logging
 import re
 import sys
+from collections.abc import Callable
 from pathlib import Path
 
 if sys.version_info >= (3, 11):
@@ -371,13 +372,26 @@ class MarkdownToAstConverter(BaseParser):
 
     """
 
-    # Bare inline tags folded back into Underline nodes, mapped to the semantic
-    # they carry. Only these two: the other inline formatting tags (<del>, <sup>,
-    # <sub>, <mark>) have the same escaping problem but are tracked separately.
-    _FOLDABLE_INLINE_TAGS: dict[str, Literal["underline", "insert"]] = {"u": "underline", "ins": "insert"}
+    # Bare inline formatting tags folded back into the AST node that already
+    # carries their meaning. Each maps to the constructor for that node, so a tag
+    # is added by naming its node rather than by touching the folding logic.
+    # ``<u>`` and ``<ins>`` share Underline and are told apart by ``semantic``.
+    _FOLDABLE_INLINE_TAGS: dict[str, Callable[[list[Node]], Node]] = {
+        "u": lambda content: Underline(content=content, semantic="underline"),
+        "ins": lambda content: Underline(content=content, semantic="insert"),
+        "del": lambda content: Strikethrough(content=content),
+        "s": lambda content: Strikethrough(content=content),
+        "sup": lambda content: Superscript(content=content),
+        "sub": lambda content: Subscript(content=content),
+        "mark": lambda content: Mark(content=content),
+    }
     # Matches only attribute-free tags -- one with attributes carries information
-    # the Underline node cannot hold, so it stays raw HTML.
-    _FOLDABLE_TAG_RE = re.compile(r"^<\s*(/)?\s*(u|ins)\s*>$", re.IGNORECASE)
+    # the node cannot hold, so it stays raw HTML. Longest name first so that the
+    # alternation cannot settle on ``s`` when the tag is ``<sub>``.
+    _FOLDABLE_TAG_RE = re.compile(
+        r"^<\s*(/)?\s*(" + "|".join(sorted(_FOLDABLE_INLINE_TAGS, key=len, reverse=True)) + r")\s*>$",
+        re.IGNORECASE,
+    )
 
     def __init__(
         self, options: MarkdownParserOptions | None = None, progress_callback: Optional[ProgressCallback] = None
@@ -1256,7 +1270,7 @@ class MarkdownToAstConverter(BaseParser):
             _, start, _ = open_tags.pop()
             content = result[start:]
             del result[start:]
-            result.append(Underline(content=content, semantic=self._FOLDABLE_INLINE_TAGS[name]))
+            result.append(self._FOLDABLE_INLINE_TAGS[name](content))
 
         # Openers that never closed: put their raw tags back where they were.
         for _, start, raw in reversed(open_tags):

--- a/tests/golden/__snapshots__/test_html_golden.ambr
+++ b/tests/golden/__snapshots__/test_html_golden.ambr
@@ -28,7 +28,7 @@
   '''
   # Complex Formatting
   
-  Text with **bold**, *italic*, `code`, ~~strikethrough~~, and highlighted text.
+  Text with **bold**, *italic*, `code`, ~~strikethrough~~, and ==highlighted== text.
   
   Text with ~subscript~ and ^superscript^.
   

--- a/tests/unit/parsers/test_markdown_inline_html_folding.py
+++ b/tests/unit/parsers/test_markdown_inline_html_folding.py
@@ -1,0 +1,138 @@
+"""Inline formatting tags must survive a Markdown round trip (#140).
+
+mistune hands raw inline HTML through as ``inline_html`` tokens, so the Markdown
+parser produced loose ``HTMLInline`` nodes rather than the AST node that already
+exists for the meaning. On the way back out the default
+``html_passthrough_mode="escape"`` -- a deliberate security posture -- escaped
+them, so ``a <del>x</del> b`` came back as ``a &lt;del&gt;x&lt;/del&gt; b``.
+
+#113 fixed this for ``<u>``/``<ins>``; these cover the rest of the family, plus
+the ``<mark>`` gap on the HTML side that the same audit predicted.
+"""
+
+import pytest
+
+from all2md import to_markdown
+from all2md.ast import Mark, Strikethrough, Subscript, Superscript, Underline
+from all2md.ast.transforms import NodeCollector
+from all2md.parsers.markdown import MarkdownToAstConverter
+
+#: tag -> the node it must fold into, and the markdown it should render as.
+FOLDED = [
+    ("del", Strikethrough, "a ~~x~~ b"),
+    ("s", Strikethrough, "a ~~x~~ b"),
+    ("sup", Superscript, "a ^x^ b"),
+    ("sub", Subscript, "a ~x~ b"),
+    ("mark", Mark, "a ==x== b"),
+    ("u", Underline, "a <u>x</u> b"),
+    ("ins", Underline, "a ^^x^^ b"),
+]
+
+
+def _nodes_of(document, node_type):
+    collector = NodeCollector(lambda n: isinstance(n, node_type))
+    document.accept(collector)
+    return collector.collected
+
+
+@pytest.mark.unit
+@pytest.mark.formatting
+class TestTagsFoldIntoTheirNode:
+    """Each tag becomes the AST node that already carries its meaning."""
+
+    @pytest.mark.parametrize("tag,node_type,_expected", FOLDED)
+    def test_tag_produces_its_node(self, tag, node_type, _expected):
+        doc = MarkdownToAstConverter().parse(f"a <{tag}>x</{tag}> b")
+        assert _nodes_of(doc, node_type), f"<{tag}> did not fold into {node_type.__name__}"
+
+    @pytest.mark.parametrize("tag,_node_type,expected", FOLDED)
+    def test_tag_is_not_escaped_on_the_way_out(self, tag, _node_type, expected):
+        assert to_markdown(f"a <{tag}>x</{tag}> b", source_format="markdown").strip() == expected
+
+    def test_u_and_ins_keep_their_distinction(self):
+        """Both are Underline; ``semantic`` is what tells them apart."""
+        underline = _nodes_of(MarkdownToAstConverter().parse("<u>x</u>"), Underline)[0]
+        insert = _nodes_of(MarkdownToAstConverter().parse("<ins>x</ins>"), Underline)[0]
+        assert (underline.semantic, insert.semantic) == ("underline", "insert")
+
+
+@pytest.mark.unit
+@pytest.mark.formatting
+class TestOutputIsStable:
+    """A second pass must not change the first pass's output."""
+
+    @pytest.mark.parametrize("tag,_node_type,_expected", FOLDED)
+    def test_round_trip_is_idempotent(self, tag, _node_type, _expected):
+        once = to_markdown(f"a <{tag}>x</{tag}> b", source_format="markdown").strip()
+        assert to_markdown(once, source_format="markdown").strip() == once
+
+
+@pytest.mark.unit
+@pytest.mark.formatting
+class TestWhatMustNotFold:
+    """The #113 constraints carry over: never guess, never silently drop."""
+
+    def test_tag_with_attributes_stays_raw(self):
+        # The attributes hold information the node cannot, so folding would lose them.
+        out = to_markdown('a <del class="z">x</del> b', source_format="markdown")
+        assert "class=" in out
+        assert not _nodes_of(MarkdownToAstConverter().parse('a <del class="z">x</del> b'), Strikethrough)
+
+    def test_unmatched_opener_stays_raw(self):
+        assert not _nodes_of(MarkdownToAstConverter().parse("a <del>x b"), Strikethrough)
+
+    def test_stray_closer_stays_raw(self):
+        assert not _nodes_of(MarkdownToAstConverter().parse("a x</del> b"), Strikethrough)
+
+    def test_nothing_is_dropped_when_a_tag_stays_raw(self):
+        # The failure mode worth guarding is silent loss, not escaping.
+        assert "x" in to_markdown("a <del>x b", source_format="markdown")
+
+
+@pytest.mark.unit
+@pytest.mark.formatting
+class TestNesting:
+    """Folding is applied to a stack, so nested spans must both survive."""
+
+    def test_nested_tags(self):
+        assert to_markdown("a <sup><sub>x</sub></sup> b", source_format="markdown").strip() == "a ^~x~^ b"
+
+    def test_mixed_nesting_keeps_both(self):
+        doc = MarkdownToAstConverter().parse("a <del>x <sup>y</sup> z</del> b")
+        assert _nodes_of(doc, Strikethrough)
+        assert _nodes_of(doc, Superscript)
+
+    def test_the_shorter_tag_name_does_not_win_the_alternation(self):
+        """``<sub>`` must not match the ``s`` branch of the tag pattern."""
+        doc = MarkdownToAstConverter().parse("a <sub>x</sub> b")
+        assert _nodes_of(doc, Subscript)
+        assert not _nodes_of(doc, Strikethrough)
+
+
+@pytest.mark.unit
+@pytest.mark.html
+class TestHtmlParserHasNoGap:
+    """``<mark>`` was listed as inline but had no handler, so it was dropped.
+
+    Not an escaping bug like the Markdown side -- the highlight was gone from the
+    output entirely, which no round-trip text comparison would notice.
+    """
+
+    def test_mark_survives_html(self):
+        assert to_markdown("<p>a <mark>x</mark> b</p>", source_format="html").strip() == "a ==x== b"
+
+    @pytest.mark.parametrize(
+        "tag,expected",
+        [
+            ("del", "a ~~x~~ b"),
+            ("s", "a ~~x~~ b"),
+            ("strike", "a ~~x~~ b"),
+            ("sup", "a ^x^ b"),
+            ("sub", "a ~x~ b"),
+            ("mark", "a ==x== b"),
+            ("u", "a <u>x</u> b"),
+            ("ins", "a ^^x^^ b"),
+        ],
+    )
+    def test_html_inline_formatting_family(self, tag, expected):
+        assert to_markdown(f"<p>a <{tag}>x</{tag}> b</p>", source_format="html").strip() == expected


### PR DESCRIPTION
Closes #140. Splits out the rest of the family #113 started.

## The bug

mistune hands raw inline HTML through as `inline_html` tokens, so the Markdown parser
produced loose `HTMLInline` nodes rather than the AST node that already existed for the
meaning. The default `html_passthrough_mode="escape"` then escaped them on the way out.

Measured on `main`:

| input | before | after |
|---|---|---|
| `a <del>x</del> b` | `a &lt;del&gt;x&lt;/del&gt; b` | `a ~~x~~ b` |
| `a <s>x</s> b` | `a &lt;s&gt;x&lt;/s&gt; b` | `a ~~x~~ b` |
| `a <sup>x</sup> b` | `a &lt;sup&gt;x&lt;/sup&gt; b` | `a ^x^ b` |
| `a <sub>x</sub> b` | `a &lt;sub&gt;x&lt;/sub&gt; b` | `a ~x~ b` |
| `a <mark>x</mark> b` | `a &lt;mark&gt;x&lt;/mark&gt; b` | `a ==x== b` |
| `a <u>x</u> b` | `a <u>x</u> b` | unchanged |
| `a <ins>x</ins> b` | `a ^^x^^ b` | unchanged |

## The fix

`_FOLDABLE_INLINE_TAGS` becomes a tag → node-constructor map, so the folding logic no
longer needs to know which node it is building — a tag is added by naming its node. The
matching and unwinding code is untouched.

The existing constraints carry over unchanged, and are tested:

- a tag carrying attributes stays raw HTML (the attributes hold information the node cannot)
- an unmatched opener or stray closer stays raw rather than being guessed at

Those two tests pass with **and** without this change on purpose — they are controls
against over-folding, not restatements of the fix.

The tag pattern is now built from the map longest-name-first. With anchored alternation
`s` could not actually swallow `<sub>`, but relying on backtracking for that would be a
trap for whoever adds the next tag.

## The gap on the HTML side

#140 suggested checking whether the HTML parser had an equivalent gap. It did, and it was
the worse kind:

```
<p>a <mark>x</mark> b</p>   ->   a x b
```

`mark` was in `INLINE_ELEMENTS` but had no entry in the element dispatch map, so it fell
through to the generic unwrap and the highlight was **dropped outright**. That is silent
loss rather than escaping, which no round-trip text comparison would notice — and indeed
the existing HTML golden snapshot had captured the damaged output as the expected value.
Updating that is the one snapshot change in this PR (one line).

## Verification

Round trips are idempotent for every tag, including nested spans
(`<sup><sub>x</sub></sup>` → `^~x~^`). Reverting `src/` leaves 15 tests failing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)