### PR TITLE
feat(benchmarks): measure content precision beside recall on the PMC lane

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Content precision beside content recall on the born-digital lane**
+  (`benchmarks.pmc.article.measure_precision`). Recall alone cannot be trusted, and this lane
+  has already been misread once because of it: the highest recall available on this corpus
+  comes from emitting the raw text layer with no structure whatsoever, so recall rising is not
+  by itself good news. The new instrument asks the converse — does the output contain anything
+  the document does not — against the PDF's own text layer rather than JATS, because JATS is
+  not what the page prints and scoring against it would charge the parser for reproducing the
+  document faithfully.
+  Raw precision turned out to need a denominator of its own, for the same reason raw recall
+  needed its attainable ceiling. Most of what a *correct* conversion emits unsupported is the
+  document's own words in an adjacency the text layer does not have: all2md orders columns and
+  joins blocks, the layer comes out in PyMuPDF's order, and every disagreement mints n-grams at
+  the seam. Measured over five articles that is **4.8%** of emitted n-grams, against **0.5%**
+  carrying a word the layer never has anywhere — so reporting the raw figure would have made
+  the result nine times worse than the parser deserves. The two are reported separately, and
+  `novel_share` is the figure to read.
+  Duplication is counted apart from both, because a block emitted twice is an unchanged set and
+  a doubled multiset — no set-based score can see it. Both figures ship with the
+  mismatched-article control the lane already applies to recall.
 - **A PDF conversion guide** (`docs/source/pdf.rst`). PDF is the format all2md works hardest
   at and the one with no dedicated page: the deepest hand-written coverage was five bullets in
   the overview that predated layout analysis entirely, and of the twelve OCR flags, nine

--- a/benchmarks/pmc/__main__.py
+++ b/benchmarks/pmc/__main__.py
@@ -198,6 +198,24 @@ def _score(args: argparse.Namespace) -> int:
             f"      {kind:12s} attainable {counts['attainable']:5d}/{counts['scored']:<5d}"
             f"   recovered {counts['attainable_recall']:6.1%} of those"
         )
+    print()
+    precision = payload["article_precision"]
+    # Printed next to recall, not in its own section: read alone, recall rewards emitting the
+    # raw text layer and precision rewards emitting nothing.
+    print("whole-article precision: did the output say anything the document does not")
+    print(f"    supported         {precision['precision']:6.1%} of {precision['emitted']} emitted n-grams")
+    # Most of the remainder is the document's own words in an adjacency the text layer does
+    # not have, which is what ordering columns and joining blocks is *for*.
+    print(
+        f"    resequenced       {precision['resequenced'] / max(precision['emitted'], 1):6.1%}"
+        "  (the document's words, new adjacency)"
+    )
+    print(f"    novel             {precision['novel_share']:6.1%}  <- the number worth reading")
+    print(f"    duplication       {precision['duplication']:6.1%}  (supported text emitted more than once)")
+    if precision["control_emitted"]:
+        print(f"    wrong article     {precision['control_precision']:6.1%}  (want ~0%)")
+    else:
+        print("    wrong article        n/a  (needs more than one article to have a control)")
     if payload["ocr_articles"]:
         print()
         print(f"OCR fired on {len(payload['ocr_articles'])} article(s): {payload['ocr_articles']}")

--- a/benchmarks/pmc/alignment.py
+++ b/benchmarks/pmc/alignment.py
@@ -209,6 +209,27 @@ def ngrams(tokens: Sequence[str]) -> set[tuple[str, ...]]:
     return {tuple(tokens[index : index + NGRAM]) for index in range(len(tokens) - NGRAM + 1)}
 
 
