### PR TITLE
fix(markdown): pass raw HTML through instead of escaping it

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -376,13 +376,21 @@ jobs:
     #   2. The direct script run scores with the branch's code (editable install)
     #      at the real thresholds. This is the ratchet.
     #
-    # The thresholds in step 2 are measured floors, not round numbers: as of
-    # 1.10.0 the worst of the repo's root markdown is README.md at 97 fidelity
-    # (11 raw HTML blocks re-parse as paragraphs) and everything scores 100
-    # confidence. So fidelity passes here with *zero* headroom, which is the point.
-    # Re-record them deliberately if they move; do not nudge them down to make a
-    # build green. A threshold well below the real floor is the failure this whole
-    # batch kept finding -- a gate that passes because it cannot fail.
+    # The thresholds in step 2 are measured floors, not round numbers. README.md
+    # used to be the worst at 97 fidelity, because 11 raw HTML blocks re-parsed as
+    # paragraphs; #178 made pass-through the markdown renderer's default and all
+    # six tracked root files now score 100 on both axes. Re-recorded here as 100.
+    # So both gates pass with *zero* headroom, which is the point. Re-record them
+    # deliberately if they move; do not nudge them down to make a build green. A
+    # threshold well below the real floor is the failure this whole batch kept
+    # finding -- a gate that passes because it cannot fail.
+    #
+    # Zero headroom at 100 means any regression fails, by design. The closest file
+    # to the edge is CHANGELOG.md, whose round trip differs by 5 "words" out of
+    # ~25,000 -- all of them runs of table-delimiter dashes that the renderer
+    # re-widths, not prose. That rounds to 100 with room to spare; if this gate
+    # ever fails on CHANGELOG.md, check whether the loss is dashes or sentences
+    # before assuming the threshold is wrong.
     #
     # `*.md` matches six tracked files here. Running the same command locally
     # scores nine, because CLAUDE.md, AGENTS.md and todo.md are gitignored -- so a
@@ -415,7 +423,7 @@ jobs:
         run: |
           python scripts/action_gate.py run \
             --paths '*.md' \
-            --roundtrip-fail-under 97 \
+            --roundtrip-fail-under 100 \
             --report-fail-under 100
 
   security-semgrep:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **Raw HTML in Markdown is passed through instead of escaped.** The Markdown renderer's
