### PR TITLE
fix(cli): add __main__.py so python -m all2md.cli runs the CLI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -130,6 +130,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **`python -m all2md.cli` runs the CLI instead of refusing to start.** `python -m all2md`
+  worked; the `cli` package had no `__main__.py`, so Python answered `'all2md.cli' is a
+  package and cannot be directly executed`. That fails *before* argparse sees the arguments,
+  which makes it worse than an ordinary unknown-command error: every invocation fails
+  identically no matter what follows it, so anything checking whether the CLI accepts a given
+  flag gets the same answer for a real flag and an invented one. Both entry points now reach
+  the same `main()`, and tests assert they can still *reject* an unknown flag, since an entry
+  point that cannot start looks exactly like one that accepts everything.
 - **Table captions survive a Markdown round trip.** Markdown has no caption syntax, so the
   renderer demoted `Table.caption` to an italic paragraph — which a reader could see, but
   which came back as ordinary prose, so the trip lost the caption *and* gained a `Paragraph`

--- a/src/all2md/cli/__main__.py
+++ b/src/all2md/cli/__main__.py
@@ -1,0 +1,20 @@
+#!/usr/bin/env python3
+"""Entry point for running the CLI package as a module.
+
+This allows the CLI to be executed as:
+    python -m all2md.cli [arguments]
+
+``python -m all2md`` already worked; this package did not, and the failure was
+worse than a plain "no such command". Python reports ``No module named
+all2md.cli.__main__; 'all2md.cli' is a package and cannot be directly executed``
+and exits *before* argparse ever sees the arguments, so every invocation fails
+identically no matter what follows it. A script checking whether a flag is
+accepted therefore gets the same answer for a real flag and an invented one.
+"""
+
+import sys
+
+from . import main
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/unit/cli/test_module_entry_points.py
+++ b/tests/unit/cli/test_module_entry_points.py
@@ -1,0 +1,69 @@
+#  Copyright (c) 2025 Tom Villani, Ph.D.
+"""``python -m all2md`` and ``python -m all2md.cli`` must both reach argparse.
+
+``all2md`` had a ``__main__.py``; ``all2md.cli`` did not. The failure mode is
+worse than an unknown command, because Python refuses to run the package *before*
+argparse sees the arguments:
+
+    No module named all2md.cli.__main__; 'all2md.cli' is a package and
+    cannot be directly executed
+
+Every invocation then fails identically regardless of what follows it. A probe
+asking "does the CLI accept this flag?" gets the same answer for a real flag and
+an invented one, which is exactly how a docs audit came to report a fabricated
+flag as accepted.
+
+So it is not enough to assert the entry point works. The tests below also assert
+it can *reject*, which is the property that was silently missing.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+_ENTRY_POINTS = ["all2md", "all2md.cli"]
+_NOT_A_FLAG = "--definitely-not-a-real-flag-xyz"
+
+
+def _run(module: str, *args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, "-m", module, *args],
+        capture_output=True,
+        text=True,
+        timeout=120,
+    )
+
+
+@pytest.mark.parametrize("module", _ENTRY_POINTS)
+def test_module_entry_point_runs(module: str) -> None:
+    """The package is executable with -m and reports a version."""
+    result = _run(module, "--version")
+
+    assert "cannot be directly executed" not in result.stderr, f"{module} has no __main__.py: {result.stderr}"
+    assert result.returncode == 0, f"{module} --version failed: {result.stderr}"
+    assert "all2md" in result.stdout
+
+
+@pytest.mark.parametrize("module", _ENTRY_POINTS)
+def test_module_entry_point_rejects_an_unknown_flag(module: str) -> None:
+    """Guard the guard: the entry point must be able to fail for the right reason.
+
+    Without this, an entry point that cannot start at all looks identical to one
+    that accepts everything.
+    """
+    result = _run(module, "-", _NOT_A_FLAG)
+
+    assert result.returncode != 0, f"{module} accepted {_NOT_A_FLAG}"
+    assert "cannot be directly executed" not in result.stderr
+    combined = (result.stderr + result.stdout).lower()
+    assert "unrecognized argument" in combined, f"{module} failed for the wrong reason: {result.stderr[:400]}"
+
+
+def test_the_two_entry_points_agree() -> None:
+    """``python -m all2md`` and ``python -m all2md.cli`` are the same program."""
+    assert _run("all2md", "--version").stdout == _run("all2md.cli", "--version").stdout


### PR DESCRIPTION
## The bug

`python -m all2md` worked; `python -m all2md.cli` did not:

```
No module named all2md.cli.__main__; 'all2md.cli' is a package and cannot be directly executed
```

## Why it deserves more than a one-line fix

This fails **before argparse sees the arguments**, so every invocation fails identically no matter what follows it. Anything asking "does the CLI accept this flag?" through that entry point gets the same answer for a real flag and an invented one.

That is not hypothetical — it is how the docs audit in this repo came to report a fabricated flag as *accepted*. Nine probe results had to be thrown away and re-run against the console script.

## The tests reflect that

Asserting the entry point runs is not sufficient, because **an entry point that cannot start looks identical to one that accepts everything.** So `test_module_entry_point_rejects_an_unknown_flag` pins that it can still fail, and fails for the right reason (`unrecognized argument`, not an import error).

`test_the_two_entry_points_agree` pins that the two are the same program rather than two that merely both start.

## Verification

Judge can fail: removing `__main__.py` fails **3 of 5** tests. The two `all2md` parametrisations keep passing in that control, as they should — that entry point already existed, and if they had failed it would mean the test was measuring something else.

ruff, black, mypy and the root-document gate are clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
