### PR TITLE
fix(markdown): round-trip table captions through a marker comment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Table captions survive a Markdown round trip.** Markdown has no caption syntax, so the
+  renderer demoted `Table.caption` to an italic paragraph — which a reader could see, but
+  which came back as ordinary prose, so the trip lost the caption *and* gained a `Paragraph`
+  node that was not in the input. The caption is now written as that same italic paragraph
+  followed by an `<!-- all2md:table-caption -->` marker, which the Markdown parser folds back
+  into `Table.caption` along with the paragraph. Readers still see the caption, the AST comes
+  back with the node count it started with, and since the marker carries no copy of the text,
+  editing the visible line edits the caption. The fold is deliberately narrow: a bare marker,
+  a marker with no table after it, or an italic paragraph with no marker are all left alone.
+  `comment_mode="ignore"` suppresses the marker, and the caption then degrades to the italic
+  paragraph as before. This was the last of the four formats in #237 — asciidoc, rst and org
+  already round-tripped their captions (#237).
+
 ### Added
 
 - **Every registered format's options class is now importable from both `all2md` and

--- a/src/all2md/constants.py
+++ b/src/all2md/constants.py
@@ -386,6 +386,14 @@ DEFAULT_HTML_PASSTHROUGH_MODE: HtmlPassthroughMode = "escape"
 HTML_PASSTHROUGH_MODES = ["pass-through", "escape", "drop", "sanitize"]
 DEFAULT_MARKDOWN_HTML_PASSTHROUGH_MODE: HtmlPassthroughMode = "escape"  # Secure by default
 
+# Markdown has no table-caption syntax, so the renderer writes the caption as an
+# italic paragraph (which readers see) followed by this marker comment (which the
+# parser sees). Neither alone is enough: the paragraph is indistinguishable from
+# ordinary prose on the way back in, and a comment carrying the text would hide
+# the caption from anyone reading the file. The marker deliberately carries no
+# caption text, so editing the visible line edits the caption. See #237.
+MARKDOWN_TABLE_CAPTION_MARKER = "all2md:table-caption"
+
 # Boilerplate text removal patterns (used by RemoveBoilerplateTextTransform)
 DEFAULT_BOILERPLATE_PATTERNS = [
     r"^CONFIDENTIAL$",

--- a/src/all2md/parsers/markdown.py
+++ b/src/all2md/parsers/markdown.py
@@ -61,7 +61,8 @@ from all2md.ast import (
     ThematicBreak,
     Underline,
 )
-from all2md.constants import DEPS_MARKDOWN
+from all2md.ast.utils import extract_text
+from all2md.constants import DEPS_MARKDOWN, MARKDOWN_TABLE_CAPTION_MARKER
 from all2md.converter_metadata import ConverterMetadata
 from all2md.options.markdown import MarkdownParserOptions
 from all2md.parsers.base import BaseParser
@@ -475,7 +476,7 @@ class MarkdownToAstConverter(BaseParser):
 
         # Convert tokens to AST (tokens should always be a list for our configuration)
         if isinstance(tokens, list):
-            children = self._process_tokens(tokens)
+            children = self._reattach_table_captions(self._process_tokens(tokens))
         else:
             # Fallback for unexpected token format
             children = []
@@ -1214,6 +1215,79 @@ class MarkdownToAstConverter(BaseParser):
                     nodes.append(node)
 
         return self._fold_underline_html(nodes)
+
+    def _reattach_table_captions(self, nodes: list[Node]) -> list[Node]:
+        """Fold ``*caption*`` + marker comment + table back into ``Table.caption``.
+
+        Markdown has no caption syntax, so the renderer emits the caption twice
+        over: an italic paragraph a reader can see, and a marker comment that
+        says the paragraph was a caption rather than prose (#237). Without the
+        marker there is nothing to distinguish the two on the way back in, and a
+        round trip both lost the caption *and* gained a paragraph node -- a
+        structural change, not just a missing attribute.
+
+        Deliberately conservative. Only the exact triple folds, and only when the
+        paragraph holds a single Emphasis; a bare marker, a marker with no table
+        after it, or an italic paragraph with no marker are all left untouched,
+        because each is more likely to be someone's real content than a caption
+        we should be rewriting. The caption text is read from the *visible*
+        paragraph, not the marker, so editing the rendered line edits the
+        caption.
+
+        Parameters
+        ----------
+        nodes : list of Node
+            Block-level nodes, in document order
+
+        Returns
+        -------
+        list of Node
+            The same nodes with any caption triples collapsed into their table
+
+        """
+        for node in nodes:
+            # Tables nest inside list items and blockquotes, so the marker can be
+            # there too; recurse before matching so the inner fold happens. Both
+            # attribute names are needed: List holds its ListItems under `items`,
+            # everything else uses `children`. DefinitionList also has `items` but
+            # holds tuples, hence the element check rather than a bare isinstance.
+            for attribute in ("children", "items"):
+                container = getattr(node, attribute, None)
+                if isinstance(container, list) and container and all(isinstance(c, Node) for c in container):
+                    setattr(node, attribute, self._reattach_table_captions(container))
+
+        result: list[Node] = []
+        index = 0
+        while index < len(nodes):
+            caption = self._caption_from_triple(nodes, index)
+            if caption is not None:
+                table = nodes[index + 2]
+                assert isinstance(table, Table)
+                table.caption = caption
+                result.append(table)
+                index += 3
+                continue
+            result.append(nodes[index])
+            index += 1
+        return result
+
+    def _caption_from_triple(self, nodes: list[Node], index: int) -> str | None:
+        """Return the caption text if ``nodes[index:index + 3]`` is a caption triple."""
+        if index + 2 >= len(nodes):
+            return None
+
+        paragraph, comment, table = nodes[index], nodes[index + 1], nodes[index + 2]
+        if not (isinstance(paragraph, Paragraph) and isinstance(comment, Comment) and isinstance(table, Table)):
+            return None
+        if comment.content.strip() != MARKDOWN_TABLE_CAPTION_MARKER:
+            return None
+        if table.caption:
+            return None
+        if len(paragraph.content) != 1 or not isinstance(paragraph.content[0], Emphasis):
+            return None
+
+        text = extract_text(paragraph.content[0], joiner="").strip()
+        return text or None
 
     def _fold_underline_html(self, nodes: list[Node]) -> list[Node]:
         """Fold ``<u>``/``<ins>`` HTMLInline pairs back into Underline nodes.

--- a/src/all2md/renderers/markdown.py
+++ b/src/all2md/renderers/markdown.py
@@ -57,6 +57,7 @@ from all2md.ast.nodes import (
     Underline,
 )
 from all2md.ast.visitors import NodeVisitor
+from all2md.constants import MARKDOWN_TABLE_CAPTION_MARKER
 from all2md.options.markdown import MarkdownRendererOptions
 from all2md.renderers.base import BaseRenderer, InlineContentMixin
 from all2md.utils.flavors import (
@@ -1126,9 +1127,16 @@ class MarkdownRenderer(NodeVisitor, InlineContentMixin, BaseRenderer):
         Split out from ``visit_table`` so the caller can capture the table in a
         buffer and shift it to the current indentation.
         """
-        # Render caption if present
+        # Render caption if present. Markdown has no caption syntax, so the
+        # caption becomes an italic paragraph plus a marker comment: the
+        # paragraph is what a reader sees, the marker is what tells our parser
+        # that paragraph was a caption rather than prose (#237). Suppressed under
+        # comment_mode="ignore", which asks for no comments in the output at all;
+        # the caption then degrades to the italic paragraph, as it always did.
         if node.caption:
             self._output.append(f"*{node.caption}*\n\n")
+            if self.options.comment_mode != "ignore":
+                self._output.append(f"<!-- {MARKDOWN_TABLE_CAPTION_MARKER} -->\n\n")
 
         # Handle tables not supported by the flavor
         if not self._flavor.supports_tables():

--- a/tests/golden/__snapshots__/test_generated_fixtures_golden.ambr
+++ b/tests/golden/__snapshots__/test_generated_fixtures_golden.ambr
@@ -477,6 +477,8 @@
   
   *Sample Data*
   
+  <!-- all2md:table-caption -->
+  
   | Column A | Column B |
   |---|---|
   | Alpha | 1 |

--- a/tests/golden/__snapshots__/test_renderer_outputs_golden.ambr
+++ b/tests/golden/__snapshots__/test_renderer_outputs_golden.ambr
@@ -95,6 +95,8 @@
   
   *Key Metrics*
   
+  <!-- all2md:table-caption -->
+  
   | Metric | Value |
   |---|---|
   | Velocity | 22.5 m/s |

--- a/tests/golden/__snapshots__/test_textual_formats_golden.ambr
+++ b/tests/golden/__snapshots__/test_textual_formats_golden.ambr
@@ -236,6 +236,8 @@
   
   *Sample Data*
   
+  <!-- all2md:table-caption -->
+  
   | Column A | Column B |
   |---|---|
   | Alpha | 1 |

--- a/tests/unit/parsers/test_markdown_table_caption.py
+++ b/tests/unit/parsers/test_markdown_table_caption.py
@@ -1,0 +1,151 @@
+#  Copyright (c) 2025 Tom Villani, Ph.D.
+"""Table captions survive a Markdown round trip (#237).
+
+Markdown has no caption syntax, so there is no lossless single answer. Emitting
+only an italic paragraph is what we did before: readable, but on the way back in
+it is indistinguishable from prose, so the round trip lost the caption *and*
+gained a Paragraph node - a structural change, not a missing attribute. Emitting
+only an HTML comment would round-trip cleanly and hide the caption from anyone
+reading the file.
+
+So the renderer emits both, and the parser folds the triple back into
+``Table.caption``. The marker carries no text: the visible line is the caption,
+which means editing the file edits the caption rather than desynchronising it
+from a hidden copy.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from all2md import to_ast
+from all2md.ast.nodes import Document, Paragraph, Table, TableCell, TableRow, Text
+from all2md.constants import MARKDOWN_TABLE_CAPTION_MARKER
+from all2md.options import MarkdownRendererOptions
+from all2md.renderers.markdown import MarkdownRenderer
+
+pytestmark = [pytest.mark.unit, pytest.mark.table]
+
+
+def _cell(text: str) -> TableCell:
+    return TableCell(content=[Text(content=text)])
+
+
+def _table(caption: str | None = "Table 1. Results") -> Table:
+    return Table(
+        header=TableRow(
+            is_header=True,
+            cells=[_cell("A"), _cell("B")],
+        ),
+        rows=[TableRow(cells=[_cell("1"), _cell("2")])],
+        caption=caption,
+    )
+
+
+def _render(document: Document, **options: object) -> str:
+    return MarkdownRenderer(MarkdownRendererOptions(**options)).render_to_string(document)  # type: ignore[arg-type]
+
+
+class TestRoundTrip:
+    def test_caption_survives_and_adds_no_node(self) -> None:
+        rendered = _render(Document(children=[_table()]))
+        parsed = to_ast(rendered.encode(), source_format="markdown")
+
+        assert [type(node).__name__ for node in parsed.children] == ["Table"]
+        assert parsed.children[0].caption == "Table 1. Results"
+
+    def test_the_caption_is_still_visible_to_a_reader(self) -> None:
+        """The reason we do not just use a comment."""
+        rendered = _render(Document(children=[_table()]))
+        assert "*Table 1. Results*" in rendered
+
+    def test_rendering_is_idempotent(self) -> None:
+        once = _render(Document(children=[_table()]))
+        twice = _render(to_ast(once.encode(), source_format="markdown"))
+        assert once == twice
+
+    def test_editing_the_visible_line_edits_the_caption(self) -> None:
+        """The marker deliberately carries no copy of the text."""
+        rendered = _render(Document(children=[_table()])).replace("Table 1. Results", "Table 1. Revised")
+        parsed = to_ast(rendered.encode(), source_format="markdown")
+        assert parsed.children[0].caption == "Table 1. Revised"
+
+    def test_a_table_without_a_caption_gains_neither_marker_nor_paragraph(self) -> None:
+        rendered = _render(Document(children=[_table(caption=None)]))
+        assert MARKDOWN_TABLE_CAPTION_MARKER not in rendered
+        parsed = to_ast(rendered.encode(), source_format="markdown")
+        assert [type(node).__name__ for node in parsed.children] == ["Table"]
+        assert parsed.children[0].caption is None
+
+    def test_a_caption_inside_a_list_item_folds_too(self) -> None:
+        """Tables nest, so the triple can be nested; the fold recurses."""
+        from all2md.ast.nodes import List, ListItem
+
+        document = Document(children=[List(ordered=False, items=[ListItem(children=[_table()])])])
+        parsed = to_ast(_render(document).encode(), source_format="markdown")
+
+        tables = [n for n in parsed.children[0].items[0].children if isinstance(n, Table)]
+        assert len(tables) == 1
+        assert tables[0].caption == "Table 1. Results"
+
+
+class TestItIsConservative:
+    """Each of these is more likely someone's real content than a caption to rewrite."""
+
+    def test_an_italic_paragraph_before_a_table_is_left_alone(self) -> None:
+        """The control that matters: without the marker, nothing is swallowed."""
+        source = b"*Just some emphasis.*\n\n| A | B |\n|---|---|\n| 1 | 2 |\n"
+        parsed = to_ast(source, source_format="markdown")
+
+        assert [type(node).__name__ for node in parsed.children] == ["Paragraph", "Table"]
+        assert parsed.children[1].caption is None
+
+    def test_a_marker_with_no_table_after_it_is_left_alone(self) -> None:
+        source = f"*Cap*\n\n<!-- {MARKDOWN_TABLE_CAPTION_MARKER} -->\n\nJust a paragraph.\n".encode()
+        parsed = to_ast(source, source_format="markdown")
+        assert [type(node).__name__ for node in parsed.children] == ["Paragraph", "Comment", "Paragraph"]
+
+    def test_a_bare_marker_before_a_table_is_left_alone(self) -> None:
+        source = f"<!-- {MARKDOWN_TABLE_CAPTION_MARKER} -->\n\n| A |\n|---|\n| 1 |\n".encode()
+        parsed = to_ast(source, source_format="markdown")
+        assert [type(node).__name__ for node in parsed.children] == ["Comment", "Table"]
+        assert parsed.children[1].caption is None
+
+    def test_a_mixed_paragraph_is_not_treated_as_a_caption(self) -> None:
+        """Only a paragraph that is *entirely* one emphasis span reads as a caption."""
+        source = f"Lead in *Cap*\n\n<!-- {MARKDOWN_TABLE_CAPTION_MARKER} -->\n\n| A |\n|---|\n| 1 |\n".encode()
+        parsed = to_ast(source, source_format="markdown")
+        assert [type(node).__name__ for node in parsed.children] == ["Paragraph", "Comment", "Table"]
+
+
+class TestCommentMode:
+    def test_ignore_suppresses_the_marker_and_says_so_by_losing_the_caption(self) -> None:
+        """``comment_mode="ignore"`` asks for no comments; the caption degrades as it used to."""
+        rendered = _render(Document(children=[_table()]), comment_mode="ignore")
+
+        assert MARKDOWN_TABLE_CAPTION_MARKER not in rendered
+        assert "*Table 1. Results*" in rendered
+
+        parsed = to_ast(rendered.encode(), source_format="markdown")
+        assert [type(node).__name__ for node in parsed.children] == ["Paragraph", "Table"]
+        assert parsed.children[1].caption is None
+
+    @pytest.mark.parametrize("mode", ["html", "blockquote"])
+    def test_every_other_comment_mode_keeps_the_round_trip(self, mode: str) -> None:
+        rendered = _render(Document(children=[_table()]), comment_mode=mode)
+        parsed = to_ast(rendered.encode(), source_format="markdown")
+        assert isinstance(parsed.children[0], Table)
+        assert parsed.children[0].caption == "Table 1. Results"
+
+
+def test_the_probe_can_see_a_lost_caption() -> None:
+    """Guard the guard: prove an un-marked caption really does fail to round trip.
+
+    Otherwise every assertion above could be passing for some unrelated reason.
+    """
+    source = b"*Table 1. Results*\n\n| A | B |\n|---|---|\n| 1 | 2 |\n"
+    parsed = to_ast(source, source_format="markdown")
+
+    assert any(isinstance(node, Paragraph) for node in parsed.children)
+    table = next(node for node in parsed.children if isinstance(node, Table))
+    assert table.caption is None

--- a/tests/unit/test_roundtrip_fuzzing.py
+++ b/tests/unit/test_roundtrip_fuzzing.py
@@ -460,15 +460,12 @@ INVARIANTS: dict[str, tuple[Document, object, object]] = {
 #: does emit the right syntax, with a parser that will not read it back, is a
 #: different fix from a renderer that emits nothing. Prefer measuring the
 #: rendered output before trusting a reason in this table.
-KNOWN_INVARIANT_GAPS: dict[tuple[str, str], str] = {
-    # The last of the four table-caption entries (#237). asciidoc, rst and org each
-    # have a caption syntax and now use it. Markdown has none, and the current
-    # behaviour is worse than a dropped attribute: the caption is demoted to an
-    # italic paragraph, which injects a node that was not in the input. Whether to
-    # keep that and document it as lossy, or round-trip through an HTML comment, is
-    # a deliberate choice about output aimed at human readers, so it is still open.
-    ("markdown", "table-caption-survives"): "renderer demotes the caption to an italic paragraph (#237)",
-}
+#:
+#: Empty since #237 closed the last table-caption entry. Markdown has no caption
+#: syntax, so the renderer emits the caption twice over -- an italic paragraph for
+#: readers, a marker comment for the parser -- and the invariant holds without
+#: making the caption invisible in the file.
+KNOWN_INVARIANT_GAPS: dict[tuple[str, str], str] = {}
 
 #: Formats the invariant gate covers. Text formats only: the invariants probe
 #: specific node attributes, and the container formats lose so much structure


### PR DESCRIPTION
Closes #237 — the last of its four formats. asciidoc, rst and org already round-tripped their captions.

## The problem was worse than a lost attribute

Markdown has no caption syntax, so the renderer demoted `Table.caption` to an italic paragraph. A reader could see it, but on the way back in it was indistinguishable from prose:

```
in:   [Table(caption="My caption")]
out:  [Paragraph, Table(caption=None)]
```

So the round trip lost the caption **and gained a node**. That is a structural change, not a missing attribute — which is why it could not just be documented as lossy.

## Why (c) and not (a) or (b)

- **(a) italic paragraph only** — what we had.
- **(b) HTML comment only** — round-trips cleanly and hides the caption from anyone reading the file. Wrong trade for output aimed at humans.
- **(c) both** — the renderer emits the italic paragraph *then* `<!-- all2md:table-caption -->`; the parser folds the triple back into `Table.caption`, dropping the paragraph and the marker with it.

```markdown
*Table 1. Results*

<!-- all2md:table-caption -->

| A | B |
|---|---|
| 1 | 2 |
```

The marker deliberately carries **no copy of the text**. Editing the visible line edits the caption, rather than desynchronising it from a hidden duplicate — there is a test for exactly that.

## The fold is narrow on purpose

Only the exact `Paragraph` / `Comment` / `Table` triple collapses, and only when the paragraph is a single `Emphasis` span. Left alone, each with its own test:

- an italic paragraph before a table with no marker (the control that matters — nothing gets swallowed)
- a bare marker before a table
- a marker with no table after it
- a paragraph that merely *contains* emphasis (`Lead in *Cap*`)

It recurses through both `children` and `items`, since tables nest inside list items and blockquotes and the marker nests with them. `List` holding its items under `items` rather than `children` is what made the nested case fail on the first pass.

`comment_mode="ignore"` asks for no comments in the output at all, so the marker is suppressed there and the caption degrades to the italic paragraph exactly as before — asserted, not assumed.

## Verification

- `KNOWN_INVARIANT_GAPS` in `test_roundtrip_fuzzing.py` is now **empty**; the `markdown-table-caption-survives` strict-xfail is deleted and the invariant passes.
- Control: neutering the parser fold fails **6** tests, including that invariant.
- A "guard the guard" test proves an unmarked caption really does fail to round-trip, so the suite cannot be passing for an unrelated reason.
- Three golden snapshots gain the marker line, two of them RST fixtures — a real `.. table::` caption now survives the trip into Markdown. Diff is +2 lines each, nothing else.
- `ruff check`, `black --check`, `mypy src/` clean; `pytest tests/unit tests/golden` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)