### PR TITLE
docs: correct seven CLI flags that do not exist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -130,6 +130,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Seven CLI flags the documentation named do not exist, and now the docs say what does.**
+  Most followed one rule the docs had backwards: a boolean option generates only the flag that
+  *changes* its default, so `require_https=True` yields `--html-network-no-require-https` and
+  there is no positive form to type. Documented as `--html-network-require-https`, and worse,
+  as **"Default: Disabled"** when HTTPS is in fact required by default — the one entry where
+  believing the docs would have left someone thinking transport security was off when it was
+  on. `--html-network-max-remote-asset-bytes` was a renamed option still documented under its
+  old name *and* its old value (the real one is `--html-max-asset-size-bytes`, 50MB not 20MB).
+  `--markdown-page-separator-template` was filed under Markdown but belongs to the paginated
+  parsers, which its own `document.pdf` examples already showed. Also corrected:
+  `--pptx-slide-numbers` → `--pptx-include-slide-numbers`, `--pdf-detect-columns` →
+  `--pdf-no-detect-columns`, `--output-type` → `--output-format`, and `--rich-word-wrap`,
+  which never existed alongside the `--rich-no-word-wrap` documented directly beneath it. A
+  test now fails if any prose page names a flag the CLI will not accept.
 - **Table captions survive a Markdown round trip.** Markdown has no caption syntax, so the
   renderer demoted `Table.caption` to an italic paragraph — which a reader could see, but
   which came back as ordinary prose, so the trip lost the caption *and* gained a `Paragraph`

--- a/docs/source/cli.rst
+++ b/docs/source/cli.rst
@@ -3395,18 +3395,21 @@ Markdown Formatting
       # Custom bullet symbols
       all2md document.docx --markdown-bullet-symbols "•◦▪"
 
-``--markdown-page-separator-template``
-   Template text used to separate pages in multi-page documents. Use ``{page_num}`` to include the page number.
+``--pdf-page-separator-template``
+   Template text used to separate pages in multi-page documents. Use ``{page_num}`` to include
+   the page number. This belongs to the paginated *parsers* rather than the Markdown renderer,
+   so the same option exists as ``--odp-page-separator-template`` and
+   ``--pptx-page-separator-template``.
 
    **Default:** ``-----``
 
    .. code-block:: bash
 
       # Custom page separator template
-      all2md document.pdf --markdown-page-separator-template "=== PAGE BREAK ==="
+      all2md document.pdf --pdf-page-separator-template "=== PAGE BREAK ==="
 
       # Include page numbers in separator
-      all2md document.pdf --markdown-page-separator-template "--- Page {page_num} ---"
+      all2md document.pdf --pdf-page-separator-template "--- Page {page_num} ---"
 
 Rich Terminal Output
 ~~~~~~~~~~~~~~~~~~~~
@@ -3421,9 +3424,6 @@ Rich Terminal Output
 ``--rich-code-theme`` / ``--rich-inline-code-theme``
    Pick Pygments themes for fenced code blocks and inline code. ``monokai`` is the default. List available styles with
    ``pygmentize -L styles``.
-
-``--rich-word-wrap``
-   Apply word-wrapping to long lines in the Rich renderer.
 
 ``--rich-no-word-wrap``
    Disable Rich's automatic line wrapping when you need wide tables or preformatted output to stay on a single line.
@@ -4326,15 +4326,16 @@ Network Security Options
       # In config.json: {"html.network.allowed_hosts": ["example.com", "cdn.example.com"]}
       all2md webpage.html --html-network-allow-remote-fetch --config config.json
 
-``--html-network-require-https``
-   Require HTTPS for all remote URL fetching.
+``--html-network-no-require-https``
+   Allow plain HTTP for remote URL fetching. HTTPS is **required by default**
+   (``NetworkFetchOptions.require_https`` is ``True``), so only the opt-out flag exists.
 
-   **Default:** Disabled
+   **Default:** HTTPS required
 
    .. code-block:: bash
 
-      # Force HTTPS for security
-      all2md webpage.html --html-network-allow-remote-fetch --html-network-require-https
+      # Permit an http:// asset host (weakens transport security)
+      all2md webpage.html --html-network-allow-remote-fetch --html-network-no-require-https
 
 ``--html-network-network-timeout``
    Timeout in seconds for remote URL fetching.
@@ -4346,15 +4347,15 @@ Network Security Options
       # Set 5-second timeout
       all2md webpage.html --html-network-allow-remote-fetch --html-network-network-timeout 5
 
