### PR TITLE
fix(pdf): import PyMuPDF as pymupdf, and stop the version guard crashing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **PyMuPDF is imported under its own name, not the deprecated `fitz` alias.** Some PyMuPDF
+  releases emit a `DeprecationWarning` on `import fitz`, which reached anyone running the
+  CLI as noise about a dependency they did not choose and could not act on. `pymupdf` has
+  been the real module name since 1.24.3 and we require 1.27.2, so nothing is lost: 149
+  references across 15 modules now use it. No public API changes — the `fitz` module object
+  is still what PyMuPDF hands back, and `_pdf_layout.py` still neutralises the layout hook
+  on both module objects, since the alias can be a distinct object in some installs (#284).
 - **A dropped keyword argument is now diagnosed by which mistake it was.** A name that is an
   option of no format still reports as `Unrecognized keyword arguments were ignored` — the
   typo case #273 was about. A name that is a real all2md option the conversion's formats
@@ -21,6 +28,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **"Your PyMuPDF is too old" now says so instead of raising `TypeError`** (PDF). The version
+  guard built its message by joining PyMuPDF's version tuple, which holds ints, so the one
+  branch that exists to tell a user to upgrade crashed from inside itself and reported
+  nothing useful. It also reconciles the minimum version, which had drifted to three
+  different values: the runtime guard demanded 1.27.2 while the converter's declared
+  dependency — the number `list-formats` prints and dependency errors quote — still said
+  1.26.4. Both now read one constant.
 - **Two columns that start level are read left-to-right, not by a hairline** (PDF). Blocks
   were ordered on `y` alone, so on a page whose gutter is too narrow for column detection
   to split, whichever column's top edge happened to be a fraction of a point higher was

--- a/docs/source/architecture.rst
+++ b/docs/source/architecture.rst
@@ -755,7 +755,7 @@ with the exact install command:
    from all2md.exceptions import DependencyError
 
    try:
-       import fitz  # PyMuPDF
+       import pymupdf  # PyMuPDF
    except ImportError as e:
        raise DependencyError(
            converter_name="pdf",

--- a/docs/source/cli.rst
+++ b/docs/source/cli.rst
@@ -5205,7 +5205,7 @@ The ``list-formats`` command displays all supported file formats, their extensio
    Extensions: .pdf
    MIME types: application/pdf
    Dependencies:
-     - PyMuPDF (fitz) - ✓ Installed (version 1.23.8)
+     - PyMuPDF (pymupdf) - ✓ Installed (version 1.23.8)
    Features:
      - Table detection and extraction
      - Multi-column layout handling

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -704,7 +704,7 @@ Common Installation Issues
 Missing Dependencies
 ~~~~~~~~~~~~~~~~~~~~
 
-**Error:** ``ImportError: No module named 'fitz'``
+**Error:** ``ImportError: No module named 'pymupdf'``
 
 **Solution:** Install PDF support: ``pip install all2md[pdf]``
 

--- a/docs/source/overview.rst
+++ b/docs/source/overview.rst
@@ -198,7 +198,7 @@ PDF Processing
 - Image extraction and placement
 - Page-specific processing
 
-**Technology:** PyMuPDF (fitz) for robust PDF parsing
+**Technology:** PyMuPDF (pymupdf) for robust PDF parsing
 
 .. code-block:: python
 

--- a/docs/source/performance.rst
+++ b/docs/source/performance.rst
@@ -190,8 +190,8 @@ For very large files, use chunked processing:
    def process_large_pdf_in_chunks(pdf_path: str, chunk_size: int = 10) -> str:
        """Process large PDF in chunks to manage memory."""
        # First, determine total pages (quick metadata read via PyMuPDF)
-       import fitz  # PyMuPDF, already required for PDF support
-       with fitz.open(pdf_path) as pdf:
+       import pymupdf  # PyMuPDF, already required for PDF support
+       with pymupdf.open(pdf_path) as pdf:
            total_pages = pdf.page_count
 
        all_markdown = []

--- a/docs/source/troubleshooting.rst
+++ b/docs/source/troubleshooting.rst
@@ -52,7 +52,7 @@ Missing Dependencies
 ~~~~~~~~~~~~~~~~~~~~
 
 **Error Messages:**
-   * ``ImportError: No module named 'fitz'``
+   * ``ImportError: No module named 'pymupdf'``
    * ``ModuleNotFoundError: No module named 'docx'``
    * ``ImportError: PyMuPDF is required for PDF processing``
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -446,6 +446,18 @@ module = "numpy.*"
 follow_imports = "skip"
 follow_imports_for_stubs = true
 
+# PyMuPDF ships `py.typed` but almost none of its methods carry annotations, so
+# following it makes `disallow_untyped_calls` fire on ~40 ordinary calls
+# (`Rect()`, `get_text()`, `find_tables()`). The legacy `fitz` shim we imported
+# until now has no `py.typed`, so `ignore_missing_imports` quietly made it Any and
+# we never saw them. This override keeps that behaviour when importing the
+# canonical name, rather than scattering per-call ignores; it declares the type
+# information we were already not getting instead of pretending we lost some.
+[[tool.mypy.overrides]]
+module = ["pymupdf", "pymupdf.*"]
+follow_imports = "skip"
+follow_imports_for_stubs = true
+
 # context_menu.py is Windows-only (winreg registry plumbing). The CI type check
 # runs on Linux, where the stdlib `winreg` module exposes no attributes
 # (attr-defined) and the `sys.platform != "win32"` guard makes the Windows code

--- a/src/all2md/_converter_manifest.py
+++ b/src/all2md/_converter_manifest.py
@@ -421,7 +421,7 @@ _MANIFEST_RECORDS: list[ConverterMetadata] = [
         magic_bytes=[(b"%PDF", 0)],
         parser_class="all2md.parsers.pdf.PdfToAstConverter",
         renderer_class="all2md.renderers.pdf.PdfRenderer",
-        parser_required_packages=[("pymupdf", "fitz", ">=1.26.4")],
+        parser_required_packages=[("pymupdf", "pymupdf", ">=1.27.2")],
         renderer_required_packages=[("reportlab", "reportlab", ">=4.0.0")],
         optional_packages=[("pytesseract", "pytesseract"), ("easyocr", "easyocr"), ("Pillow", "PIL")],
         import_error_message="PDF conversion requires 'PyMuPDF'. Install with: pip install pymupdf",

--- a/src/all2md/constants.py
+++ b/src/all2md/constants.py
@@ -217,6 +217,11 @@ DocumentFormat = Literal[
 # Each spec is a list of tuples: (pip_package, import_name, version_constraint)
 # These are used with the @requires_dependencies decorator to check for optional deps
 
+# Lives here rather than in the PDF section below so the dependency spec and the
+# runtime guard in pdf.py cannot disagree; they had drifted to three different
+# minimums across the codebase.
+PDF_MIN_PYMUPDF_VERSION = "1.27.2"
+
 # Document parsers
 DEPS_CHM = [("pychm", "chm", "")]
 DEPS_DOCX = [("python-docx", "docx", "")]
@@ -230,7 +235,7 @@ DEPS_ODF = [("odfpy", "odf", "")]  # Used by ODP, ODS, ODT
 DEPS_OPENAPI = [("PyYAML", "yaml", ">=5.1")]
 DEPS_ORG = [("orgparse", "orgparse", "")]
 DEPS_OUTLOOK = [("extract-msg", "extract_msg", "")]
-DEPS_PDF = [("pymupdf", "fitz", ">=1.27.2")]
+DEPS_PDF = [("pymupdf", "pymupdf", f">={PDF_MIN_PYMUPDF_VERSION}")]
 DEPS_PPTX = [("python-pptx", "pptx", ">=1.0.2")]
 DEPS_RST = [("docutils", "docutils", ">=0.18")]
 DEPS_RTF = [("pyth3", "pyth", "")]
@@ -708,8 +713,7 @@ DANGEROUS_REGEX_PATTERNS = [
 # Format-Specific Constants - PDF
 # =============================================================================
 
-# Version requirements
-PDF_MIN_PYMUPDF_VERSION = "1.27.2"
+# Version requirements: PDF_MIN_PYMUPDF_VERSION is defined with DEPS_PDF above.
 
 # Header detection
 DEFAULT_HEADER_MIN_OCCURRENCES = 5  # Increased from 3 to reduce false positives

--- a/src/all2md/converter_metadata.py
+++ b/src/all2md/converter_metadata.py
@@ -59,7 +59,7 @@ class ConverterMetadata:
         The install_name is the package name for pip install, import_name is
         the name used in Python import statements, and version_spec is the
         version requirement (can be empty string for no requirement).
-        e.g., [("pymupdf", "fitz", ">=1.26.4"), ("Pillow", "PIL", ">=9.0.0")]
+        e.g., [("pymupdf", "pymupdf", ">=1.26.4"), ("Pillow", "PIL", ">=9.0.0")]
     renderer_required_packages : list[tuple[str, str, str]]
         Required packages for the renderer as (install_name, import_name, version_spec) tuples.
         Same format as parser_required_packages. Empty list if no renderer or no special

--- a/src/all2md/parsers/_ocr/__init__.py
+++ b/src/all2md/parsers/_ocr/__init__.py
@@ -16,7 +16,7 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    import fitz
+    import pymupdf
 
     from all2md.options.pdf import PdfOptions
 
@@ -45,17 +45,17 @@ class OcrParagraph:
 
 
 def ocr_pixmap_layout(
-    pix: "fitz.Pixmap",
-    page: "fitz.Page",
+    pix: "pymupdf.Pixmap",
+    page: "pymupdf.Page",
     options: "PdfOptions",
 ) -> list[OcrParagraph] | None:
     """Run OCR and keep the engine's paragraph and line segmentation.
 
     Parameters
     ----------
-    pix : fitz.Pixmap
+    pix : pymupdf.Pixmap
         The page rendered to a pixmap at the configured OCR DPI.
-    page : fitz.Page
+    page : pymupdf.Page
         The source page, supplying the coordinate space results are mapped back into.
     options : PdfOptions
         PDF conversion options; ``options.ocr.engine`` selects the backend.
@@ -77,14 +77,14 @@ def ocr_pixmap_layout(
     return _run(pix, page, options)
 
 
-def ocr_pixmap(pix: "fitz.Pixmap", page: "fitz.Page", options: "PdfOptions") -> str:
+def ocr_pixmap(pix: "pymupdf.Pixmap", page: "pymupdf.Page", options: "PdfOptions") -> str:
     """Run OCR on a rendered page pixmap using the configured engine.
 
     Parameters
     ----------
-    pix : fitz.Pixmap
+    pix : pymupdf.Pixmap
         The page rendered to a pixmap at the configured OCR DPI.
-    page : fitz.Page
+    page : pymupdf.Page
         The source page (used for language auto-detection).
     options : PdfOptions
         PDF conversion options; ``options.ocr.engine`` selects the backend.

--- a/src/all2md/parsers/_ocr/easyocr.py
+++ b/src/all2md/parsers/_ocr/easyocr.py
@@ -23,7 +23,7 @@ from all2md.parsers._pdf_ocr import detect_page_language
 from all2md.utils.decorators import requires_dependencies
 
 if TYPE_CHECKING:
-    import fitz
+    import pymupdf
 
     from all2md.options.pdf import PdfOptions
 
@@ -125,7 +125,7 @@ _EASYOCR_LANG_MAP: dict[str, str] = {
 }
 
 
-def _resolve_languages(page: "fitz.Page", options: "PdfOptions") -> list[str]:
+def _resolve_languages(page: "pymupdf.Page", options: "PdfOptions") -> list[str]:
     """Resolve the configured OCR languages to EasyOCR language codes."""
     ocr_opts = options.ocr
 
@@ -213,14 +213,14 @@ def _results_to_text(results: list[Any]) -> str:
 
 
 @requires_dependencies("pdf", DEPS_PDF_OCR_EASYOCR)
-def ocr_pixmap(pix: "fitz.Pixmap", page: "fitz.Page", options: "PdfOptions") -> str:
+def ocr_pixmap(pix: "pymupdf.Pixmap", page: "pymupdf.Page", options: "PdfOptions") -> str:
     """Extract text from a rendered page pixmap using EasyOCR.
 
     Parameters
     ----------
-    pix : fitz.Pixmap
+    pix : pymupdf.Pixmap
         Page rendered to an RGB pixmap.
-    page : fitz.Page
+    page : pymupdf.Page
         Source page (used for language auto-detection).
     options : PdfOptions
         PDF conversion options containing OCR settings.

--- a/src/all2md/parsers/_ocr/tesseract.py
+++ b/src/all2md/parsers/_ocr/tesseract.py
@@ -21,7 +21,7 @@ from all2md.utils.decorators import requires_dependencies
 if TYPE_CHECKING:
     from collections.abc import Iterable
 
-    import fitz
+    import pymupdf
 
     from all2md.options.pdf import PdfOptions
     from all2md.parsers._ocr import OcrParagraph
@@ -30,14 +30,14 @@ logger = logging.getLogger(__name__)
 
 
 @requires_dependencies("pdf", DEPS_PDF_OCR)
-def ocr_pixmap(pix: "fitz.Pixmap", page: "fitz.Page", options: "PdfOptions") -> str:
+def ocr_pixmap(pix: "pymupdf.Pixmap", page: "pymupdf.Page", options: "PdfOptions") -> str:
     """Extract text from a rendered page pixmap using Tesseract.
 
     Parameters
     ----------
-    pix : fitz.Pixmap
+    pix : pymupdf.Pixmap
         Page rendered to an RGB pixmap.
-    page : fitz.Page
+    page : pymupdf.Page
         Source page (used for language auto-detection).
     options : PdfOptions
         PDF conversion options containing OCR settings.
@@ -85,7 +85,7 @@ def ocr_pixmap(pix: "fitz.Pixmap", page: "fitz.Page", options: "PdfOptions") -> 
     return ocr_text
 
 
-def _resolve_language(page: "fitz.Page", options: "PdfOptions") -> str:
+def _resolve_language(page: "pymupdf.Page", options: "PdfOptions") -> str:
     ocr_opts = options.ocr
     if ocr_opts.auto_detect_language:
         return detect_page_language(page, options)
@@ -96,8 +96,8 @@ def _resolve_language(page: "fitz.Page", options: "PdfOptions") -> str:
 
 @requires_dependencies("pdf", DEPS_PDF_OCR)
 def ocr_pixmap_layout(
-    pix: "fitz.Pixmap",
-    page: "fitz.Page",
+    pix: "pymupdf.Pixmap",
+    page: "pymupdf.Page",
     options: "PdfOptions",
 ) -> "list[OcrParagraph] | None":
     """Extract text from a pixmap while keeping Tesseract's own segmentation.
@@ -109,9 +109,9 @@ def ocr_pixmap_layout(
 
     Parameters
     ----------
-    pix : fitz.Pixmap
+    pix : pymupdf.Pixmap
         Page rendered to an RGB pixmap.
-    page : fitz.Page
+    page : pymupdf.Page
         Source page, supplying the coordinate space and language auto-detection.
     options : PdfOptions
         PDF conversion options containing OCR settings.

--- a/src/all2md/parsers/_pdf_headers.py
+++ b/src/all2md/parsers/_pdf_headers.py
@@ -37,7 +37,7 @@ class IdentifyHeaders:
 
     Parameters
     ----------
-    doc : fitz.Document
+    doc : pymupdf.Document
         PDF document to analyze
     pages : list[int], range, or None, optional
         Pages to analyze for font size distribution. If None, samples first 5 pages
@@ -76,7 +76,7 @@ class IdentifyHeaders:
 
         Parameters
         ----------
-        doc : fitz.Document
+        doc : pymupdf.Document
             PDF document to analyze
         pages : list[int], range, or None, optional
             Pages to analyze for font size distribution. If None, samples first 5 pages.
@@ -126,7 +126,7 @@ class IdentifyHeaders:
 
         Parameters
         ----------
-        doc : fitz.Document
+        doc : pymupdf.Document
             PDF document
         pages : list[int], range, or None
             User-specified pages to analyze
@@ -195,7 +195,7 @@ class IdentifyHeaders:
 
         Parameters
         ----------
-        doc : fitz.Document
+        doc : pymupdf.Document
             PDF document
         pages_to_use : list[int]
             Page indices to analyze
@@ -207,7 +207,7 @@ class IdentifyHeaders:
             mapping font sizes to character counts
 
         """
-        import fitz
+        import pymupdf
 
         fontsizes: dict[int, int] = {}
         fontweight_sizes: dict[int, int] = {}
@@ -215,7 +215,7 @@ class IdentifyHeaders:
 
         for pno in pages_to_use:
             page = doc[pno]
-            blocks = page.get_text("dict", flags=fitz.TEXTFLAGS_TEXT)["blocks"]
+            blocks = page.get_text("dict", flags=pymupdf.TEXTFLAGS_TEXT)["blocks"]
 
             for span in self._iter_horizontal_spans(blocks):
                 fontsz = round(span["size"])

--- a/src/all2md/parsers/_pdf_images.py
+++ b/src/all2md/parsers/_pdf_images.py
@@ -17,7 +17,7 @@ from all2md.options.pdf import PdfOptions
 from all2md.utils.attachments import generate_attachment_filename, process_attachment
 
 if TYPE_CHECKING:
-    import fitz
+    import pymupdf
 
 __all__ = ["extract_page_images", "detect_image_caption"]
 
@@ -39,7 +39,7 @@ def _bbox_in_any_region(bbox: Any, regions: list[Any], coverage: float = 0.7) ->
     return False
 
 
-def detect_image_caption(page: "fitz.Page", image_bbox: "fitz.Rect") -> str | None:
+def detect_image_caption(page: "pymupdf.Page", image_bbox: "pymupdf.Rect") -> str | None:
     """Detect caption text near an image.
 
     Looks for text blocks immediately below or above the image
@@ -64,13 +64,13 @@ def detect_image_caption(page: "fitz.Page", image_bbox: "fitz.Rect") -> str | No
         r"^(Figure|Fig\.?|Image|Picture|Photo|Illustration|Table)\s+[A-Z]\.",
     ]
 
-    import fitz
+    import pymupdf
 
     # Search below image
-    search_below = fitz.Rect(image_bbox.x0 - 20, image_bbox.y1, image_bbox.x1 + 20, image_bbox.y1 + 50)
+    search_below = pymupdf.Rect(image_bbox.x0 - 20, image_bbox.y1, image_bbox.x1 + 20, image_bbox.y1 + 50)
 
     # Search above image (less common)
-    search_above = fitz.Rect(image_bbox.x0 - 20, image_bbox.y0 - 50, image_bbox.x1 + 20, image_bbox.y0)
+    search_above = pymupdf.Rect(image_bbox.x0 - 20, image_bbox.y0 - 50, image_bbox.x1 + 20, image_bbox.y0)
 
     for search_rect in [search_below, search_above]:
         text = page.get_textbox(search_rect)
@@ -93,7 +93,7 @@ def detect_image_caption(page: "fitz.Page", image_bbox: "fitz.Rect") -> str | No
 
 
 def extract_page_images(
-    page: "fitz.Page",
+    page: "pymupdf.Page",
     page_num: int,
     options: PdfOptions | None = None,
     base_filename: str = "document",
@@ -117,7 +117,7 @@ def extract_page_images(
         Base filename stem for generating standardized image names
     attachment_sequencer : object, optional
         Sequencer for generating unique attachment names
-    excluded_regions : list of fitz.Rect, optional
+    excluded_regions : list of pymupdf.Rect, optional
         Regions on the page where images should be skipped (e.g. page-header
         and page-footer zones from layout analysis). An image is dropped if
         its bbox is mostly contained in any excluded region.
@@ -156,7 +156,7 @@ def extract_page_images(
     if options.attachment_mode == "alt_text":
         return [], collected_footnotes
 
-    import fitz
+    import pymupdf
 
     min_dim = float(options.min_image_dimension or 0.0)
     exclusion_rects = list(excluded_regions or [])
@@ -190,13 +190,13 @@ def extract_page_images(
             if exclusion_rects and _bbox_in_any_region(bbox, exclusion_rects):
                 continue
 
-            pix = fitz.Pixmap(page.parent, xref)
+            pix = pymupdf.Pixmap(page.parent, xref)
 
             # Convert to RGB if needed
             if pix.n - pix.alpha < 4:  # GRAY or RGB
                 pix_rgb = pix
             else:
-                pix_rgb = fitz.Pixmap(fitz.csRGB, pix)
+                pix_rgb = pymupdf.Pixmap(pymupdf.csRGB, pix)
 
             # Determine image format and convert pixmap to bytes
             img_format = options.image_format if options.image_format else "png"

--- a/src/all2md/parsers/_pdf_layout.py
+++ b/src/all2md/parsers/_pdf_layout.py
@@ -29,7 +29,7 @@ from typing import TYPE_CHECKING, Any, Iterator
 from all2md.constants import DEFAULT_LAYOUT_FEATURE_SET
 
 if TYPE_CHECKING:
-    import fitz
+    import pymupdf
 
 __all__ = [
     "LayoutPrediction",
@@ -203,12 +203,12 @@ def get_layout_model(feature_set: str = DEFAULT_LAYOUT_FEATURE_SET) -> Any:
     return _layout_models[feature_set]
 
 
-def predict_page_layout(page: "fitz.Page", feature_set: str = DEFAULT_LAYOUT_FEATURE_SET) -> list[LayoutPrediction]:
+def predict_page_layout(page: "pymupdf.Page", feature_set: str = DEFAULT_LAYOUT_FEATURE_SET) -> list[LayoutPrediction]:
     """Run layout prediction on a single page.
 
     Parameters
     ----------
-    page : fitz.Page
+    page : pymupdf.Page
         PDF page to analyze.
     feature_set : str
         Which classifier to run -- see `LayoutFeatureSet`.
@@ -358,19 +358,19 @@ def annotate_lines_with_layout(
         Number of lines stamped, for logging.
 
     """
-    import fitz
+    import pymupdf
 
     if not predictions:
         return 0
 
-    rects = [(pred, fitz.Rect(pred.bbox)) for pred in predictions]
+    rects = [(pred, pymupdf.Rect(pred.bbox)) for pred in predictions]
     stamped = 0
     for block in blocks:
         for line in block.get("lines", ()):
             bbox = line.get("bbox")
             if bbox is None:
                 continue
-            rect = fitz.Rect(bbox)
+            rect = pymupdf.Rect(bbox)
             area = abs(rect)
             if area <= 0:
                 continue

--- a/src/all2md/parsers/_pdf_ocr.py
+++ b/src/all2md/parsers/_pdf_ocr.py
@@ -20,7 +20,7 @@ from all2md.options.pdf import PdfOptions
 from all2md.utils.decorators import requires_dependencies
 
 if TYPE_CHECKING:
-    import fitz
+    import pymupdf
 
 __all__ = [
     "should_use_ocr",
@@ -162,7 +162,7 @@ def dehyphenate_blocks(blocks: list[dict[str, Any]]) -> None:
             index += 1
 
 
-def calculate_image_coverage(page: "fitz.Page") -> float:
+def calculate_image_coverage(page: "pymupdf.Page") -> float:
     """Calculate the ratio of image area to total page area.
 
     This function analyzes a PDF page to determine what fraction of the page
@@ -170,7 +170,7 @@ def calculate_image_coverage(page: "fitz.Page") -> float:
 
     Parameters
     ----------
-    page : fitz.Page
+    page : pymupdf.Page
         PDF page to analyze
 
     Returns
@@ -215,7 +215,7 @@ def calculate_image_coverage(page: "fitz.Page") -> float:
     return coverage_ratio
 
 
-def largest_image_coverage(page: "fitz.Page") -> float:
+def largest_image_coverage(page: "pymupdf.Page") -> float:
     """Calculate the share of the page covered by its single largest image.
 
     This is the scan test. A scanned page is one raster the size of the page, so the
@@ -226,7 +226,7 @@ def largest_image_coverage(page: "fitz.Page") -> float:
 
     Parameters
     ----------
-    page : fitz.Page
+    page : pymupdf.Page
         PDF page to analyze
 
     Returns
@@ -253,7 +253,7 @@ def largest_image_coverage(page: "fitz.Page") -> float:
     return min(1.0, largest)
 
 
-def should_use_ocr(page: "fitz.Page", extracted_text: str, options: PdfOptions) -> bool:
+def should_use_ocr(page: "pymupdf.Page", extracted_text: str, options: PdfOptions) -> bool:
     """Determine whether OCR should be applied to a PDF page.
 
     Analyzes the page content based on the OCR mode and detection thresholds
@@ -261,7 +261,7 @@ def should_use_ocr(page: "fitz.Page", extracted_text: str, options: PdfOptions) 
 
     Parameters
     ----------
-    page : fitz.Page
+    page : pymupdf.Page
         PDF page to analyze
     extracted_text : str
         Text extracted by PyMuPDF from the page
@@ -413,7 +413,7 @@ def get_tesseract_lang(detected_lang_code: str) -> str:
 
 
 @requires_dependencies("pdf", DEPS_PDF_LANGDETECT)
-def detect_page_language(page: "fitz.Page", options: PdfOptions) -> str:
+def detect_page_language(page: "pymupdf.Page", options: PdfOptions) -> str:
     """Attempt to auto-detect the language of a PDF page for OCR.
 
     This is an experimental feature that tries to determine the language
@@ -421,7 +421,7 @@ def detect_page_language(page: "fitz.Page", options: PdfOptions) -> str:
 
     Parameters
     ----------
-    page : fitz.Page
+    page : pymupdf.Page
         PDF page to analyze
     options : PdfOptions
         PDF conversion options containing OCR settings

--- a/src/all2md/parsers/_pdf_tables.py
+++ b/src/all2md/parsers/_pdf_tables.py
@@ -14,7 +14,7 @@ import re
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    import fitz
+    import pymupdf
 
 __all__ = [
     "MAX_DOT_LEADER_CELL_RATIO",
@@ -106,7 +106,7 @@ _DOT_LEADER_TAIL = re.compile(r"\n\s*[.…](?:\s*[.…]){2,}\s*$")
 _WORD_TOKEN = re.compile(r"[^\W\d_]+", re.UNICODE)
 
 
-def split_word_ratio(page: "fitz.Page", table_data: list[list[str | None]]) -> float:
+def split_word_ratio(page: "pymupdf.Page", table_data: list[list[str | None]]) -> float:
     """Share of a grid's word tokens that are not whole words of the page.
 
     A grid whose columns fall in the whitespace gutters between cells holds whole words. One
@@ -233,7 +233,7 @@ def _extract_ruling_lines(
 
 
 def page_has_table_signals(
-    page: "fitz.Page",
+    page: "pymupdf.Page",
     threshold: float = TABLE_SIGNAL_RULING_THRESHOLD,
 ) -> bool:
     """Return True if the page has drawings that could indicate a table.
@@ -296,7 +296,7 @@ def page_has_table_signals(
     return False
 
 
-def _check_table_overlap(table_rect: "fitz.Rect", existing_rects: list["fitz.Rect"]) -> bool:
+def _check_table_overlap(table_rect: "pymupdf.Rect", existing_rects: list["pymupdf.Rect"]) -> bool:
     """Check if a table rect overlaps significantly with existing tables.
 
     Returns
@@ -314,7 +314,7 @@ def _check_table_overlap(table_rect: "fitz.Rect", existing_rects: list["fitz.Rec
 def _find_table_regions(
     h_lines: list[tuple],
     v_lines: list[tuple],
-) -> list["fitz.Rect"]:
+) -> list["pymupdf.Rect"]:
     """Find table regions from horizontal and vertical lines.
 
     Parameters
@@ -326,13 +326,13 @@ def _find_table_regions(
 
     Returns
     -------
-    list[fitz.Rect]
+    list[pymupdf.Rect]
         List of detected table bounding boxes
 
     """
-    import fitz
+    import pymupdf
 
-    table_rects: list["fitz.Rect"] = []
+    table_rects: list["pymupdf.Rect"] = []
 
     if len(h_lines) < 2 or len(v_lines) < 2:
         return table_rects
@@ -353,7 +353,7 @@ def _find_table_regions(
             x_min = min(min(h_lines[i][0], h_lines[j][0]), min(v[0] for v in spanning_vlines))
             x_max = max(max(h_lines[i][2], h_lines[j][2]), max(v[2] for v in spanning_vlines))
 
-            table_rect = fitz.Rect(x_min, y1, x_max, y2)
+            table_rect = pymupdf.Rect(x_min, y1, x_max, y2)
 
             if not table_rect.is_empty and not _check_table_overlap(table_rect, table_rects):
                 table_rects.append(table_rect)
@@ -362,7 +362,7 @@ def _find_table_regions(
 
 
 def _collect_lines_for_tables(
-    table_rects: list["fitz.Rect"],
+    table_rects: list["pymupdf.Rect"],
     h_lines: list[tuple],
     v_lines: list[tuple],
 ) -> list[tuple[list[tuple], list[tuple]]]:
@@ -383,8 +383,8 @@ def _collect_lines_for_tables(
 
 
 def detect_tables_by_ruling_lines(
-    page: "fitz.Page", threshold: float = 0.5
-) -> tuple[list["fitz.Rect"], list[tuple[list[tuple], list[tuple]]]]:
+    page: "pymupdf.Page", threshold: float = 0.5
+) -> tuple[list["pymupdf.Rect"], list[tuple[list[tuple], list[tuple]]]]:
     """Fallback table detection using ruling lines and text alignment.
 
     Uses page drawing commands to detect horizontal and vertical lines
@@ -425,7 +425,7 @@ def detect_tables_by_ruling_lines(
 
     # Drop rects whose internal line count would produce an absurdly large
     # grid - those are essentially always bordered non-tabular content.
-    filtered_rects: list["fitz.Rect"] = []
+    filtered_rects: list["pymupdf.Rect"] = []
     filtered_lines: list[tuple[list[tuple], list[tuple]]] = []
     for rect, (th, tv) in zip(table_rects, table_lines, strict=True):
         # cols = len(v_lines) - 1, rows = len(h_lines) - 1

--- a/src/all2md/parsers/_pdf_text.py
+++ b/src/all2md/parsers/_pdf_text.py
@@ -158,9 +158,9 @@ def resolve_links(
     if not links or not span.get("text"):
         return None
 
-    import fitz
+    import pymupdf
 
-    bbox = fitz.Rect(span["bbox"])  # span bbox
+    bbox = pymupdf.Rect(span["bbox"])  # span bbox
     span_text = span["text"]
 
     # Use provided threshold or fall back to default

--- a/src/all2md/parsers/base.py
+++ b/src/all2md/parsers/base.py
@@ -162,7 +162,7 @@ class BaseParser(ABC):
         ----------
         document : Any
             The loaded document object (format-specific type, e.g.,
-            docx.Document, fitz.Document, email.message.Message, etc.)
+            docx.Document, pymupdf.Document, email.message.Message, etc.)
 
         Returns
         -------

--- a/src/all2md/parsers/pdf.py
+++ b/src/all2md/parsers/pdf.py
@@ -22,7 +22,7 @@ from all2md.utils.attachments import create_attachment_sequencer
 from all2md.utils.parser_helpers import attachment_result_to_image_node
 
 if TYPE_CHECKING:
-    import fitz
+    import pymupdf
 
     from all2md.parsers._ocr import OcrParagraph
 
@@ -509,7 +509,7 @@ def _block_outside_table_regions(block: dict, regions: list[Any]) -> dict | None
         that really is the table.
 
     """
-    import fitz
+    import pymupdf
 
     lines = block.get("lines")
     if not lines:
@@ -521,7 +521,7 @@ def _block_outside_table_regions(block: dict, regions: list[Any]) -> dict | None
         if bbox is None:
             kept.append(line)
             continue
-        rect = fitz.Rect(bbox)
+        rect = pymupdf.Rect(bbox)
         area = abs(rect)
         # Judge a line by the same majority rule used for blocks, so a line straddling the
         # region boundary is assigned rather than duplicated or dropped by both sides.
@@ -545,7 +545,7 @@ def _block_outside_table_regions(block: dict, regions: list[Any]) -> dict | None
     for line in kept:
         if line.get("bbox") is None:
             continue
-        rect = fitz.Rect(line["bbox"])
+        rect = pymupdf.Rect(line["bbox"])
         tightened = rect if tightened is None else (tightened | rect)
 
     remainder = dict(block)
@@ -617,18 +617,22 @@ def _check_pymupdf_version() -> None:
 
     Notes
     -----
-    This function assumes fitz is already imported. It should be called
+    This function assumes pymupdf is already imported. It should be called
     after dependency checking via the @requires_dependencies decorator.
 
     """
-    import fitz
+    import pymupdf
 
     min_version = tuple(map(int, PDF_MIN_PYMUPDF_VERSION.split(".")))
-    if fitz.pymupdf_version_tuple < min_version:
+    if pymupdf.pymupdf_version_tuple < min_version:
+        # str() per component: the tuple holds ints, and joining it directly
+        # raised TypeError from inside the error path, so the one user this
+        # branch exists for got a traceback instead of "upgrade pymupdf".
+        installed = ".".join(str(part) for part in pymupdf.pymupdf_version_tuple)
         raise DependencyError(
             converter_name="pdf",
             missing_packages=[],
-            version_mismatches=[("pymupdf", PDF_MIN_PYMUPDF_VERSION, ".".join(fitz.pymupdf_version_tuple))],
+            version_mismatches=[("pymupdf", PDF_MIN_PYMUPDF_VERSION, installed)],
         )
 
 
@@ -652,11 +656,11 @@ def _silence_pymupdf_layout_advisory() -> None:
     ``pdf_layout`` extra and already reports its absence through its own
     dependency machinery, which writes to stderr.
     """
-    import fitz
+    import pymupdf
 
     # Guarded: the entry point is PyMuPDF's own, but it is not load-bearing, and
     # a version without it should convert rather than crash.
-    suppress = getattr(fitz, "no_recommend_layout", None)
+    suppress = getattr(pymupdf, "no_recommend_layout", None)
     if suppress is not None:
         suppress()
 
@@ -717,7 +721,7 @@ class PdfToAstConverter(BaseParser):
             AST document node
 
         """
-        import fitz
+        import pymupdf
 
         _check_pymupdf_version()
         _silence_pymupdf_layout_advisory()
@@ -739,25 +743,25 @@ class PdfToAstConverter(BaseParser):
 
         # Validate and convert input
         doc_input, input_type = validate_and_convert_input(
-            input_data, supported_types=["path-like", "file-like (BytesIO)", "fitz.Document objects"]
+            input_data, supported_types=["path-like", "file-like (BytesIO)", "pymupdf.Document objects"]
         )
 
         # Open document based on input type
         try:
             if input_type == "path":
-                doc = fitz.open(filename=str(doc_input))
+                doc = pymupdf.open(filename=str(doc_input))
             elif input_type in ("file", "bytes"):
                 # PyMuPDF expects bytes, not file-like objects
                 stream_bytes = normalize_stream_to_bytes(doc_input)
-                doc = fitz.open(stream=stream_bytes, filetype="pdf")
+                doc = pymupdf.open(stream=stream_bytes, filetype="pdf")
             elif input_type == "object":
-                if isinstance(doc_input, fitz.Document) or (
+                if isinstance(doc_input, pymupdf.Document) or (
                     hasattr(doc_input, "page_count") and hasattr(doc_input, "__getitem__")
                 ):
                     doc = doc_input
                 else:
                     raise ValidationError(
-                        f"Expected fitz.Document object, got {type(doc_input).__name__}",
+                        f"Expected pymupdf.Document object, got {type(doc_input).__name__}",
                         parameter_name="input_data",
                         parameter_value=doc_input,
                     )
@@ -859,16 +863,16 @@ class PdfToAstConverter(BaseParser):
         return block_text if block_text else None
 
     def _collect_page_blocks(
-        self, doc: "fitz.Document", sample_pages: list[int]
+        self, doc: "pymupdf.Document", sample_pages: list[int]
     ) -> dict[int, list[tuple[str, float, float]]]:
         """Collect text blocks with positions from sampled pages."""
-        import fitz
+        import pymupdf
 
         page_blocks: dict[int, list[tuple[str, float, float]]] = {}
 
         for page_num in sample_pages:
             page = doc[page_num]
-            blocks = page.get_text("dict", flags=fitz.TEXTFLAGS_TEXT)["blocks"]
+            blocks = page.get_text("dict", flags=pymupdf.TEXTFLAGS_TEXT)["blocks"]
             page_blocks[page_num] = []
 
             for block in blocks:
@@ -937,7 +941,7 @@ class PdfToAstConverter(BaseParser):
 
         return max_header_y, max_footer_y
 
-    def _auto_detect_header_footer_zones(self, doc: "fitz.Document", pages_to_use: range | list[int]) -> None:
+    def _auto_detect_header_footer_zones(self, doc: "pymupdf.Document", pages_to_use: range | list[int]) -> None:
         """Automatically detect and set header/footer zones by analyzing repeating text patterns.
 
         This method analyzes text blocks across multiple pages to identify repeating
@@ -947,7 +951,7 @@ class PdfToAstConverter(BaseParser):
 
         Parameters
         ----------
-        doc : fitz.Document
+        doc : pymupdf.Document
             PDF document to analyze
         pages_to_use : range or list[int]
             Pages to process (used to determine sample range)
@@ -977,7 +981,7 @@ class PdfToAstConverter(BaseParser):
             footer_height_value = int(page_height - max_footer_y + 5)
             self.options = self.options.create_updated(footer_height=footer_height_value, trim_headers_footers=True)
 
-    def extract_metadata(self, document: "fitz.Document") -> DocumentMetadata:
+    def extract_metadata(self, document: "pymupdf.Document") -> DocumentMetadata:
         """Extract metadata from PDF document.
 
         Extracts standard metadata fields from a PDF document including title,
@@ -987,7 +991,7 @@ class PdfToAstConverter(BaseParser):
 
         Parameters
         ----------
-        document : fitz.Document
+        document : pymupdf.Document
             PyMuPDF document object to extract metadata from
 
         Returns
@@ -1116,12 +1120,12 @@ class PdfToAstConverter(BaseParser):
             pass
         return date_str
 
-    def convert_to_ast(self, doc: "fitz.Document", pages_to_use: range | list[int], base_filename: str) -> Document:
+    def convert_to_ast(self, doc: "pymupdf.Document", pages_to_use: range | list[int], base_filename: str) -> Document:
         """Convert PDF document to AST Document.
 
         Parameters
         ----------
-        doc : fitz.Document
+        doc : pymupdf.Document
             PDF document to convert
         pages_to_use : range or list of int
             Pages to process
@@ -1243,7 +1247,7 @@ class PdfToAstConverter(BaseParser):
 
     def _render_pages(
         self,
-        doc: "fitz.Document",
+        doc: "pymupdf.Document",
         pages_list: list[int],
         base_filename: str,
         attachment_sequencer: Any,
@@ -1321,7 +1325,7 @@ class PdfToAstConverter(BaseParser):
 
     def _maybe_retry_with_ocr(
         self,
-        doc: "fitz.Document",
+        doc: "pymupdf.Document",
         pages_list: list[int],
         base_filename: str,
         total_pages: int,
@@ -1372,7 +1376,7 @@ class PdfToAstConverter(BaseParser):
         return children
 
     @staticmethod
-    def _ocr_page_to_text(page: "fitz.Page", options: PdfOptions) -> str:
+    def _ocr_page_to_text(page: "pymupdf.Page", options: PdfOptions) -> str:
         """Extract text from a PDF page using OCR (Optical Character Recognition).
 
         Renders the page to an image at the configured DPI and hands it to the
@@ -1382,7 +1386,7 @@ class PdfToAstConverter(BaseParser):
 
         Parameters
         ----------
-        page : fitz.Page
+        page : pymupdf.Page
             PDF page to extract text from
         options : PdfOptions
             PDF conversion options containing OCR settings
@@ -1400,7 +1404,7 @@ class PdfToAstConverter(BaseParser):
             If the Tesseract binary is missing, or EasyOCR cannot initialize
 
         """
-        import fitz
+        import pymupdf
 
         from all2md.parsers._ocr import ocr_pixmap
 
@@ -1411,7 +1415,7 @@ class PdfToAstConverter(BaseParser):
         # Initialize pixmap reference for proper cleanup in finally block
         pix = None
         try:
-            mat = fitz.Matrix(zoom, zoom)
+            mat = pymupdf.Matrix(zoom, zoom)
             pix = page.get_pixmap(matrix=mat)
             return ocr_pixmap(pix, page, options)
         finally:
@@ -1421,12 +1425,12 @@ class PdfToAstConverter(BaseParser):
                 pix = None
 
     @staticmethod
-    def _ocr_page_to_layout(page: "fitz.Page", options: PdfOptions) -> "list[OcrParagraph] | None":
+    def _ocr_page_to_layout(page: "pymupdf.Page", options: PdfOptions) -> "list[OcrParagraph] | None":
         """OCR a page and keep the engine's paragraph segmentation.
 
         Parameters
         ----------
-        page : fitz.Page
+        page : pymupdf.Page
             PDF page to extract text from
         options : PdfOptions
             PDF conversion options containing OCR settings
@@ -1437,14 +1441,14 @@ class PdfToAstConverter(BaseParser):
             Paragraphs in PDF coordinates, or ``None`` if the engine reports no layout.
 
         """
-        import fitz
+        import pymupdf
 
         from all2md.parsers._ocr import ocr_pixmap_layout
 
         zoom = options.ocr.dpi / 72.0
         pix = None
         try:
-            mat = fitz.Matrix(zoom, zoom)
+            mat = pymupdf.Matrix(zoom, zoom)
             pix = page.get_pixmap(matrix=mat)
             return ocr_pixmap_layout(pix, page, options)
         except Exception as exc:  # noqa: BLE001 - layout is an enhancement, never a reason to lose the page
@@ -1488,13 +1492,13 @@ class PdfToAstConverter(BaseParser):
         return blocks
 
     def _detect_page_tables(
-        self, page: "fitz.Page", page_num: int, total_pages: int
+        self, page: "pymupdf.Page", page_num: int, total_pages: int
     ) -> tuple[list[dict], list[Any], list[Any]]:
         """Detect tables on a PDF page.
 
         Parameters
         ----------
-        page : fitz.Page
+        page : pymupdf.Page
             PDF page to analyze
         page_num : int
             Page number (0-based)
@@ -1507,7 +1511,7 @@ class PdfToAstConverter(BaseParser):
             (table_info, fallback_table_rects, fallback_table_lines)
 
         """
-        import fitz
+        import pymupdf
 
         mode = self.options.table_detection_mode.lower()
 
@@ -1550,7 +1554,7 @@ class PdfToAstConverter(BaseParser):
         table_info = []
         for i, t in enumerate(tabs.tables):
             try:
-                bbox = fitz.Rect(t.bbox) | fitz.Rect(t.header.bbox)
+                bbox = pymupdf.Rect(t.bbox) | pymupdf.Rect(t.header.bbox)
             except ValueError:
                 # PyMuPDF may detect a table structure with no cells,
                 # causing t.bbox to fail with "min() iterable argument is empty".
@@ -1576,13 +1580,13 @@ class PdfToAstConverter(BaseParser):
         return table_info, fallback_table_rects, fallback_table_lines
 
     def _apply_ocr_if_needed(
-        self, page: "fitz.Page", all_blocks: list[dict], extracted_text: str
+        self, page: "pymupdf.Page", all_blocks: list[dict], extracted_text: str
     ) -> tuple[list[dict], bool]:
         """Apply OCR to page if needed based on options and content.
 
         Parameters
         ----------
-        page : fitz.Page
+        page : pymupdf.Page
             PDF page
         all_blocks : list of dict
             Extracted text blocks
@@ -1841,14 +1845,14 @@ class PdfToAstConverter(BaseParser):
         bbox = data.get("bbox")
         return float(bbox[0]) if bbox else 0.0
 
-    def _process_table_item(self, item_data: dict, page: "fitz.Page", page_num: int) -> Node | None:
+    def _process_table_item(self, item_data: dict, page: "pymupdf.Page", page_num: int) -> Node | None:
         """Process a single table item and return its AST node.
 
         Parameters
         ----------
         item_data : dict
             Table information dictionary
-        page : fitz.Page
+        page : pymupdf.Page
             PDF page
         page_num : int
             Page number
@@ -1869,12 +1873,12 @@ class PdfToAstConverter(BaseParser):
             return self._extract_table_from_layout_region(page, item_data["bbox"], page_num)
         return None
 
-    def _get_page_links(self, page: "fitz.Page") -> list:
+    def _get_page_links(self, page: "pymupdf.Page") -> list:
         """Extract URI links from a page.
 
         Parameters
         ----------
-        page : fitz.Page
+        page : pymupdf.Page
             PDF page
 
         Returns
@@ -1892,7 +1896,7 @@ class PdfToAstConverter(BaseParser):
         self,
         columns: list[list[dict]],
         table_info: list[dict],
-        page: "fitz.Page",
+        page: "pymupdf.Page",
         page_num: int,
         page_images: list[Any],
     ) -> list[Node]:
@@ -1904,7 +1908,7 @@ class PdfToAstConverter(BaseParser):
             Text block columns
         table_info : list of dict
             Table information
-        page : fitz.Page
+        page : pymupdf.Page
             PDF page
         page_num : int
             Page number
@@ -1951,7 +1955,7 @@ class PdfToAstConverter(BaseParser):
 
     def _process_page_to_ast(
         self,
-        page: "fitz.Page",
+        page: "pymupdf.Page",
         page_num: int,
         base_filename: str,
         attachment_sequencer: Callable[[str, str], tuple[str, int]],
@@ -1961,7 +1965,7 @@ class PdfToAstConverter(BaseParser):
 
         Parameters
         ----------
-        page : fitz.Page
+        page : pymupdf.Page
             PDF page to process
         page_num : int
             Page number (0-based)
@@ -1978,14 +1982,14 @@ class PdfToAstConverter(BaseParser):
             List of AST nodes representing the page
 
         """
-        import fitz
+        import pymupdf
 
         # Detect tables on the page
         table_info, _, _ = self._detect_page_tables(page, page_num, total_pages)
 
         # Extract all text blocks from the page
         try:
-            all_blocks = page.get_text("dict", flags=fitz.TEXTFLAGS_TEXT, sort=False)["blocks"]
+            all_blocks = page.get_text("dict", flags=pymupdf.TEXTFLAGS_TEXT, sort=False)["blocks"]
             if self.options.merge_hyphenated_words:
                 dehyphenate_blocks(all_blocks)
         except (AttributeError, KeyError, Exception):
@@ -2046,7 +2050,7 @@ class PdfToAstConverter(BaseParser):
         # Supplement table detection with layout-predicted tables
         if layout:
             for pred in layout.get_predictions_by_label("table"):
-                pred_rect = fitz.Rect(pred.x0, pred.y0, pred.x1, pred.y1)
+                pred_rect = pymupdf.Rect(pred.x0, pred.y0, pred.x1, pred.y1)
                 # Check both directions: layout region covered by existing table,
                 # OR existing table covered by layout region
                 already_covered = any(
@@ -2070,7 +2074,7 @@ class PdfToAstConverter(BaseParser):
                 text_blocks.append(block)
                 continue
 
-            block_rect = fitz.Rect(block["bbox"])
+            block_rect = pymupdf.Rect(block["bbox"])
             is_in_table = any(abs(block_rect & table["bbox"]) > 0.5 * abs(block_rect) for table in table_info)
             if not is_in_table:
                 text_blocks.append(block)
@@ -2281,14 +2285,14 @@ class PdfToAstConverter(BaseParser):
 
         return state.nodes
 
-    def _process_text_region_to_ast(self, page: "fitz.Page", clip: "fitz.Rect", page_num: int) -> list[Node]:
+    def _process_text_region_to_ast(self, page: "pymupdf.Page", clip: "pymupdf.Rect", page_num: int) -> list[Node]:
         """Process a text region to AST nodes.
 
         Parameters
         ----------
-        page : fitz.Page
+        page : pymupdf.Page
             PDF page
-        clip : fitz.Rect
+        clip : pymupdf.Rect
             Clipping rectangle for text extraction
         page_num : int
             Page number for source tracking
@@ -2299,7 +2303,7 @@ class PdfToAstConverter(BaseParser):
             List of AST nodes (paragraphs, headings, code blocks)
 
         """
-        import fitz
+        import pymupdf
 
         # Extract URL type links on page
         try:
@@ -2312,7 +2316,7 @@ class PdfToAstConverter(BaseParser):
             blocks = page.get_text(
                 "dict",
                 clip=clip,
-                flags=fitz.TEXTFLAGS_TEXT,
+                flags=pymupdf.TEXTFLAGS_TEXT,
                 sort=False,
             )["blocks"]
             if self.options.merge_hyphenated_words:
@@ -3044,9 +3048,9 @@ class PdfToAstConverter(BaseParser):
         if not links or not span.get("text"):
             return None
 
-        import fitz
+        import pymupdf
 
-        bbox = fitz.Rect(span["bbox"])
+        bbox = pymupdf.Rect(span["bbox"])
 
         # Calculate span height
         span_height = bbox.height
@@ -3098,7 +3102,7 @@ class PdfToAstConverter(BaseParser):
             return ""
         return str(cell_text).strip()
 
-    def _process_table_to_ast(self, table: Any, page: "fitz.Page", page_num: int) -> Node | None:
+    def _process_table_to_ast(self, table: Any, page: "pymupdf.Page", page_num: int) -> Node | None:
         """Process a PyMuPDF table to AST Table node.
 
         Directly accesses table cell data from PyMuPDF table object instead of
@@ -3108,7 +3112,7 @@ class PdfToAstConverter(BaseParser):
         ----------
         table : PyMuPDF Table
             Table object from find_tables()
-        page : fitz.Page
+        page : pymupdf.Page
             Page containing the table. Used to recover the region's text when the
             detection is rejected as a degenerate grid.
         page_num : int
@@ -3122,7 +3126,7 @@ class PdfToAstConverter(BaseParser):
             the region has no usable content.
 
         """
-        import fitz
+        import pymupdf
 
         try:
             # Try to extract cells directly from PyMuPDF table object
@@ -3158,13 +3162,13 @@ class PdfToAstConverter(BaseParser):
                     f"{MIN_TABLE_ROWS}x{MIN_TABLE_COLS})"
                 )
                 self._record_table_rejection("degenerate_grid")
-                return self._region_text_as_paragraph(page, fitz.Rect(table.bbox), page_num)
+                return self._region_text_as_paragraph(page, pymupdf.Rect(table.bbox), page_num)
             if n_cols > MAX_TABLE_COLS or n_rows > MAX_TABLE_ROWS:
                 logger.debug(
                     f"Rejecting pymupdf table on page {page_num + 1}: {n_rows}x{n_cols} grid exceeds size caps"
                 )
                 self._record_table_rejection("oversized_grid")
-                return self._region_text_as_paragraph(page, fitz.Rect(table.bbox), page_num)
+                return self._region_text_as_paragraph(page, pymupdf.Rect(table.bbox), page_num)
             n_empty = sum(1 for r in table_data for c in r if c is None or not str(c).strip())
             if n_empty / n_cells > MAX_TABLE_EMPTY_RATIO:
                 logger.debug(
@@ -3172,7 +3176,7 @@ class PdfToAstConverter(BaseParser):
                     f"{n_empty}/{n_cells} ({n_empty / n_cells:.0%}) cells empty"
                 )
                 self._record_table_rejection("mostly_empty")
-                return self._region_text_as_paragraph(page, fitz.Rect(table.bbox), page_num)
+                return self._region_text_as_paragraph(page, pymupdf.Rect(table.bbox), page_num)
             unique_texts = {str(c).strip() for r in table_data for c in r if c is not None and str(c).strip()}
             n_filled = n_cells - n_empty
             if len(unique_texts) == 1 and n_filled >= MIN_FILLED_FOR_UNIFORMITY_CHECK:
@@ -3181,7 +3185,7 @@ class PdfToAstConverter(BaseParser):
                     f"all {n_filled} non-empty cells have identical content"
                 )
                 self._record_table_rejection("uniform_cells")
-                return self._region_text_as_paragraph(page, fitz.Rect(table.bbox), page_num)
+                return self._region_text_as_paragraph(page, pymupdf.Rect(table.bbox), page_num)
             n_dot_leader = sum(1 for r in table_data for c in r if c is not None and is_dot_leader_cell(str(c)))
             if n_filled and n_dot_leader / n_filled > MAX_DOT_LEADER_CELL_RATIO:
                 logger.debug(
@@ -3190,7 +3194,7 @@ class PdfToAstConverter(BaseParser):
                     f"dot-leader noise (looks like TOC region)"
                 )
                 self._record_table_rejection("dot_leader_toc")
-                return self._region_text_as_paragraph(page, fitz.Rect(table.bbox), page_num)
+                return self._region_text_as_paragraph(page, pymupdf.Rect(table.bbox), page_num)
 
             # Separate header row (first row) from data rows
             header_row_data = table_data[0] if table_data else []
@@ -3271,7 +3275,12 @@ class PdfToAstConverter(BaseParser):
             return None
 
     def _extract_table_from_ruling_rect(
-        self, page: "fitz.Page", table_rect: "fitz.Rect", h_lines: list[tuple], v_lines: list[tuple], page_num: int
+        self,
+        page: "pymupdf.Page",
+        table_rect: "pymupdf.Rect",
+        h_lines: list[tuple],
+        v_lines: list[tuple],
+        page_num: int,
     ) -> AstTable | None:
         """Extract table content from a bounding box using ruling lines.
 
@@ -3280,9 +3289,9 @@ class PdfToAstConverter(BaseParser):
 
         Parameters
         ----------
-        page : fitz.Page
+        page : pymupdf.Page
             PDF page containing the table
-        table_rect : fitz.Rect
+        table_rect : pymupdf.Rect
             Bounding box of the table
         h_lines : list of tuple
             Horizontal ruling lines as (x0, y0, x1, y1) tuples
@@ -3326,7 +3335,7 @@ class PdfToAstConverter(BaseParser):
         n_cols = len(col_x_coords)
         n_cells = n_rows * n_cols
 
-        import fitz
+        import pymupdf
 
         n_empty = 0
         n_dot_leader = 0
@@ -3336,7 +3345,7 @@ class PdfToAstConverter(BaseParser):
             cells: list[TableCell] = []
 
             for _col_idx, (x0, x1) in enumerate(col_x_coords):
-                cell_rect = fitz.Rect(x0, y0, x1, y1)
+                cell_rect = pymupdf.Rect(x0, y0, x1, y1)
                 cell_text = page.get_textbox(cell_rect).strip()
 
                 if cell_text:
@@ -3395,7 +3404,7 @@ class PdfToAstConverter(BaseParser):
         )
 
     def _extract_table_from_layout_region(
-        self, page: "fitz.Page", table_rect: "fitz.Rect", page_num: int
+        self, page: "pymupdf.Page", table_rect: "pymupdf.Rect", page_num: int
     ) -> Node | None:
         """Extract the content of a region the layout model predicted to be a table.
 
@@ -3419,9 +3428,9 @@ class PdfToAstConverter(BaseParser):
 
         Parameters
         ----------
-        page : fitz.Page
+        page : pymupdf.Page
             PDF page containing the region.
-        table_rect : fitz.Rect
+        table_rect : pymupdf.Rect
             Bounding box predicted by the layout model.
         page_num : int
             Page number for source tracking.
@@ -3481,7 +3490,9 @@ class PdfToAstConverter(BaseParser):
             self._record_table_rejection("layout_region_not_tabular")
         return paragraph
 
-    def _region_text_as_paragraph(self, page: "fitz.Page", region: "fitz.Rect", page_num: int) -> AstParagraph | None:
+    def _region_text_as_paragraph(
+        self, page: "pymupdf.Page", region: "pymupdf.Rect", page_num: int
+    ) -> AstParagraph | None:
         """Return a region's text as a paragraph, for regions rejected as tables.
 
         Text inside a detected table's bbox is removed from the ordinary text blocks so
@@ -3556,12 +3567,12 @@ class PdfToAstConverter(BaseParser):
         """
         if layout is None or not self.options.filter_header_footer_images:
             return []
-        import fitz
+        import pymupdf
 
         regions: list[Any] = []
         for label in ("page-header", "page-footer"):
             for pred in layout.get_predictions_by_label(label):
-                regions.append(fitz.Rect(pred.x0, pred.y0, pred.x1, pred.y1))
+                regions.append(pymupdf.Rect(pred.x0, pred.y0, pred.x1, pred.y1))
         return regions
 
     def _create_image_node(self, img_info: dict, page_num: int) -> AstParagraph | None:
@@ -3601,14 +3612,14 @@ class PdfToAstConverter(BaseParser):
             logger.debug(f"Failed to create image node: {e}")
             return None
 
-    def _filter_headers_footers(self, blocks: list[dict], page: "fitz.Page") -> list[dict]:
+    def _filter_headers_footers(self, blocks: list[dict], page: "pymupdf.Page") -> list[dict]:
         """Filter out text blocks in header/footer zones.
 
         Parameters
         ----------
         blocks : list of dict
             Text blocks from PyMuPDF
-        page : fitz.Page
+        page : pymupdf.Page
             PDF page
 
         Returns
@@ -4341,7 +4352,7 @@ CONVERTER_METADATA = ConverterMetadata(
     parser_class=PdfToAstConverter,
     renderer_class="all2md.renderers.pdf.PdfRenderer",
     renders_as_string=False,
-    parser_required_packages=[("pymupdf", "fitz", ">=1.26.4")],
+    parser_required_packages=DEPS_PDF,
     renderer_required_packages=[("reportlab", "reportlab", ">=4.0.0")],
     optional_packages=[
         ("pytesseract", "pytesseract"),

--- a/src/all2md/utils/decorators.py
+++ b/src/all2md/utils/decorators.py
@@ -37,8 +37,8 @@ def requires_dependencies(converter_name: str, packages: List[Tuple[str, str, st
         in error messages to help users identify which converter needs dependencies.
     packages : list of tuple
         Required packages as (install_name, import_name, version_spec) tuples where:
-        - install_name: Package name for pip install (e.g., "pymupdf")
-        - import_name: Module name for import statement (e.g., "fitz")
+        - install_name: Package name for pip install (e.g., "Pillow")
+        - import_name: Module name for import statement, which often differs (e.g., "PIL")
         - version_spec: Version requirement (e.g., ">=1.26.4" or "" for any version)
 
     Returns
@@ -60,9 +60,9 @@ def requires_dependencies(converter_name: str, packages: List[Tuple[str, str, st
     --------
     Apply to a parser's parse method:
 
-        >>> @requires_dependencies("pdf", [("pymupdf", "fitz", ">=1.26.4")])
+        >>> @requires_dependencies("pdf", [("pymupdf", "pymupdf", ">=1.26.4")])
         ... def parse(self, input_data):
-        ...     import fitz
+        ...     import pymupdf
         ...     # parsing logic here
 
     Apply to a renderer's render method:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -33,15 +33,15 @@ except ImportError:
 
 def _setup_test_imports():
     """Setup imports needed for testing while maintaining lazy loading in production."""
-    # Make fitz available for PDF tests that need to mock it
+    # Make pymupdf available for PDF tests that need to mock it
     try:
-        import fitz
+        import pymupdf
 
         import all2md.parsers.pdf
 
-        all2md.parsers.pdf.fitz = fitz
+        all2md.parsers.pdf.pymupdf = pymupdf
     except ImportError:
-        # If fitz isn't available, that's ok - tests that need it will skip
+        # If pymupdf isn't available, that's ok - tests that need it will skip
         pass
 
     # Make Hyperlink available for DOCX tests (already handled in the module)

--- a/tests/fixtures/generators/pdf_test_fixtures.py
+++ b/tests/fixtures/generators/pdf_test_fixtures.py
@@ -7,32 +7,32 @@ for testing various aspects of PDF-to-Markdown conversion.
 import tempfile
 from pathlib import Path
 
-import fitz
+import pymupdf
 
 
-def create_pdf_with_figures() -> fitz.Document:
+def create_pdf_with_figures() -> pymupdf.Document:
     """Create a PDF with figure placeholders (shapes) for testing image-like content."""
-    doc = fitz.open()
+    doc = pymupdf.open()
     page = doc.new_page(width=595, height=842)  # A4 size
 
     # Add title
     page.insert_text((50, 50), "Test Document with Figures", fontsize=16, color=(0, 0, 0))
 
     # Create first "figure" using drawn shapes
-    fig1_rect = fitz.Rect(100, 100, 200, 150)
+    fig1_rect = pymupdf.Rect(100, 100, 200, 150)
     page.draw_rect(fig1_rect, color=(0, 0, 1), fill=(0.8, 0.8, 1.0), width=2)
-    page.draw_circle(fitz.Point(150, 125), 15, color=(1, 0, 0), fill=(1, 0.8, 0.8))
+    page.draw_circle(pymupdf.Point(150, 125), 15, color=(1, 0, 0), fill=(1, 0.8, 0.8))
 
     # Add image caption
     page.insert_text((100, 160), "Figure 1: Sample chart showing data trends", fontsize=10)
 
     # Create second "figure"
-    fig2_rect = fitz.Rect(300, 200, 400, 250)
+    fig2_rect = pymupdf.Rect(300, 200, 400, 250)
     page.draw_rect(fig2_rect, color=(0, 1, 0), fill=(0.8, 1.0, 0.8), width=2)
     # Draw a simple bar chart-like shape
-    page.draw_rect(fitz.Rect(310, 230, 320, 240), fill=(0, 0.5, 0))
-    page.draw_rect(fitz.Rect(325, 220, 335, 240), fill=(0, 0.5, 0))
-    page.draw_rect(fitz.Rect(340, 210, 350, 240), fill=(0, 0.5, 0))
+    page.draw_rect(pymupdf.Rect(310, 230, 320, 240), fill=(0, 0.5, 0))
+    page.draw_rect(pymupdf.Rect(325, 220, 335, 240), fill=(0, 0.5, 0))
+    page.draw_rect(pymupdf.Rect(340, 210, 350, 240), fill=(0, 0.5, 0))
 
     # Add second caption
     page.insert_text((300, 260), "Figure 2: Additional visualization", fontsize=10)
@@ -44,9 +44,9 @@ def create_pdf_with_figures() -> fitz.Document:
     return doc
 
 
-def create_pdf_with_tables() -> fitz.Document:
+def create_pdf_with_tables() -> pymupdf.Document:
     """Create a PDF with tables for testing table detection."""
-    doc = fitz.open()
+    doc = pymupdf.open()
     page = doc.new_page(width=595, height=842)
 
     # Add title
@@ -63,7 +63,7 @@ def create_pdf_with_tables() -> fitz.Document:
         x = table1_start[0] + i * cell_width
         y = table1_start[1]
         # Draw cell border
-        rect = fitz.Rect(x, y, x + cell_width, y + cell_height)
+        rect = pymupdf.Rect(x, y, x + cell_width, y + cell_height)
         page.draw_rect(rect, color=(0, 0, 0), width=1)
         # Add text
         page.insert_text((x + 5, y + 15), header, fontsize=10, color=(0, 0, 0))
@@ -76,7 +76,7 @@ def create_pdf_with_tables() -> fitz.Document:
             x = table1_start[0] + col_idx * cell_width
             y = table1_start[1] + (row_idx + 1) * cell_height
             # Draw cell border
-            rect = fitz.Rect(x, y, x + cell_width, y + cell_height)
+            rect = pymupdf.Rect(x, y, x + cell_width, y + cell_height)
             page.draw_rect(rect, color=(0, 0, 0), width=1)
             # Add text
             page.insert_text((x + 5, y + 15), cell, fontsize=10, color=(0, 0, 0))
@@ -93,7 +93,7 @@ def create_pdf_with_tables() -> fitz.Document:
     for i, header in enumerate(headers2):
         x = table2_start[0] + i * cell_width2
         y = table2_start[1]
-        rect = fitz.Rect(x, y, x + cell_width2, y + cell_height)
+        rect = pymupdf.Rect(x, y, x + cell_width2, y + cell_height)
         page.draw_rect(rect, color=(0, 0, 0), width=1)
         page.insert_text((x + 5, y + 15), header, fontsize=10, color=(0, 0, 0))
 
@@ -104,16 +104,16 @@ def create_pdf_with_tables() -> fitz.Document:
         for col_idx, cell in enumerate(row):
             x = table2_start[0] + col_idx * cell_width2
             y = table2_start[1] + (row_idx + 1) * cell_height
-            rect = fitz.Rect(x, y, x + cell_width2, y + cell_height)
+            rect = pymupdf.Rect(x, y, x + cell_width2, y + cell_height)
             page.draw_rect(rect, color=(0, 0, 0), width=1)
             page.insert_text((x + 5, y + 15), cell, fontsize=10, color=(0, 0, 0))
 
     return doc
 
 
-def create_pdf_with_formatting() -> fitz.Document:
+def create_pdf_with_formatting() -> pymupdf.Document:
     """Create a PDF with various text formatting for testing emphasis detection."""
-    doc = fitz.open()
+    doc = pymupdf.open()
     page = doc.new_page(width=595, height=842)
 
     # Normal text
@@ -151,9 +151,9 @@ def create_pdf_with_formatting() -> fitz.Document:
     return doc
 
 
-def create_pdf_with_complex_layout() -> fitz.Document:
+def create_pdf_with_complex_layout() -> pymupdf.Document:
     """Create a PDF with complex layout including figures and text flow."""
-    doc = fitz.open()
+    doc = pymupdf.open()
     page = doc.new_page(width=595, height=842)
 
     # Title
@@ -167,12 +167,12 @@ def create_pdf_with_complex_layout() -> fitz.Document:
     page.insert_text((50, 100), para1, fontsize=12, color=(0, 0, 0))
 
     # Insert figure that text should flow around (using shapes instead of image)
-    fig_rect = fitz.Rect(350, 150, 450, 200)
+    fig_rect = pymupdf.Rect(350, 150, 450, 200)
     page.draw_rect(fig_rect, color=(0.5, 0.5, 0.5), fill=(0.9, 0.9, 0.9), width=1)
     # Draw a simple chart-like visualization
-    page.draw_line(fitz.Point(360, 190), fitz.Point(440, 190), color=(0, 0, 0))  # X-axis
-    page.draw_line(fitz.Point(360, 190), fitz.Point(360, 160), color=(0, 0, 0))  # Y-axis
-    page.draw_line(fitz.Point(370, 185), fitz.Point(430, 165), color=(1, 0, 0), width=2)  # Data line
+    page.draw_line(pymupdf.Point(360, 190), pymupdf.Point(440, 190), color=(0, 0, 0))  # X-axis
+    page.draw_line(pymupdf.Point(360, 190), pymupdf.Point(360, 160), color=(0, 0, 0))  # Y-axis
+    page.draw_line(pymupdf.Point(370, 185), pymupdf.Point(430, 165), color=(1, 0, 0), width=2)  # Data line
 
     page.insert_text((350, 210), "Figure: Sample chart", fontsize=10, color=(0, 0, 0))
 
@@ -190,7 +190,7 @@ def create_pdf_with_complex_layout() -> fitz.Document:
 
     for i, header in enumerate(headers):
         x, y = table_start[0] + i * cell_w, table_start[1]
-        rect = fitz.Rect(x, y, x + cell_w, y + cell_h)
+        rect = pymupdf.Rect(x, y, x + cell_w, y + cell_h)
         page.draw_rect(rect, color=(0, 0, 0), width=1)
         page.insert_text((x + 5, y + 12), header, fontsize=10)
 
@@ -199,7 +199,7 @@ def create_pdf_with_complex_layout() -> fitz.Document:
         for col_i, cell in enumerate(row):
             x = table_start[0] + col_i * cell_w
             y = table_start[1] + (row_i + 1) * cell_h
-            rect = fitz.Rect(x, y, x + cell_w, y + cell_h)
+            rect = pymupdf.Rect(x, y, x + cell_w, y + cell_h)
             page.draw_rect(rect, color=(0, 0, 0), width=1)
             page.insert_text((x + 5, y + 12), cell, fontsize=10)
 

--- a/tests/integration/formats/pdf/test_pdf_layout_advanced.py
+++ b/tests/integration/formats/pdf/test_pdf_layout_advanced.py
@@ -100,7 +100,7 @@ class TestPdfLayoutAdvanced:
         assert len(columns) == 1
         assert len(columns[0]) == len(blocks)
 
-    @patch("all2md.parsers.pdf.fitz.open")
+    @patch("all2md.parsers.pdf.pymupdf.open")
     def test_rotated_text_handling(self, mock_fitz_open):
         """Test handling of rotated text blocks."""
         # Mock PDF with rotated text
@@ -216,7 +216,7 @@ class TestPdfLayoutAdvanced:
         columns_large = detect_columns(blocks, column_gap_threshold=50)
         assert len(columns_large) <= 3
 
-    @patch("all2md.parsers.pdf.fitz.open")
+    @patch("all2md.parsers.pdf.pymupdf.open")
     def test_header_detection_with_rotation(self, mock_fitz_open):
         """Test header detection considering rotated text."""
         mock_doc = Mock()
@@ -301,7 +301,7 @@ class TestPdfLayoutAdvanced:
         """Test column detection on complex.pdf with spanning header."""
         from pathlib import Path
 
-        import fitz
+        import pymupdf
 
         # Use the actual complex.pdf fixture
         pdf_path = Path("tests/fixtures/documents/complex.pdf")
@@ -310,9 +310,9 @@ class TestPdfLayoutAdvanced:
             return
 
         # Test that column detection works
-        doc = fitz.open(str(pdf_path))
+        doc = pymupdf.open(str(pdf_path))
         page = doc[0]
-        blocks = page.get_text("dict", flags=fitz.TEXTFLAGS_TEXT)["blocks"]
+        blocks = page.get_text("dict", flags=pymupdf.TEXTFLAGS_TEXT)["blocks"]
 
         columns = detect_columns(blocks, column_gap_threshold=20)
 

--- a/tests/integration/metadata/test_metadata_conversion.py
+++ b/tests/integration/metadata/test_metadata_conversion.py
@@ -13,7 +13,7 @@ from all2md.options import MarkdownRendererOptions
 # Check for optional dependencies
 ODFPY_AVAILABLE = importlib.util.find_spec("odf") is not None
 PYTH_AVAILABLE = importlib.util.find_spec("pyth") is not None
-PYMUPDF_AVAILABLE = importlib.util.find_spec("fitz") is not None
+PYMUPDF_AVAILABLE = importlib.util.find_spec("pymupdf") is not None
 DOCX_AVAILABLE = importlib.util.find_spec("docx") is not None
 OPENPYXL_AVAILABLE = importlib.util.find_spec("openpyxl") is not None
 
@@ -323,13 +323,13 @@ Content-Type: text/html; charset=utf-8
     @pytest.mark.skipif(not PYMUPDF_AVAILABLE, reason="PyMuPDF not installed")
     def test_pdf_metadata_extraction_integration(self):
         """Test PDF metadata extraction."""
-        import fitz
+        import pymupdf
 
         from all2md import PdfOptions
 
         # Create a PDF with metadata using PyMuPDF
         pdf_file = self.temp_dir / "test.pdf"
-        doc = fitz.open()
+        doc = pymupdf.open()
         page = doc.new_page(width=595, height=842)
 
         # Add content

--- a/tests/integration/test_confidence_report.py
+++ b/tests/integration/test_confidence_report.py
@@ -26,8 +26,8 @@ COMPLEX_DOCX = FIXTURES / "complex.docx"
 @pytest.fixture
 def blank_pdf(tmp_path) -> Path:
     """A single blank page — the near-empty / scanned-PDF shape (no text layer)."""
-    fitz = pytest.importorskip("fitz")
-    doc = fitz.open()
+    pymupdf = pytest.importorskip("pymupdf")
+    doc = pymupdf.open()
     doc.new_page()
     path = tmp_path / "blank.pdf"
     doc.save(str(path))

--- a/tests/integration/test_optimize.py
+++ b/tests/integration/test_optimize.py
@@ -15,7 +15,7 @@ Measured here it was anti-correlated with the truth (Pearson r = -0.88): it reli
 recommended the worst settings available.
 """
 
-import fitz
+import pymupdf
 import pytest
 
 from all2md import optimizable_formats, optimize_options, to_markdown
@@ -59,7 +59,7 @@ def gnarly_pdf(tmp_path_factory) -> str:
     We place every element, so the correct parse is known: the header and footer are
     furniture and should be trimmed; both columns and every table cell must survive.
     """
-    doc = fitz.open()
+    doc = pymupdf.open()
     for page_no in range(2):
         left_tag = "Alpha" if page_no == 0 else "Gamma"
         right_tag = "Beta" if page_no == 0 else "Delta"
@@ -72,8 +72,8 @@ def gnarly_pdf(tmp_path_factory) -> str:
 
         col_left = " ".join(f"{left_tag} sentence A{i}: {t}." for i, t in enumerate(BODIES[left_tag], 1))
         col_right = " ".join(f"{right_tag} sentence B{i}: {t}." for i, t in enumerate(BODIES[right_tag], 1))
-        page.insert_textbox(fitz.Rect(72, 100, 280, 290), col_left, fontsize=9)
-        page.insert_textbox(fitz.Rect(320, 100, 540, 290), col_right, fontsize=9)
+        page.insert_textbox(pymupdf.Rect(72, 100, 280, 290), col_left, fontsize=9)
+        page.insert_textbox(pymupdf.Rect(320, 100, 540, 290), col_right, fontsize=9)
 
         # A ruled 4x3 table with known cell text.
         top, left, row_h, col_w = 320, 72, 20, 150

--- a/tests/integration/test_page_selection.py
+++ b/tests/integration/test_page_selection.py
@@ -11,7 +11,7 @@ contains the marker of the requested page or it does not. Every way of expressin
 selection -- string range, list, and the CLI flag -- is checked against the same document.
 """
 
-import fitz
+import pymupdf
 import pytest
 
 from all2md import to_markdown
@@ -26,7 +26,7 @@ MARKERS = ["Alpha", "Beta", "Gamma", "Delta", "Epsilon"]
 @pytest.fixture(scope="module")
 def marked_pdf(tmp_path_factory) -> str:
     """A five-page PDF whose page N contains the marker word MARKERS[N-1] and nothing else."""
-    doc = fitz.open()
+    doc = pymupdf.open()
     for marker in MARKERS:
         page = doc.new_page()
         page.insert_text((72, 100), marker, fontsize=14)

--- a/tests/unit/cli/test_cli_enhancements.py
+++ b/tests/unit/cli/test_cli_enhancements.py
@@ -146,7 +146,7 @@ class TestListFormatsCommand:
         )
         mock_metadata.priority = 100
         # required_packages is a list of (install_name, import_name, version_spec) tuples
-        mock_metadata.required_packages = [("pymupdf", "fitz", ">=1.24.0")]
+        mock_metadata.required_packages = [("pymupdf", "pymupdf", ">=1.24.0")]
 
         mock_registry.get_format_info = Mock(return_value=[mock_metadata])
 

--- a/tests/unit/formats/pdf/test_pdf2markdown.py
+++ b/tests/unit/formats/pdf/test_pdf2markdown.py
@@ -8,7 +8,7 @@ various PDF-specific features.
 
 import tempfile
 
-import fitz
+import pymupdf
 import pytest
 
 import all2md.parsers.pdf as pdf_parser
@@ -63,7 +63,7 @@ def test_identify_headers_mapping():
 @pytest.mark.unit
 def test_resolve_links_no_overlap():
     span = {"bbox": (0, 0, 10, 10), "text": "X"}
-    link = {"from": fitz.Rect(50, 50, 60, 60), "uri": "u"}  # Link is completely outside span
+    link = {"from": pymupdf.Rect(50, 50, 60, 60), "uri": "u"}  # Link is completely outside span
     assert resolve_links([link], span) is None
 
 
@@ -71,7 +71,7 @@ def test_resolve_links_no_overlap():
 def test_resolve_links_partial_overlap():
     """Test link resolution with partial overlap."""
     span = {"bbox": (0, 0, 100, 10), "text": "Click here for more info"}
-    link = {"from": fitz.Rect(0, 0, 50, 10), "uri": "http://example.com"}
+    link = {"from": pymupdf.Rect(0, 0, 50, 10), "uri": "http://example.com"}
     # Link covers 50% of span, use 50% threshold so it's detected
     result = resolve_links([link], span, overlap_threshold=50.0)
     assert result is not None
@@ -83,8 +83,8 @@ def test_resolve_links_multiple_links():
     """Test handling of multiple links in one span."""
     span = {"bbox": (0, 0, 200, 10), "text": "Link1 and Link2 here"}
     links = [
-        {"from": fitz.Rect(0, 0, 50, 10), "uri": "http://link1.com"},
-        {"from": fitz.Rect(100, 0, 150, 10), "uri": "http://link2.com"},
+        {"from": pymupdf.Rect(0, 0, 50, 10), "uri": "http://link1.com"},
+        {"from": pymupdf.Rect(100, 0, 150, 10), "uri": "http://link2.com"},
     ]
     # Each link covers 25% of span, use 20% threshold so both are detected
     result = resolve_links(links, span, overlap_threshold=20.0)
@@ -176,7 +176,7 @@ def test_detect_tables_by_ruling_lines_empty():
     # This would need a mock page with drawing commands
     # For now, test that the function exists and handles empty input
     class MockPage:
-        rect = fitz.Rect(0, 0, 600, 800)
+        rect = pymupdf.Rect(0, 0, 600, 800)
 
         def get_drawings(self):
             return []
@@ -212,7 +212,7 @@ def test_image_extraction_options():
 @pytest.mark.unit
 def test_resolve_links_overlap():
     span = {"bbox": (0, 0, 10, 10), "text": " click "}
-    link = {"from": fitz.Rect(0, 0, 10, 10), "uri": "http://test"}
+    link = {"from": pymupdf.Rect(0, 0, 10, 10), "uri": "http://test"}
     res = resolve_links([link], span)
     assert res == "[click](http://test)"
 
@@ -227,7 +227,7 @@ def test_link_overlap_threshold_high():
     """Test link resolution with high overlap threshold (90%)."""
     span = {"bbox": (0, 0, 100, 10), "text": "Click here for info"}
     # Link only covers first 40% of span
-    link = {"from": fitz.Rect(0, 0, 40, 10), "uri": "http://example.com"}
+    link = {"from": pymupdf.Rect(0, 0, 40, 10), "uri": "http://example.com"}
 
     # With 90% threshold, should NOT detect link
     result = resolve_links([link], span, overlap_threshold=90.0)
@@ -263,9 +263,9 @@ def test_link_overlap_multiple_links_threshold():
     span = {"bbox": (0, 0, 200, 10), "text": "Link1 and Link2 and more text"}
     links = [
         # First link covers chars 0-50 (25% of span)
-        {"from": fitz.Rect(0, 0, 50, 10), "uri": "http://link1.com"},
+        {"from": pymupdf.Rect(0, 0, 50, 10), "uri": "http://link1.com"},
         # Second link covers chars 100-150 (25% of span)
-        {"from": fitz.Rect(100, 0, 150, 10), "uri": "http://link2.com"},
+        {"from": pymupdf.Rect(100, 0, 150, 10), "uri": "http://link2.com"},
     ]
 
     # With 50% threshold, neither link should be detected (each is only 25%)
@@ -364,23 +364,23 @@ def test_detect_tables_by_ruling_lines():
 
     # Create a mock page with drawing commands
     class MockPage:
-        rect = fitz.Rect(0, 0, 600, 800)
+        rect = pymupdf.Rect(0, 0, 600, 800)
 
         def get_drawings(self):
             # Simulate a simple 2x2 table with horizontal and vertical lines
             return [
                 {
                     "items": [
-                        ("l", fitz.Point(100, 100), fitz.Point(400, 100)),  # Top h-line
-                        ("l", fitz.Point(100, 150), fitz.Point(400, 150)),  # Middle h-line
-                        ("l", fitz.Point(100, 200), fitz.Point(400, 200)),  # Bottom h-line
+                        ("l", pymupdf.Point(100, 100), pymupdf.Point(400, 100)),  # Top h-line
+                        ("l", pymupdf.Point(100, 150), pymupdf.Point(400, 150)),  # Middle h-line
+                        ("l", pymupdf.Point(100, 200), pymupdf.Point(400, 200)),  # Bottom h-line
                     ]
                 },
                 {
                     "items": [
-                        ("l", fitz.Point(100, 100), fitz.Point(100, 200)),  # Left v-line
-                        ("l", fitz.Point(250, 100), fitz.Point(250, 200)),  # Middle v-line
-                        ("l", fitz.Point(400, 100), fitz.Point(400, 200)),  # Right v-line
+                        ("l", pymupdf.Point(100, 100), pymupdf.Point(100, 200)),  # Left v-line
+                        ("l", pymupdf.Point(250, 100), pymupdf.Point(250, 200)),  # Middle v-line
+                        ("l", pymupdf.Point(400, 100), pymupdf.Point(400, 200)),  # Right v-line
                     ]
                 },
             ]

--- a/tests/unit/formats/pdf/test_pdf_dehyphenation.py
+++ b/tests/unit/formats/pdf/test_pdf_dehyphenation.py
@@ -10,7 +10,7 @@ as a pure function or drove the OCR path; none ran a real text PDF through the
 parser and asserted the word came back joined. These do.
 """
 
-import fitz
+import pymupdf
 import pytest
 
 from all2md import to_markdown
@@ -26,9 +26,9 @@ def _pdf_with_lines(tmp_path, text: str, name: str = "h.pdf") -> str:
     each line in its own block, where no dehyphenator (ours or PyMuPDF's) can join
     them; that is a property of the fixture, not of the parser.
     """
-    doc = fitz.open()
+    doc = pymupdf.open()
     page = doc.new_page()
-    page.insert_textbox(fitz.Rect(50, 50, 400, 300), text, fontsize=10)
+    page.insert_textbox(pymupdf.Rect(50, 50, 400, 300), text, fontsize=10)
     path = tmp_path / name
     doc.save(str(path))
     doc.close()

--- a/tests/unit/formats/pdf/test_pdf_formatting.py
+++ b/tests/unit/formats/pdf/test_pdf_formatting.py
@@ -72,7 +72,7 @@ class TestPdfFormatting:
         assert bold_italic_span["flags"] & 16  # Bold flag set
         assert bold_italic_span["flags"] & 2  # Italic flag set
 
-    @patch("all2md.parsers.pdf.fitz.open")
+    @patch("all2md.parsers.pdf.pymupdf.open")
     def test_emphasis_mapping_to_markdown(self, mock_fitz_open):
         """Test mapping of PDF font flags to Markdown emphasis."""
         mock_doc = Mock()
@@ -263,7 +263,7 @@ class TestPdfFormatting:
         # The proportional_span is defined for documentation purposes
         assert "Courier" in monospace_span.get("font", "")
 
-    @patch("all2md.parsers.pdf.fitz.open")
+    @patch("all2md.parsers.pdf.pymupdf.open")
     def test_mixed_formatting_in_paragraph(self, mock_fitz_open):
         """Test paragraphs with mixed formatting within same line."""
         mock_doc = Mock()

--- a/tests/unit/formats/pdf/test_pdf_formatting_detection.py
+++ b/tests/unit/formats/pdf/test_pdf_formatting_detection.py
@@ -4,7 +4,7 @@ These tests focus on the core formatting detection algorithms without mocking,
 using real PDF fixtures to test font flag interpretation and emphasis mapping.
 """
 
-import fitz
+import pymupdf
 import pytest
 from fixtures.generators.pdf_test_fixtures import create_pdf_with_figures
 
@@ -279,13 +279,13 @@ class TestPdfTextAssembly:
         assert normalize_whitespace("normal text") == "normal text"
 
 
-def _make_pdf(spans: list[tuple[str, float, bool]]) -> fitz.Document:
+def _make_pdf(spans: list[tuple[str, float, bool]]) -> pymupdf.Document:
     """Build a single-page PDF where each (text, size, bold) spans onto its own line.
 
     Used by the regression tests below to construct documents with
     precisely-controlled font distributions.
     """
-    doc = fitz.open()
+    doc = pymupdf.open()
     page = doc.new_page(width=612, height=792)
     y = 60.0
     for text, size, bold in spans:

--- a/tests/unit/formats/pdf/test_pdf_header_footer_trim.py
+++ b/tests/unit/formats/pdf/test_pdf_header_footer_trim.py
@@ -19,7 +19,7 @@ layout model **off**, which is what a stock install and CI actually have.
 
 from __future__ import annotations
 
-import fitz
+import pymupdf
 import pytest
 
 from all2md import to_markdown
@@ -33,7 +33,7 @@ class _StubPage:
     """Just enough page for the zone filter: it only reads ``rect.height``."""
 
     def __init__(self, height: float) -> None:
-        self.rect = fitz.Rect(0, 0, 612, height)
+        self.rect = pymupdf.Rect(0, 0, 612, height)
 
 
 HEADER = "ACME CONFIDENTIAL -- INTERNAL USE ONLY"
@@ -58,14 +58,14 @@ def _no_layout_model(monkeypatch):
 
 
 def _make_pdf(tmp_path, n_pages: int, *, footer: str = "Page {n} of {total}") -> str:
-    doc = fitz.open()
+    doc = pymupdf.open()
     for i in range(n_pages):
         page = doc.new_page(width=612, height=792)
         page.insert_text((72, 40), HEADER, fontsize=8)
         page.insert_text((72, 760), footer.format(n=i + 1, total=n_pages), fontsize=8)
         # Body sits clear of the header zone (the top 20% of the page).
         page.insert_textbox(
-            fitz.Rect(72, 220, 540, 520), f"Section {i + 1} opens here. {BODIES[i % len(BODIES)]}", fontsize=11
+            pymupdf.Rect(72, 220, 540, 520), f"Section {i + 1} opens here. {BODIES[i % len(BODIES)]}", fontsize=11
         )
     path = tmp_path / f"doc{n_pages}.pdf"
     doc.save(str(path))
@@ -163,12 +163,12 @@ class TestNonFurnitureIsSafe:
         position check these headings key alike, repeat often enough, and get trimmed --
         taking every line above them with them.
         """
-        doc = fitz.open()
+        doc = pymupdf.open()
         for i in range(4):
             page = doc.new_page(width=612, height=792)
             # Same text shape, but it drifts down the page: not anchored, not furniture.
             page.insert_text((72, 60 + i * 12), f"Section {i + 1}", fontsize=14)
-            page.insert_textbox(fitz.Rect(72, 200, 540, 400), f"Body of section {i + 1}.", fontsize=11)
+            page.insert_textbox(pymupdf.Rect(72, 200, 540, 400), f"Body of section {i + 1}.", fontsize=11)
         path = tmp_path / "sections.pdf"
         doc.save(str(path))
         doc.close()

--- a/tests/unit/formats/pdf/test_pdf_layout_line_labels.py
+++ b/tests/unit/formats/pdf/test_pdf_layout_line_labels.py
@@ -125,12 +125,12 @@ class TestPageEmitsAHeadingInsideAColumn:
 
     @staticmethod
     def _column_page(tmp_path):
-        import fitz
+        import pymupdf
 
-        doc = fitz.open()
+        doc = pymupdf.open()
         page = doc.new_page(width=300, height=500)
-        writer = fitz.TextWriter(page.rect)
-        font = fitz.Font("helv")
+        writer = pymupdf.TextWriter(page.rect)
+        font = pymupdf.Font("helv")
         # A uniform cadence and one font size throughout, so the font heuristic has nothing
         # to go on and only the layout label can promote the heading. A larger heading font
         # would let the existing heuristic pass the test without the fix.
@@ -144,7 +144,7 @@ class TestPageEmitsAHeadingInsideAColumn:
         return str(path)
 
     def test_the_heading_line_becomes_a_heading(self, tmp_path, monkeypatch):
-        import fitz
+        import pymupdf
 
         from all2md.ast.nodes import Heading
         from all2md.ast.transforms import NodeCollector
@@ -154,7 +154,7 @@ class TestPageEmitsAHeadingInsideAColumn:
         from all2md.parsers.pdf import PdfToAstConverter
 
         path = self._column_page(tmp_path)
-        doc = fitz.open(path)
+        doc = pymupdf.open(path)
         page = doc[0]
 
         blocks = [b for b in page.get_text("dict")["blocks"] if b.get("type") == 0]

--- a/tests/unit/formats/pdf/test_pdf_layout_region_tables.py
+++ b/tests/unit/formats/pdf/test_pdf_layout_region_tables.py
@@ -78,9 +78,9 @@ def converter() -> PdfToAstConverter:
 
 
 def _rect(*values: float):
-    import fitz
+    import pymupdf
 
-    return fitz.Rect(*values)
+    return pymupdf.Rect(*values)
 
 
 # A booktabs table: real columns, whole words in every cell.

--- a/tests/unit/formats/pdf/test_pdf_line_join_spacing.py
+++ b/tests/unit/formats/pdf/test_pdf_line_join_spacing.py
@@ -17,7 +17,7 @@ threshold that a long paragraph would have absorbed.
 
 import re
 
-import fitz
+import pymupdf
 import pytest
 
 from all2md import to_markdown
@@ -98,10 +98,10 @@ class TestBoldRunAcrossLineBreak:
         single paragraph and therefore makes the inter-line join happen at all.
         """
         size = 8.0
-        doc = fitz.open()
+        doc = pymupdf.open()
         page = doc.new_page()
-        writer = fitz.TextWriter(page.rect)
-        fonts = {False: fitz.Font("helv"), True: fitz.Font("hebo")}
+        writer = pymupdf.TextWriter(page.rect)
+        fonts = {False: pymupdf.Font("helv"), True: pymupdf.Font("hebo")}
 
         x = 60.0
         for text, is_bold in first_line:

--- a/tests/unit/formats/pdf/test_pdf_partial_table_region.py
+++ b/tests/unit/formats/pdf/test_pdf_partial_table_region.py
@@ -58,7 +58,7 @@ class TestBlockOutsideTableRegions:
     """The unit that decides what survives a partially-covering region."""
 
     def test_keeps_the_lines_above_a_region_covering_the_lower_half(self):
-        import fitz
+        import pymupdf
 
         block = _block(
             _line(90, 100, "reference nineteen"),
@@ -66,7 +66,7 @@ class TestBlockOutsideTableRegions:
             _line(400, 410, "cell one"),
             _line(410, 420, "cell two"),
         )
-        region = fitz.Rect(50, 380, 300, 430)
+        region = pymupdf.Rect(50, 380, 300, 430)
 
         remainder = _block_outside_table_regions(block, [region])
 
@@ -74,11 +74,11 @@ class TestBlockOutsideTableRegions:
         assert _text_of(remainder) == "reference nineteen reference twenty"
 
     def test_tightens_the_bbox_to_what_survives(self):
-        import fitz
+        import pymupdf
 
         block = _block(_line(90, 100, "kept"), _line(400, 410, "covered"))
 
-        remainder = _block_outside_table_regions(block, [fitz.Rect(50, 380, 300, 430)])
+        remainder = _block_outside_table_regions(block, [pymupdf.Rect(50, 380, 300, 430)])
 
         assert remainder is not None
         # A stale bbox would still claim the region's rows, and reading order is decided by
@@ -87,44 +87,44 @@ class TestBlockOutsideTableRegions:
         assert remainder["bbox"][3] == 100
 
     def test_returns_none_when_the_region_covers_every_line(self):
-        import fitz
+        import pymupdf
 
         block = _block(_line(400, 410, "cell one"), _line(410, 420, "cell two"))
 
-        assert _block_outside_table_regions(block, [fitz.Rect(50, 380, 300, 430)]) is None
+        assert _block_outside_table_regions(block, [pymupdf.Rect(50, 380, 300, 430)]) is None
 
     def test_does_not_mutate_the_original_block(self):
-        import fitz
+        import pymupdf
 
         block = _block(_line(90, 100, "kept"), _line(400, 410, "covered"))
 
-        _block_outside_table_regions(block, [fitz.Rect(50, 380, 300, 430)])
+        _block_outside_table_regions(block, [pymupdf.Rect(50, 380, 300, 430)])
 
         assert len(block["lines"]) == 2
         assert block["bbox"][3] == 410
 
     def test_a_line_straddling_the_boundary_is_assigned_not_duplicated(self):
-        import fitz
+        import pymupdf
 
         # Mostly below the region edge, so it belongs to the region and must not also appear
         # in the remainder; the alternative is the same words emitted twice.
         block = _block(_line(90, 100, "prose"), _line(374, 390, "straddler"))
 
-        remainder = _block_outside_table_regions(block, [fitz.Rect(50, 380, 300, 430)])
+        remainder = _block_outside_table_regions(block, [pymupdf.Rect(50, 380, 300, 430)])
 
         assert _text_of(remainder) == "prose"
 
     def test_a_line_mostly_outside_the_region_survives(self):
-        import fitz
+        import pymupdf
 
         block = _block(_line(90, 100, "prose"), _line(370, 386, "straddler"))
 
-        remainder = _block_outside_table_regions(block, [fitz.Rect(50, 380, 300, 430)])
+        remainder = _block_outside_table_regions(block, [pymupdf.Rect(50, 380, 300, 430)])
 
         assert _text_of(remainder) == "prose straddler"
 
     def test_several_regions_are_all_honoured(self):
-        import fitz
+        import pymupdf
 
         block = _block(
             _line(90, 100, "top prose"),
@@ -132,37 +132,37 @@ class TestBlockOutsideTableRegions:
             _line(300, 310, "middle prose"),
             _line(500, 510, "second table"),
         )
-        regions = [fitz.Rect(50, 195, 300, 215), fitz.Rect(50, 495, 300, 515)]
+        regions = [pymupdf.Rect(50, 195, 300, 215), pymupdf.Rect(50, 495, 300, 515)]
 
         remainder = _block_outside_table_regions(block, regions)
 
         assert _text_of(remainder) == "top prose middle prose"
 
     def test_whitespace_only_survivors_are_not_rescued(self):
-        import fitz
+        import pymupdf
 
         # The lines bordering a table region are routinely blank or a single space. Rescuing
         # those turns a dropped block into an empty paragraph, which shows up as a stray gap
         # in the output -- caught by the PDF golden snapshot, which only runs on Linux.
         block = _block(_line(90, 100, " "), _line(400, 410, "cell one"))
 
-        assert _block_outside_table_regions(block, [fitz.Rect(50, 380, 300, 430)]) is None
+        assert _block_outside_table_regions(block, [pymupdf.Rect(50, 380, 300, 430)]) is None
 
     def test_real_text_beside_whitespace_still_survives(self):
-        import fitz
+        import pymupdf
 
         block = _block(_line(90, 100, " "), _line(100, 110, "prose"), _line(400, 410, "cell"))
 
-        remainder = _block_outside_table_regions(block, [fitz.Rect(50, 380, 300, 430)])
+        remainder = _block_outside_table_regions(block, [pymupdf.Rect(50, 380, 300, 430)])
 
         assert _text_of(remainder) == "  prose"
 
     def test_a_block_without_lines_yields_nothing(self):
-        import fitz
+        import pymupdf
 
         # Image blocks carry no lines; there is no prose to rescue and the caller's existing
         # decision to drop them stands.
-        assert _block_outside_table_regions({"bbox": (0, 0, 10, 10), "type": 1}, [fitz.Rect(0, 0, 10, 10)]) is None
+        assert _block_outside_table_regions({"bbox": (0, 0, 10, 10), "type": 1}, [pymupdf.Rect(0, 0, 10, 10)]) is None
 
 
 class TestPageKeepsProseAboveAPartialRegion:
@@ -181,12 +181,12 @@ class TestPageKeepsProseAboveAPartialRegion:
         which is the precondition for the bug -- a region over the bottom rows then clears
         the majority-area bar for the whole column.
         """
-        import fitz
+        import pymupdf
 
-        doc = fitz.open()
+        doc = pymupdf.open()
         page = doc.new_page(width=300, height=500)
-        writer = fitz.TextWriter(page.rect)
-        font = fitz.Font("helv")
+        writer = pymupdf.TextWriter(page.rect)
+        font = pymupdf.Font("helv")
         # One uninterrupted 10pt cadence across both halves. A wider gap at the join makes
         # PyMuPDF start a second block, and two blocks cannot reproduce this at all.
         for idx in range(10):
@@ -200,13 +200,13 @@ class TestPageKeepsProseAboveAPartialRegion:
         return str(path)
 
     def test_prose_above_the_region_survives(self, tmp_path, monkeypatch):
-        import fitz
+        import pymupdf
 
         from all2md.options.pdf import PdfOptions
         from all2md.parsers.pdf import PdfToAstConverter
 
         path = self._column_page(tmp_path, "column.pdf")
-        doc = fitz.open(path)
+        doc = pymupdf.open(path)
         page = doc[0]
 
         block = next(b for b in page.get_text("dict")["blocks"] if b.get("type") == 0)
@@ -215,8 +215,8 @@ class TestPageKeepsProseAboveAPartialRegion:
         # loosened.
         assert block["bbox"][1] < 100 and block["bbox"][3] > 300
 
-        region = fitz.Rect(40, 155, 290, 360)
-        assert abs(region & fitz.Rect(block["bbox"])) > 0.5 * abs(fitz.Rect(block["bbox"]))
+        region = pymupdf.Rect(40, 155, 290, 360)
+        assert abs(region & pymupdf.Rect(block["bbox"])) > 0.5 * abs(pymupdf.Rect(block["bbox"]))
 
         converter = PdfToAstConverter(options=PdfOptions())
         monkeypatch.setattr(

--- a/tests/unit/formats/pdf/test_pdf_reading_order_rows.py
+++ b/tests/unit/formats/pdf/test_pdf_reading_order_rows.py
@@ -9,7 +9,7 @@ Note those values are *not* equal, which is why the obvious ``(y, x)`` sort key
 does not fix it: the blocks have to be treated as level first.
 """
 
-import fitz
+import pymupdf
 import pytest
 
 from all2md import to_markdown
@@ -118,7 +118,7 @@ class TestEndToEnd:
         the columns wide enough for the gap here to be similarly narrow.
         """
         padding = "filler text to widen the column " * 4
-        doc = fitz.open()
+        doc = pymupdf.open()
         page = doc.new_page()
         # Right column drawn first and started a hair higher, reproducing the
         # shape of the reported page.

--- a/tests/unit/formats/pdf/test_pdf_rejected_region_text.py
+++ b/tests/unit/formats/pdf/test_pdf_rejected_region_text.py
@@ -25,7 +25,7 @@ from all2md.parsers.pdf import PdfToAstConverter
 
 pytestmark = [pytest.mark.unit, pytest.mark.pdf]
 
-fitz = pytest.importorskip("fitz")
+pymupdf = pytest.importorskip("pymupdf")
 
 
 TOP = 100
@@ -33,7 +33,7 @@ TOP = 100
 
 def _pdf_bytes(*lines: str) -> bytes:
     """A one-page PDF holding ``lines``, one under the other."""
-    doc = fitz.open()
+    doc = pymupdf.open()
     page = doc.new_page()
     for offset, line in enumerate(lines):
         page.insert_text((72, TOP + offset * 14), line, fontsize=11)
@@ -42,8 +42,8 @@ def _pdf_bytes(*lines: str) -> bytes:
 
 def _page_with_lines(*lines: str):
     """The same page, re-opened from bytes, plus a rect covering every line on it."""
-    page = fitz.open(stream=_pdf_bytes(*lines), filetype="pdf")[0]
-    region = fitz.Rect(60, TOP - 14, 400, TOP + len(lines) * 14 + 4)
+    page = pymupdf.open(stream=_pdf_bytes(*lines), filetype="pdf")[0]
+    region = pymupdf.Rect(60, TOP - 14, 400, TOP + len(lines) * 14 + 4)
     return page, region
 
 
@@ -124,7 +124,7 @@ class TestTheRestOfTheFallbackIsUnchanged:
 
     def test_a_region_with_no_text_still_yields_nothing(self):
         page, region = _page_with_lines("text well below the region")
-        empty = fitz.Rect(0, 0, 20, 20)
+        empty = pymupdf.Rect(0, 0, 20, 20)
 
         converter = PdfToAstConverter(options=PdfOptions())
 

--- a/tests/unit/formats/pdf/test_pdf_stdout_advisory.py
+++ b/tests/unit/formats/pdf/test_pdf_stdout_advisory.py
@@ -16,7 +16,7 @@ exotic one.
 
 import importlib.util
 
-import fitz
+import pymupdf
 import pytest
 
 from all2md import to_markdown
@@ -32,13 +32,13 @@ def _one_page_pdf(tmp_path) -> str:
     so a prose-only page never reaches the call that emits the advisory. Drawing
     a grid is what arms it.
     """
-    doc = fitz.open()
+    doc = pymupdf.open()
     page = doc.new_page()
     page.insert_text((72, 72), "Peregrine falcons nest nearby.")
     for offset in (0, 20, 40):
-        page.draw_line(fitz.Point(72, 120 + offset), fitz.Point(300, 120 + offset))
+        page.draw_line(pymupdf.Point(72, 120 + offset), pymupdf.Point(300, 120 + offset))
     for offset in (0, 114, 228):
-        page.draw_line(fitz.Point(72 + offset, 120), fitz.Point(72 + offset, 160))
+        page.draw_line(pymupdf.Point(72 + offset, 120), pymupdf.Point(72 + offset, 160))
     path = tmp_path / "advisory.pdf"
     doc.save(str(path))
     doc.close()
@@ -97,5 +97,5 @@ class TestSuppressionIsNotLoadBearing:
     """A PyMuPDF without the entry point must convert, not crash."""
 
     def test_missing_entry_point_is_tolerated(self, tmp_path, monkeypatch):
-        monkeypatch.delattr(fitz, "no_recommend_layout", raising=False)
+        monkeypatch.delattr(pymupdf, "no_recommend_layout", raising=False)
         assert "Peregrine" in to_markdown(_one_page_pdf(tmp_path))

--- a/tests/unit/formats/pdf/test_pdf_wrapped_headings.py
+++ b/tests/unit/formats/pdf/test_pdf_wrapped_headings.py
@@ -176,12 +176,12 @@ class TestWrappedHeadingOnAPage:
 
     @staticmethod
     def _page_with_a_wrapped_title(tmp_path):
-        import fitz
+        import pymupdf
 
-        doc = fitz.open()
+        doc = pymupdf.open()
         page = doc.new_page(width=300, height=400)
-        writer = fitz.TextWriter(page.rect)
-        font = fitz.Font("helv")
+        writer = pymupdf.TextWriter(page.rect)
+        font = pymupdf.Font("helv")
         # A two-line title at a size the font heuristic promotes, over body text that it
         # does not.
         writer.append((40, 60), "Long-term outcomes of an", font=font, fontsize=20)
@@ -195,13 +195,13 @@ class TestWrappedHeadingOnAPage:
         return str(path)
 
     def test_the_title_is_one_heading(self, tmp_path):
-        import fitz
+        import pymupdf
 
         from all2md.ast.transforms import NodeCollector
         from all2md.parsers._pdf_headers import IdentifyHeaders
 
         path = self._page_with_a_wrapped_title(tmp_path)
-        doc = fitz.open(path)
+        doc = pymupdf.open(path)
         page = doc[0]
 
         options = PdfOptions()

--- a/tests/unit/formats/pdf/test_pymupdf_import_name.py
+++ b/tests/unit/formats/pdf/test_pymupdf_import_name.py
@@ -1,0 +1,96 @@
+#  Copyright (c) 2025 Tom Villani, Ph.D.
+"""We import PyMuPDF under its canonical name, and say so when it is too old.
+
+`fitz` is PyMuPDF's legacy top-level alias. Some releases emit a DeprecationWarning
+on `import fitz`, which surfaces to anyone running the CLI as noise they cannot act
+on - all2md's dependency, not theirs. `pymupdf` has been the real module name since
+1.24.3 and we require 1.27.2, so there is nothing to weigh up; these tests keep the
+old name from creeping back.
+
+The version guard is here too because it was unreachable in practice: it built its
+own error message by joining a tuple of ints, so the one code path that exists to
+tell a user "upgrade PyMuPDF" raised TypeError instead.
+"""
+
+from __future__ import annotations
+
+import re
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from all2md.constants import DEPS_PDF, PDF_MIN_PYMUPDF_VERSION
+from all2md.exceptions import DependencyError
+
+pytestmark = [pytest.mark.unit, pytest.mark.pdf]
+
+_FITZ = re.compile(r"\bfitz\b")
+
+# `_pdf_layout.py` neutralizes the layout hook on both module objects on purpose,
+# because the alias can be a distinct module object in some installs. Those are
+# the only mentions that are *about* the alias rather than uses of it.
+_ALIAS_IS_THE_POINT = {"src/all2md/parsers/_pdf_layout.py": 2}
+
+
+def _tracked_python_sources() -> list[Path]:
+    listing = subprocess.run(
+        ["git", "ls-files", "src/*.py"],
+        capture_output=True,
+        text=True,
+        check=True,
+        cwd=Path(__file__).resolve().parents[4],
+    )
+    root = Path(__file__).resolve().parents[4]
+    return [root / line for line in listing.stdout.split()]
+
+
+def test_the_scan_actually_reads_files() -> None:
+    """Guard the guard: an empty file list would make the check below vacuous."""
+    sources = _tracked_python_sources()
+    assert len(sources) > 100, f"only found {len(sources)} source files"
+    assert any("parsers/pdf.py" in source.as_posix() for source in sources)
+
+
+def test_no_source_module_uses_the_legacy_fitz_alias() -> None:
+    offenders: dict[str, int] = {}
+    root = Path(__file__).resolve().parents[4]
+    for source in _tracked_python_sources():
+        hits = len(_FITZ.findall(source.read_bytes().decode("utf-8", "replace")))
+        if hits:
+            offenders[source.relative_to(root).as_posix()] = hits
+
+    assert (
+        offenders == _ALIAS_IS_THE_POINT
+    ), "import PyMuPDF as `pymupdf`, not `fitz`: the alias is deprecated and some releases warn on import"
+
+
+def test_the_declared_dependency_matches_the_runtime_guard() -> None:
+    """Three different minimums used to be declared across the codebase."""
+    (_install_name, import_name, spec), *rest = DEPS_PDF
+    assert rest == []
+    assert import_name == "pymupdf"
+    assert spec == f">={PDF_MIN_PYMUPDF_VERSION}"
+
+
+def test_an_old_pymupdf_is_reported_rather_than_crashing(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The version guard must name the installed version, not raise from inside itself."""
+    import pymupdf
+
+    from all2md.parsers.pdf import _check_pymupdf_version
+
+    monkeypatch.setattr(pymupdf, "pymupdf_version_tuple", (1, 24, 3), raising=False)
+
+    with pytest.raises(DependencyError) as excinfo:
+        _check_pymupdf_version()
+
+    message = str(excinfo.value)
+    assert "1.24.3" in message, message
+    assert PDF_MIN_PYMUPDF_VERSION in message, message
+
+
+def test_a_current_pymupdf_passes_the_guard() -> None:
+    """Control: the guard is not raising for everyone."""
+    from all2md.parsers.pdf import _check_pymupdf_version
+
+    _check_pymupdf_version()

--- a/tests/unit/parsers/test_pdf_ocr.py
+++ b/tests/unit/parsers/test_pdf_ocr.py
@@ -86,7 +86,7 @@ class TestOCROptions:
 
 
 class _Box:
-    """A stand-in for ``fitz.Rect`` carrying only what the coverage helpers read."""
+    """A stand-in for ``pymupdf.Rect`` carrying only what the coverage helpers read."""
 
     def __init__(self, width: float, height: float) -> None:
         self.width = width
@@ -346,7 +346,7 @@ class TestDetectPageLanguage:
 class TestOCRPageToText:
     """Test OCR text extraction method."""
 
-    @patch("fitz.Matrix")
+    @patch("pymupdf.Matrix")
     @patch("pytesseract.image_to_string")
     @patch("PIL.Image")
     def test_ocr_page_to_text_success(self, mock_image: Mock, mock_pytesseract: Mock, mock_matrix_class: Mock) -> None:
@@ -366,7 +366,7 @@ class TestOCRPageToText:
         # Mock pytesseract
         mock_pytesseract.return_value = "Extracted text from OCR"
 
-        # Mock fitz.Matrix
+        # Mock pymupdf.Matrix
         mock_matrix = Mock()
         mock_matrix_class.return_value = mock_matrix
 
@@ -378,7 +378,7 @@ class TestOCRPageToText:
         mock_pytesseract.assert_called_once()
         mock_matrix_class.assert_called_once_with(300 / 72.0, 300 / 72.0)
 
-    @patch("fitz.Matrix")
+    @patch("pymupdf.Matrix")
     @patch("pytesseract.image_to_string")
     @patch("pytesseract.TesseractNotFoundError", new=Exception)
     @patch("PIL.Image")
@@ -401,7 +401,7 @@ class TestOCRPageToText:
         # Mock pytesseract raising TesseractNotFoundError
         mock_pytesseract.side_effect = Exception("Tesseract not found")
 
-        # Mock fitz.Matrix
+        # Mock pymupdf.Matrix
         mock_matrix = Mock()
         mock_matrix_class.return_value = mock_matrix
 
@@ -410,7 +410,7 @@ class TestOCRPageToText:
         with pytest.raises(RuntimeError, match="Tesseract OCR is not installed"):
             PdfToAstConverter._ocr_page_to_text(mock_page, options)
 
-    @patch("fitz.Matrix")
+    @patch("pymupdf.Matrix")
     @patch("pytesseract.image_to_string")
     @patch("PIL.Image")
     def test_ocr_page_to_text_with_config(
@@ -432,7 +432,7 @@ class TestOCRPageToText:
         # Mock pytesseract
         mock_pytesseract.return_value = "OCR text"
 
-        # Mock fitz.Matrix
+        # Mock pymupdf.Matrix
         mock_matrix = Mock()
         mock_matrix_class.return_value = mock_matrix
 
@@ -557,7 +557,7 @@ class TestOCRSpanBbox:
     """
 
     def _ocr_blocks(self, *, preserve: bool, extracted: str) -> list[dict]:
-        import fitz
+        import pymupdf
 
         options = PdfOptions(
             ocr=OCROptions(enabled=True, mode="force", preserve_existing_text=preserve),
@@ -565,7 +565,7 @@ class TestOCRSpanBbox:
         converter = PdfToAstConverter(options=options)
 
         mock_page = Mock()
-        mock_page.rect = fitz.Rect(0, 0, 612, 792)
+        mock_page.rect = pymupdf.Rect(0, 0, 612, 792)
 
         with patch.object(PdfToAstConverter, "_ocr_page_to_text", return_value="scanned text"):
             blocks, applied = converter._apply_ocr_if_needed(mock_page, [], extracted_text=extracted)
@@ -586,13 +586,13 @@ class TestOCRSpanBbox:
 
     def test_resolve_link_for_span_handles_ocr_span(self) -> None:
         """The OCR span no longer crashes link resolution (issue: KeyError('bbox'))."""
-        import fitz
+        import pymupdf
 
         converter = PdfToAstConverter(options=PdfOptions(ocr=OCROptions(enabled=True, mode="force")))
         span = self._ocr_blocks(preserve=False, extracted="")[0]["lines"][0]["spans"][0]
 
         # A small hyperlink hotspot on the page (as returned by page.get_links()).
-        links = [{"from": fitz.Rect(100, 100, 200, 120), "uri": "https://example.com/"}]
+        links = [{"from": pymupdf.Rect(100, 100, 200, 120), "uri": "https://example.com/"}]
 
         # Must not raise, and a page-sized span must not spuriously match a tiny link.
         assert converter._resolve_link_for_span(links, span, average_line_height=12.0) is None
@@ -653,7 +653,7 @@ class TestOCRLayoutRecovery:
     with: no headings, no tables, no columns, no header/footer trimming.
     """
 
-    @patch("fitz.Matrix")
+    @patch("pymupdf.Matrix")
     @patch("pytesseract.image_to_data")
     @patch("PIL.Image")
     def test_paragraphs_and_lines_survive_with_real_geometry(
@@ -684,7 +684,7 @@ class TestOCRLayoutRecovery:
         assert paragraphs[0].lines[0].bbox == (50.0, 50.0, 135.0, 60.0)
         assert paragraphs[0].bbox != paragraphs[1].bbox
 
-    @patch("fitz.Matrix")
+    @patch("pymupdf.Matrix")
     @patch("pytesseract.image_to_data")
     @patch("PIL.Image")
     def test_a_page_with_no_recognized_words_reports_no_layout(
@@ -789,8 +789,8 @@ class TestEngineReadingOrderIsPreserved:
     def test_a_table_on_the_page_falls_back_to_sorting(self) -> None:
         """A table has to be placed relative to the text, and only y can do that."""
         converter = PdfToAstConverter()
-        fitz = pytest.importorskip("fitz")
-        table = {"bbox": fitz.Rect(43.0, 110.0, 570.0, 130.0)}
+        pymupdf = pytest.importorskip("pymupdf")
+        table = {"bbox": pymupdf.Rect(43.0, 110.0, 570.0, 130.0)}
 
         items = converter._build_sorted_column_items(self._blocks(engine_segmented=True), [table])
 

--- a/tests/unit/renderers/test_pdf_renderer.py
+++ b/tests/unit/renderers/test_pdf_renderer.py
@@ -1186,7 +1186,7 @@ class TestLineBreakInline:
 
     def test_soft_line_break_renders_as_space(self, tmp_path):
         """Test soft line break renders as a space, keeping text on one line."""
-        import fitz
+        import pymupdf
 
         from all2md.ast import LineBreak
 
@@ -1205,7 +1205,7 @@ class TestLineBreakInline:
         output_file = tmp_path / "soft_line_break.pdf"
         renderer.render(doc, output_file)
 
-        with fitz.open(str(output_file)) as pdf:
+        with pymupdf.open(str(output_file)) as pdf:
             text = pdf[0].get_text()
         assert "Line 1 Line 2" in text
         if PDF_VERIFICATION_AVAILABLE:

--- a/tests/unit/test_omnidocbench_benchmark.py
+++ b/tests/unit/test_omnidocbench_benchmark.py
@@ -308,24 +308,24 @@ def test_strict_result_json_rejects_non_finite_scores(tmp_path: Path) -> None:
 
 def _write_vector_pdf(path: Path) -> None:
     """A born-digital page: real text and a ruled box."""
-    fitz = pytest.importorskip("fitz")
-    document = fitz.open()
+    pymupdf = pytest.importorskip("pymupdf")
+    document = pymupdf.open()
     page = document.new_page()
     page.insert_text((72, 100), "Quarterly results", fontsize=12)
-    page.draw_rect(fitz.Rect(72, 120, 300, 200))
+    page.draw_rect(pymupdf.Rect(72, 120, 300, 200))
     document.save(path)
     document.close()
 
 
 def _write_scanned_pdf(path: Path, tmp_path: Path) -> None:
     """A scanned page: one full-page raster, no text layer, no vector drawings."""
-    fitz = pytest.importorskip("fitz")
+    pymupdf = pytest.importorskip("pymupdf")
     source = tmp_path / "_source.pdf"
     _write_vector_pdf(source)
-    with fitz.open(source) as origin:
+    with pymupdf.open(source) as origin:
         pixmap = origin[0].get_pixmap(dpi=72)
         rect = origin[0].rect
-    document = fitz.open()
+    document = pymupdf.open()
     page = document.new_page(width=rect.width, height=rect.height)
     page.insert_image(page.rect, pixmap=pixmap)
     document.save(path)
@@ -334,15 +334,15 @@ def _write_scanned_pdf(path: Path, tmp_path: Path) -> None:
 
 def _write_illustrated_pdf(path: Path, tmp_path: Path) -> None:
     """A born-digital page carrying one figure: text, no vector drawings, one small image."""
-    fitz = pytest.importorskip("fitz")
+    pymupdf = pytest.importorskip("pymupdf")
     source = tmp_path / "_figure_source.pdf"
     _write_vector_pdf(source)
-    with fitz.open(source) as origin:
+    with pymupdf.open(source) as origin:
         pixmap = origin[0].get_pixmap(dpi=36)
-    document = fitz.open()
+    document = pymupdf.open()
     page = document.new_page()
     page.insert_text((72, 100), "Figure 1 shows the assay results.", fontsize=12)
-    page.insert_image(fitz.Rect(72, 120, 220, 240), pixmap=pixmap)
+    page.insert_image(pymupdf.Rect(72, 120, 220, 240), pixmap=pixmap)
     document.save(path)
     document.close()
 
@@ -385,13 +385,13 @@ def test_a_page_with_one_figure_is_not_reported_as_a_scan(tmp_path: Path) -> Non
 
 def test_input_traits_count_every_page_not_just_the_first(tmp_path: Path) -> None:
     """A title page is not a sample of the document behind it."""
-    fitz = pytest.importorskip("fitz")
+    pymupdf = pytest.importorskip("pymupdf")
     scanned = tmp_path / "scanned.pdf"
     _write_scanned_pdf(scanned, tmp_path)
     mixed = tmp_path / "mixed.pdf"
-    document = fitz.open()
+    document = pymupdf.open()
     document.new_page().insert_text((72, 100), "Title only", fontsize=18)
-    with fitz.open(scanned) as source:
+    with pymupdf.open(scanned) as source:
         document.insert_pdf(source)
         document.insert_pdf(source)
     document.save(mixed)

--- a/tests/unit/test_pmc_corpus.py
+++ b/tests/unit/test_pmc_corpus.py
@@ -470,17 +470,17 @@ def test_the_committed_manifest_spreads_across_the_id_range() -> None:
 
 def _make_pdf(path: Path, *, pages: int, drawings: int, text: bool, full_page_image: bool) -> None:
     """Build a real PDF so the characterization is tested against its actual instrument."""
-    import fitz
+    import pymupdf
 
-    document = fitz.open()
+    document = pymupdf.open()
     for _ in range(pages):
         page = document.new_page()
         if text:
             page.insert_text((72, 72), "born digital")
         for index in range(drawings):
-            page.draw_rect(fitz.Rect(10 + index, 10 + index, 40 + index, 40 + index), color=(0, 0, 0))
+            page.draw_rect(pymupdf.Rect(10 + index, 10 + index, 40 + index, 40 + index), color=(0, 0, 0))
         if full_page_image:
-            pixmap = fitz.Pixmap(fitz.csRGB, fitz.IRect(0, 0, 8, 8))
+            pixmap = pymupdf.Pixmap(pymupdf.csRGB, pymupdf.IRect(0, 0, 8, 8))
             page.insert_image(page.rect, pixmap=pixmap)
     document.save(path)
     document.close()
@@ -686,7 +686,7 @@ def test_placement_never_uses_page_order() -> None:
 
 def test_the_control_collapses_when_blocks_meet_the_wrong_article(tmp_path: Path) -> None:
     """A placement rate is meaningless unless the same method fails on the wrong article."""
-    import fitz
+    import pymupdf
 
     from benchmarks.pmc.alignment import measure
 
@@ -698,7 +698,7 @@ def test_the_control_collapses_when_blocks_meet_the_wrong_article(tmp_path: Path
     for article_id, sentence in sentences.items():
         pdf_path = tmp_path / f"{article_id}.pdf"
         xml_path = tmp_path / f"{article_id}.xml"
-        document = fitz.open()
+        document = pymupdf.open()
         page = document.new_page()
         page.insert_text((40, 60), sentence)
         document.save(pdf_path)


### PR DESCRIPTION
Closes #284 (the remainder — the stdout advisory half shipped in #309).

## The deprecation warning

`fitz` is PyMuPDF's legacy top-level alias. Some releases emit a `DeprecationWarning` on `import fitz`, and it reaches anyone running the CLI as noise about a dependency they did not choose and cannot act on.

It does not reproduce on our pinned 1.28.0, which is why I could not find it last night — @thomas-villani saw it from a `uv tool` environment carrying an older PyMuPDF. That makes the version-dependent alias exactly the thing to remove rather than to chase.

`pymupdf` has been the real module name since 1.24.3 and we require 1.27.2, so there is nothing to weigh up. 149 references across 15 modules and 25 test files.

**Two mentions survive on purpose.** `_pdf_layout.py` neutralizes the layout hook on *both* module objects, because the alias can be a distinct object in some installs — that code is about the alias rather than a use of it. `test_no_source_module_uses_the_legacy_fitz_alias` asserts exactly those two and nothing else, so the old name cannot creep back unnoticed.

## What the rename surfaced

**mypy sees PyMuPDF differently under its real name.** It ships `py.typed` but annotates almost nothing, so following it makes `disallow_untyped_calls` fire on ~40 ordinary calls (`Rect()`, `get_text()`, `find_tables()`). The `fitz` shim has no `py.typed`, so `ignore_missing_imports` had quietly been making it `Any` all along.

The `follow_imports = "skip"` override — same shape as the existing numpy one — keeps that behaviour. It declares the type information we were already not getting rather than pretending we lost some. It also clears the pre-existing `_pdf_layout.py:201` error that CI never saw, since CI does not install the `pdf_layout` extra.

I checked the one non-`no-untyped-call` error it reported before muting: `tuple(Rect)` at `pdf.py:554` is a stub gap, not a bug. `Rect` has no `__iter__` but does have `__getitem__`, so it iterates via the legacy sequence protocol — verified at runtime, `tuple(Rect(1,2,3,4)) == (1.0, 2.0, 3.0, 4.0)`.

**`_check_pymupdf_version` crashed from inside itself.** It built its `DependencyError` by joining `pymupdf_version_tuple`, which holds ints:

```
TypeError: sequence item 0: expected str instance, int found
```

So the one branch that exists to tell a user to upgrade PyMuPDF reported nothing useful. Verified the new test catches it: reverting just the `str()` fix fails `test_an_old_pymupdf_is_reported_rather_than_crashing` with that exact TypeError.

**The minimum version had drifted to three values.**

| where | said |
|---|---|
| `pyproject.toml` | `>=1.28.0` |
| `PDF_MIN_PYMUPDF_VERSION` (runtime guard) | `1.27.2` |
| converter metadata / `_converter_manifest.py` | `>=1.26.4` |

The third is what `list-formats` prints and what dependency errors quote — it advertised a version the guard would then refuse. `DEPS_PDF` and the parser's declared requirement now both read `PDF_MIN_PYMUPDF_VERSION`. The effective floor is unchanged at 1.27.2, deliberately below the pyproject pin so a working install is not refused.

## Checks

- `ruff check`, `black --check src tests` clean
- `mypy src/` — **zero** errors now, including the one that was previously local-only
- `pytest tests/unit` — no failures
- `pytest tests/golden tests/integration` — no failures
- Manifest regenerated with `scripts/generate_converter_manifest.py --update`
- Controls: the version test fails with `TypeError` on the unfixed join; the alias scan reads 100+ tracked sources and asserts it found `parsers/pdf.py`, so it cannot pass vacuously

🤖 Generated with [Claude Code](https://claude.com/claude-code)