### PR TITLE
fix(action): stop reading an unassessed placeholder as a passing confidence score

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -419,12 +419,17 @@ jobs:
           python -m pip install --upgrade pip
           pip install -e ".[all,dev]"
 
+      # `--report-fail-under` is deliberately absent. Markdown has no confidence
+      # instrumentation, so `all2md report` returns a placeholder 100 banded
+      # `not_assessed` for every file here -- an empty one, a valid one and a broken one
+      # alike. Gating on it read as a second quality bar and was a constant. The gate now
+      # refuses that configuration outright rather than passing, so leaving the flag in
+      # would fail this job. Fidelity is the real bar for these documents.
       - name: Gate this branch against our own docs
         run: |
           python scripts/action_gate.py run \
             --paths '*.md' \
-            --roundtrip-fail-under 100 \
-            --report-fail-under 100
+            --roundtrip-fail-under 100
 
   security-semgrep:
     name: Security Scan (Semgrep)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -162,6 +162,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **`report-fail-under` is a measurement again instead of a constant.** The GitHub Action
+  advertises it as "fail if any document's conversion confidence falls below this score",
+  and for most formats it could not fail at any threshold. `all2md report` returns a
+  hardcoded score of **100** banded `not_assessed` whenever no detector ran for the
+  document's producer — which is every markdown, text, docx, pptx and html input, PDF
+  being the only richly instrumented format. `all2md.confidence` names this "a vacuous 100
+  that means 'no detector ran', not 'verified clean'"; the gate read `score` and discarded
+  `band`, so an empty file, a valid file and a deliberately broken file all passed
+  `--report-fail-under 100` identically.
+  The gate now reads the band. An unassessed document is neither a pass nor a failure: it
+  is reported as *not assessed*, excluded from the threshold comparison, and never
+  rendered as a bare 100. If a threshold was set and **nothing** could be assessed, the run
+  is a configuration error — the same class as an empty glob, and exit 2 rather than 1, so
+  it cannot read as "your documents failed". A mixed corpus keeps working; only a wholly
+  unassessable one is refused.
+  This repo's own CI was one of the affected consumers: `--report-fail-under 100` over
+  `*.md` has been dropped from the docs gate, because Markdown can never satisfy it
+  honestly. Fidelity remains gated at 100.
 - **The two external ground-truth lanes no longer disagree about which dimensions may support
   a verdict.** `block_structure_similarity` compares block-category sequences without ever
   inspecting the text underneath, so content-free output scores 1.0 on it (issue #256). The

--- a/action.yml
+++ b/action.yml
@@ -24,6 +24,10 @@ inputs:
   report-fail-under:
     description: >-
       Fail if any document's conversion confidence falls below this score (0-100).
+      Only PDF carries confidence instrumentation today; docx, pptx, html, markdown and
+      text report a placeholder score banded "not_assessed", and the gate refuses a run
+      in which nothing could be assessed rather than passing it. Use roundtrip-fail-under
+      for those formats.
     required: false
     default: ""
   via:

--- a/scripts/action_gate.py
+++ b/scripts/action_gate.py
@@ -62,13 +62,23 @@ class GateError(Exception):
 
 @dataclass
 class DocumentScores:
-    """One document's scores, keyed by tool. ``None`` means it could not be scored."""
+    """One document's scores, keyed by tool.
+
+    Three states, not two, because "could not be measured" and "measured badly" are
+    different verdicts and only one of them is the document's fault:
+
+    * an ``int`` in ``scores`` -- a real measurement, comparable to a threshold;
+    * ``None`` in ``scores`` -- the document could not be converted at all, a failure;
+    * the tool's name in ``unassessed`` -- the tool ran and declined to judge, which is
+      neither. See `score_document`.
+    """
 
     path: str
     scores: dict[str, Optional[int]] = field(default_factory=dict)
+    unassessed: set[str] = field(default_factory=set)
 
     def scored(self, tool: str) -> Optional[int]:
-        """Return the score for *tool*, or ``None`` if scoring failed."""
+        """Return the score for *tool*, or ``None`` if it was not measured."""
         return self.scores.get(tool)
 
 
@@ -125,11 +135,22 @@ def expand_paths(patterns: str, root: Path) -> list[Path]:
     return found
 
 
-def score_document(tool: str, path: Path, via: str, executable: Optional[str] = None) -> tuple[Optional[int], str]:
-    """Score one document, returning ``(score, note)``.
+def score_document(
+    tool: str, path: Path, via: str, executable: Optional[str] = None
+) -> tuple[Optional[int], str, bool]:
+    """Score one document, returning ``(score, note, assessed)``.
 
-    A ``None`` score means the document could not be scored at all, which the
-    caller must treat as a failure rather than as missing data.
+    A ``None`` score means the document could not be scored at all, which the caller
+    must treat as a failure rather than as missing data.
+
+    ``assessed=False`` means something different and had been silently read as a pass:
+    the confidence report emits ``band: "not_assessed"`` with a **hardcoded score of
+    100** when no detector ran for the document's producer. `all2md.confidence` calls
+    that "a vacuous 100 that means 'no detector ran', not 'verified clean'", and it is
+    the value every Markdown, text, docx, pptx and html input returns. Reading only
+    ``score`` therefore turned ``--report-fail-under`` into a constant for those
+    formats: an empty file, a valid file and a deliberately broken file all score 100.
+    The band is the field that says so, so it is now read.
     """
     command = [executable or sys.executable, "-m", "all2md", tool, str(path), "--json"]
     if tool == "roundtrip":
@@ -137,17 +158,19 @@ def score_document(tool: str, path: Path, via: str, executable: Optional[str] = 
     proc = subprocess.run(command, capture_output=True, text=True)
     if proc.returncode != 0:
         detail = proc.stderr.strip().splitlines()
-        return None, detail[-1] if detail else f"{tool} exited {proc.returncode}"
+        return None, detail[-1] if detail else f"{tool} exited {proc.returncode}", True
     try:
         payload = json.loads(proc.stdout)
     except json.JSONDecodeError:
-        return None, "the report was not valid JSON"
+        return None, "the report was not valid JSON", True
     if isinstance(payload, list):
         payload = payload[0] if payload else {}
     score = payload.get("score")
     if not isinstance(score, int):
-        return None, "the report carried no score"
-    return score, ""
+        return None, "the report carried no score", True
+    if payload.get("band") == "not_assessed":
+        return None, "no confidence detector ran for this format", False
+    return score, "", True
 
 
 def _thresholds(args: argparse.Namespace) -> dict[str, int]:
@@ -176,6 +199,11 @@ def _summarise(rows: list[DocumentScores], thresholds: dict[str, int], calibrati
         cells = []
         for tool in thresholds:
             score = row.scored(tool)
+            if tool in row.unassessed:
+                # Never a bare number here: the underlying payload says 100, and printing
+                # it is how this read as a passing gate for every Markdown document.
+                cells.append("_not assessed_")
+                continue
             if score is None:
                 cells.append("**not convertible**")
             else:
@@ -241,15 +269,36 @@ def run(args: argparse.Namespace) -> int:
     for path in files:
         row = DocumentScores(path=path.relative_to(root).as_posix())
         for tool in thresholds:
-            score, note = score_document(tool, path, args.via, args.executable)
+            score, note, assessed = score_document(tool, path, args.via, args.executable)
             row.scores[tool] = score
-            if score is None:
+            if not assessed:
+                row.unassessed.add(tool)
+                print(f"{row.path}: {_METRIC[tool]} not assessed -- {note}", file=sys.stderr)
+            elif score is None:
                 print(f"{row.path}: {tool} could not score this document -- {note}", file=sys.stderr)
         rows.append(row)
+
+    # A threshold that judged nothing is the defect this gate exists to refuse, and it is
+    # the one the gate had itself: every root Markdown file returns an unassessed 100, so
+    # `--report-fail-under 100` could not fail. Refusing here rather than passing keeps a
+    # mixed corpus working -- only a threshold with no assessable document at all is an
+    # error, not one whose Markdown files happen to be unassessable.
+    for tool in thresholds:
+        if all(tool in row.unassessed for row in rows):
+            raise GateError(
+                f"{tool}-fail-under was set, but not one of the {len(rows)} matched "
+                f"document(s) could be assessed for {_METRIC[tool]}: all2md reports "
+                f"band 'not_assessed' for every one, which carries a placeholder score "
+                f"of 100 rather than a measurement. This threshold could only ever pass. "
+                f"Drop {tool}-fail-under, or point it at formats with "
+                f"{_METRIC[tool]} detectors."
+            )
 
     failures = []
     for row in rows:
         for tool, threshold in thresholds.items():
+            if tool in row.unassessed:
+                continue
             score = row.scored(tool)
             if score is None:
                 failures.append(f"{row.path}: could not be converted at all")

--- a/tests/unit/test_action_gate.py
+++ b/tests/unit/test_action_gate.py
@@ -134,7 +134,7 @@ class TestRefusalsToPass:
 
     def test_an_unconvertible_document_fails_rather_than_being_skipped(self, tmp_path, monkeypatch):
         (tmp_path / "a.md").write_text("hi")
-        monkeypatch.setattr(gate, "score_document", lambda *a, **k: (None, "boom"))
+        monkeypatch.setattr(gate, "score_document", lambda *a, **k: (None, "boom", True))
         assert gate.run(_args(working_directory=str(tmp_path))) == 1
 
     @pytest.mark.parametrize("threshold", [-1, 101])
@@ -147,24 +147,24 @@ class TestRefusalsToPass:
 class TestScoring:
     def test_a_score_above_the_threshold_passes(self, tmp_path, monkeypatch):
         (tmp_path / "a.md").write_text("hi")
-        monkeypatch.setattr(gate, "score_document", lambda *a, **k: (95, ""))
+        monkeypatch.setattr(gate, "score_document", lambda *a, **k: (95, "", True))
         assert gate.run(_args(working_directory=str(tmp_path), roundtrip_fail_under=90)) == 0
 
     def test_a_score_below_the_threshold_fails(self, tmp_path, monkeypatch):
         (tmp_path / "a.md").write_text("hi")
-        monkeypatch.setattr(gate, "score_document", lambda *a, **k: (89, ""))
+        monkeypatch.setattr(gate, "score_document", lambda *a, **k: (89, "", True))
         assert gate.run(_args(working_directory=str(tmp_path), roundtrip_fail_under=90)) == 1
 
     def test_a_score_exactly_on_the_threshold_passes(self, tmp_path, monkeypatch):
         """``--fail-under`` means *under*, matching the CLI it wraps."""
         (tmp_path / "a.md").write_text("hi")
-        monkeypatch.setattr(gate, "score_document", lambda *a, **k: (90, ""))
+        monkeypatch.setattr(gate, "score_document", lambda *a, **k: (90, "", True))
         assert gate.run(_args(working_directory=str(tmp_path), roundtrip_fail_under=90)) == 0
 
     def test_one_bad_document_in_a_good_batch_fails_the_build(self, tmp_path, monkeypatch):
         for name in ("a.md", "b.md", "c.md"):
             (tmp_path / name).write_text("hi")
-        scores = iter([(100, ""), (50, ""), (100, "")])
+        scores = iter([(100, "", True), (50, "", True), (100, "", True)])
         monkeypatch.setattr(gate, "score_document", lambda *a, **k: next(scores))
         assert gate.run(_args(working_directory=str(tmp_path), roundtrip_fail_under=90)) == 1
 
@@ -172,7 +172,7 @@ class TestScoring:
         """The batched CLI aborts on the first bad file; this must not."""
         for name in ("a.md", "b.md"):
             (tmp_path / name).write_text("hi")
-        monkeypatch.setattr(gate, "score_document", lambda *a, **k: (10, ""))
+        monkeypatch.setattr(gate, "score_document", lambda *a, **k: (10, "", True))
         gate.run(_args(working_directory=str(tmp_path), roundtrip_fail_under=90))
         err = capsys.readouterr().err
         assert "a.md" in err and "b.md" in err
@@ -183,7 +183,7 @@ class TestScoring:
         monkeypatch.setattr(
             gate,
             "score_document",
-            lambda tool, *a, **k: (100, "") if tool == "roundtrip" else (40, ""),
+            lambda tool, *a, **k: (100, "", True) if tool == "roundtrip" else (40, "", True),
         )
         args = _args(working_directory=str(tmp_path), roundtrip_fail_under=90, report_fail_under=90)
         assert gate.run(args) == 1
@@ -206,7 +206,7 @@ class TestScoreDocument:
 
     def test_a_valid_report_yields_its_score(self, monkeypatch):
         self._fake_run(monkeypatch, stdout='{"score": 87}')
-        assert gate.score_document("roundtrip", Path("a.md"), "markdown") == (87, "")
+        assert gate.score_document("roundtrip", Path("a.md"), "markdown") == (87, "", True)
 
     def test_a_single_element_list_is_unwrapped(self, monkeypatch):
         self._fake_run(monkeypatch, stdout='[{"score": 42}]')
@@ -214,12 +214,12 @@ class TestScoreDocument:
 
     def test_a_nonzero_exit_reports_the_last_stderr_line(self, monkeypatch):
         self._fake_run(monkeypatch, returncode=4, stderr="noise\nError: Input file not found")
-        score, note = gate.score_document("roundtrip", Path("a.md"), "markdown")
+        score, note, _assessed = gate.score_document("roundtrip", Path("a.md"), "markdown")
         assert score is None and "not found" in note
 
     def test_a_silent_nonzero_exit_still_reports_something(self, monkeypatch):
         self._fake_run(monkeypatch, returncode=9, stderr="")
-        score, note = gate.score_document("roundtrip", Path("a.md"), "markdown")
+        score, note, _assessed = gate.score_document("roundtrip", Path("a.md"), "markdown")
         assert score is None and "exited 9" in note
 
     def test_unparseable_output_is_not_a_score(self, monkeypatch):
@@ -229,7 +229,7 @@ class TestScoreDocument:
     def test_a_report_without_a_score_is_not_a_score(self, monkeypatch):
         """Must not become 0 -- that reads as a real, terrible score."""
         self._fake_run(monkeypatch, stdout='{"band": "high"}')
-        score, note = gate.score_document("roundtrip", Path("a.md"), "markdown")
+        score, note, _assessed = gate.score_document("roundtrip", Path("a.md"), "markdown")
         assert score is None and "no score" in note
 
     def test_an_empty_list_is_not_a_score(self, monkeypatch):
@@ -261,13 +261,13 @@ class TestCalibrationWarning:
 
     def test_a_threshold_with_dead_headroom_is_flagged(self, tmp_path, monkeypatch, capsys):
         (tmp_path / "a.md").write_text("hi")
-        monkeypatch.setattr(gate, "score_document", lambda *a, **k: (100, ""))
+        monkeypatch.setattr(gate, "score_document", lambda *a, **k: (100, "", True))
         gate.run(_args(working_directory=str(tmp_path), roundtrip_fail_under=80))
         assert "points of headroom" in capsys.readouterr().out
 
     def test_a_well_calibrated_threshold_is_not_flagged(self, tmp_path, monkeypatch, capsys):
         (tmp_path / "a.md").write_text("hi")
-        monkeypatch.setattr(gate, "score_document", lambda *a, **k: (100, ""))
+        monkeypatch.setattr(gate, "score_document", lambda *a, **k: (100, "", True))
         gate.run(_args(working_directory=str(tmp_path), roundtrip_fail_under=95))
         assert "points of headroom" not in capsys.readouterr().out
 
@@ -310,6 +310,61 @@ class TestAgainstRealDocuments:
             ]
         )
         assert code == 1
+
+    def test_the_confidence_gate_refuses_a_corpus_it_cannot_assess(self, tmp_path):
+        """The defect this gate exists to refuse, which it had itself.
+
+        Markdown has no confidence detector, so `all2md report` returns a hardcoded 100
+        with `band: "not_assessed"` for every one of these files -- an empty file, a valid
+        file and a deliberately broken file alike. Reading only `score` made
+        `--report-fail-under 100` a constant, which is how this repo's own root-docs gate
+        ran for months.
+        """
+        (tmp_path / "empty.md").write_text("")
+        (tmp_path / "fine.md").write_text("# Title\n\nBody text.\n")
+        (tmp_path / "broken.md").write_text("| broken |\n|---\n\n### \n\n[x](\n")
+        code = gate.main(
+            [
+                "run",
+                "--paths",
+                "*.md",
+                "--working-directory",
+                str(tmp_path),
+                "--report-fail-under",
+                "100",
+            ]
+        )
+        # 2, not 1: this is a misconfigured gate, the same class as an empty glob, and it
+        # must not read as "your documents failed".
+        assert code == 2
+
+    def test_the_confidence_gate_still_judges_a_format_that_has_detectors(self, fixtures):
+        """The control: the refusal above must not have disabled the gate everywhere.
+
+        Without this, deleting the confidence comparison outright would satisfy the test
+        above and look like a fix. PDF is the control because it is the only producer with
+        real instrumentation -- `basic.pdf` bands `high`, where every docx, pptx, html and
+        markdown input bands `not_assessed`.
+        """
+        code = gate.main(
+            [
+                "run",
+                "--paths",
+                "basic.pdf",
+                "--working-directory",
+                str(fixtures),
+                "--report-fail-under",
+                "50",
+            ]
+        )
+        assert code == 0
+
+    def test_an_unassessed_document_is_not_rendered_as_a_hundred(self):
+        """Printing the placeholder score is how a vacuous gate reads as a passing one."""
+        row = gate.DocumentScores(path="a.md", scores={"report": None}, unassessed={"report"})
+        summary = gate._summarise([row], {"report": 100}, [])
+        assert "not assessed" in summary
+        assert "100" not in summary.split("| `a.md` |")[1].split("\n")[0]
 
     def test_a_file_that_is_not_a_document_fails(self, tmp_path):
         """Garbage in must not score as missing data and slip through."""


### PR DESCRIPTION
`action.yml` advertises `report-fail-under` as *"Fail if any document's conversion confidence falls below this score."* For most formats it could not fail at any threshold.

```
$ all2md report empty.md   --json  →  {"score": 100, "band": "not_assessed", "signals": {}}
$ all2md report fine.md    --json  →  {"score": 100, "band": "not_assessed", "signals": {}}
$ all2md report broken.md  --json  →  {"score": 100, "band": "not_assessed", "signals": {}}
```

`all2md.confidence` is explicit that this is *"a vacuous 100 that means 'no detector ran', not 'verified clean'"* and names docx, pptx and html as formats on that path — markdown and text are there too. **PDF is the only richly instrumented producer.** `action_gate.py` read `payload.get("score")` and never read `band`.

## What changes

An unassessed document becomes a **third state**, not a pass and not a failure:

- reported as *not assessed* and excluded from the threshold comparison
- **never rendered as a bare 100** — printing the placeholder is exactly how this read as a passing gate
- if a threshold was set and *nothing* could be assessed, that's a configuration error: **exit 2**, the same class as an empty glob, so it can't be misread as "your documents failed"

A mixed corpus keeps working — only a wholly unassessable one is refused.

## This repo was an affected consumer

`--report-fail-under 100` over `*.md` is dropped from the docs gate. Markdown can never satisfy it honestly. Fidelity stays gated at 100.

## Verification

The previous suite had a real hole: **every `report` test monkeypatched `score_document`**, so nothing ever exercised the confidence half against a real document. Both directions are now covered:

- three real Markdown files (empty, valid, broken) → refused with exit 2
- `basic.pdf`, which bands `high` → still gated normally

The second test is the control. Without it, deleting the confidence comparison outright would satisfy the first and look like a fix.

Note the scope is wider than the phrase "docx, pptx, html" in the source comment suggests — I found `basic.docx` also unassessed while writing the control, which is why PDF is what the control uses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)