+def ngram_counts(tokens: Sequence[str]) -> Counter[tuple[str, ...]]:
+    """Return token `NGRAM`-grams with their occurrence counts.
+
+    The counted counterpart to `ngrams`. Placement does not care how often a phrase appears,
+    but *duplication* is only visible in the counts: text emitted twice is a set that has not
+    changed at all, and a multiset that has doubled.
+
+    Parameters
+    ----------
+    tokens : Sequence[str]
+        Normalized tokens.
+
+    Returns
+    -------
+    collections.Counter
+        N-gram occurrence counts.
+
+    """
+    return Counter(tuple(tokens[index : index + NGRAM]) for index in range(len(tokens) - NGRAM + 1))
+
+
 def page_ngrams(pdf_path: Path) -> list[set[tuple[str, ...]]]:
     """Index each PDF page by its token n-grams.
 

--- a/benchmarks/pmc/article.py
+++ b/benchmarks/pmc/article.py
@@ -24,8 +24,16 @@ own per-page loop, which emits a separator per PDF page. Content cannot migrate 
 groups, and a dropped page raises `benchmarks.pmc.convert.PageBoundaryError` instead of
 scoring. A page-sequence metric would report a perfect score by construction.
 
-What remains is recall, measured with n-gram containment -- the one instrument on this
-corpus with a published false-positive rate, 0.8% against a mismatched article.
+What remains is recall and its converse, both measured with n-gram containment -- the one
+instrument on this corpus with a published false-positive rate, 0.8% against a mismatched
+article.
+
+**Recall is reported with precision because recall alone is gameable.** The highest recall
+available here comes from emitting the raw text layer with no structure whatsoever, so a
+recall figure rising is not by itself good news. `measure_precision` asks the opposite
+question -- does the output contain anything the document does not -- against the PDF's own
+text layer rather than JATS, and reports duplication separately because a block emitted
+twice leaves every set-based measure unmoved.
 
 **Raw recall is not readable on its own, so the ceiling ships with it.** Much of a JATS
 article cannot be recovered from the PDF by *any* parser, because the markup does not record
@@ -44,7 +52,7 @@ from collections import Counter
 from dataclasses import dataclass
 from typing import Iterable, Mapping, Sequence
 
-from benchmarks.pmc.alignment import MIN_NGRAMS, ngrams, normalize
+from benchmarks.pmc.alignment import MIN_NGRAMS, ngram_counts, ngrams, normalize
 
 #: Share of a block's n-grams that must appear in the output for the block to count as
 #: recovered. Not 1.0: de-hyphenation, ligature folding and a dropped soft hyphen each cost
@@ -195,6 +203,157 @@ def measure_recall(
         by_kind={kind: KindRecall(*counts) for kind, counts in sorted(by_kind.items())},
         control_recovered=control_recovered,
         control_scored=control_scored,
+    )
+
+
+@dataclass(frozen=True, slots=True)
+class PrecisionReport:
+    """Whether the output says anything the document does not, with its mismatch control.
+
+    Attributes
+    ----------
+    supported : int
+        Distinct emitted n-grams the PDF's own text layer also holds.
+    resequenced : int
+        Unsupported n-grams every one of whose *words* the layer holds. The adjacency is new,
+        not the text: all2md orders columns and joins blocks, and the layer is extracted in
+        PyMuPDF's own order, so every place the two disagree mints n-grams that are nobody's
+        defect. Measured rather than assumed -- it is 4.8% of emitted n-grams against 0.5%
+        genuinely novel, so folding it into the failure would have made the headline number
+        nine times worse than the parser deserves.
+    novel : int
+        Unsupported n-grams containing a word the layer never has anywhere. The residue that
+        actually indicts the parser.
+    emitted : int
+        Distinct emitted n-grams.
+    excess : int
+        Occurrences of *supported* n-grams emitted more often than the text layer holds
+        them. Restricted to supported n-grams on purpose: an unsupported n-gram is already
+        counted by `precision`, and letting it score here too would make one defect move two
+        numbers.
+    occurrences : int
+        Total emitted n-gram occurrences -- the denominator `excess` is a share of.
+    control_supported : int
+        Emitted n-grams "supported" by a *different* article's text layer. The noise floor:
+        without it a high precision may only mean that English n-grams are common.
+    control_emitted : int
+        Distinct emitted n-grams scored against the mismatched article.
+
+    """
+
+    supported: int
+    resequenced: int
+    novel: int
+    emitted: int
+    excess: int
+    occurrences: int
+    control_supported: int
+    control_emitted: int
+
+    @property
+    def precision(self) -> float:
+        """Share of emitted n-grams the document itself accounts for, phrase for phrase."""
+        return self.supported / self.emitted if self.emitted else 0.0
+
+    @property
+    def novel_share(self) -> float:
+        """Share of emitted n-grams containing a word the document does not have.
+
+        The number worth reading, and the counterpart of `RecallReport.attainable_recall`:
+        both exist because the raw figure is dominated by something that is not the parser's
+        doing.
+        """
+        return self.novel / self.emitted if self.emitted else 0.0
+
+    @property
+    def duplication(self) -> float:
+        """Share of emitted n-gram occurrences that repeat text the page prints once."""
+        return self.excess / self.occurrences if self.occurrences else 0.0
+
+    @property
+    def control_precision(self) -> float:
+        """Share of emitted n-grams the *wrong* article's text layer appears to account for."""
+        return self.control_supported / self.control_emitted if self.control_emitted else 0.0
+
+
+def measure_precision(
+    articles: Iterable[tuple[str, Sequence[tuple[str, str]], str, str]],
+) -> PrecisionReport:
+    """Measure whether the output contains text the document does not.
+
+    The converse of `measure_recall`, and it exists because recall alone cannot be trusted:
+    the highest recall on this corpus is obtained by emitting the raw text layer with no
+    structure at all, which is exactly how a 99% page-level text recall coexisted with less
+    than half of section titles becoming headings. A pair of numbers that fail in opposite
+    directions is readable; either one alone is not.
+
+    **The reference is the PDF's own text layer, not JATS.** JATS is not what the page
+    prints -- it omits running heads and folios the parser legitimately sees, and orders
+    citation and byline text the way the markup declares it rather than the way it is
+    typeset. Scoring against it would charge the parser for reproducing the document. The
+    text layer is what the file actually contains, so anything outside it is unexplained.
+
+    Two defects, two numbers, because the set-based one cannot see the second:
+
+    * **Invented text** lowers `precision`. The proven case on this corpus is auto-OCR
+      firing on a page that already had a good text layer and substituting its own guesses.
+    * **Duplicated text** raises `duplication` and leaves `precision` untouched, because a
+      block emitted twice is an unchanged set and a doubled multiset.
+
+    **Raw precision is not readable on its own either, so the split ships with it.** Most of
+    what a correct conversion emits "unsupported" is the document's own words in an adjacency
+    the text layer does not have: all2md orders columns and joins blocks, while the layer
+    comes out in PyMuPDF's order, and every disagreement mints n-grams at the seam. On the
+    first five articles that accounted for 4.8% of emitted n-grams against 0.5% carrying a
+    word the layer never has. `novel_share` is therefore the figure to read, exactly as
+    `attainable_recall` rather than raw recall is on the other side.
+
+    Parameters
+    ----------
+    articles : Iterable
+        ``(article_id, blocks, emitted_text, pdf_text)`` tuples, as `measure_recall` takes.
+        ``blocks`` is accepted and unused, so both instruments can be driven from one
+        sequence rather than two that could drift apart.
+
+    Returns
+    -------
+    PrecisionReport
+        Precision, duplication and the mismatched-article control.
+
+    """
+    indexed = []
+    for _article_id, _blocks, emitted, pdf_text in articles:
+        layer_tokens = normalize(pdf_text)
+        indexed.append((ngram_counts(normalize(emitted)), ngram_counts(layer_tokens), set(layer_tokens)))
+
+    supported = resequenced = novel = emitted_total = excess = occurrences = 0
+    control_supported = control_emitted = 0
+    for position, (emitted_counts, layer, words) in enumerate(indexed):
+        other = indexed[(position + 1) % len(indexed)][1]
+        for gram, count in emitted_counts.items():
+            emitted_total += 1
+            occurrences += count
+            held = layer.get(gram, 0)
+            if held:
+                supported += 1
+                excess += max(0, count - held)
+            elif all(token in words for token in gram):
+                resequenced += 1
+            else:
+                novel += 1
+            if other is not layer:
+                control_emitted += 1
+                control_supported += other.get(gram, 0) > 0
+
+    return PrecisionReport(
+        supported=supported,
+        resequenced=resequenced,
+        novel=novel,
+        emitted=emitted_total,
+        excess=excess,
+        occurrences=occurrences,
+        control_supported=control_supported,
+        control_emitted=control_emitted,
     )
 
 

