### PR TITLE
docs(roadmap): correct Theme 8 for the OCR geometry work that shipped

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -456,13 +456,20 @@ to unwind later.
 But the adapter contract is:
 
 ```python
-def ocr_pixmap(pix: fitz.Pixmap, page: fitz.Page, options: PdfOptions) -> str
+def ocr_pixmap(pix: pymupdf.Pixmap, page: pymupdf.Page, options: PdfOptions) -> str
 ```
 
 It returns **`str`**, and the geometry is destroyed twice on the way out: EasyOCR already
 returns bounding boxes, and our adapter uses them to reconstruct reading order and then
 discards them; then the PDF parser wraps the resulting flat string in a single synthetic
 PyMuPDF block spanning the whole page.
+
+**The second of those two losses is now fixed** (unreleased). A geometry-carrying contract
+sits beside the flat one — `ocr_pixmap_layout(...) -> list[OcrParagraph] | None` — which
+Tesseract implements through `image_to_data`, and the PDF parser emits one block per
+returned paragraph. The first loss stands: EasyOCR still returns flat text and still
+discards its own boxes, so `ocr_pixmap_layout` returns `None` for it and `-> str` remains a
+live fallback rather than a replaced one.
 
 So a socket on top of this contract lets you plug in Textract, Azure Document Intelligence,
 Google Document AI, surya or olmOCR — and then discard precisely the thing you are paying
@@ -476,11 +483,14 @@ one thread.
   `constants.py`, with the `choices` list duplicated in the options metadata — an engine name
   lives in three places. A registry-backed `str` with dynamically-populated choices is needed;
   the transforms registry resolves the same tension by validating at lookup time.
-- **The "generic" OCR layer is PyMuPDF-coupled.** `fitz.Pixmap` + a live `fitz.Page` in the
-  signature — the page only for language auto-detection, which both adapters call themselves.
-  Any non-PDF caller would have to fabricate a `fitz.Page`. Both adapters immediately convert
-  to PIL anyway, so the natural contract is image-bytes/PIL + `OCROptions`, with language
-  detection hoisted out.
+- **The "generic" OCR layer is PyMuPDF-coupled.** `pymupdf.Pixmap` + a live `pymupdf.Page` in
+  the signature. Any non-PDF caller would have to fabricate a `pymupdf.Page`. Both adapters
+  immediately convert to PIL anyway, so the natural contract is image-bytes/PIL +
+  `OCROptions`, with language detection hoisted out. **This got harder, not easier:** the page
+  used to be needed only for language auto-detection, but `ocr_pixmap_layout` also reads
+  `page.rect` for the scale factors that map results back into PDF points. Hoisting language
+  detection is therefore no longer sufficient on its own — the target coordinate space has to
+  be passed in as well.
 - **Engine-specific fields sit on shared options.** `tesseract_config` and `gpu` both live on
   `OCROptions`. This does not scale and a plugin cannot add its own — wants an
   `engine_options: dict[str, Any]` passthrough.
@@ -489,11 +499,15 @@ one thread.
 
 ### Shape (staged, each stage independently useful)
 
-1. 🌱 **A geometry-carrying OCR result type.** Replace `-> str` with a result object
-   carrying text + per-span bboxes + confidence. Stop the EasyOCR adapter from flattening;
-   stop the PDF parser from collapsing to one page-sized block. **No new engine, no plugin
-   API** — this stage is pure internal correctness and is where the value is. Tesseract
-   exposes boxes via `image_to_data`, so both existing engines can honour it.
+1. 🌱 **A geometry-carrying OCR result type** — *partially shipped (unreleased).*
+   `OcrParagraph`/`OcrLine` exist, Tesseract fills them from `image_to_data`, and the PDF
+   parser no longer collapses a page to one block; per-paragraph bboxes reach the AST
+   through `SourceLocation.metadata['bbox']`. **Three pieces are still open:** granularity is
+   the line rather than the span; confidence is *read* from Tesseract only to drop `conf < 0`
+   rows and then discarded, so nothing downstream can weigh a low-confidence region; and the
+   EasyOCR adapter still flattens, which is what keeps `-> str` alive as a fallback instead
+   of replacing it. **No new engine, no plugin API** — this stage is pure internal
+   correctness and is where the value is.
 2. 🌱 **Decouple + then socket.** Move to PIL/bytes + `OCROptions`, hoist language detection,
    add `engine_options` passthrough, *then* add an `all2md.ocr_engines` entry-point group
    modelled on the transforms registry. Cheap once (1) fixed the contract; actively harmful

