### PR TITLE
docs(changelog): record #265, which merged without an entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **`json_to_ast` no longer crashes on explicit JSON nulls.** A producer outside this library
+  routinely writes `null` for a field it has nothing to say about, and `"children": [null]`,
+  `"content": null` or a null `metadata` object reached the node constructors unchanged. The
+  failure then surfaced much later, inside a renderer, as a `TypeError` naming nothing that
+  would help. Null list and object fields now read as empty, null child entries are skipped,
+  and a field that is structurally required — a `Heading` level, a `List` ordered flag —
+  raises a `ValueError` naming the node and the field instead of defaulting to something
+  plausible. Thanks to @santhreal (#265).
+
 ### Added
 
 - **Every registered format's options class is now importable from both `all2md` and


### PR DESCRIPTION
#265 landed on `main` without a CHANGELOG line, so a user-visible fix would have shipped invisible.

`json_to_ast` crashing on explicit JSON nulls is exactly the kind of thing someone integrating all2md with another producer needs to be able to find in the changelog. Credited to @santhreal.

Verified `CHANGELOG.md` still round-trips at 100 under both `escape` and `pass-through`, since #314 raises the doc gate to 100 with zero headroom.

🤖 Generated with [Claude Code](https://claude.com/claude-code)