--- a/benchmarks/pmc/benchmark.py
+++ b/benchmarks/pmc/benchmark.py
@@ -35,12 +35,21 @@ from typing import Any, Callable, Mapping, Sequence
 
 from benchmarks.omnidocbench.oracles import PageProjection, project_ast, score_page
 from benchmarks.pmc.alignment import TOKEN_PLACEMENT_MIN
-from benchmarks.pmc.article import RECALL_MIN, RecallReport, measure_recall, summarize
+from benchmarks.pmc.article import (
+    RECALL_MIN,
+    PrecisionReport,
+    RecallReport,
+    measure_precision,
+    measure_recall,
+    summarize,
+)
 from benchmarks.pmc.convert import convert_article, pdf_options
 from benchmarks.pmc.oracles import coverage, project_jats, to_projection
 from benchmarks.pmc.pages import ASSIGNMENTS, assign_pages, index_pages
 
-SCHEMA_VERSION = 1
+#: 2 adds ``article_precision``. A reader that expects 1 would silently see recall with no
+#: converse and read it as the whole story, which is the misreading this lane just fixed.
+SCHEMA_VERSION = 2
 ORACLE_SCHEMA_VERSION = 1
 
 #: Fixed seed: a control that scrambles differently every run cannot be compared across
@@ -280,6 +289,7 @@ def normalize_results(
     snapshot: Any,
     evaluations: Sequence[ArticleEvaluation],
     recall: RecallReport,
+    precision: PrecisionReport,
     all2md_commit: str,
     worktree_dirty: bool = False,
     parser_runtime: Mapping[str, str],
@@ -294,6 +304,8 @@ def normalize_results(
         Per-article results.
     recall : RecallReport
         Whole-article content recall with its control.
+    precision : PrecisionReport
+        Whether the output says anything the document does not, with its control.
     all2md_commit : str
         Commit the parser was scored at.
     worktree_dirty : bool
@@ -399,6 +411,30 @@ def normalize_results(
             "control_scored": recall.control_scored,
             "discrimination": recall.recall - recall.control_recall,
         },
+        # Recall's converse, and it ships beside it rather than somewhere else because either
+        # number alone is gameable: the highest recall on this corpus comes from emitting the
+        # raw text layer with no structure at all, and the highest precision from emitting
+        # almost nothing.
+        "article_precision": {
+            "precision": precision.precision,
+            "supported": precision.supported,
+            "emitted": precision.emitted,
+            # Unsupported splits two ways, and only one of them is the parser's doing: a
+            # resequenced n-gram is the document's own words in an order the text layer does
+            # not have, which column ordering and block joins produce by design.
+            "resequenced": precision.resequenced,
+            "novel": precision.novel,
+            "novel_share": precision.novel_share,
+            # Occurrences of supported text emitted more often than the page prints it.
+            # Separate from precision because a block emitted twice is an unchanged set.
+            "duplication": precision.duplication,
+            "excess": precision.excess,
+            "occurrences": precision.occurrences,
+            "control_precision": precision.control_precision,
+            # As with recall's control: reported so a zero cannot be misread as passing.
+            "control_emitted": precision.control_emitted,
+            "discrimination": precision.precision - precision.control_precision,
+        },
         "dimensions": dimensions,
         "conversion_failures": failures,
         # Expected to be empty: this corpus was characterized as 0.0% scan-shaped. A
@@ -431,17 +467,19 @@ def run(snapshot: Any, *, all2md_commit: str = "unknown", worktree_dirty: bool =
     import fitz
 
     evaluations = evaluate_corpus(snapshot.articles)
-    recall = measure_recall(
-        [
-            (result.article_id, result.truth_blocks, result.emitted_text, result.pdf_text)
-            for result in evaluations
-            if result.error is None
-        ]
-    )
+    # One sequence drives both instruments, so they cannot end up describing different runs.
+    scored = [
+        (result.article_id, result.truth_blocks, result.emitted_text, result.pdf_text)
+        for result in evaluations
+        if result.error is None
+    ]
+    recall = measure_recall(scored)
+    precision = measure_precision(scored)
     return normalize_results(
         snapshot=snapshot,
         evaluations=evaluations,
         recall=recall,
+        precision=precision,
         all2md_commit=all2md_commit,
         worktree_dirty=worktree_dirty,
         parser_runtime={

--- a/tests/unit/test_pmc_oracle.py
+++ b/tests/unit/test_pmc_oracle.py
@@ -329,6 +329,95 @@ def test_recall_collapses_against_a_different_article() -> None:
 
 
 # ---------------------------------------------------------------------------
+# Precision: does the output say anything the document does not
+# ---------------------------------------------------------------------------
+
+_LAYER = "the participants completed every session of the supervised training programme"
+_FOREIGN = "vector drawings were counted on each page of the publisher issued document"
+
+
+def _precision(emitted: str, layer: str = _LAYER) -> article.PrecisionReport:
+    return article.measure_precision([("A", [], emitted, layer)])
+
+
+def test_reproducing_the_text_layer_is_fully_supported() -> None:
+    report = _precision(_LAYER)
+    assert report.precision == pytest.approx(1.0)
+    assert report.duplication == pytest.approx(0.0)
+
+
+def test_precision_falls_when_the_output_invents_text() -> None:
+    """The proven case here is auto-OCR replacing a good text layer with its own guesses."""
+    report = _precision(f"{_LAYER} {_FOREIGN}")
+    assert report.precision < 0.55
+    assert report.novel_share > 0.4
+    # Recall is untouched by the invention, which is the whole reason for the second number.
+    recall = article.measure_recall([("A", [("text_block", _LAYER)], f"{_LAYER} {_FOREIGN}", _LAYER)])
+    assert recall.attainable_recall == pytest.approx(1.0)
+
+
+def test_reordering_the_document_is_not_counted_as_inventing_text() -> None:
+    """Measured: seam n-grams are 4.8% of emitted against 0.5% genuinely novel.
+
+    all2md orders columns and joins blocks; the text layer comes out in PyMuPDF's order.
+    Charging the parser for every disagreement would make the headline nine times worse than
+    it deserves, so the two are separated rather than summed.
+    """
+    first = "the participants completed every session of the supervised training programme"
+    second = "vector drawings were counted on each page of the publisher issued document"
+    report = _precision(f"{second} {first}", f"{first} {second}")
+
+    assert report.novel == 0
+    assert report.resequenced > 0
+    # Strict precision registers the seam; the number worth reading does not.
+    assert report.precision < 1.0
+    assert report.novel_share == pytest.approx(0.0)
+
+
+def test_duplication_is_visible_where_a_set_based_score_is_blind() -> None:
+    """Emitting a block twice barely moves precision, because the multiset is what doubled.
+
+    Precision is not *completely* blind to it: rejoining the text creates a handful of
+    n-grams spanning the seam that the layer does not hold. Those are a rounding error in a
+    real article and would be the whole signal in a two-sentence one, so the block is
+    duplicated inside surrounding text here rather than on its own.
+    """
+    layer = f"{_LAYER} and afterwards {_FOREIGN} and finally the analysis was repeated twice"
+    clean = _precision(layer, layer)
+    doubled = _precision(f"{_LAYER} and afterwards {layer}", layer)
+
+    # The comparison is against the same document emitted once, so the threshold is a
+    # measured difference rather than a number chosen to pass.
+    assert clean.duplication == pytest.approx(0.0)
+    assert doubled.duplication > 0.15
+    # Precision meanwhile barely moves: only the seam is unsupported.
+    assert clean.precision == pytest.approx(1.0)
+    assert doubled.precision > 0.85
+
+
+def test_precision_collapses_against_a_different_article() -> None:
+    """Without the control, a high precision may only mean English n-grams are common."""
+    report = article.measure_precision(
+        [("A", [], _LAYER, _LAYER), ("B", [], _FOREIGN, _FOREIGN)],
+    )
+    assert report.precision == pytest.approx(1.0)
+    assert report.control_precision == pytest.approx(0.0)
+
+
+def test_a_single_article_reports_no_precision_control_rather_than_a_flattering_zero() -> None:
+    report = _precision(_LAYER)
+    assert report.control_emitted == 0
+    assert report.control_precision == 0.0
+
+
+def test_an_empty_conversion_scores_zero_precision_rather_than_a_perfect_one() -> None:
+    """Emitting nothing says nothing false. It must not therefore look flawless."""
+    report = _precision("")
+    assert report.emitted == 0
+    assert report.precision == 0.0
+
+
+# ---------------------------------------------------------------------------
 # Controls that qualify the scores
 # ---------------------------------------------------------------------------
 
@@ -403,9 +492,31 @@ def test_page_scores_and_the_error_budget_come_from_the_same_run(tmp_path: Path)
             )
         ],
         recall=article.measure_recall([]),
+        precision=article.measure_precision([]),
         all2md_commit="deadbeef",
         parser_runtime={},
     )
     assert payload["projection"]["error_budget"] == pytest.approx(0.1)
     assert payload["projection"]["excluded_reasons"] == {"missing": 1}
     assert payload["ocr_articles"] == []
+
+
+def test_recall_and_precision_are_reported_together() -> None:
+    """Either number alone rewards a degenerate converter, so the payload carries both."""
+    layer = f"{_LAYER} and afterwards {_FOREIGN}"
+    scored = [("A", [("text_block", _LAYER)], layer, layer), ("B", [("text_block", _FOREIGN)], _FOREIGN, _FOREIGN)]
+    payload = benchmark.normalize_results(
+        snapshot=type(
+            "Snapshot",
+            (),
+            {"manifest_sha256": "a" * 64, "bucket": "b", "complete": True, "expected_articles": 2},
+        )(),
+        evaluations=[],
+        recall=article.measure_recall(scored),
+        precision=article.measure_precision(scored),
+        all2md_commit="deadbeef",
+        parser_runtime={},
+    )
+    assert payload["article_recall"]["attainable_recall"] > 0.0
+    assert payload["article_precision"]["precision"] == pytest.approx(1.0)
+    assert payload["article_precision"]["control_emitted"] > 0


### PR DESCRIPTION
Recall alone is gameable, and this lane has already been misread because of it: the highest recall available on this corpus comes from emitting the raw text layer with no structure at all, so recall rising is not by itself good news. `measure_precision` asks the converse — does the output contain anything the document does not.

## The reference is the text layer, not JATS

JATS is not what the page prints. It omits running heads the parser legitimately sees, and orders citation and byline text the way the markup declares it rather than the way it is typeset. Scoring against it would charge the parser for reproducing the document.

## Raw precision needed a denominator of its own

For the same reason raw recall needed its attainable ceiling. Most of what a *correct* conversion emits "unsupported" is the document's own words in an adjacency the layer does not have — all2md orders columns and joins blocks, the layer comes out in PyMuPDF's order, and every disagreement mints n-grams at the seam.

Measured over five articles:

| | share of emitted n-grams |
|---|---|
| supported | 94.6% |
| resequenced (the document's words, new adjacency) | 4.8% |
| **novel (a word the layer never has)** | **0.5%** |

Reporting the raw figure would have made the result nine times worse than the parser deserves. The two are split and `novel_share` is the figure to read.

Duplication is counted separately again, because a block emitted twice is an unchanged set and a doubled multiset — no set-based score can see it. `ngram_counts` alongside the existing `ngrams` is what makes it visible.

## It already found things

The first five-article run surfaced two candidates in the novel residue, both filed for follow-up rather than fixed here:

- `lt` / `gt` appearing as literal words in a reference DOI, suggesting entity text reaching the content stream
- `biomarkerde fined` — a de-hyphenation join landing at the wrong boundary

## Verification

Every test asserts the instrument can fail: precision falls on invented text, duplication rises where precision is nearly blind, resequenced text scores zero novel, an empty conversion scores 0.0 rather than a flattering 1.0, and both controls collapse against the wrong article.

One test was written wrong first and the suite caught it — I had claimed precision was *completely* blind to duplication, and the seam n-grams say otherwise. The test now states the real behaviour and compares against the same document emitted once, so the threshold is a measured difference rather than a number chosen to pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)