--- a/src/all2md/parsers/pdf.py
+++ b/src/all2md/parsers/pdf.py
@@ -1412,17 +1412,13 @@ class PdfToAstConverter(BaseParser):
         # the zoom matrix (DPI/72 = zoom factor).
         zoom = options.ocr.dpi / 72.0
 
-        # Initialize pixmap reference for proper cleanup in finally block
-        pix = None
-        try:
-            mat = pymupdf.Matrix(zoom, zoom)
-            pix = page.get_pixmap(matrix=mat)
-            return ocr_pixmap(pix, page, options)
-        finally:
-            # Clean up pixmap resources to prevent memory leaks
-            # This is critical for long-running OCR operations
-            if pix is not None:
-                pix = None
+        # No explicit pixmap cleanup: the buffer is freed when the last reference to it
+        # goes away, and that is this function returning. Rebinding the local to None
+        # first — as this did — happens after the return value is computed and drops a
+        # reference that is about to be dropped anyway.
+        mat = pymupdf.Matrix(zoom, zoom)
+        pix = page.get_pixmap(matrix=mat)
+        return ocr_pixmap(pix, page, options)
 
     @staticmethod
     def _ocr_page_to_layout(page: "pymupdf.Page", options: PdfOptions) -> "list[OcrParagraph] | None":
@@ -1446,7 +1442,6 @@ class PdfToAstConverter(BaseParser):
         from all2md.parsers._ocr import ocr_pixmap_layout
 
         zoom = options.ocr.dpi / 72.0
-        pix = None
         try:
             mat = pymupdf.Matrix(zoom, zoom)
             pix = page.get_pixmap(matrix=mat)


### PR DESCRIPTION
## Why

Theme 8 describes the OCR layer as it stood before PR #280 and before the `fitz` → `pymupdf` rename in #313. It claims as future work things that are already done, and understates one blocker that got *harder*.

## ROADMAP corrections

| Claim | Status |
|---|---|
| Adapter contract is `ocr_pixmap(pix: fitz.Pixmap, page: fitz.Page, ...)` | `pymupdf` since #313 |
| "The geometry is destroyed twice on the way out" | Half fixed — see below |
| Stage 1, a geometry-carrying result type: not started | Partially shipped |
| Blocker: page needed "only for language auto-detection" | No longer true |

**The second loss is fixed, the first is not.** `ocr_pixmap_layout(...) -> list[OcrParagraph] | None` now sits beside the flat contract, Tesseract implements it through `image_to_data`, and the parser emits one block per returned paragraph. But EasyOCR still returns flat text and still discards its own boxes, so `ocr_pixmap_layout` returns `None` for it and `-> str` stays a live fallback rather than a replaced one. Stage 1 is marked with the doc's own `*partially shipped*` idiom (as Theme 1 already uses) and names the three pieces still open: line rather than span granularity, confidence read from Tesseract only to drop `conf < 0` rows and then discarded, and the EasyOCR flattening.

**The coupling blocker needed strengthening, not softening.** It said the page was needed only for language auto-detection, implying that hoisting that call would decouple the layer. `ocr_pixmap_layout` now *also* reads `page.rect` for the scale factors that map results back into PDF points, so the target coordinate space has to be passed in as well.

## Dead code

`_ocr_page_to_text` carried a `finally` block rebinding a local to `None` immediately before returning, commented "critical for long-running OCR operations." It is a no-op — the rebinding runs after the return value is computed and drops a reference that is about to be dropped anyway. CodeQL removed the identical block from the sibling `_ocr_page_to_layout` during the #280 merge but never flagged this copy. The sibling's now-unused `pix = None` initialiser goes too, so the two functions read the same way.

## Verification

The no-op claim is measured, not asserted. Forcing OCR over a synthetic scan and hashing the output of `to_markdown`, `_ocr_page_to_text` and `_ocr_page_to_layout`:

```
                       dead code present      dead code removed
layout                 5e7f3c78acc66360   =   5e7f3c78acc66360
flat                   5e7f3c78acc66360   =   5e7f3c78acc66360
_ocr_page_to_text      8b58204da19644a5   =   8b58204da19644a5
_ocr_page_to_layout    1942c68d31b62451   =   1942c68d31b62451
```

Tesseract genuinely ran in both arms (3 paragraphs recovered, non-empty flat text), so the comparison had the opportunity to fail.

Also: 84 OCR tests pass, `tests/unit/parsers` exits 0, ruff and mypy clean, and the root-document quality gate still scores all nine at fidelity 100 / confidence 100 — `ROADMAP.md` included, which has no headroom.

No CHANGELOG entry: no shipped behaviour changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
