### PR TITLE
docs: quote a benchmark comparison the two runs can actually support

### DIFF
--- a/.github/workflows/pmc-borndigital.yml
+++ b/.github/workflows/pmc-borndigital.yml
@@ -76,6 +76,11 @@ jobs:
 
       - name: Score the corpus
         run: |
+          # Without pipefail, `tee` supplies the exit status and the scorer's own is
+          # discarded -- so a traceback lands in pmc-summary.txt and the job goes green.
+          # This lane is ungated on *fidelity* by design; that is not a reason to lose a
+          # hard crash too. Every other piped step in this repo sets this.
+          set -o pipefail
           ARGS=(--out benchmarks/pmc/.cache/results/current.json --commit "${GITHUB_SHA}")
           if [ -n "${LIMIT}" ]; then
             ARGS+=(--limit "${LIMIT}")

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -162,6 +162,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **The PDF optimization page no longer compares two different corpora.** It led with
+  "reduced the corpus benchmark from 21.4 minutes to 6.7 minutes — a 3.2x improvement",
+  taken from the two committed reference runs' corpus-wide totals. The arithmetic is right
+  and the comparison is not: the runs cover **160 and 149 documents with 115 in common**,
+  and the `arxiv` overlap is **zero** — that source samples the most recent cs.CL
+  submissions and the runs are nine days apart. Documents present in only one run account
+  for 46% of the baseline's wall time and 86% of the optimized run's, so the headline
+  measured a change of corpus as much as a change of code. The same applies to the PDF
+  percentile rows: both runs have 80 PDFs, 30 of them different papers.
+  The page now leads with the **115 shared documents: 11.5 minutes to 55.4 seconds, a
+  12.4x improvement** — a defensible figure, and a larger one than the number it replaces.
+  The `govdocs1` rows (p50 30x, mean 12.7x) and the `000887.pdf` case study (10.7x) were
+  already sound, because that shard is fixed, and they remain.
+- **Three places called the corpus sample "deterministic" or "reproducible" when two of its
+  four sources are neither.** `corpus.toml` has marked `arxiv` and `poi`
+  `reproducible = false` all along, and `benchmarks/corpus/README.md` contradicted itself
+  between its opening line and its own reproducibility section. Roughly 60 of 160 documents
+  can differ between runs, which is exactly the trap the entry above fell into.
+- **The born-digital benchmark workflow no longer discards the scorer's exit status.** It
+  pipes into `tee` without `set -o pipefail`, so `tee` supplied the exit code and a
+  traceback in the summary file went green. The lane is ungated on fidelity by design;
+  that was never a reason to lose a hard crash as well.
 - **The two external ground-truth lanes no longer disagree about which dimensions may support
   a verdict.** `block_structure_similarity` compares block-category sequences without ever
   inspecting the text underneath, so content-free output scores 1.0 on it (issue #256). The

--- a/benchmarks/corpus/README.md
+++ b/benchmarks/corpus/README.md
@@ -1,13 +1,20 @@
 # all2md corpus benchmark
 
-A reproducible performance benchmark over a few hundred real-world documents
-pulled from public corpora. Useful for spotting regressions, finding files that
-break the parser, and producing comparable timing numbers across machines.
+A performance benchmark over a few hundred real-world documents pulled from public
+corpora. Useful for spotting regressions, finding files that break the parser, and
+producing comparable timing numbers across machines.
+
+**Two of the four sources are reproducible, not all four** — `arxiv` and `poi`
+resolve against upstream state that moves, so roughly 60 of 160 documents can differ
+between runs. Read
+[Reproducibility, and why only half the corpus is gated](#reproducibility-and-why-only-half-the-corpus-is-gated)
+before comparing two runs.
 
 ## What it does
 
-1. **Download** — pulls a deterministic sample from each configured source into
-   `benchmarks/corpus/.cache/<source>/` (gitignored).
+1. **Download** — pulls a sample from each configured source into
+   `benchmarks/corpus/.cache/<source>/` (gitignored). Deterministic for the sources
+   marked `reproducible = true` in `corpus.toml`; a fresh draw for the others.
 2. **Benchmark** — runs `all2md.to_markdown()` once per cached doc, captures
    per-doc timings + errors, writes `results/results_<timestamp>.json`.
 3. **Report** — renders a stratified markdown report next to the JSON

--- a/docs/source/optimizations.rst
+++ b/docs/source/optimizations.rst
@@ -1,11 +1,20 @@
 PDF Parsing Optimizations
 ==========================
 
-Between releases 1.1.0 and 1.1.1 a series of profile-driven changes reduced the
-corpus benchmark from **21.4 minutes to 6.7 minutes** — a 3.2x improvement, with
-the worst-case single file dropping from **2.1 min to 11.65 s** (10.7x). This
-page documents the methodology, the contributing changes, and the work that
-remains.
+Between releases 1.1.0 and 1.1.1 a series of profile-driven changes cut conversion
+time on the 115 documents the two benchmark runs share from **11.5 minutes to 55
+seconds** — a 12.4x improvement — with the worst-case single file dropping from
+**2.1 min to 11.65 s** (10.7x). This page documents the methodology, the
+contributing changes, and the work that remains.
+
+.. note::
+
+   Earlier revisions of this page led with "21.4 minutes to 6.7 minutes, a 3.2x
+   improvement", comparing the two runs' *corpus-wide* totals. That arithmetic is
+   right and the comparison is not: the runs cover different document sets, so the
+   figure conflates the optimization with a change of corpus. See
+   :ref:`why-corpus-wide-totals-are-not-quoted`. The shared-document figure above is
+   both defensible and larger.
 
 .. contents::
    :local:
@@ -17,10 +26,13 @@ Methodology
 The work followed a tight measure / fix / re-measure loop with three
 complementary tools shipped with the repo:
 
-* **Corpus benchmark** (``benchmarks/corpus/run.py``) — pulls a deterministic
-  sample from public corpora (arxiv, govdocs1, Apache POI, Enron), times
-  conversion of each doc, and produces stratified p50 / p95 / mean tables
-  per source and per format. See :doc:`performance` for a full reference.
+* **Corpus benchmark** (``benchmarks/corpus/run.py``) — samples public corpora
+  (arxiv, govdocs1, Apache POI, Enron), times conversion of each doc, and produces
+  stratified p50 / p95 / mean tables per source and per format. Two of the four
+  sources are reproducible run to run (``enron`` and ``govdocs1``, both frozen
+  archives); ``arxiv`` and ``poi`` track upstream state that moves, so only the
+  first two are comparable across runs. See :doc:`performance` for a full
+  reference.
 * **Single-file profiler** — for the slowest doc in each report, an isolated
   ``cProfile`` run dumps cumulative-time and self-time call graphs to attribute
   wall-clock cost to specific functions.
@@ -37,7 +49,8 @@ inspect helper verifies correctness. All three were needed.
 Headline impact
 ---------------
 
-Corpus-wide on a single 149-doc run:
+Every row below is measured over documents present in **both** runs, so the only
+thing that changed between the columns is the code:
 
 .. list-table::
    :header-rows: 1
@@ -47,38 +60,79 @@ Corpus-wide on a single 149-doc run:
      - Baseline (b0e4224)
      - Optimized (3516bc9)
      - Improvement
-   * - Total wall time
-     - 21.4 min
-     - 6.7 min
-     - 3.2x faster
-   * - Aggregate MB/s
-     - 0.08
-     - 0.37
-     - 4.6x
-   * - PDF p50
-     - 8.54 s
-     - 728 ms
-     - **11.7x faster**
-   * - PDF p95
-     - 1.1 min
-     - 13.5 s
-     - 4.9x
-   * - PDF mean
-     - 16.0 s
-     - 5.0 s
-     - 3.2x
-   * - govdocs1 p50
+   * - Shared-document total (115 docs)
+     - 11.5 min
+     - 55.4 s
+     - **12.4x faster**
+   * - govdocs1 p50 (same 50 docs)
      - 5.91 s
      - 194 ms
      - **30x faster**
-   * - govdocs1 mean
+   * - govdocs1 mean (same 50 docs)
      - 13.7 s
      - 1.08 s
      - 12.7x
+   * - Worst single file (``govdocs1/000887.pdf``)
+     - 2.1 min
+     - 11.65 s
+     - 10.7x
+
+``govdocs1`` carries the per-source rows because it is a fixed shard: the same 50
+documents in both runs.
 
 The two underlying reports — ``b0e4224-baseline.md/json`` and
 ``3516bc9-optimized.md/json`` — are committed under ``benchmarks/reference/``
 for verification.
+
+.. _why-corpus-wide-totals-are-not-quoted:
+
+Why corpus-wide totals are not quoted
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The two reference runs do not cover the same documents, because two of the four
+corpus sources resolve against upstream state that moves:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 22 20 20 20
+
+   * - Source
+     - Baseline
+     - Optimized
+     - In both
+   * - arxiv
+     - 30
+     - 30
+     - **0**
+   * - poi
+     - 30
+     - 19
+     - 15
+   * - govdocs1
+     - 50
+     - 50
+     - 50
+   * - enron
+     - 50
+     - 50
+     - 50
+   * - **Total**
+     - **160**
+     - **149**
+     - **115**
+
+The ``arxiv`` sample is drawn from the most recent cs.CL submissions, and the runs
+are nine days apart — so the overlap is **zero**. Documents present in only one run
+account for 46% of the baseline's wall time and 86% of the optimized run's.
+
+Any corpus-wide aggregate over those two runs therefore measures a change of corpus
+as much as a change of code, and the same applies to the PDF percentiles: both runs
+have 80 PDFs, but 30 of them are different papers. That is why this page quotes the
+shared-document total and the fixed ``govdocs1`` shard instead.
+
+The underlying property is documented in ``benchmarks/corpus/corpus.toml``, which
+marks ``arxiv`` and ``poi`` as ``reproducible = false``. It is also why the corpus
+gate scores only ``enron`` and ``govdocs1``.
 
 Case study: the file that drove the investigation
 --------------------------------------------------

--- a/docs/source/performance.rst
+++ b/docs/source/performance.rst
@@ -904,10 +904,23 @@ Corpus Benchmark Harness
 
 For stress testing across a wider variety of real-world documents than ad-hoc
 benchmarks can cover, all2md ships a corpus benchmark harness in
-``benchmarks/corpus/``. It pulls a deterministic sample from public corpora
-(arxiv, Digital Corpora govdocs1, Apache POI test data, the Enron email
-release), times conversion of each doc, and produces a stratified markdown
-report.
+``benchmarks/corpus/``. It samples public corpora (arxiv, Digital Corpora
+govdocs1, Apache POI test data, the Enron email release), times conversion of
+each doc, and produces a stratified markdown report.
+
+.. warning::
+
+   **Only two of the four sources are reproducible.** ``enron`` and ``govdocs1``
+   are frozen archives and yield the same documents on every run. ``arxiv`` samples
+   the most recent submissions and ``poi`` tracks a live upstream test corpus, so
+   both return different documents over time — ``corpus.toml`` marks them
+   ``reproducible = false``. Roughly 60 of 160 documents can differ between two
+   runs.
+
+   Corpus-wide totals from two runs taken at different times are therefore not
+   comparable, and neither are per-format aggregates that mix the sources. Compare
+   the reproducible sources, or the documents the runs share. This is also why the
+   corpus gate scores ``enron`` and ``govdocs1`` only.
 
 .. note::
 


### PR DESCRIPTION
`optimizations.rst` led with **"21.4 minutes to 6.7 minutes — a 3.2x improvement"**, taken from the corpus-wide totals of the two committed reference runs. The arithmetic is right. The comparison is not.

| | baseline | optimized | shared |
|---|---|---|---|
| documents | **160** | **149** | 115 |
| arxiv | 30 | 30 | **0** |
| poi | 30 | 19 | 15 |
| govdocs1 | 50 | 50 | 50 |
| enron | 50 | 50 | 50 |

`arxiv` samples the most recent cs.CL submissions and the two runs are nine days apart, so the overlap is **zero**. Documents present in only one run account for **46%** of the baseline's wall time and **86%** of the optimized run's. The page also said "149-doc run" for a column that has 160.

The PDF percentile rows have the same problem: 80 PDFs on both sides, 30 of them different papers.

## What it says now

The **115 shared documents: 687.8s → 55.4s, a 12.4x improvement.** Defensible, and larger than the number it replaces.

The `govdocs1` rows (p50 30x, mean 12.7x) and the `000887.pdf` case study (124.96s → 11.65s, 10.7x) were already sound — that shard is fixed at the same 50 documents — and they stay. I re-derived all of them from the committed JSON.

A new section states the document counts and why corpus-wide totals aren't quoted.

## The claim underneath it

Three places described the sample as "deterministic" or "a reproducible performance benchmark". `corpus.toml` has marked `arxiv` and `poi` as `reproducible = false` all along, and `benchmarks/corpus/README.md` contradicted itself between line 3 and its own reproducibility section. That's the property the bad headline tripped over, so it's corrected in the same PR.

## Also included

`set -o pipefail` in `pmc-borndigital.yml`, which pipes into `tee` and was letting `tee` supply the exit status — a scorer traceback would land in the summary file with the job green. One line, same class of defect, and every other piped step in the repo already sets it.

Docs build clean under `-W`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)