### PR TITLE
fix(pdf): read level columns left-to-right instead of by a hairline y difference

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Two columns that start level are read left-to-right, not by a hairline** (PDF). Blocks
+  were ordered on `y` alone, so on a page whose gutter is too narrow for column detection
+  to split, whichever column's top edge happened to be a fraction of a point higher was
+  read first — and that decided the order of the entire page. On page 16 of `PMC7500012.1`
+  the two columns begin at `y=89.708191` and `y=89.702942`, five thousandths of a point
+  apart, and the references came out running 39–61 and then 19–38: a document that looks
+  correct and is not. Blocks whose tops fall within a twentieth of the page's average line
+  height are now treated as starting on the same row and ordered by `x`. That is a
+  size-relative measure rather than a constant, since what reads as "level" scales with the
+  type size, and it is deliberately small: it only reaches blocks that begin at effectively
+  the same height, where the `y` order was noise to begin with. Measured on the PMC
+  born-digital corpus (117 pages), reading-order similarity rises from 0.779 to 0.785 mean
+  and 0.821 to 0.835 median, with block structure and text content up slightly and tables
+  and whole-article recall unchanged — no dimension regressed.
 - **`.tar.gz`, `.tar.bz2` and `.tar.xz` are accepted on the command line again.** Every
   read-side command collects inputs through one extension filter, and that filter compared
   `Path.suffix` — which returns only the last dot-separated component — against the set of

--- a/src/all2md/constants.py
+++ b/src/all2md/constants.py
@@ -745,6 +745,21 @@ PDF_COLUMN_FREQ_THRESHOLD_RATIO = 0.3  # Ratio of max frequency for gap detectio
 PDF_COLUMN_MIN_BLOCKS_FOR_WIDTH_CHECK = 3  # Minimum blocks to perform median width check
 PDF_COLUMN_SINGLE_COLUMN_WIDTH_RATIO = 0.6  # Width ratio threshold for single column detection
 
+# Reading order: how close two block tops must be to count as starting on the same
+# row, in which case they are read left-to-right instead of by a hairline y
+# difference. A fraction of the page's average line height rather than a constant,
+# because what reads as "level" scales with the type size.
+#
+# Deliberately a twentieth of a line, not a quarter. The defect this corrects is
+# float-level noise -- the two columns of PMC7500012.1 p16 start 0.005pt apart --
+# so the tolerance only has to cover blocks that begin at effectively the same
+# height. A quarter of a line also swept up genuine offsets: it put a left-margin
+# "OPEN" badge sitting 2.2pt below a paper's title ahead of the title. Both values
+# score the same on the PMC corpus (reading order 0.785 mean / 0.835 median), so
+# the corpus could not choose between them and the conservative one wins.
+PDF_READING_ORDER_ROW_TOLERANCE_RATIO = 0.05
+PDF_READING_ORDER_MIN_ROW_TOLERANCE = 0.25  # Points floor, for pages with no measurable lines
+
 # Table detection and extraction
 DEFAULT_TABLE_DETECTION_MODE: TableDetectionMode = "both"
 DEFAULT_TABLE_FALLBACK_DETECTION = True

--- a/src/all2md/parsers/pdf.py
+++ b/src/all2md/parsers/pdf.py
@@ -60,6 +60,8 @@ from all2md.constants import (
     DEPS_PDF,
     DEPS_PDF_LAYOUT,
     PDF_MIN_PYMUPDF_VERSION,
+    PDF_READING_ORDER_MIN_ROW_TOLERANCE,
+    PDF_READING_ORDER_ROW_TOLERANCE_RATIO,
 )
 from all2md.converter_metadata import ConverterMetadata
 from all2md.exceptions import DependencyError, MalformedFileError, PasswordProtectedError, ValidationError
@@ -1738,8 +1740,76 @@ class PdfToAstConverter(BaseParser):
         # order instead. Scoped to engine-segmented pages with no tables to interleave;
         # native blocks keep the existing behaviour exactly.
         if col_tables or not items or not all(item[2].get("_engine_segmented") for item in items):
