### PR TITLE
chore(release): prepare v1.12.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.12.0] - 2026-08-12
+
 ### Added
 
 - **A conversion fidelity page** (`docs/source/benchmarks.rst`), with a committed evidence
@@ -2391,7 +2393,8 @@ surfaced one real conversion bug, which is the reason to take the release.
 - NumPy-style docstrings
 - Modular architecture with clear separation of concerns
 
-[Unreleased]: https://github.com/thomas-villani/all2md/compare/v1.11.0...HEAD
+[Unreleased]: https://github.com/thomas-villani/all2md/compare/v1.12.0...HEAD
+[1.12.0]: https://github.com/thomas-villani/all2md/releases/tag/v1.12.0
 [1.11.0]: https://github.com/thomas-villani/all2md/releases/tag/v1.11.0
 [1.10.1]: https://github.com/thomas-villani/all2md/releases/tag/v1.10.1
 [1.10.0]: https://github.com/thomas-villani/all2md/releases/tag/v1.10.0

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -37,7 +37,7 @@ if str(SCRIPTS_PATH) not in sys.path:
 project = "all2md"
 copyright = "2025, Tom Villani, Ph.D."
 author = "Tom Villani, Ph.D."
-release = "1.11.0"
+release = "1.12.0"
 
 # -- General configuration ---------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration

--- a/mcpb/manifest.json
+++ b/mcpb/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": "0.4",
   "name": "all2md",
   "display_name": "all2md",
-  "version": "1.11.0",
+  "version": "1.12.0",
   "description": "Convert PDFs, Office files, HTML, email, and 40+ formats to Markdown and back, directly inside Claude.",
   "long_description": "all2md's built-in MCP server, packaged for one-click install. Lets AI assistants read and convert documents across 40+ formats via an AST-based conversion pipeline, render Markdown back out to PDF/DOCX/PPTX/EPUB/HTML/RST, and edit documents section-by-section. Read-only query tools let assistants search across a corpus (grep + keyword/BM25), diff two documents, and outline a document's headings. Includes smart source auto-detection (file path, data URI, base64, plain text), section extraction, and security controls (a user-chosen workspace folder, network off by default, and path validation).",
   "author": {

--- a/mcpb/pyproject.toml
+++ b/mcpb/pyproject.toml
@@ -7,10 +7,10 @@
 # [tool.bumpversion] config — do NOT hand-edit the version strings below.
 [project]
 name = "all2md-mcpb"
-version = "1.11.0"
+version = "1.12.0"
 requires-python = ">=3.10"
 dependencies = [
-    "all2md[mcp,pdf,pdf_render,docx,html,xlsx,pptx,epub,rst,markdown,odf]>=1.11.0",
+    "all2md[mcp,pdf,pdf_render,docx,html,xlsx,pptx,epub,rst,markdown,odf]>=1.12.0",
     # The search_documents MCP tool defaults to keyword (BM25) mode, which needs
     # rank-bm25. Depend on it directly rather than via the `search` extra: that
     # extra also pulls faiss-cpu and sentence-transformers for vector/hybrid

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "all2md"
-version = "1.11.0"
+version = "1.12.0"
 description = "Rapid, lightweight conversion of various document formats to markdown for LLMs"
 readme = "README.md"
 authors = [
@@ -492,7 +492,7 @@ skips = [
 ]
 
 [tool.bumpversion]
-current_version = "1.11.0"
+current_version = "1.12.0"
 parse = "(?P<major>\\d+)\\.(?P<minor>\\d+)\\.(?P<patch>\\d+)"
 serialize = ["{major}.{minor}.{patch}"]
 commit = true

--- a/src/all2md/__init__.py
+++ b/src/all2md/__init__.py
@@ -85,7 +85,7 @@ if sys.version_info < (3, 10):
         f"all2md requires Python 3.10 or later. You are using Python {sys.version_info.major}.{sys.version_info.minor}."
     )
 
-__version__ = "1.11.0"
+__version__ = "1.12.0"
 
 from typing import TYPE_CHECKING, Any
 

--- a/uv.lock
+++ b/uv.lock
@@ -61,7 +61,7 @@ wheels = [
 
 [[package]]
 name = "all2md"
-version = "1.11.0"
+version = "1.12.0"
 source = { editable = "." }
 dependencies = [
     { name = "platformdirs" },


### PR DESCRIPTION
Rolls `[Unreleased]` over to `[1.12.0]` and bumps the version across all seven locations,
via `bump-my-version --no-commit --no-tag` rather than by hand.

**Minor, not patch.** The release adds public API surface: every registered format's options
class is now importable from both `all2md` and `all2md.options`, along with `OCROptions` and
`MetadataRenderPolicy`. On top of that, a PDF conversion guide, the conversion fidelity page,
and a precision instrument beside recall on the born-digital lane.

## Diff

Eight version-string edits and the CHANGELOG rollover. Nothing else:

| File | |
|---|---|
| `pyproject.toml` | `project.version`, `tool.bumpversion.current_version` |
| `src/all2md/__init__.py` | `__version__` |
| `docs/source/conf.py` | `release` |
| `mcpb/manifest.json` | `version` |
| `mcpb/pyproject.toml` | `version`, the `all2md[...]>=` pin |
| `uv.lock` | the anchored `all2md` package entry |

## Verified rather than assumed

- All seven sites read `1.12.0`, with no straggler — the surviving `1.11.0` strings in
  `uv.lock` are the unrelated `py` and `pyperclip` packages
- The anchored `uv.lock` edit landed on the `all2md` entry, not a neighbour
- `mcpb/manifest.json` still parses as JSON, and its dependency pin moved with the version
- `import all2md` reports `1.12.0`
- `CHANGELOG.md` and `README.md` still round-trip at fidelity **100**, which has zero headroom
- `[Unreleased]` is left empty and `[1.12.0]` carries all 45 entries; both link references added

## Artifact drift

Checked rather than assumed, the way `8f5d8cd0` did for v1.11.0:

- converter manifest validates clean against the live modules
- `docs/source/options.rst` regenerates byte-identical
- `docs/source/_generated_formats.rst.inc` regenerates byte-identical

## After merge

Tag `main` with `v1.12.0` and push the tag — that fires the PyPI publish, gated on CI success
via `workflow_run`. Note that v1.11.0's tag landed on the *changelog-date* commit rather than
the prep commit, so tag whatever `main` actually points at.

Known-open and deliberately not in this release: #332 (restore the PMC corpus to 66 articles),
#328 (Semgrep finding triage).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