+  `html_passthrough_mode` now defaults to `pass-through`. Escaping was described as a
+  security posture, but it was not the one doing the work: in the `html → markdown`
+  direction — the direction where untrusted input actually arrives — the HTML *parser* maps
+  tags to AST nodes and drops `<script>`, `<iframe>`, `<form>`, `<object>`, `<embed>` and
+  `<svg onload>` outright, so they never reach a renderer to be escaped. The `HTMLBlock` and
+  `HTMLInline` nodes the Markdown renderer actually saw came from the Markdown *parser*:
+  HTML an author wrote in their own Markdown, which Markdown permits by design and which
+  any downstream renderer would have rendered from the original file anyway. Escaping it
+  broke `markdown → markdown` for no gain — our own `README.md` lost the contents of all
+  eleven `<details>` sections and scored 97; it now scores 100 with no deltas, as do all six
+  tracked root documents, and the CI fidelity gate is re-recorded from 97 to 100. Converting
+  *untrusted* Markdown is the case that wants the old behaviour: pass
+  `html_passthrough_mode="escape"` (or `--markdown-html-passthrough-mode escape`). Only the
+  Markdown renderer changes; the HTML, AsciiDoc and Textile renderers still default to
+  `escape` (#178).
+
 ### Added
 
 - **Every registered format's options class is now importable from both `all2md` and

--- a/benchmarks/roundtrip/README.md
+++ b/benchmarks/roundtrip/README.md
@@ -41,11 +41,12 @@ the table has started lying about the codebase, so it must be updated in the sam
 commit that changes the behavior. Without that, an allowlist decays into a
 permanent excuse list and the ratchet quietly stops being one.
 
-Currently allowlisted: **`raw-html:idempotency`** — the escape policy
-(`html_passthrough_mode="escape"`) turns `<div>` into `&lt;div&gt;` on the second
-pass. That is a deliberate security posture, not a roundtrip bug; it is the same
-root cause as the `html_equivalence` policy skip below. Never add an entry to
-silence a genuine regression.
+Currently allowlisted: **nothing**. The table held one entry —
+`raw-html:idempotency`, where escaping turned `<div>` into `&lt;div&gt;` on the
+second pass — until #178 made `pass-through` the Markdown renderer's default and
+the case started passing on its own. The XPASS is how we found out, which is the
+whole point of failing on one. Never add an entry to silence a genuine
+regression.
 
 ## Two oracles
 
@@ -65,9 +66,10 @@ slip past both:
   AST + render halves of the pipeline, not of the parse half. That matches our
   failure surface but is not a fully third-party judge.
 
-Documents containing raw HTML are **skipped** by the HTML oracle: all2md escapes
-raw HTML by policy (`html_passthrough_mode="escape"`), so a difference there is
-expected, not a bug.
+Documents containing raw HTML used to be **skipped** by the HTML oracle, because
+escaping made a difference there expected rather than a bug. Since #178 the
+Markdown renderer passes raw HTML through, so the oracle judges those documents
+like any other.
 
 ## Corpus
 

--- a/benchmarks/roundtrip/corpus.py
+++ b/benchmarks/roundtrip/corpus.py
@@ -3,9 +3,9 @@
 Phase 0/1 ships the *synthetic* corpus only: labeled Markdown files under
 ``corpus/synthetic/``, one construct family per file plus a ``kitchen-sink``
 document that combines them. Each file's stem is its construct family; tags are
-derived from content (e.g. ``has_raw_html`` marks a doc that is lossy by policy
-under all2md's ``html_passthrough_mode="escape"`` posture, so the HTML oracle
-skips it rather than flagging an expected loss).
+derived from content (e.g. ``has_raw_html`` marks a doc carrying raw HTML; it
+gated an HTML-oracle skip while the Markdown renderer escaped raw HTML, and is
+descriptive only now that pass-through is the default).
 
 The CommonMark / GFM spec suites (Phase 2) will land as an additional loader
 here; the ``Case`` shape is already source-agnostic to accommodate them.
@@ -37,8 +37,10 @@ class Case:
     """One corpus document.
 
     ``source`` distinguishes the synthetic corpus from later spec suites.
-    ``has_raw_html`` flags documents the HTML-equivalence oracle should skip
-    because all2md intentionally escapes raw HTML (a policy loss, not a bug).
+    ``has_raw_html`` records that a document carries raw HTML. It used to gate a
+    skip of the HTML-equivalence oracle, back when the Markdown renderer escaped
+    raw HTML; since #178 made pass-through the default, both oracles judge those
+    documents and the flag is descriptive only, carried into the JSON report.
     """
 
     name: str

--- a/benchmarks/roundtrip/corpus/synthetic/raw-html.md
+++ b/benchmarks/roundtrip/corpus/synthetic/raw-html.md
@@ -8,6 +8,6 @@ A raw HTML block:
   <p>A paragraph inside a raw HTML block.</p>
 </div>
 
-A paragraph after the block. Raw HTML is escaped by policy under all2md's
-default `html_passthrough_mode="escape"`, so the HTML-equivalence oracle skips
-this document; idempotency should still hold.
+A paragraph after the block. Raw HTML passes through by default, so both
+oracles judge this document: it must be idempotent and must agree with the
+reference renderer.

--- a/benchmarks/roundtrip/run.py
+++ b/benchmarks/roundtrip/run.py
@@ -32,34 +32,27 @@ from .oracles import CheckResult, html_equivalence_check, idempotency_check
 # codebase, so it must be updated in the same commit that changes the behavior.
 # An expected failure is for behavior we have *decided* to accept; never add an
 # entry to silence a genuine regression.
-EXPECTED_FAILURES: dict[tuple[str, str], str] = {
-    ("raw-html", "idempotency"): (
-        "all2md escapes raw HTML by policy (html_passthrough_mode='escape'), so pass 2 sees "
-        "&lt;div&gt; where pass 1 saw <div>. Deliberate - the escape policy is a security "
-        "posture, not a roundtrip bug. Same root cause as the html_equivalence policy skip."
-    ),
-}
+# Emptied by #178: raw HTML used to fail idempotency because the Markdown renderer
+# escaped it, so pass 2 saw &lt;div&gt; where pass 1 saw <div>. The default is now
+# pass-through and the case passes on its own. This table found that out by going
+# red on the XPASS, which is what it is for.
+EXPECTED_FAILURES: dict[tuple[str, str], str] = {}
 
 
 def evaluate_case(case: Case) -> list[CheckResult]:
     """Run every oracle against one case, honoring policy skips.
 
-    Idempotency always runs. The HTML-equivalence oracle is skipped for cases it
-    cannot fairly judge: raw HTML (lossy by all2md's escape policy) and
-    admonitions (the reference mistune renderer has no method for all2md's custom
-    admonition block token). Skips are neither a pass nor a failure.
+    Idempotency always runs. The HTML-equivalence oracle is skipped for the one
+    case it cannot fairly judge: admonitions, where the reference mistune renderer
+    has no method for all2md's custom admonition block token. Skips are neither a
+    pass nor a failure.
+
+    Raw HTML used to be skipped here too, on the grounds that the escape policy
+    made it lossy. #178 made pass-through the default, so the oracle can judge it
+    like anything else and the exemption is gone.
     """
     results = [idempotency_check(case.markdown)]
-    if case.has_raw_html:
-        results.append(
-            CheckResult(
-                "html_equivalence",
-                passed=True,
-                skipped=True,
-                detail="raw HTML present; lossy by policy (html_passthrough_mode='escape')",
-            )
-        )
-    elif case.has_admonitions:
+    if case.has_admonitions:
         results.append(
             CheckResult(
                 "html_equivalence",

--- a/docs/source/options.rst
+++ b/docs/source/options.rst
@@ -5434,10 +5434,10 @@ The Markdown format has no dedicated CLI flags. The common Markdown formatting f
 
 **html_passthrough_mode**
 
-   How to handle raw HTML content in markdown: pass-through (allow HTML as-is), escape (show as text), drop (remove entirely), sanitize (remove dangerous elements). Default is 'escape' for security. Does not affect code blocks.
+   How to handle raw HTML content in markdown: pass-through (allow HTML as-is), escape (show as text), drop (remove entirely), sanitize (remove dangerous elements). Default is 'pass-through', since markdown permits raw HTML and escaping it breaks a round trip; use 'escape' for untrusted markdown. Does not affect code blocks.
 
    :Type: ``Literal['pass-through', 'escape', 'drop', 'sanitize']``
-   :Default: ``'escape'``
+   :Default: ``'pass-through'``
    :Choices: ``pass-through``, ``escape``, ``drop``, ``sanitize``
    :Importance: security
 
@@ -11456,11 +11456,11 @@ modules to ensure consistent Markdown generation.
 
 **html_passthrough_mode**
 
-   How to handle raw HTML content in markdown: pass-through (allow HTML as-is), escape (show as text), drop (remove entirely), sanitize (remove dangerous elements). Default is 'escape' for security. Does not affect code blocks.
+   How to handle raw HTML content in markdown: pass-through (allow HTML as-is), escape (show as text), drop (remove entirely), sanitize (remove dangerous elements). Default is 'pass-through', since markdown permits raw HTML and escaping it breaks a round trip; use 'escape' for untrusted markdown. Does not affect code blocks.
 
    :Type: ``Literal['pass-through', 'escape', 'drop', 'sanitize']``
    :CLI flag: ``--markdown-html-passthrough-mode``
-   :Default: ``'escape'``
+   :Default: ``'pass-through'``
    :Choices: ``pass-through``, ``escape``, ``drop``, ``sanitize``
    :Importance: security
 

--- a/docs/source/security.rst
+++ b/docs/source/security.rst
@@ -29,7 +29,8 @@ Secure by Default
    - Remote fetching is DISABLED by default
    - robots.txt is ENFORCED by default (strict mode)
    - Local file access is DISABLED by default
-   - HTML is ESCAPED by default
+   - Executable HTML (``<script>``, ``<iframe>``, ``<form>``, ``<svg onload>``) is
+     DROPPED by the HTML parser, before any renderer sees it
    - OCR is DISABLED by default
    - Dangerous URL schemes are BLOCKED
    - Private IP ranges are BLOCKED
@@ -52,7 +53,7 @@ Secure by Default
            └──────────────┬──────────────┘
                           │
            ┌──────────────▼──────────────┐
-           │      Sanitized output       │  -- HTML escaping, attachment policies, metadata limits
+           │      Sanitized output       │  -- tag allowlisting, attachment policies, metadata limits
            └─────────────────────────────┘
 
 Key Risk Areas

--- a/src/all2md/constants.py
+++ b/src/all2md/constants.py
@@ -384,7 +384,15 @@ DEFAULT_UNSUPPORTED_INLINE_MODE: UnsupportedInlineMode = "force"
 DEFAULT_MATH_MODE: MathMode = "latex"
 DEFAULT_HTML_PASSTHROUGH_MODE: HtmlPassthroughMode = "escape"
 HTML_PASSTHROUGH_MODES = ["pass-through", "escape", "drop", "sanitize"]
-DEFAULT_MARKDOWN_HTML_PASSTHROUGH_MODE: HtmlPassthroughMode = "escape"  # Secure by default
+# Markdown permits raw HTML by design, and the HTMLBlock/HTMLInline nodes that
+# reach *this* renderer overwhelmingly come from the markdown parser - i.e. HTML
+# the author wrote in their own markdown. Escaping those corrupts the document
+# and buys nothing, because anything rendering our output would have rendered
+# that HTML from the original file too. The `html -> markdown` direction, which
+# is where untrusted input actually arrives, is protected by the HTML *parser*:
+# it maps tags to AST nodes and drops <script>, <iframe>, <form> and <svg>
+# outright, so they never reach a renderer to be escaped. See #178.
+DEFAULT_MARKDOWN_HTML_PASSTHROUGH_MODE: HtmlPassthroughMode = "pass-through"
 
 # Boilerplate text removal patterns (used by RemoveBoilerplateTextTransform)
 DEFAULT_BOILERPLATE_PATTERNS = [

--- a/src/all2md/options/markdown.py
+++ b/src/all2md/options/markdown.py
@@ -265,15 +265,15 @@ class MarkdownRendererOptions(BaseRendererOptions):
         constraints.
     html_passthrough_mode : {"pass-through", "escape", "drop", "sanitize"}, default "pass-through"
         How to handle raw HTML content in markdown (HTMLBlock and HTMLInline nodes):
-        - "pass-through": Pass HTML through unchanged (the default; markdown permits
-          raw HTML, and escaping it breaks a Markdown -> Markdown round trip)
+        - "pass-through": Pass HTML through unchanged; markdown permits raw HTML
         - "escape": HTML-escape the content to show as text
         - "drop": Remove HTML content entirely
         - "sanitize": Remove dangerous elements/attributes (requires bleach for best results)
-        Note: This does not affect fenced code blocks with language="html", which are
-        always rendered as code and are already safe. Converting *untrusted* markdown
-        is the case for "escape": the `html -> markdown` direction needs no such help,
-        because the HTML parser drops script/iframe/form/svg before any renderer runs.
+        Escaping breaks a Markdown to Markdown round trip, so it is no longer the default.
+        Converting *untrusted* markdown is the case for it; the html-to-markdown direction
+        needs no such help, because the HTML parser drops script/iframe/form/svg before
+        any renderer runs. This does not affect fenced code blocks with language="html",
+        which are always rendered as code and are already safe.
     comment_mode : {"html", "blockquote", "ignore"}, default "html"
         How to render Comment and CommentInline AST nodes:
         - "html": Render as HTML comments (<!-- Comment text -->)

--- a/src/all2md/options/markdown.py
+++ b/src/all2md/options/markdown.py
@@ -263,14 +263,17 @@ class MarkdownRendererOptions(BaseRendererOptions):
         requested representation is unavailable on a node, the renderer falls
         back to any available representation while preserving flavor
         constraints.
-    html_passthrough_mode : {"pass-through", "escape", "drop", "sanitize"}, default "escape"
+    html_passthrough_mode : {"pass-through", "escape", "drop", "sanitize"}, default "pass-through"
         How to handle raw HTML content in markdown (HTMLBlock and HTMLInline nodes):
-        - "pass-through": Pass HTML through unchanged (use only with trusted content)
-        - "escape": HTML-escape the content to show as text (secure default)
+        - "pass-through": Pass HTML through unchanged (the default; markdown permits
+          raw HTML, and escaping it breaks a Markdown -> Markdown round trip)
+        - "escape": HTML-escape the content to show as text
         - "drop": Remove HTML content entirely
         - "sanitize": Remove dangerous elements/attributes (requires bleach for best results)
         Note: This does not affect fenced code blocks with language="html", which are
-        always rendered as code and are already safe.
+        always rendered as code and are already safe. Converting *untrusted* markdown
+        is the case for "escape": the `html -> markdown` direction needs no such help,
+        because the HTML parser drops script/iframe/form/svg before any renderer runs.
     comment_mode : {"html", "blockquote", "ignore"}, default "html"
         How to render Comment and CommentInline AST nodes:
         - "html": Render as HTML comments (<!-- Comment text -->)
@@ -498,7 +501,9 @@ class MarkdownRendererOptions(BaseRendererOptions):
             "help": "How to handle raw HTML content in markdown: "
             "pass-through (allow HTML as-is), escape (show as text), "
             "drop (remove entirely), sanitize (remove dangerous elements). "
-            "Default is 'escape' for security. Does not affect code blocks.",
+            "Default is 'pass-through', since markdown permits raw HTML and escaping it "
+            "breaks a round trip; use 'escape' for untrusted markdown. "
+            "Does not affect code blocks.",
             "choices": HTML_PASSTHROUGH_MODES,
             "importance": "security",
         },

--- a/tests/integration/test_roundtrip.py
+++ b/tests/integration/test_roundtrip.py
@@ -113,15 +113,21 @@ class TestRoundTripApi:
     def test_escaped_inline_html_is_priced_as_a_real_loss(self, escaping_html_md):
         """Escaped raw HTML costs fidelity, and the score says so.
 
-        The Markdown renderer escapes raw HTML by default
-        (``html_passthrough_mode="escape"``, a security posture), so a document
-        carrying a tag with no AST equivalent (``<span>``) cannot round trip
-        perfectly -- and the score reports that rather than quietly forgiving it.
+        Escaping is no longer the Markdown renderer's default (#178) but remains
+        the right setting for untrusted markdown, and it is genuinely lossy: a tag
+        with no AST equivalent (``<span>``) cannot survive it. The score has to
+        report that rather than quietly forgiving it.
         """
-        report = roundtrip_report(escaping_html_md)
+        report = roundtrip_report(escaping_html_md, html_passthrough_mode="escape")
         assert report.score < 100
         assert {delta.kind for delta in report.deltas} == {"inline_lost", "text_lost"}
         assert any(delta.detail == "htmlinline" for delta in report.deltas)
+
+    def test_raw_inline_html_survives_under_the_default(self, escaping_html_md):
+        """The other half of #178: the default no longer costs those points."""
+        report = roundtrip_report(escaping_html_md)
+        assert report.score == 100
+        assert report.deltas == []
 
     def test_underline_html_roundtrips_losslessly(self):
         """``<u>`` is not "raw HTML" to the scorer -- it is an Underline node.
@@ -138,9 +144,11 @@ class TestRoundTripApi:
         """The score must move when converter options move.
 
         This is what makes it usable as the ``optimize`` capstone's fitness
-        function: flipping one renderer option recovers the lost points.
+        function: flipping one renderer option moves the points. Asserted against
+        an explicit ``pass-through`` rather than the default, so the comparison
+        keeps meaning if the default moves again.
         """
-        escaped = roundtrip_report(escaping_html_md)
+        escaped = roundtrip_report(escaping_html_md, html_passthrough_mode="escape")
         passed_through = roundtrip_report(escaping_html_md, html_passthrough_mode="pass-through")
 
         assert passed_through.score == 100

--- a/tests/unit/parsers/test_html_dangerous_tags_never_reach_a_renderer.py
+++ b/tests/unit/parsers/test_html_dangerous_tags_never_reach_a_renderer.py
@@ -1,0 +1,76 @@
+#  Copyright (c) 2025 Tom Villani, Ph.D.
+"""The HTML parser, not the markdown renderer, is what makes `html -> markdown` safe.
+
+#178 changed the markdown renderer's `html_passthrough_mode` default from "escape"
+to "pass-through". That is only defensible because of the invariant asserted here:
+the HTML parser maps tags to AST nodes and drops the executable ones outright, so
+`<script>` and friends never become an `HTMLBlock`/`HTMLInline` for a renderer to
+decide about. The renderer's default was never the thing standing between a scraped
+page and a `<script>` in the output.
+
+If a future change makes the HTML parser emit raw-HTML nodes for these tags, this
+file fails - and the pass-through default has to be reconsidered along with it.
+The two opt-ins that *do* produce `HTMLBlock` from HTML (`figures_parsing="html"`,
+`details_parsing="html"`) are asked for explicitly and are not covered by this.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from all2md import from_ast, to_ast
+from all2md.ast.nodes import HTMLBlock, HTMLInline, Node
+from all2md.ast.transforms import NodeCollector
+
+pytestmark = [pytest.mark.unit, pytest.mark.html]
+
+
+def _raw_html_nodes(document: Node) -> list[Node]:
+    collector = NodeCollector(lambda node: isinstance(node, (HTMLBlock, HTMLInline)))
+    document.accept(collector)
+    return collector.collected
+
+
+_EXECUTABLE = {
+    "script": b"<p>before</p><script>alert(1)</script><p>after</p>",
+    "iframe": b"<p>before</p><iframe src='https://example.invalid'></iframe>",
+    "form": b"<form action='/x'><input onclick='alert(1)'></form>",
+    "svg-onload": b"<svg onload='alert(1)'><circle r='1'/></svg>",
+    "object": b"<object data='x.swf'></object>",
+    "embed": b"<embed src='x.swf'>",
+}
+
+
+@pytest.mark.parametrize("markup", _EXECUTABLE.values(), ids=list(_EXECUTABLE))
+def test_the_html_parser_emits_no_raw_html_node_for_executable_markup(markup: bytes) -> None:
+    document = to_ast(markup, source_format="html")
+    assert _raw_html_nodes(document) == []
+
+
+@pytest.mark.parametrize("markup", _EXECUTABLE.values(), ids=list(_EXECUTABLE))
+def test_executable_markup_is_absent_from_the_rendered_markdown(markup: bytes) -> None:
+    """The end-to-end claim, under the new default rather than a forced one."""
+    rendered = from_ast(to_ast(markup, source_format="html"), target_format="markdown")
+    lowered = rendered.lower()
+    for tag in ("<script", "<iframe", "<object", "<embed", "onload=", "onclick="):
+        assert tag not in lowered, f"{tag} survived into markdown:\n{rendered}"
+
+
+def test_the_harness_can_actually_see_a_raw_html_node() -> None:
+    """Guard the guard: a probe that never finds anything proves nothing.
+
+    Markdown *does* hand raw HTML through to the AST - that is the whole reason
+    #178 exists - so it makes the control the checks above need.
+    """
+    document = to_ast(b"# T\n\n<div align='center'>\n  <b>hi</b>\n</div>\n", source_format="markdown")
+    assert len(_raw_html_nodes(document)) == 1
+
+
+def test_ordinary_markup_still_survives_as_real_nodes() -> None:
+    """Dropping the executable tags must not be dropping everything."""
+    rendered = from_ast(
+        to_ast(b"<h1>Title</h1><p>Body <strong>bold</strong></p>", source_format="html"),
+        target_format="markdown",
+    )
+    assert "# Title" in rendered
+    assert "**bold**" in rendered

--- a/tests/unit/renderers/test_markdown_renderer.py
+++ b/tests/unit/renderers/test_markdown_renderer.py
@@ -982,11 +982,11 @@ class TestHTMLNodes:
         doc = Document(children=[HTMLBlock(content="<div>Custom HTML</div>")])
         renderer = MarkdownRenderer()
         result = renderer.render_to_string(doc)
-        assert result == "&lt;div&gt;Custom HTML&lt;/div&gt;"
-
-        renderer = MarkdownRenderer(MarkdownRendererOptions(html_passthrough_mode="pass-through"))
-        result = renderer.render_to_string(doc)
         assert result == "<div>Custom HTML</div>"
+
+        renderer = MarkdownRenderer(MarkdownRendererOptions(html_passthrough_mode="escape"))
+        result = renderer.render_to_string(doc)
+        assert result == "&lt;div&gt;Custom HTML&lt;/div&gt;"
 
     def test_html_inline(self):
         """Test rendering inline HTML."""
@@ -1003,11 +1003,11 @@ class TestHTMLNodes:
         )
         renderer = MarkdownRenderer()
         result = renderer.render_to_string(doc)
-        assert result == "Text with &lt;span&gt;HTML&lt;/span&gt; inline"
-
-        renderer = MarkdownRenderer(MarkdownRendererOptions(html_passthrough_mode="pass-through"))
-        result = renderer.render_to_string(doc)
         assert result == "Text with <span>HTML</span> inline"
+
+        renderer = MarkdownRenderer(MarkdownRendererOptions(html_passthrough_mode="escape"))
+        result = renderer.render_to_string(doc)
+        assert result == "Text with &lt;span&gt;HTML&lt;/span&gt; inline"
 
 
 @pytest.mark.unit
@@ -1205,19 +1205,44 @@ class TestFootnotes:
 class TestHTMLSanitization:
     """Tests for HTML sanitization options."""
 
-    def test_html_block_escape_default(self):
-        """Test that HTML blocks are escaped by default (secure-by-default)."""
-        doc = Document(children=[HTMLBlock(content="<script>alert('xss')</script>")])
+    def test_html_block_passes_through_by_default(self):
+        """Markdown permits raw HTML, so the renderer emits it rather than escaping (#178).
+
+        Escaping here corrupted a Markdown -> Markdown round trip without buying
+        anything: whatever renders our output would have rendered the same HTML
+        straight from the original file.
+        """
+        doc = Document(children=[HTMLBlock(content="<details><summary>S</summary>")])
         renderer = MarkdownRenderer()
         result = renderer.render_to_string(doc)
-        # Should be escaped
+        assert result == "<details><summary>S</summary>"
+
+    def test_html_block_escape_is_one_option_away(self):
+        """Converting untrusted markdown is what "escape" is for."""
+        doc = Document(children=[HTMLBlock(content="<script>alert('xss')</script>")])
+        renderer = MarkdownRenderer(MarkdownRendererOptions(html_passthrough_mode="escape"))
+        result = renderer.render_to_string(doc)
         assert "&lt;script&gt;" in result
         assert "&lt;/script&gt;" in result
-        # Should not contain raw HTML
         assert "<script>" not in result
 
-    def test_html_inline_escape_default(self):
-        """Test that inline HTML is escaped by default (secure-by-default)."""
+    def test_html_inline_passes_through_by_default(self):
+        doc = Document(
+            children=[
+                Paragraph(
+                    content=[
+                        Text(content="Text with "),
+                        HTMLInline(content="<abbr title='x'>HTML</abbr>"),
+                        Text(content=" inline"),
+                    ]
+                )
+            ]
+        )
+        renderer = MarkdownRenderer()
+        result = renderer.render_to_string(doc)
+        assert result == "Text with <abbr title='x'>HTML</abbr> inline"
+
+    def test_html_inline_escape_is_one_option_away(self):
         doc = Document(
             children=[
                 Paragraph(
@@ -1229,12 +1254,9 @@ class TestHTMLSanitization:
                 )
             ]
         )
-        renderer = MarkdownRenderer()
+        renderer = MarkdownRenderer(MarkdownRendererOptions(html_passthrough_mode="escape"))
         result = renderer.render_to_string(doc)
-        # Should be escaped
         assert "&lt;img" in result
-        assert "&gt;" in result
-        # Should not contain raw HTML
         assert "<img" not in result
 
     def test_html_sanitization_pass_through_mode(self):

--- a/tests/unit/test_roundtrip_benchmark.py
+++ b/tests/unit/test_roundtrip_benchmark.py
@@ -139,7 +139,8 @@ def test_synthetic_corpus_loads() -> None:
     assert cases, "synthetic corpus should not be empty"
     names = {c.name for c in cases}
     assert "kitchen-sink" in names
-    # The raw-html document must be flagged so the HTML oracle skips it.
+    # The raw-html document is still detected as such; the flag is descriptive
+    # now rather than gating a skip (#178).
     raw = next(c for c in cases if c.name == "raw-html")
     assert raw.has_raw_html
     # The admonitions document must be flagged so the HTML oracle skips it.
@@ -147,11 +148,17 @@ def test_synthetic_corpus_loads() -> None:
     assert adm.has_admonitions
 
 
-def test_evaluate_case_skips_html_oracle_for_raw_html() -> None:
+def test_evaluate_case_judges_raw_html_rather_than_skipping_it() -> None:
+    """Raw HTML used to be exempt from the HTML oracle because escaping made it lossy.
+
+    #178 made pass-through the Markdown renderer's default, so there is nothing
+    left to excuse: both oracles judge the document like any other.
+    """
     case = corpus.Case(name="x", markdown="<div>raw</div>\n", has_raw_html=True)
     results = {r.oracle: r for r in evaluate_case(case)}
-    assert results["html_equivalence"].skipped
-    assert "idempotency" in results
+    assert not results["html_equivalence"].skipped
+    assert results["html_equivalence"].passed
+    assert results["idempotency"].passed
 
 
 def test_evaluate_case_skips_html_oracle_for_admonitions() -> None:


### PR DESCRIPTION
Closes #178.

## Why the premise didn't hold

`escape` was described as a security posture. I went looking for the threat it stops and could not find it on this path.

The HTML **parser** maps tags to AST nodes and drops the executable ones outright — they never become an `HTMLBlock`/`HTMLInline` for a renderer to have an opinion about:

| input (`source_format="html"`) | raw HTML nodes | markdown out |
|---|---|---|
| `<script>alert(1)</script>` | 0 | `before\n\nafter` |
| `<iframe src=…>` | 0 | `before` |
| `<form><input onclick=…>` | 0 | *(empty)* |
| `<svg onload="alert(1)">` | 0 | *(empty)* |
| `<object>` / `<embed>` | 0 | *(empty)* |

Grepping every parser, the HTML parser constructs `HTMLBlock` in exactly two places: `figures_parsing="html"` and `details_parsing="html"`. Both are explicit opt-ins where raw HTML is what was asked for.

So the nodes the Markdown renderer was escaping came from the **Markdown parser** — HTML an author wrote in their own Markdown. Markdown permits that by design, and anything rendering our output would have rendered the same HTML straight from the original file. Escaping it broke `markdown → markdown` and bought nothing.

## What it costs and recovers

`README.md`: **97 → 100**, no deltas. All eleven `<details>` sections come back. All six tracked root documents now score 100/100, so `roundtrip-fail-under` is re-recorded 97 → **100** — still zero headroom, which is what that gate is for.

The `sanitize` alternative is disqualified for a different reason worth recording: it needs `bleach`, which lives in the `sanitizer` extra and is **not in `all`**, so the default would silently behave differently depending on an extra almost nobody installs.

## The benchmark caught it before I did

`benchmarks/roundtrip`'s `EXPECTED_FAILURES` table goes red on XPASS, precisely so a stale exemption cannot outlive a behaviour change. It did:

```
raw-html                      XPASS          SKIP
37 passed, 1 xpassed, 2 skipped
```

The entry is deleted, and the HTML-equivalence oracle no longer skips documents carrying raw HTML — it judges them. `raw-html` now passes both oracles; the allowlist is empty (`39 passed, 1 skipped`, the remaining skip being admonitions).

## Scope and the honest trade

Markdown renderer only. HTML, AsciiDoc and Textile still default to `escape`.

Converting **untrusted markdown** to markdown now preserves a `<script>` that `escape` used to neutralise. That is the real trade. It matches pandoc and CommonMark, sanitising is the final HTML renderer's job, and `escape` is one option away — but it is a genuine change in posture, so `docs/source/security.rst` no longer claims "HTML is ESCAPED by default" and says what actually protects the untrusted path instead.

`tests/unit/parsers/test_html_dangerous_tags_never_reach_a_renderer.py` asserts the invariant this rests on, with a control that proves the probe can see a raw-HTML node (markdown produces one) so it cannot pass vacuously. If the HTML parser ever starts emitting raw HTML for those tags, that file fails and the default gets reconsidered rather than quietly becoming unsafe.

## Checks

- `ruff check`, `black --check src tests benchmarks`, `mypy src/` all clean
- `pytest tests/unit tests/golden` — no failures
- `pytest tests/integration tests/e2e` — two tests encoded the old default and were rewritten to force `escape` explicitly, so they keep testing escaping's real cost rather than a default that can move; one new test covers the other half
- `scripts/action_gate.py run --paths '*.md' --roundtrip-fail-under 100 --report-fail-under 100` — 9/9 at 100 locally (CI sees 6; three are gitignored)
- `docs/source/options.rst` regenerated

🤖 Generated with [Claude Code](https://claude.com/claude-code)