-            items.sort(key=lambda x: x[1])
+            items = self._sort_items_into_reading_order(items, column)
         return items
+
+    def _sort_items_into_reading_order(
+        self, items: list[tuple[str, float, Any]], column: list[dict]
+    ) -> list[tuple[str, float, Any]]:
+        """Order items top-to-bottom, and left-to-right among those starting level.
+
+        Sorting on ``y`` alone makes the *first* item decided by whichever block's
+        top edge is a hair higher, and on a two-column page that column detection
+        read as one, that hair decides the order of the whole page. On page 16 of
+        ``PMC7500012.1`` the two columns start at ``y=89.708`` and ``y=89.703`` --
+        five thousandths of a point apart -- and the right column wins, so the
+        references read 39-61 and then 19-38 (#290).
+
+        The blocks are not exactly level, so a plain ``(y, x)`` key does not help:
+        they have to be treated as level first. Items whose tops fall within
+        ``row_tolerance`` of the row's first item form one row and are ordered by
+        ``x``. The tolerance is a quarter of the page's average line height rather
+        than a constant, because what counts as "level" scales with the type size
+        -- the same reason an absolute ``column_gap_threshold`` misjudges this
+        page. At a quarter of a line it cannot merge consecutive lines of running
+        text; it only reaches blocks that begin at effectively the same height,
+        where the ``y`` order was noise to begin with.
+
+        Parameters
+        ----------
+        items : list of tuple
+            ``(item_type, y_coord, item_data)`` tuples to order.
+        column : list of dict
+            The column's text blocks, used to size the tolerance.
+
+        Returns
+        -------
+        list of tuple
+            The same tuples in reading order.
+
+        """
+        ordered = sorted(items, key=lambda item: item[1])
+        if len(ordered) < 2:
+            return ordered
+
+        average_line_height = self._calculate_blocks_average_line_height(column)
+        row_tolerance = max(
+            PDF_READING_ORDER_MIN_ROW_TOLERANCE,
+            (average_line_height or 0.0) * PDF_READING_ORDER_ROW_TOLERANCE_RATIO,
+        )
+
+        result: list[tuple[str, float, Any]] = []
+        start = 0
+        while start < len(ordered):
+            end = start + 1
+            # Compared against the row's first item, not its predecessor, so a
+            # column of near-level blocks cannot chain into one giant row.
+            while end < len(ordered) and ordered[end][1] - ordered[start][1] <= row_tolerance:
+                end += 1
+            row = ordered[start:end]
+            row.sort(key=lambda item: self._item_x0(item))
+            result.extend(row)
+            start = end
+        return result
+
+    @staticmethod
+    def _item_x0(item: tuple[str, float, Any]) -> float:
+        """Return the left edge of a block or table item."""
+        kind, _, data = item
+        if kind == "table":
+            return float(data["bbox"].x0)
+        bbox = data.get("bbox")
+        return float(bbox[0]) if bbox else 0.0
 
     def _process_table_item(self, item_data: dict, page: "fitz.Page", page_num: int) -> Node | None:
         """Process a single table item and return its AST node.

--- a/tests/unit/formats/pdf/test_pdf_reading_order_rows.py
+++ b/tests/unit/formats/pdf/test_pdf_reading_order_rows.py
@@ -1,0 +1,134 @@
+"""Two columns starting level must read left-to-right, not by a hairline (#290).
+
+Blocks were ordered on ``y`` alone, so whichever column's top edge was a fraction
+of a point higher was read first. On page 16 of ``PMC7500012.1`` the columns start
+at ``y=89.708191`` and ``y=89.702942`` -- five thousandths of a point apart -- and
+the right one won, so the references read 39-61 and then 19-38.
+
+Note those values are *not* equal, which is why the obvious ``(y, x)`` sort key
+does not fix it: the blocks have to be treated as level first.
+"""
+
+import fitz
+import pytest
+
+from all2md import to_markdown
+from all2md.parsers.pdf import PdfToAstConverter
+
+# Taken from the page in the report, so the test fails for the reason the bug did.
+LEFT_Y = 89.708191
+RIGHT_Y = 89.702942
+
+
+def _block(x0: float, y0: float, text: str) -> dict:
+    """A block whose lines give it a measurable height, as a real one has."""
+    return {
+        "bbox": [x0, y0, x0 + 230.0, y0 + 640.0],
+        "lines": [{"bbox": [x0, y0, x0 + 230.0, y0 + 9.0], "spans": [{"text": text}]}],
+    }
+
+
+def _order(blocks: list[dict]) -> list[str]:
+    converter = PdfToAstConverter()
+    items = converter._build_sorted_column_items(blocks, [])
+    return [item[2]["lines"][0]["spans"][0]["text"] for item in items]
+
+
+@pytest.mark.unit
+@pytest.mark.pdf
+class TestLevelBlocksReadLeftToRight:
+    """The reported geometry, and the general rule behind it."""
+
+    def test_hairline_higher_right_column_does_not_win(self):
+        right = _block(304.7, RIGHT_Y, "right")
+        left = _block(56.7, LEFT_Y, "left")
+        # Input order deliberately puts the right column first, so a stable sort
+        # alone would leave it there.
+        assert _order([right, left]) == ["left", "right"]
+
+    def test_running_head_above_both_still_comes_first(self):
+        head = _block(56.7, 32.6, "head")
+        right = _block(304.7, RIGHT_Y, "right")
+        left = _block(56.7, LEFT_Y, "left")
+        assert _order([right, head, left]) == ["head", "left", "right"]
+
+    def test_three_level_columns(self):
+        blocks = [
+            _block(400.0, 100.02, "c"),
+            _block(60.0, 100.00, "a"),
+            _block(230.0, 100.01, "b"),
+        ]
+        assert _order(blocks) == ["a", "b", "c"]
+
+
+@pytest.mark.unit
+@pytest.mark.pdf
+class TestGenuineVerticalOffsetsAreLeftAlone:
+    """Controls: the rule must not become a general left-to-right sort.
+
+    These pass before and after the change. Without them the tolerance could be
+    widened arbitrarily and the tests above would still be green.
+    """
+
+    def test_a_block_clearly_below_stays_below(self):
+        upper = _block(304.7, 100.0, "upper-right")
+        lower = _block(56.7, 140.0, "lower-left")
+        assert _order([upper, lower]) == ["upper-right", "lower-left"]
+
+    def test_a_margin_badge_below_a_title_does_not_overtake_it(self):
+        """The case that ruled out a quarter-line tolerance.
+
+        A left-margin badge sitting 2.2pt below a title is a real offset, not
+        noise, and reading it first would demote the title.
+        """
+        title = _block(155.9, 128.3, "title")
+        badge = _block(93.6, 130.5, "badge")
+        assert _order([title, badge]) == ["title", "badge"]
+
+    def test_consecutive_lines_of_running_text_keep_their_order(self):
+        first = _block(56.7, 100.0, "first")
+        second = _block(56.7, 109.0, "second")
+        assert _order([second, first]) == ["first", "second"]
+
+
+@pytest.mark.unit
+@pytest.mark.pdf
+class TestEmptyAndSingleInputs:
+    """The grouping must not disturb the trivial cases."""
+
+    def test_no_blocks(self):
+        assert _order([]) == []
+
+    def test_one_block(self):
+        assert _order([_block(56.7, 100.0, "only")]) == ["only"]
+
+
+@pytest.mark.unit
+@pytest.mark.pdf
+class TestEndToEnd:
+    """A rendered two-column page reads down the left column first."""
+
+    def test_two_column_page_with_a_gutter_too_narrow_to_detect(self, tmp_path):
+        """The gutter has to be narrow, or the bug cannot happen.
+
+        With a wide gutter ``detect_columns`` splits the page and orders the
+        columns by their x centres, which is already correct -- the reported page
+        fails precisely because its 14.3pt gutter is under ``column_gap_threshold``
+        and both columns land in one column ordered by y. Padding the text makes
+        the columns wide enough for the gap here to be similarly narrow.
+        """
+        padding = "filler text to widen the column " * 4
+        doc = fitz.open()
+        page = doc.new_page()
+        # Right column drawn first and started a hair higher, reproducing the
+        # shape of the reported page.
+        for index in range(6):
+            page.insert_text((300.0, 90.0 + index * 12), f"right{index} {padding}", fontsize=5)
+        for index in range(6):
+            page.insert_text((56.0, 90.05 + index * 12), f"left{index} {padding}", fontsize=5)
+        path = tmp_path / "two_column.pdf"
+        doc.save(str(path))
+        doc.close()
+
+        markdown = to_markdown(str(path))
+        assert markdown.index("left0") < markdown.index("right0")


### PR DESCRIPTION
Closes #290.

## The bug

On a page whose gutter is too narrow for `detect_columns` to split, every block lands in
one column ordered by `y`. So whichever column's top edge is a fraction of a point higher
is read first — and that decides the order of the **whole page**.

Page 16 of `PMC7500012.1`:

```
left  column  y0 = 89.708191   (references 19-38)
right column  y0 = 89.702942   (references 39-61)
```

Five thousandths of a point. The references come out `39…61` then `19…38` — a document
that looks correct and is not.

## One correction to the issue

The suggested tie-break — "when two blocks share a `y`, ordering by `x` would give the
right answer" — **cannot work as written**. The blocks do not share a `y`: `89.708191` and
`89.702942` are distinct floats, so a `(y, x)` sort key changes nothing. I nearly shipped
exactly that before checking the actual coordinates.

They have to be treated as *level* first. Items whose tops fall within a row tolerance of
the row's first item are grouped and ordered by `x`. Compared against the row's first item
rather than its predecessor, so a column of near-level blocks cannot chain into one giant
row.

## Choosing the tolerance

A fraction of the page's average line height rather than a constant — for exactly the
reason the issue gives about `column_gap_threshold`: what reads as "level" scales with the
type size.

**A twentieth of a line, not a quarter.** I tried a quarter first; it swept up genuine
offsets, putting a left-margin `OPEN` badge sitting 2.2pt below a paper's title *ahead of
the title* on `PMC11500000.1`. Both values score identically on the corpus, so the
measurement could not choose between them and the conservative one wins. The defect is
float-level noise, so the tolerance only needs to cover blocks starting at effectively the
same height.

## Measurement

PMC born-digital corpus, 117 pages. Baseline built by neutralising the tolerance — which
reproduces the 39-first ordering, so it is a real control rather than an assumed one.

| dimension | before | after |
|---|---|---|
| `reading_order_similarity` (mean) | 0.779 | **0.785** |
| `reading_order_similarity` (median) | 0.821 | **0.835** |
| `block_structure_similarity` | 0.581 | 0.585 |
| `text_content_similarity` | 0.570 | 0.573 |
| `table_content` / `table_structure` | same | same |
| whole-article recall | 96.5% | 96.5% |

**No dimension regressed.** Byte-comparing 22 PDFs before and after: 13 changed, all on
two-column pages. One hunk repairs a sentence that had a section heading spliced into the
middle of it.

## Tests

Three fail without the change, including end-to-end. The end-to-end fixture needs a
*narrow* gutter — my first version had a wide one, so column detection handled it correctly
and the test passed either way, testing nothing.

Four control tests pass with and without the change (a block clearly below stays below, a
margin badge does not overtake a title, consecutive lines keep their order), so the
tolerance cannot be widened without failing them.

Not addressed here: the issue's other half, that `column_gap_threshold` itself wants to be
size-relative. That needs its own corpus measurement — this fix makes the page read
correctly *despite* the detection failing, rather than fixing the detection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)