### PR TITLE
feat(options): export OCROptions and MetadataRenderPolicy from the public API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   reachable from `all2md` but not from `all2md.options`, which is backwards from every
   sibling. The two surfaces are now derived from the converter registry and a test fails if
   either drifts from it again, so adding a format cannot quietly skip the export (#184).
+- **`OCROptions` and `MetadataRenderPolicy` are importable from `all2md` and `all2md.options`
+  too.** Both are the declared type of a field on an exported options class — `PdfOptions.ocr`
+  and `BaseRendererOptions.metadata_policy`, the latter reaching every renderer — so a caller
+  has to construct one to set that field, and neither was reachable from either public
+  surface. Configuring OCR from the Python API meant importing `all2md.options.common`, which
+  the `PdfOptions` docstring told you to do; passing a plain dict instead did not work, and
+  failed deep inside parsing with `'dict' object has no attribute 'enabled'` rather than at
+  the call. The check that was supposed to catch this could not: #184 derives its expectation
+  from the converter manifest, which names only *format* options classes, and a nested
+  configuration group belongs to no format. The new rule is derived rather than listed — any
+  dataclass appearing in a public options class's field annotations must be public itself —
+  and it resolves the annotations before looking, because this package uses `from __future__
+  import annotations` and 91% of those fields carry their type as a plain string, so the
+  obvious version of the check inspects 89 of 982 fields and reports success.
 - **`layout_feature_set`, choosing which layout classifier reads the page** (`--pdf-layout-feature-set`,
   requires `pymupdf-layout`; inert otherwise). The package bundles three: `imf+rf` (the
   default, image and text-geometry features), `imf` (image only) and `rf` (text geometry

--- a/src/all2md/__init__.py
+++ b/src/all2md/__init__.py
@@ -160,9 +160,10 @@ from all2md.optimize import Candidate, DocumentMetrics, OptimizationReport
 
 # Keep only base and common option classes that are lightweight and frequently used
 from all2md.options.base import BaseParserOptions, BaseRendererOptions
-from all2md.options.common import LocalFileAccessOptions, NetworkFetchOptions
+from all2md.options.common import LocalFileAccessOptions, NetworkFetchOptions, OCROptions
 from all2md.progress import ProgressCallback, ProgressEvent
 from all2md.roundtrip import RoundTripReport, StructuralDelta
+from all2md.utils.metadata import MetadataRenderPolicy
 
 # Import parsers to trigger registration (must be eager, not lazy)
 from . import parsers  # noqa: F401
@@ -282,6 +283,8 @@ __all__ = [
     "BaseParserOptions",
     "NetworkFetchOptions",
     "LocalFileAccessOptions",
+    "MetadataRenderPolicy",
+    "OCROptions",
     "ArchiveOptions",
     "AsciiDocOptions",
     "AsciiDocRendererOptions",

--- a/src/all2md/options/__init__.py
+++ b/src/all2md/options/__init__.py
@@ -47,6 +47,7 @@ if TYPE_CHECKING:
         AttachmentOptionsMixin,
         LocalFileAccessOptions,
         NetworkFetchOptions,
+        OCROptions,
     )
     from all2md.options.csv import CsvOptions, CsvRendererOptions
     from all2md.options.docx import DocxOptions, DocxRendererOptions
@@ -83,6 +84,10 @@ if TYPE_CHECKING:
     from all2md.options.xlsx import XlsxOptions
     from all2md.options.yaml import YamlParserOptions, YamlRendererOptions
     from all2md.options.zip import ZipOptions
+
+    # Defined in all2md.utils.metadata, but it is the type of a field on every
+    # renderer's options, so a caller setting metadata_policy needs it from here.
+    from all2md.utils.metadata import MetadataRenderPolicy
 
 #: Exported name -> the ``all2md.options`` submodule that defines it.
 _LAZY_EXPORTS: dict[str, str] = {
@@ -125,8 +130,12 @@ _LAZY_EXPORTS: dict[str, str] = {
     "MboxOptions": "mbox",
     "MediaWikiOptions": "mediawiki",
     "MediaWikiParserOptions": "mediawiki",
+    # Really all2md.utils.metadata.MetadataRenderPolicy; base re-exports it, and the
+    # lazy table addresses submodules of this package.
+    "MetadataRenderPolicy": "base",
     "MhtmlOptions": "mhtml",
     "NetworkFetchOptions": "common",
+    "OCROptions": "common",
     "OdpOptions": "odp",
     "OdpRendererOptions": "odp",
     "OdsSpreadsheetOptions": "ods",
@@ -217,7 +226,9 @@ __all__ = [
     "BaseParserOptions",
     "BaseRendererOptions",
     "LocalFileAccessOptions",
+    "MetadataRenderPolicy",
     "NetworkFetchOptions",
+    "OCROptions",
     "ArchiveOptions",
     "AsciiDocOptions",
     "AsciiDocRendererOptions",

--- a/src/all2md/options/pdf.py
+++ b/src/all2md/options/pdf.py
@@ -230,7 +230,7 @@ class PdfOptions(PaginatedParserOptions):
         ... )
 
     Enable OCR for scanned PDF documents:
-        >>> from all2md.options.common import OCROptions
+        >>> from all2md.options import OCROptions
         >>> options = PdfOptions(
         ...     ocr=OCROptions(enabled=True, mode="auto", languages="eng")
         ... )

--- a/tests/unit/test_nested_options_export_surface.py
+++ b/tests/unit/test_nested_options_export_surface.py
@@ -1,0 +1,136 @@
+#  Copyright (c) 2025 Tom Villani, Ph.D.
+"""A nested options type must be as public as the options class that declares it.
+
+``test_options_export_surface.py`` derives its expectation from the converter
+manifest, which names only *format* options classes. That structurally cannot see
+a class which is not any converter's options but is the declared type of a field
+on one - so two of them were unreachable from either public surface:
+
+* ``OCROptions``, the type of ``PdfOptions.ocr``. Configuring OCR from the Python
+  API meant importing from ``all2md.options.common``, and passing a plain dict
+  instead failed deep inside parsing with ``'dict' object has no attribute
+  'enabled'`` rather than at the call.
+* ``MetadataRenderPolicy``, the type of ``BaseRendererOptions.metadata_policy`` -
+  so it reaches *every* renderer's options class.
+
+The rule below is derived, not listed: walk the resolved type hints of every
+publicly exported options class, and require any dataclass found in one to be
+exported too. Adding a nested options group cannot quietly skip the export.
+
+The annotations must be *resolved* to check this at all. This package uses
+``from __future__ import annotations``, so 91% of these fields carry their type as
+a plain string, and a probe that reads ``dataclasses.Field.type`` directly sees
+almost nothing and reports success. ``test_the_probe_resolves_string_annotations``
+exists to keep that failure from coming back silently.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import inspect
+import typing
+
+import pytest
+
+import all2md
+from all2md import options
+
+pytestmark = pytest.mark.unit
+
+
+def _public_option_classes() -> dict[str, type]:
+    """Every dataclass reachable from ``all2md.options.__all__``."""
+    found: dict[str, type] = {}
+    for name in options.__all__:
+        value = getattr(options, name, None)
+        if inspect.isclass(value) and dataclasses.is_dataclass(value):
+            found[name] = value
+    return found
+
+
+def _nested_dataclasses(cls: type) -> set[type]:
+    """Dataclasses appearing in ``cls``'s resolved field annotations."""
+    hints = typing.get_type_hints(cls)
+    nested: set[type] = set()
+    for field in dataclasses.fields(cls):
+        annotation = hints.get(field.name)
+        # Unwrap Optional[X] / X | None / list[X] one level, which is as deep as
+        # any options field currently nests.
+        candidates = (annotation, *(getattr(annotation, "__args__", ()) or ()))
+        for candidate in candidates:
+            if inspect.isclass(candidate) and dataclasses.is_dataclass(candidate):
+                nested.add(candidate)
+    return nested
+
+
+def _all_nested() -> dict[type, list[str]]:
+    """Nested dataclass -> the ``Class.field`` paths that declare it."""
+    declared: dict[type, list[str]] = {}
+    for name, cls in _public_option_classes().items():
+        for nested in _nested_dataclasses(cls):
+            declared.setdefault(nested, []).append(f"{name}.{cls.__name__}")
+    return declared
+
+
+_EXPORTED_CLASSES = {getattr(options, n) for n in options.__all__ if inspect.isclass(getattr(options, n, None))}
+_NESTED = _all_nested()
+_NESTED_NAMES = sorted({cls.__name__ for cls in _NESTED})
+
+
+def test_the_probe_resolves_string_annotations() -> None:
+    """Guard the guard: unresolved annotations make every check below vacuous.
+
+    Reading ``Field.type`` without resolving finds 89 of 982 fields. If this ever
+    drops toward zero the suite would pass while checking almost nothing.
+    """
+    raw_strings = 0
+    resolved = 0
+    for cls in _public_option_classes().values():
+        hints = typing.get_type_hints(cls)
+        for field in dataclasses.fields(cls):
+            if isinstance(field.type, str):
+                raw_strings += 1
+                if not isinstance(hints.get(field.name), str):
+                    resolved += 1
+
+    assert raw_strings > 500, f"expected most fields to be string annotations, got {raw_strings}"
+    assert resolved == raw_strings, f"{raw_strings - resolved} annotations did not resolve"
+
+
+def test_the_probe_finds_nested_dataclasses_at_all() -> None:
+    """Guard the guard: if the walk found nothing, the parametrised test is empty."""
+    assert len(_NESTED) >= 2, f"expected the walk to find nested options types, found {_NESTED_NAMES}"
+
+
+@pytest.mark.parametrize("name", _NESTED_NAMES)
+def test_nested_options_type_is_exported_from_both_surfaces(name: str) -> None:
+    """A type a caller must construct has to be importable from the public API."""
+    assert name in options.__all__, f"{name} is a field type on a public options class but missing from all2md.options"
+    assert name in all2md.__all__, f"{name} is a field type on a public options class but missing from all2md"
+    assert getattr(options, name) is getattr(all2md, name), f"{name} resolves to different objects on the two surfaces"
+
+
+@pytest.mark.parametrize("name", ["OCROptions", "MetadataRenderPolicy"])
+def test_the_two_classes_that_were_missing_import_and_construct(name: str) -> None:
+    """The specific regression, pinned by name so a refactor cannot lose it quietly."""
+    cls = getattr(all2md, name)
+    assert cls is getattr(options, name)
+    assert dataclasses.is_dataclass(cls)
+    cls()  # constructible with no arguments, as every options class is
+
+
+def test_ocr_options_configures_a_pdf_parse() -> None:
+    """The end the export exists for: reach OCR settings without a private import."""
+    from all2md import OCROptions, PdfOptions
+
+    parsed = PdfOptions(ocr=OCROptions(enabled=True, mode="force", dpi=150))
+    assert parsed.ocr.enabled is True
+    assert parsed.ocr.dpi == 150
+
+
+def test_metadata_policy_configures_a_renderer() -> None:
+    """``metadata_policy`` is on BaseRendererOptions, so this covers every renderer."""
+    from all2md import MarkdownRendererOptions, MetadataRenderPolicy
+
+    rendered = MarkdownRendererOptions(metadata_policy=MetadataRenderPolicy(visibility="core"))
+    assert rendered.metadata_policy.visibility == "core"

--- a/tests/unit/test_options_export_surface.py
+++ b/tests/unit/test_options_export_surface.py
@@ -40,13 +40,18 @@ def _registered_options_classes() -> set[str]:
     return names
 
 
-# Exported from ``all2md.options`` but not tied to any one format.
+# Exported from ``all2md.options`` but not tied to any one format. The last two are
+# nested configuration objects rather than a converter's own options: they are the
+# declared type of a field on an exported options class, so a caller has to be able
+# to construct one. ``test_nested_options_export_surface.py`` derives that rule.
 _NOT_FORMAT_OPTIONS = frozenset(
     {
         "BaseParserOptions",
         "BaseRendererOptions",
         "LocalFileAccessOptions",
+        "MetadataRenderPolicy",
         "NetworkFetchOptions",
+        "OCROptions",
         "UNSET",
         "create_updated_options",
     }


### PR DESCRIPTION
Follow-on to #184, found while writing a verification script for #318: `PdfOptions(ocr=...)` needs an `OCROptions` instance, and there was no public way to get one.

## The gap

Both classes are the declared type of a field on an exported options class, so a caller must construct one to set that field — and neither was importable from `all2md` or `all2md.options`:

| Field | Type | Reach |
|---|---|---|
| `PdfOptions.ocr` | `OCROptions` | PDF parsing |
| `BaseRendererOptions.metadata_policy` | `MetadataRenderPolicy` | **every** renderer |

Configuring OCR from the Python API meant `from all2md.options.common import OCROptions` — which the `PdfOptions` docstring itself instructed, and which this PR corrects. Passing a dict instead is not a workaround: it fails deep inside parsing with `AttributeError("'dict' object has no attribute 'enabled'")` rather than at the call site.

## Why #184's test could not see it

#184 derives its expectation from the converter manifest, which names only **format** options classes. A nested configuration group belongs to no format, so it is invisible to that rule no matter how the manifest grows.

The new rule is derived rather than listed: **any dataclass appearing in a public options class's field annotations must itself be public.** Adding a nested options group cannot quietly skip the export.

## The part worth reviewing

The check is worthless unless it resolves annotations first. This package uses `from __future__ import annotations`, so **893 of 982** option fields carry their type as a plain string. A probe reading `dataclasses.Field.type` directly inspects 89 fields, finds `OCROptions`, misses `MetadataRenderPolicy` entirely, and reports success.

My first pass did exactly that — it reported one miss, and only re-running with `typing.get_type_hints` surfaced the second, wider one. Two guards now pin this:

- `test_the_probe_resolves_string_annotations` — asserts >500 string annotations exist *and* that every one resolves.
- `test_the_probe_finds_nested_dataclasses_at_all` — fails if the walk returns nothing.

## Verification

The judge can fail: with the two export tables reverted, the new file fails **6** tests; restored, all 12 pass.

Both classes are reached through modules already imported eagerly (`all2md.options.common`, `all2md.utils.metadata` via `options.base`), so there is no import-cost change. The generated `options.rst` is unchanged — it already documented both as field types. ruff, black, mypy, `tests/unit` + `tests/golden`, and the root-document gate (9/9 at fidelity 100) are clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