-``--html-network-max-remote-asset-bytes``
-   Maximum allowed size in bytes for downloaded remote assets.
+``--html-max-asset-size-bytes``
+   Maximum allowed size in bytes for a downloaded asset.
 
-   **Default:** 20971520 (20MB)
+   **Default:** 52428800 (50MB)
 
    .. code-block:: bash
 
-      # Limit remote assets to 2MB
-      all2md webpage.html --html-network-allow-remote-fetch --html-network-max-remote-asset-bytes 2097152
+      # Limit assets to 2MB
+      all2md webpage.html --html-network-allow-remote-fetch --html-max-asset-size-bytes 2097152
 
 Global Network Control
 ^^^^^^^^^^^^^^^^^^^^^^^
@@ -4559,13 +4560,15 @@ For absolute maximum security across all operations (not just HTML), use the ``A
 PowerPoint Options
 ~~~~~~~~~~~~~~~~~~
 
-``--pptx-slide-numbers``
+``--pptx-include-slide-numbers``
    Include slide numbers in output.
+
+   **Default:** Disabled
 
    .. code-block:: bash
 
       # Add slide numbers
-      all2md presentation.pptx --pptx-slide-numbers
+      all2md presentation.pptx --pptx-include-slide-numbers
 
 ``--pptx-no-include-notes``
    Exclude speaker notes from conversion.
@@ -5892,7 +5895,7 @@ The generated completion scripts provide:
 * **Global option completion** - Complete universal options like ``--out``, ``--format``, ``--verbose``
 * **Format-aware completion** - When ``--format pdf`` is present, suggest PDF-specific options
 * **File extension detection** - Automatically detect format from input file extension
-* **Renderer context** - Suggest renderer options when ``--output-type`` is specified
+* **Renderer context** - Suggest renderer options when ``--output-format`` is specified
 * **Choice completion** - Complete valid values for options with predefined choices
 
 Install Skills Command

--- a/docs/source/environment_variables.rst
+++ b/docs/source/environment_variables.rst
@@ -611,7 +611,7 @@ Pattern: ALL2MD_<OPTION_NAME>
      - ``--pdf-pages``
      - ``1-10``
    * - ``ALL2MD_PDF_DETECT_COLUMNS``
-     - ``--pdf-detect-columns``
+     - ``--pdf-no-detect-columns``
      - ``true``
    * - ``ALL2MD_HTML_STRIP_DANGEROUS_ELEMENTS``
      - ``--html-strip-dangerous-elements``

