### PR TITLE
fix(benchmarks): record a withdrawn PMC article instead of failing the load

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,26 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Fixed
-
-- **A withdrawn PMC article no longer takes the whole born-digital lane down with it.** The
-  committed manifest pins each article's SHA-256, which guarantees what the bytes *are* but
-  says nothing about whether they are still served — and PMC reprocesses articles and drops
-  the superseded version. `PMC11000011.1` was fetched successfully one morning and 404'd that
-  same evening, from two networks, with `.2` and `.3` equally absent (#329). The lane's only
-  response was to abort the load, so a single upstream withdrawal made the corpus unscoreable
-  on any machine without a warm cache, and the monthly scheduled run would have begun failing
-  regardless of anything in this repository.
-  A 404 is now recorded rather than raised: the article lands in
-  `CorpusSnapshot.unavailable`, the snapshot stops reporting itself as `complete`, and the ids
-  appear in the payload as `corpus.articles_unavailable` (payload schema 3) and in the CLI
-  summary beside the article count. That last part is the point — a score over 65 of 66
-  articles is a different measurement from one over 66, and nothing downstream could
-  previously tell. Tolerance is capped at a tenth of the selection, and losing every article
-  is spelled out separately so a one-article run cannot pass having scored nothing. Transient
-  failures and digest mismatches are still fatal, because those are claims about the bytes
-  rather than about the object's existence.
-
 ### Added
 
 - **Content precision beside content recall on the born-digital lane**
@@ -182,6 +162,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **A withdrawn PMC article no longer takes the whole born-digital lane down with it.** The
+  committed manifest pins each article's SHA-256, which guarantees what the bytes *are* but
+  says nothing about whether they are still served — and PMC reprocesses articles and drops
+  the superseded version. `PMC11000011.1` was fetched successfully one morning and 404'd that
+  same evening, from two networks, with `.2` and `.3` equally absent (#329). The lane's only
+  response was to abort the load, so a single upstream withdrawal made the corpus unscoreable
+  on any machine without a warm cache, and the monthly scheduled run would have begun failing
+  regardless of anything in this repository.
+  A 404 is now recorded rather than raised: the article lands in
+  `CorpusSnapshot.unavailable`, the snapshot stops reporting itself as `complete`, and the ids
+  appear in the payload as `corpus.articles_unavailable` (payload schema 3) and in the CLI
+  summary beside the article count. That last part is the point — a score over 65 of 66
+  articles is a different measurement from one over 66, and nothing downstream could
+  previously tell. Tolerance is capped at a tenth of the selection, and losing every article
+  is spelled out separately so a one-article run cannot pass having scored nothing. Transient
+  failures and digest mismatches are still fatal, because those are claims about the bytes
+  rather than about the object's existence.
 - **The PDF optimization page no longer compares two different corpora.** It led with
   "reduced the corpus benchmark from 21.4 minutes to 6.7 minutes — a 3.2x improvement",
   taken from the two committed reference runs' corpus-wide totals. The arithmetic is right

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **A withdrawn PMC article no longer takes the whole born-digital lane down with it.** The
+  committed manifest pins each article's SHA-256, which guarantees what the bytes *are* but
+  says nothing about whether they are still served — and PMC reprocesses articles and drops
+  the superseded version. `PMC11000011.1` was fetched successfully one morning and 404'd that
+  same evening, from two networks, with `.2` and `.3` equally absent (#329). The lane's only
+  response was to abort the load, so a single upstream withdrawal made the corpus unscoreable
+  on any machine without a warm cache, and the monthly scheduled run would have begun failing
+  regardless of anything in this repository.
+  A 404 is now recorded rather than raised: the article lands in
+  `CorpusSnapshot.unavailable`, the snapshot stops reporting itself as `complete`, and the ids
+  appear in the payload as `corpus.articles_unavailable` (payload schema 3) and in the CLI
+  summary beside the article count. That last part is the point — a score over 65 of 66
+  articles is a different measurement from one over 66, and nothing downstream could
+  previously tell. Tolerance is capped at a tenth of the selection, and losing every article
+  is spelled out separately so a one-article run cannot pass having scored nothing. Transient
+  failures and digest mismatches are still fatal, because those are claims about the bytes
+  rather than about the object's existence.
+
 ### Added
 
 - **Content precision beside content recall on the born-digital lane**

--- a/benchmarks/pmc/__main__.py
+++ b/benchmarks/pmc/__main__.py
@@ -52,6 +52,10 @@ def _load(args: argparse.Namespace) -> int:
     print(f"pin        : {snapshot.manifest_sha256}")
     print(f"articles   : {len(snapshot.articles)} of {snapshot.expected_articles}")
     print(f"complete   : {snapshot.complete}")
+    if snapshot.unavailable:
+        print(f"unavailable: {len(snapshot.unavailable)} pinned article(s) the bucket no longer serves")
+        for article_id, error in sorted(snapshot.unavailable.items()):
+            print(f"    {article_id:20s} {error}")
     total = sum(article.pdf_size_bytes + article.xml_size_bytes for article in snapshot.articles)
     print(f"bytes      : {total:,}")
     return 0
@@ -154,6 +158,13 @@ def _score(args: argparse.Namespace) -> int:
     projection = payload["projection"]
     print(f"pin        : {payload['provenance']['corpus_pin']}")
     print(f"articles   : {corpus_facts['articles_converted']} of {corpus_facts['articles_scored']} converted")
+    if corpus_facts["articles_unavailable"]:
+        # Beside the article count, not in a footer: every number below it is computed over
+        # a smaller corpus than the pin names.
+        print(
+            f"  withdrawn: {len(corpus_facts['articles_unavailable'])} pinned article(s) no longer "
+            f"served: {', '.join(corpus_facts['articles_unavailable'])}"
+        )
     print(f"pages      : {corpus_facts['pages_scored']} scored")
     print(f"coverage   : {corpus_facts['coverage']['median']:.2f} median ground-truth words per PDF word")
     print(

--- a/benchmarks/pmc/benchmark.py
+++ b/benchmarks/pmc/benchmark.py
@@ -50,7 +50,10 @@ from benchmarks.pmc.pages import ASSIGNMENTS, assign_pages, index_pages
 
 #: 2 adds ``article_precision``. A reader that expects 1 would silently see recall with no
 #: converse and read it as the whole story, which is the misreading this lane just fixed.
-SCHEMA_VERSION = 2
+#: 3 adds ``corpus.articles_unavailable``. Under 2 a run that lost pinned articles was
+#: indistinguishable from one that scored them all, so every payload without this key has
+#: an unknown denominator rather than a complete one.
+SCHEMA_VERSION = 3
 ORACLE_SCHEMA_VERSION = 1
 
 #: Fixed seed: a control that scrambles differently every run cannot be compared across
@@ -358,6 +361,10 @@ def normalize_results(
         },
         "corpus": {
             "articles_expected": snapshot.expected_articles,
+            # Named separately from `articles_expected - articles_scored`, which a `--limit`
+            # produces too: one is a sample the operator asked for, the other is corpus the
+            # run was denied.
+            "articles_unavailable": sorted(snapshot.unavailable),
             "articles_scored": len(evaluations),
             "articles_converted": sum(1 for result in evaluations if result.error is None),
             "pages_scored": len(pages),

--- a/benchmarks/pmc/corpus.py
+++ b/benchmarks/pmc/corpus.py
@@ -180,9 +180,15 @@ class CorpusSnapshot:
         Validated articles selected for this invocation.
     expected_articles : int
         Article count of the complete pinned corpus.
+    unavailable : dict[str, str]
+        Article id to error text, for pinned articles the bucket no longer serves.
+        Empty on a healthy run.  A first-class field rather than a log line because a
+        score computed over 65 of 66 articles is a different measurement from one
+        computed over 66, and nothing downstream can tell unless it is told.
     complete : bool
-        ``True`` only when the caller requested the whole manifest.  Supplying a
-        ``limit`` always produces ``False``, even when it equals the manifest size.
+        ``True`` only when the caller requested the whole manifest *and* every pinned
+        article was materialized.  Supplying a ``limit`` always produces ``False``,
+        even when it equals the manifest size.
 
     """
 
@@ -191,6 +197,7 @@ class CorpusSnapshot:
     bucket: str
     articles: tuple[CorpusArticle, ...]
     expected_articles: int
+    unavailable: dict[str, str]
     complete: bool
 
 
@@ -261,6 +268,12 @@ def load_corpus(
     Every selected PDF and JATS file is revalidated against the manifest digest on each
     call, whether it was just downloaded or found warm in the cache.
 
+    The manifest pins what the bytes *are*, which is not the same as pinning that they
+    are still served.  PMC reprocesses articles and withdraws the superseded version, so
+    a pinned object can start returning 404 without a single retained byte changing.
+    Those articles land in ``CorpusSnapshot.unavailable`` and the snapshot is no longer
+    ``complete``; only a large enough share of them aborts the load.
+
     Parameters
     ----------
     cache_dir : pathlib.Path
@@ -288,7 +301,8 @@ def load_corpus(
     CorpusCacheError
         If the manifest is unreadable or a cached artifact fails validation.
     CorpusDownloadError
-        If a manifest artifact cannot be downloaded.
+        If a manifest artifact cannot be downloaded, or if so many pinned articles have
+        been withdrawn that what remains is no longer the pinned corpus.
     CorpusIntegrityError
         If a freshly downloaded artifact does not match the manifest.
 
@@ -300,14 +314,15 @@ def load_corpus(
 
     corpus_dir = _prepare_cache_dir(Path(cache_dir), manifest.sha256)
     with _cache_lock(corpus_dir, manifest.sha256):
-        articles = _materialize(selected, corpus_dir, workers=workers)
+        articles, unavailable = _materialize(selected, corpus_dir, workers=workers)
     return CorpusSnapshot(
         manifest_path=manifest.path,
         manifest_sha256=manifest.sha256,
         bucket=manifest.bucket,
         articles=articles,
         expected_articles=len(manifest.articles),
-        complete=limit is None,
+        unavailable=unavailable,
+        complete=limit is None and not unavailable,
     )
 
 
@@ -502,28 +517,40 @@ def _materialize(
     corpus_dir: Path,
     *,
     workers: int,
-) -> tuple[CorpusArticle, ...]:
-    def materialize(entry: ManifestArticle) -> CorpusArticle:
+) -> tuple[tuple[CorpusArticle, ...], dict[str, str]]:
+    """Materialize every selected article, tolerating ones the bucket has withdrawn.
+
+    A 404 is the one download failure a retry cannot fix, and the only one that says
+    nothing about the bytes: everything still served matches the manifest exactly.
+    Every other failure -- a transient network error, a digest mismatch, an unreadable
+    warm file -- still raises, because those are claims about the artifact rather than
+    about its existence.
+    """
+
+    def materialize(entry: ManifestArticle) -> CorpusArticle | str:
         pmcid, version = _parse_article_id(entry.article_id, source="corpus manifest")
         article_dir = corpus_dir / "articles" / entry.article_id
         _require_contained(article_dir, corpus_dir)
         article_dir.mkdir(parents=True, exist_ok=True)
         pdf_path = article_dir / f"{entry.article_id}.pdf"
         xml_path = article_dir / f"{entry.article_id}.xml"
-        _ensure_artifact(
-            pdf_path,
-            url=_object_url(entry.article_id, "pdf"),
-            sha256=entry.pdf_sha256,
-            size_bytes=entry.pdf_size_bytes,
-            label=f"PDF {entry.article_id}",
-        )
-        _ensure_artifact(
-            xml_path,
-            url=_object_url(entry.article_id, "xml"),
-            sha256=entry.xml_sha256,
-            size_bytes=entry.xml_size_bytes,
-            label=f"JATS {entry.article_id}",
-        )
+        try:
+            _ensure_artifact(
+                pdf_path,
+                url=_object_url(entry.article_id, "pdf"),
+                sha256=entry.pdf_sha256,
+                size_bytes=entry.pdf_size_bytes,
+                label=f"PDF {entry.article_id}",
+            )
+            _ensure_artifact(
+                xml_path,
+                url=_object_url(entry.article_id, "xml"),
+                sha256=entry.xml_sha256,
+                size_bytes=entry.xml_size_bytes,
+                label=f"JATS {entry.article_id}",
+            )
+        except ArtifactMissingError as exc:
+            return str(exc)
         return CorpusArticle(
             article_id=entry.article_id,
             pmcid=pmcid,
@@ -539,9 +566,26 @@ def _materialize(
         )
 
     if len(selected) == 1:
-        return (materialize(selected[0]),)
-    with ThreadPoolExecutor(max_workers=min(workers, len(selected))) as executor:
-        return tuple(executor.map(materialize, selected))
+        outcomes: list[CorpusArticle | str] = [materialize(selected[0])]
+    else:
+        with ThreadPoolExecutor(max_workers=min(workers, len(selected))) as executor:
+            outcomes = list(executor.map(materialize, selected))
+
+    articles = tuple(outcome for outcome in outcomes if isinstance(outcome, CorpusArticle))
+    unavailable = {
+        entry.article_id: outcome for entry, outcome in zip(selected, outcomes, strict=True) if isinstance(outcome, str)
+    }
+    # A tolerance, not a licence to erode: past this point the surviving articles are a
+    # different corpus than the one the pin names, and reporting them under that pin
+    # would be the quiet truncation the manifest exists to prevent.  The empty case is
+    # spelled out because the share test alone would wave through losing the only
+    # article of a one-article selection.
+    if not articles or len(unavailable) > max(1, int(_MAX_UNAVAILABLE_SHARE * len(selected))):
+        raise CorpusDownloadError(
+            f"corpus pin is no longer served: {len(unavailable)} of {len(selected)} pinned "
+            f"articles have been withdrawn ({', '.join(sorted(unavailable))}); rebuild the manifest"
+        )
+    return articles, unavailable
 
 
 def _ensure_artifact(

--- a/tests/unit/test_pmc_corpus.py
+++ b/tests/unit/test_pmc_corpus.py
@@ -305,6 +305,102 @@ def test_an_incomplete_load_is_marked_incomplete(tmp_path: Path, monkeypatch: py
     assert len(snapshot.articles) == 3
 
 
+def _install_downloader_missing(monkeypatch: pytest.MonkeyPatch, gone: set[str]) -> None:
+    """Serve every article except `gone`, which 404s the way a withdrawn object does."""
+
+    def download(url: str, destination: Path, *, label: str, retries: int = 0) -> None:
+        article_id = Path(url).stem
+        if article_id in gone:
+            raise corpus.ArtifactMissingError(f"{label} does not exist: {url}")
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        destination.write_bytes(_pdf_bytes(article_id) if url.endswith(".pdf") else _xml_bytes(article_id))
+
+    monkeypatch.setattr(corpus, "_download", download)
+
+
+def test_a_withdrawn_article_is_reported_rather_than_aborting_the_load(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """PMC withdraws superseded versions, so a pin can 404 with no retained byte changed."""
+    manifest_path = _write_manifest(tmp_path)
+    _install_downloader_missing(monkeypatch, {"PMC7000002.1"})
+
+    snapshot = corpus.load_corpus(tmp_path / "cache", manifest_path=manifest_path, workers=1)
+
+    assert [article.article_id for article in snapshot.articles] == ["PMC2000001.1", "PMC9000003.2"]
+    assert set(snapshot.unavailable) == {"PMC7000002.1"}
+    assert "does not exist" in snapshot.unavailable["PMC7000002.1"]
+    # The whole point: the survivors are not the pinned corpus, and the snapshot says so.
+    assert snapshot.complete is False
+    assert snapshot.expected_articles == 3
+
+
+def test_a_withdrawn_article_does_not_disturb_the_others(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Every surviving article is still digest-validated, and none is silently renumbered."""
+    manifest_path = _write_manifest(tmp_path)
+    _install_downloader_missing(monkeypatch, {"PMC2000001.1"})
+
+    snapshot = corpus.load_corpus(tmp_path / "cache", manifest_path=manifest_path, workers=2)
+
+    for article in snapshot.articles:
+        assert article.pdf_path.read_bytes() == _pdf_bytes(article.article_id)
+        assert article.xml_path.read_bytes() == _xml_bytes(article.article_id)
+
+
+def test_losing_too_much_of_the_corpus_is_fatal(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Tolerating one withdrawal must not become tolerating the corpus dissolving."""
+    manifest_path = _write_manifest(tmp_path)
+    _install_downloader_missing(monkeypatch, {"PMC2000001.1", "PMC7000002.1"})
+
+    with pytest.raises(corpus.CorpusDownloadError, match="no longer served"):
+        corpus.load_corpus(tmp_path / "cache", manifest_path=manifest_path, workers=1)
+
+
+def test_a_lone_article_vanishing_is_fatal_rather_than_an_empty_pass(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A share test alone waves this through: 1 of 1 lost is not more than max(1, 0)."""
+    manifest_path = _write_manifest(tmp_path, _manifest_payload(["PMC2000001.1"]))
+    _install_downloader_missing(monkeypatch, {"PMC2000001.1"})
+
+    with pytest.raises(corpus.CorpusDownloadError, match="no longer served"):
+        corpus.load_corpus(tmp_path / "cache", manifest_path=manifest_path, workers=1)
+
+
+def test_a_transient_failure_is_still_fatal(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Availability tolerance is for 404 alone; a flaky network must not shrink the corpus."""
+    manifest_path = _write_manifest(tmp_path)
+
+    def download(url: str, destination: Path, *, label: str, retries: int = 0) -> None:
+        raise corpus.CorpusDownloadError(f"failed to download {label}: timed out")
+
+    monkeypatch.setattr(corpus, "_download", download)
+
+    with pytest.raises(corpus.CorpusDownloadError, match="timed out"):
+        corpus.load_corpus(tmp_path / "cache", manifest_path=manifest_path, workers=1)
+
+
+def test_a_warm_article_survives_its_object_being_withdrawn(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The cached bytes still match the pin; availability is a property of the bucket."""
+    manifest_path = _write_manifest(tmp_path)
+    _install_downloader(monkeypatch)
+    corpus.load_corpus(tmp_path / "cache", manifest_path=manifest_path, workers=1)
+
+    _install_downloader_missing(monkeypatch, {"PMC2000001.1", "PMC7000002.1", "PMC9000003.2"})
+    reloaded = corpus.load_corpus(tmp_path / "cache", manifest_path=manifest_path, workers=1)
+
+    assert reloaded.unavailable == {}
+    assert reloaded.complete is True
+
+
 @pytest.mark.parametrize("workers", [0, -1, True, "eight"])
 def test_invalid_worker_counts_are_rejected(tmp_path: Path, workers: Any) -> None:
     with pytest.raises(ValueError, match="workers must be a positive integer"):
@@ -509,6 +605,7 @@ def _snapshot_of(paths: dict[str, Path]) -> Any:
         bucket=corpus.BUCKET,
         articles=articles,
         expected_articles=len(articles),
+        unavailable={},
         complete=True,
     )
 

--- a/tests/unit/test_pmc_oracle.py
+++ b/tests/unit/test_pmc_oracle.py
@@ -475,7 +475,13 @@ def test_page_scores_and_the_error_budget_come_from_the_same_run(tmp_path: Path)
         snapshot=type(
             "Snapshot",
             (),
-            {"manifest_sha256": "a" * 64, "bucket": "b", "complete": True, "expected_articles": 1},
+            {
+                "manifest_sha256": "a" * 64,
+                "bucket": "b",
+                "complete": True,
+                "expected_articles": 1,
+                "unavailable": {},
+            },
         )(),
         evaluations=[
             benchmark.ArticleEvaluation(
@@ -509,7 +515,13 @@ def test_recall_and_precision_are_reported_together() -> None:
         snapshot=type(
             "Snapshot",
             (),
-            {"manifest_sha256": "a" * 64, "bucket": "b", "complete": True, "expected_articles": 2},
+            {
+                "manifest_sha256": "a" * 64,
+                "bucket": "b",
+                "complete": True,
+                "expected_articles": 2,
+                "unavailable": {},
+            },
         )(),
         evaluations=[],
         recall=article.measure_recall(scored),


### PR DESCRIPTION
Closes #329.

## The defect

The PMC manifest pins each article's SHA-256. That fixes **what the bytes are**; it says
nothing about **whether they are still served**. PMC reprocesses articles and drops the
superseded version, so a pinned object can start returning 404 without a single retained
byte changing.

`PMC11000011.1` downloaded cleanly at ~10:00 and was gone by ~19:00 the same day. Verified
from two independent networks; `.2` and `.3` are equally absent, and a control article in
the same corpus returns 200.

The load's only response to a 404 was to abort. So one upstream withdrawal was enough to
make the corpus unscoreable on any machine without a warm cache — and the monthly scheduled
run would have started failing on the 15th regardless of anything in this repository. Two CI
runs failed identically before this was diagnosed.

## The fix

A 404 is recorded rather than raised:

- the article lands in `CorpusSnapshot.unavailable`
- the snapshot stops reporting itself as `complete`
- the ids reach the payload as `corpus.articles_unavailable` (schema 2 → 3) and the CLI
  summary, beside the article count

That last part is the substance of the change. A score computed over 65 of 66 articles is a
different measurement from one computed over 66, and nothing downstream could previously
tell. It is named separately from `expected - scored`, which a `--limit` produces too: a
sample the operator asked for is not corpus the run was denied.

## What still fails

Tolerance is not erosion. The load still raises when:

- more than a tenth of the selection has been withdrawn — past that the survivors are not
  the corpus the pin names
- **every** article is gone, spelled out separately because the share test alone waves
  through losing the only article of a one-article selection (`1 > max(1, 0)` is false)
- the failure is transient, or a digest mismatches, or a warm file is unreadable — those are
  claims about the bytes rather than about the object's existence

## Verification

Six new tests in `tests/unit/test_pmc_corpus.py` cover the withdrawal path, the two fatal
caps, transient-stays-fatal, and that a warm article survives its object being withdrawn
(the cached bytes still match the pin; availability is a property of the bucket). 70 tests in
the file pass; ruff, black and mypy clean; `CHANGELOG.md` still round-trips at fidelity 100.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