--- a/docs/source/overview.rst
+++ b/docs/source/overview.rst
@@ -381,7 +381,17 @@ Options can also be provided as keyword arguments, which are merged with (and ov
    # Method 3: Mixed (kwargs override options)
    markdown = to_markdown('doc.pdf', parser_options=options, attachment_mode='base64')
 
-All CLI flags are generated from these dataclasses (nesting included), so ``HtmlOptions.network.require_https`` maps to ``--html-network-require-https`` and also honours the ``ALL2MD_HTML_NETWORK_REQUIRE_HTTPS`` environment variable.
+All CLI flags are generated from these dataclasses (nesting included), so ``PdfOptions.pages``
+maps to ``--pdf-pages`` and also honours the ``ALL2MD_PDF_PAGES`` environment variable.
+
+One wrinkle worth knowing, because it is the difference between a flag that exists and one that
+does not: a boolean field generates only the flag that *changes* its default, so there is never a
+flag for turning on something already on. ``HtmlOptions.network.require_https`` defaults to
+``True``, and the only generated flag is therefore ``--html-network-no-require-https``. A field
+defaulting to ``False`` works the other way round: ``PptxOptions.include_slide_numbers`` gives you
+``--pptx-include-slide-numbers`` and no negative form. The environment variable keeps the field's
+own name in both cases (``ALL2MD_HTML_NETWORK_REQUIRE_HTTPS``) and takes ``true`` or ``false``,
+so it does not mirror the flag spelling.
 
 * :doc:`options` — the complete option reference for every format
 * :doc:`configuration` — config files, presets, and precedence rules

--- a/tests/unit/cli/test_documented_flags_exist.py
+++ b/tests/unit/cli/test_documented_flags_exist.py
@@ -1,0 +1,157 @@
+#  Copyright (c) 2025 Tom Villani, Ph.D.
+"""Every ``--flag`` the prose docs name must be a flag the CLI actually has.
+
+Seven documented flags did not exist. The pattern behind most of them is the
+boolean-default rule: a bool field generates only the flag that *changes* its
+default, so ``require_https=True`` yields ``--html-network-no-require-https`` and
+the docs wrote the positive form nobody can type. Two were worse than a wrong
+name - ``--html-network-require-https`` was documented as "Default: Disabled"
+when HTTPS is required by default, and ``--html-network-max-remote-asset-bytes``
+was a renamed option still documented at its old name *and* its old value.
+
+Building the real flag set is the hard half, and getting it wrong is easy in a
+direction that reads as success:
+
+* ``create_parser()`` has no subparsers - every subcommand builds its own
+  standalone parser inside its module, so the top-level parser alone misses 130+.
+* Not every flag exists as a string literal. ``argparse.BooleanOptionalAction``
+  synthesises ``--no-x`` from ``--x``, which is where ``--no-regex`` comes from.
+* ``benchmarks/`` has its own CLI, and ``optimizations.rst`` documents it.
+
+So this walks the AST for ``add_argument`` calls, synthesises the
+BooleanOptionalAction negatives, and unions that with the top-level parser.
+``test_the_flag_inventory_is_not_empty`` and ``test_a_fabricated_flag_is_caught``
+exist because every one of the failure modes above produces a *passing* test.
+"""
+
+from __future__ import annotations
+
+import argparse
+import ast
+import re
+from pathlib import Path
+
+import pytest
+
+from all2md.cli import create_parser
+
+pytestmark = pytest.mark.unit
+
+_REPO = Path(__file__).resolve().parents[3]
+_DOC_DIR = _REPO / "docs" / "source"
+
+# ``options.rst`` is generated from the option dataclasses by
+# scripts/generate_options_doc.py, so it cannot drift by hand.
+_GENERATED = {"options.rst"}
+
+_FLAG_IN_PROSE = re.compile(r"``(--[a-z0-9][a-z0-9-]*)``")
+
+# Flags named deliberately while not being real flags. Keep this as close to empty
+# as possible: every entry is a flag the check can no longer catch. overview.rst
+# explains the boolean-default rule *without* naming the non-existent positive
+# form in literal markup, precisely so it does not need an exemption here - an
+# entry for it would have masked the original bug on that very page.
+_NOT_MEANT_TO_EXIST = {
+    # lint_guide.rst uses it as a stand-in for "some rule flag".
+    "--foo",
+}
+
+
+def _flags_from_source() -> set[str]:
+    """Long options registered anywhere, including generated ``--no-`` forms."""
+    found: set[str] = set()
+    for root in (_REPO / "src" / "all2md", _REPO / "benchmarks"):
+        if not root.exists():
+            continue
+        for path in root.rglob("*.py"):
+            try:
+                tree = ast.parse(path.read_text(encoding="utf-8", errors="replace"))
+            except SyntaxError:
+                continue
+            for node in ast.walk(tree):
+                if not (isinstance(node, ast.Call) and isinstance(node.func, ast.Attribute)):
+                    continue
+                if node.func.attr != "add_argument":
+                    continue
+                names = [a.value for a in node.args if isinstance(a, ast.Constant) and isinstance(a.value, str)]
+                longs = [n for n in names if n.startswith("--")]
+                found.update(longs)
+
+                boolean_optional = any(
+                    kw.arg == "action" and "BooleanOptionalAction" in ast.dump(kw.value) for kw in node.keywords
+                )
+                if boolean_optional:
+                    found.update(f"--no-{n[2:]}" for n in longs)
+    return found
+
+
+_REAL_FLAGS = {
+    s for a in create_parser()._actions for s in a.option_strings if s.startswith("--")
+} | _flags_from_source()
+
+
+def _documented_flags() -> dict[str, set[str]]:
+    """Prose page -> the flags it names in ``literal`` markup."""
+    documented: dict[str, set[str]] = {}
+    for path in sorted(_DOC_DIR.glob("*.rst")):
+        if path.name in _GENERATED:
+            continue
+        flags = set(_FLAG_IN_PROSE.findall(path.read_text(encoding="utf-8", errors="replace")))
+        if flags:
+            documented[path.name] = flags
+    return documented
+
+
+_DOCUMENTED = _documented_flags()
+
+
+def test_the_flag_inventory_is_not_empty() -> None:
+    """Guard the guard: an empty or tiny inventory makes every doc flag 'undefined'.
+
+    Conversely a *broken* inventory that returned everything would make the real
+    test vacuous - so this pins the order of magnitude, not just non-emptiness.
+    """
+    assert len(_REAL_FLAGS) > 1000, f"expected the full generated flag surface, found {len(_REAL_FLAGS)}"
+    assert "--pdf-pages" in _REAL_FLAGS, "top-level format flags missing from the inventory"
+    assert "--no-wait" in _REAL_FLAGS, "subcommand flags missing from the inventory"
+    assert "--no-regex" in _REAL_FLAGS, "BooleanOptionalAction negatives missing from the inventory"
+
+
+def test_the_docs_actually_name_flags() -> None:
+    """Guard the guard: if the prose scan finds nothing, nothing can fail."""
+    total = sum(len(v) for v in _DOCUMENTED.values())
+    assert total > 200, f"expected the docs to name many flags, found {total}"
+
+
+def test_a_fabricated_flag_is_caught() -> None:
+    """The check must be able to fail."""
+    assert "--definitely-not-a-real-flag-xyz" not in _REAL_FLAGS
+
+
+@pytest.mark.parametrize("page", sorted(_DOCUMENTED))
+def test_documented_flags_exist(page: str) -> None:
+    """No prose page may name a flag the CLI does not accept."""
+    undefined = sorted(_DOCUMENTED[page] - _REAL_FLAGS - _NOT_MEANT_TO_EXIST)
+    assert not undefined, f"{page} documents flags that do not exist: {undefined}"
+
+
+def test_the_boolean_default_rule_still_holds() -> None:
+    """The rule behind most of the bugs, pinned so the docs' explanation stays true.
+
+    A bool defaulting True generates only the negative flag; one defaulting False
+    generates only the positive.
+    """
+    assert "--html-network-no-require-https" in _REAL_FLAGS
+    assert "--html-network-require-https" not in _REAL_FLAGS
+
+    assert "--pptx-include-slide-numbers" in _REAL_FLAGS
+    assert "--pptx-no-include-slide-numbers" not in _REAL_FLAGS
+
+
+def test_boolean_optional_action_is_still_how_no_regex_exists() -> None:
+    """If grep stops using BooleanOptionalAction, the inventory logic needs revisiting."""
+    from all2md.cli.commands import search
+
+    assert hasattr(argparse, "BooleanOptionalAction")
+    source = Path(search.__file__).read_text(encoding="utf-8")
+    assert "BooleanOptionalAction" in source


### PR DESCRIPTION
Auditing every ``--flag`` named in the prose docs against the real parser found **seven** the CLI will not accept.

## The seven

| Documented | Reality |
|---|---|
| `--html-network-require-https` | `--html-network-no-require-https` — **and** documented as "Default: Disabled" when HTTPS is required by default |
| `--html-network-max-remote-asset-bytes` | `--html-max-asset-size-bytes`, 50MB not 20MB (renamed option, old name *and* old value) |
| `--markdown-page-separator-template` | belongs to the paginated parsers (`--pdf-page-separator-template`); its own examples already used `document.pdf` |
| `--pptx-slide-numbers` | `--pptx-include-slide-numbers` |
| `--pdf-detect-columns` | `--pdf-no-detect-columns` |
| `--output-type` | `--output-format` |
| `--rich-word-wrap` | never existed — `--rich-no-word-wrap` was already documented directly beneath it |

Most follow one rule the docs had backwards: **a boolean option generates only the flag that changes its default.** `require_https=True` produces only the `--no-` form; there is no positive form to turn on something already on. `overview.rst` now states that rule outright, in both directions.

The `require_https` entry is the one worth calling out — believing the docs would have left a reader thinking transport security was off when it was on.

## The test needed four guards, because I got the instrument wrong three times

Each of these mistakes produces a **passing** test, which is why the inventory's size and contents are asserted rather than assumed:

1. **`create_parser()` has no subparsers.** Every subcommand builds its own standalone parser inside its module, so the top-level parser alone reported **130** false positives.
2. **Not every flag is a string literal.** `argparse.BooleanOptionalAction` synthesises `--no-regex` from `--regex`, so a source grep can't see it. The AST walk now synthesises those.
3. **`benchmarks/` has its own CLI**, documented by `optimizations.rst` — which is why `--use-layout-model` looked broken and is not.

A fourth instrument, probing `python -m all2md.cli <flag>`, reported a *fabricated* flag as accepted; that root cause is fixed separately in #320.

## Exemptions

One entry, `--foo`, a placeholder in `lint_guide.rst`. `overview.rst` deliberately explains the rule **without** naming the non-existent positive form in literal markup, so it needs no exemption — an entry for it would have masked the original bug on that very page.

## Verification

Judge can fail: reverting the three doc files fails on `cli.rst` and `environment_variables.rst` with exactly the six flags fixed there; reverting `overview.rst` alone fails that page. `tests/unit/cli` exits 0, ruff/black clean, `sphinx -W` builds clean, root-document gate 9/9 at 100.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
