### PR TITLE
fix(benchmarks): restore the PMC corpus to 66 articles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,44 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **The PMC born-digital corpus is back to 66 articles.** `PMC11000011.1` was withdrawn
+  upstream (#329), and since #330 the lane degraded gracefully and scored 65 of 66. That is
+  the right behaviour for an incident and the wrong steady state: a permanently-false
+  `complete_corpus` is a permanently-yellow test, so the *second* withdrawal would be
+  invisible against a run that already looks like that — and it quietly consumes the
+  tolerance budget that exists for real incidents, which aborts the load past a tenth of the
+  selection.
+  The replacement is drawn by the selection process rather than chosen: only the
+  `PMC11000000` seed was re-walked, through the same `build_manifest` entry point with the
+  committed stride, `per_seed`, candidate cap and filter, because a hand-picked article would
+  bias the corpus in a way nothing downstream could detect. The walk also shows the
+  withdrawal is a rejection rather than an outage — the prefix still lists and only the PDF
+  404s — so stride alignment is preserved and the seed's two surviving members re-select
+  byte-for-byte identically. Only the third slot moves, to `PMC11000033.1`. The pin moves
+  `34cc7c50` → `9ba5c0cd`, so the next run uses a new digest-keyed cache directory.
+  Re-recorded `benchmarks/pmc/reference.json` against the new pin on CI, and updated every
+  figure in `docs/source/benchmarks.rst` in the same change. The headline readings barely
+  move, which is what a representative corpus should do when one article of 66 is swapped:
+  recall of attainable text 95.3%, novel n-grams 1.0%, both unchanged to the published
+  precision. Tables go from 88-against-117 to 92-against-121 (#332).
+- **The published fidelity figures are now checked against the artifacts they come from.**
+  `docs/source/benchmarks.rst` is the one place the project makes a public quality claim, and
+  the claim rests entirely on each number coming from a committed artifact — but nothing
+  enforced the correspondence. The page and the artifacts were written in the same change and
+  agreed on the day; the first time a pin moved they could silently stop agreeing, and a
+  stale figure on that page reads exactly like a measured one. This lane had already
+  published a comparison between two runs covering different corpora, so the failure mode is
+  demonstrated rather than theoretical.
+  The check is built the strong way round: rather than scraping numbers out of the prose and
+  asking whether each looks plausible — which cannot see a figure that should be there and is
+  not, and needs an exemption for every incidental integer — each published claim is declared
+  as a snippet rendered *from* the artifact, and the page must contain it verbatim. Matching
+  the whole line rather than the number alone means a stale line fails too. Verified the
+  judge can fail: against the pre-update page it reports exactly the nine figures that
+  moved, while the unchanged OmniDocBench readings still match.
+
 ## [1.12.0] - 2026-08-12
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   the whole line rather than the number alone means a stale line fails too. Verified the
   judge can fail: against the pre-update page it reports exactly the nine figures that
   moved, while the unchanged OmniDocBench readings still match.
+  Two stronger invariants ride along, because matching rendered text still assumes the
+  artifact itself describes the right corpus. `reference.json`'s `corpus_pin` must equal the
+  SHA-256 of the committed `manifest.json`, so a manifest edit landing without a re-record —
+  precisely what #332 had to repair — fails immediately rather than at the next scheduled run;
+  and the published reference must be a *complete* run covering every article the manifest
+  names, since `complete_corpus` going false is the right signal for a run and the wrong state
+  for the artifact a public page quotes as its reading.
 
 ## [1.12.0] - 2026-08-12
 

--- a/benchmarks/pmc/manifest.json
+++ b/benchmarks/pmc/manifest.json
@@ -56,14 +56,6 @@
       "xml_sha256": "c982b8bf7167544f57703266814451f4a6722051bb730a44c1931d6836df923f",
       "xml_size_bytes": 41377
     },
-    "PMC11000011.1": {
-      "licence": "https://creativecommons.org/licenses/by/4.0/",
-      "paragraphs": 64,
-      "pdf_sha256": "ddc5a5421d0878e4bd72c3348be627565e9e9edc5c23f87bf0d4de049807788c",
-      "pdf_size_bytes": 4829374,
-      "xml_sha256": "b724e3c933e10c5acf3b1d5253b19983985828cfc85f63f186a4580c315def1b",
-      "xml_size_bytes": 316408
-    },
     "PMC11000022.1": {
       "licence": "https://creativecommons.org/licenses/by-nc/4.0/",
       "paragraphs": 42,
@@ -71,6 +63,14 @@
       "pdf_size_bytes": 1780546,
       "xml_sha256": "746e77c4dafb1fdbca3eae89d771f23ae8ac25f6379a90739a5f390ecdaf9ba9",
       "xml_size_bytes": 105792
+    },
+    "PMC11000033.1": {
+      "licence": "https://creativecommons.org/licenses/by/4.0/",
+      "paragraphs": 48,
+      "pdf_sha256": "e0551b507fc62ee655277519af9589e16daad3f000168e16408d7ee8508ad3a7",
+      "pdf_size_bytes": 132089,
+      "xml_sha256": "5baab31409350fe0570da0a2575e23b859436f8e0203738cfe730a1c0f3c38e9",
+      "xml_size_bytes": 61719
     },
     "PMC11500000.1": {
       "licence": "https://creativecommons.org/licenses/by-nc-nd/4.0/",
@@ -532,6 +532,7 @@
   "bucket": "pmc-oa-opendata",
   "rejected": {
     "PMC10000000.1": "no_paragraphs",
+    "PMC11000011.1": "pdf_missing",
     "PMC4000013.1": "pdf_missing",
     "PMC4000025.1": "pdf_missing",
     "PMC4000036.1": "pdf_missing",
@@ -574,17 +575,26 @@
   "rejection_counts": {
     "no_paragraphs": 32,
     "no_vector_drawings": 0,
-    "pdf_missing": 7,
+    "pdf_missing": 8,
     "pdf_unreadable": 0,
     "xml_missing": 0,
     "xml_unparsable": 0
   },
   "schema_version": 1,
   "selection": {
-    "candidates": 105,
+    "candidates": 106,
     "filter": "JATS <p> > 0 and vector drawings on some PDF page",
     "max_candidates_per_seed": 60,
     "per_seed": 3,
+    "rewalks": [
+      {
+        "accepted": "PMC11000033.1",
+        "issue": 332,
+        "reason": "PMC11000011.1 withdrawn from the bucket; its PDF 404s while the prefix still lists",
+        "rejected": "PMC11000011.1",
+        "seed": "PMC11000000"
+      }
+    ],
     "seeds": [
       "PMC1500000",
       "PMC2000000",

--- a/benchmarks/pmc/reference.json
+++ b/benchmarks/pmc/reference.json
@@ -1,157 +1,155 @@
 {
   "article_precision": {
-    "control_emitted": 438975,
-    "control_precision": 0.0071051882225639275,
-    "discrimination": 0.9312512102055926,
-    "duplication": 0.004572057167902784,
-    "emitted": 438975,
+    "control_emitted": 443281,
+    "control_precision": 0.007024889404237944,
+    "discrimination": 0.9315513184639089,
+    "duplication": 0.004527158697335614,
+    "emitted": 443281,
     "excess": 2128,
-    "novel": 4261,
-    "novel_share": 0.009706703115211572,
-    "occurrences": 465436,
-    "precision": 0.9383563984281565,
-    "resequenced": 22799,
-    "supported": 411915
+    "novel": 4287,
+    "novel_share": 0.009671066434158018,
+    "occurrences": 470052,
+    "precision": 0.9385762078681469,
+    "resequenced": 22941,
+    "supported": 416053
   },
   "article_recall": {
-    "attainable": 5494,
-    "attainable_recall": 0.9528576629049873,
+    "attainable": 5561,
+    "attainable_recall": 0.9534256428699874,
     "by_kind": {
       "table": {
-        "attainable": 107,
-        "attainable_recall": 0.8317757009345794,
-        "recovered": 90,
-        "scored": 119
+        "attainable": 110,
+        "attainable_recall": 0.8363636363636363,
+        "recovered": 93,
+        "scored": 123
       },
       "text_block": {
-        "attainable": 3124,
-        "attainable_recall": 0.9759923175416133,
-        "recovered": 3079,
-        "scored": 6289
+        "attainable": 3160,
+        "attainable_recall": 0.9762658227848101,
+        "recovered": 3115,
+        "scored": 6356
       },
       "title": {
-        "attainable": 2263,
-        "attainable_recall": 0.926646045072912,
-        "recovered": 2123,
-        "scored": 2397
+        "attainable": 2291,
+        "attainable_recall": 0.9275425578350065,
+        "recovered": 2151,
+        "scored": 2426
       }
     },
-    "ceiling": 0.6239636570130608,
-    "control_recall": 0.003634298693923907,
-    "control_scored": 8805,
-    "discrimination": 0.5973878478137421,
-    "recall": 0.601022146507666,
-    "recovered": 5292,
-    "scored": 8805,
-    "too_short": 2570
+    "ceiling": 0.624480628860191,
+    "control_recall": 0.003593486805165637,
+    "control_scored": 8905,
+    "discrimination": 0.5982032565974171,
+    "recall": 0.6017967434025828,
+    "recovered": 5359,
+    "scored": 8905,
+    "too_short": 2598
   },
   "conversion_failures": {},
   "corpus": {
-    "articles_converted": 65,
+    "articles_converted": 66,
     "articles_expected": 66,
-    "articles_scored": 65,
-    "articles_unavailable": [
-      "PMC11000011.1"
-    ],
+    "articles_scored": 66,
+    "articles_unavailable": [],
     "coverage": {
-      "count": 65.0,
+      "count": 66.0,
       "maximum": 1.1974210089736823,
-      "mean": 0.9646370447748418,
-      "median": 0.9834683954619124,
+      "mean": 0.9650180243987616,
+      "median": 0.9844624081486973,
       "minimum": 0.09476843910806175,
-      "stdev": 0.13621574832109762
+      "stdev": 0.13519930586338003
     },
-    "ground_truth_blocks": 11375,
-    "pages_scored": 699,
-    "pages_with_emitted_table": 67,
-    "pages_with_expected_table": 92,
-    "tables_emitted": 88,
-    "tables_expected": 117
+    "ground_truth_blocks": 11503,
+    "pages_scored": 706,
+    "pages_with_emitted_table": 69,
+    "pages_with_expected_table": 94,
+    "tables_emitted": 92,
+    "tables_expected": 121
   },
   "degraded_events": {
-    "table_rejected": 100
+    "table_rejected": 101
   },
   "dimensions": {
     "block_structure_similarity": {
-      "control_mean": 0.44477015471855613,
-      "count": 699.0,
+      "control_mean": 0.444966651809884,
+      "count": 706.0,
       "direction": "higher",
-      "discrimination": 0.10860080708839287,
+      "discrimination": 0.10894954604621127,
       "maximum": 1.0,
-      "mean": 0.553370961806949,
+      "mean": 0.5539161978560952,
       "median": 0.5714285714285714,
       "minimum": 0.016393442622950838,
       "mutation_drop": {
-        "halved": 0.08048727169312125,
-        "reversed": 0.008931599647340019,
-        "shuffled": 0.021105204174661576
+        "halved": 0.08100948154670065,
+        "reversed": 0.008751660091300871,
+        "shuffled": 0.02068652727439497
       },
-      "stdev": 0.2035308134591419,
+      "stdev": 0.20297905026461505,
       "ungateable": "compares kind sequences without inspecting the text under a block, so content-free output scores 1.0 (issue #256); eleven text categories collapse to `text_block`, so fully reversed output scores exactly 1.0 on 153 of the 981 pinned pages; and on the born-digital lane it separates own-page from wrong-page output by only ~0.06 while *rising* when half the emitted content is deleted, which rewards dropping blocks"
     },
     "reading_order_similarity": {
-      "control_mean": 0.289276363029886,
-      "count": 699.0,
+      "control_mean": 0.28872975957995617,
+      "count": 706.0,
       "direction": "higher",
-      "discrimination": 0.4737108796419468,
+      "discrimination": 0.47600569800761094,
       "maximum": 1.0,
-      "mean": 0.7629872426718328,
-      "median": 0.7936507936507936,
+      "mean": 0.7647354575875671,
+      "median": 0.7968697968697969,
       "minimum": 0.0,
       "mutation_drop": {
-        "halved": 0.327080903335266,
-        "reversed": 0.4355050729667941,
-        "shuffled": 0.20203765039149885
+        "halved": 0.32680517032583656,
+        "reversed": 0.43991109322823835,
+        "shuffled": 0.20385363703260995
       },
-      "stdev": 0.21871713873751256
+      "stdev": 0.2183936420081225
     },
     "table_content_similarity": {
-      "control_mean": 0.025807012965666117,
-      "count": 112.0,
+      "control_mean": 0.026460610945399348,
+      "count": 114.0,
       "direction": "higher",
-      "discrimination": 0.27574490528133505,
+      "discrimination": 0.2868819009496966,
       "maximum": 1.0,
-      "mean": 0.30155191824700117,
+      "mean": 0.313342511895096,
       "median": 0.0,
       "minimum": 0.0,
       "mutation_drop": {
-        "halved": 0.2832438647594491,
+        "halved": 0.28757152934921126,
         "reversed": 0.0,
         "shuffled": 0.0
       },
-      "stdev": 0.398820123564122
+      "stdev": 0.40510101310490293
     },
     "table_structure_similarity": {
-      "control_mean": 0.060566312501200446,
-      "count": 112.0,
+      "control_mean": 0.06397272420063532,
+      "count": 114.0,
       "direction": "higher",
-      "discrimination": 0.22167317433513126,
+      "discrimination": 0.22939706403622856,
       "maximum": 1.0,
-      "mean": 0.2822394868363317,
+      "mean": 0.2933697882368639,
       "median": 0.0,
       "minimum": 0.0,
       "mutation_drop": {
-        "halved": 0.2595106674937074,
+        "halved": 0.26441861305506026,
         "reversed": 0.0,
         "shuffled": 0.0
       },
-      "stdev": 0.3667505412022915
+      "stdev": 0.373158289883106
     },
     "text_content_similarity": {
-      "control_mean": 0.23168532321615054,
-      "count": 699.0,
+      "control_mean": 0.23194245079400155,
+      "count": 706.0,
       "direction": "higher",
-      "discrimination": 0.33607319751797515,
+      "discrimination": 0.3379984238661681,
       "maximum": 0.9901380670611439,
-      "mean": 0.5677585207341257,
-      "median": 0.5410639290713952,
+      "mean": 0.5699408746601696,
+      "median": 0.5440650241687568,
       "minimum": 0.010652463382157085,
       "mutation_drop": {
-        "halved": 0.24782331110942807,
-        "reversed": 0.18364141745839718,
-        "shuffled": 0.1202661449939388
+        "halved": 0.24829681578792712,
+        "reversed": 0.18663777322996467,
+        "shuffled": 0.1228484750939727
       },
-      "stdev": 0.23048325889923907
+      "stdev": 0.23081827781970696
     }
   },
   "ocr_articles": [
@@ -160,27 +158,27 @@
   ],
   "projection": {
     "assignments": {
-      "clean": 7083,
-      "excluded": 473,
-      "inherited": 1068,
-      "phrase": 1458,
-      "spans": 316,
-      "tokens": 977
+      "clean": 7167,
+      "excluded": 476,
+      "inherited": 1078,
+      "phrase": 1476,
+      "spans": 319,
+      "tokens": 987
     },
-    "error_budget": 0.04158241758241758,
+    "error_budget": 0.041380509432322,
     "excluded_reasons": {
-      "missing": 325,
+      "missing": 328,
       "split": 104,
       "too_short": 44
     },
     "unsplit_spans": 42
   },
   "provenance": {
-    "all2md_commit": "002b0551ecda8bfa56f0b3f9f56c703a47a3a86c",
+    "all2md_commit": "200e74677c89edc5b1186061f712648b7a65d174",
     "bucket": "pmc-oa-opendata",
-    "complete_corpus": false,
-    "corpus_pin": "34cc7c503bba146884a23399d32e34555ad0ee376d0e9a80a0b25f884242e373",
-    "created_at": "2026-08-12T21:36:34.054494+00:00",
+    "complete_corpus": true,
+    "corpus_pin": "9ba5c0cd59067bda102b9e27a7c1e613987c145f9fb61a4c26b811d9fd24dc58",
+    "created_at": "2026-08-13T00:27:44.499597+00:00",
     "oracle_schema_version": 1,
     "parser_config": {
       "include_page_numbers": true,

--- a/docs/source/benchmarks.rst
+++ b/docs/source/benchmarks.rst
@@ -55,7 +55,7 @@ scores the result against the JATS XML the publisher deposited alongside them. T
 pinned by a committed manifest of per-file SHA-256 digests, revalidated on every load.
 
 The figures below are :file:`benchmarks/pmc/reference.json`, recorded on Linux with
-dependencies resolved from the lockfile. It covers **65 articles and 699 pages**.
+dependencies resolved from the lockfile. It covers **66 articles and 706 pages**.
 
 Did the text survive?
 ~~~~~~~~~~~~~~~~~~~~~
@@ -68,8 +68,8 @@ Did the text survive?
      - Value
      -
    * - Raw recall
-     - 60.1%
-     - of 8,805 ground-truth blocks
+     - 60.2%
+     - of 8,905 ground-truth blocks
    * - Attainable ceiling
      - 62.4%
      - what the PDF's own text layer reproduces
@@ -80,7 +80,7 @@ Did the text survive?
      - 0.4%
      - wants to be ~0%
 
-Raw recall is 60.1%, and that figure is close to meaningless on its own. A large share of
+Raw recall is 60.2%, and that figure is close to meaningless on its own. A large share of
 any JATS article cannot be recovered by *any* parser, because the markup records words in an
 order the page never prints — author affiliation blocks, structured metadata, citation
 fields. Charging a PDF parser for failing to reproduce text the PDF does not contain
@@ -101,17 +101,17 @@ By block kind:
      - Recovered
      - Share of attainable
    * - Text blocks
-     - 3,124 of 6,289
-     - 3,079
+     - 3,160 of 6,356
+     - 3,115
      - **97.6%**
    * - Titles
-     - 2,263 of 2,397
-     - 2,123
-     - **92.7%**
+     - 2,291 of 2,426
+     - 2,151
+     - **92.8%**
    * - Tables
-     - 107 of 119
-     - 90
-     - **83.2%**
+     - 110 of 123
+     - 93
+     - **83.6%**
 
 Did the output invent anything?
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -135,7 +135,7 @@ Unsupported output is therefore split in two:
      - Share
      - Meaning
    * - Supported
-     - **93.8%**
+     - **93.9%**
      - the n-gram appears in the document's text layer
    * - Resequenced
      - 5.2%
@@ -150,7 +150,7 @@ Unsupported output is therefore split in two:
      - 0.7%
      - wants to be ~0%
 
-Over 438,975 emitted n-grams, 4,261 are novel. Reporting the raw unsupported figure instead
+Over 443,281 emitted n-grams, 4,287 are novel. Reporting the raw unsupported figure instead
 would have made the result roughly six times worse than the parser deserves.
 
 Duplication is counted apart from both, because it is invisible to either. Text emitted
@@ -159,8 +159,8 @@ twice is an unchanged *set* and a doubled *multiset* — no set-based score can 
 Tables
 ~~~~~~
 
-Tables are the weakest area and the artifact says so plainly: **88 emitted against 117
-expected**, on 67 of 92 pages that should carry one.
+Tables are the weakest area and the artifact says so plainly: **92 emitted against 121
+expected**, on 69 of 94 pages that should carry one.
 
 The bottleneck is detection rather than extraction. On the pages that miss, the table's text
 is usually present in the output as ordinary prose — the content survived, the *structure*

--- a/tests/unit/test_published_benchmark_figures.py
+++ b/tests/unit/test_published_benchmark_figures.py
@@ -30,6 +30,7 @@ produce a *passing* test.
 
 from __future__ import annotations
 
+import hashlib
 import json
 from collections.abc import Callable
 from pathlib import Path
@@ -130,6 +131,37 @@ def test_published_figures_match_their_artifacts() -> None:
     """Every number on the fidelity page comes from a committed artifact."""
     mismatches = _mismatches()
     assert not mismatches, "docs/source/benchmarks.rst disagrees with its artifacts:\n  " + "\n  ".join(mismatches)
+
+
+def test_the_reference_was_recorded_against_the_committed_manifest() -> None:
+    """The strongest form of "the docs and the pin must never disagree".
+
+    The figures above are only meaningful if the run that produced them scored
+    the corpus this repository actually names. ``corpus_pin`` is the SHA-256 of
+    the manifest, so a manifest edit that lands without a re-record -- exactly
+    what #332 had to repair -- is caught here rather than at the next scheduled
+    run, or not at all.
+    """
+    manifest = _REPO / "benchmarks" / "pmc" / "manifest.json"
+    recorded = json.loads(_PMC.read_bytes())["provenance"]["corpus_pin"]
+    actual = hashlib.sha256(manifest.read_bytes()).hexdigest()
+    assert recorded == actual, (
+        f"benchmarks/pmc/reference.json was recorded against corpus pin {recorded[:16]}, "
+        f"but the committed manifest hashes to {actual[:16]} -- re-record the reference"
+    )
+
+
+def test_the_reference_covers_the_whole_corpus() -> None:
+    """A partial run must not sit behind figures the page presents as the corpus.
+
+    ``complete_corpus`` going false is the lane's incident signal (#330). It is
+    the right behaviour for a run and the wrong state for a *published*
+    reference, because the page quotes the artifact as the reading.
+    """
+    reference = json.loads(_PMC.read_bytes())
+    manifest_articles = len(json.loads((_REPO / "benchmarks" / "pmc" / "manifest.json").read_bytes())["articles"])
+    assert reference["provenance"]["complete_corpus"] is True, "the published reference is a partial run"
+    assert reference["corpus"]["articles_scored"] == manifest_articles
 
 
 def test_a_perturbed_artifact_is_caught() -> None:

--- a/tests/unit/test_published_benchmark_figures.py
+++ b/tests/unit/test_published_benchmark_figures.py
@@ -1,0 +1,150 @@
+#  Copyright (c) 2025 Tom Villani, Ph.D.
+"""Every figure ``benchmarks.rst`` publishes must match the artifact behind it.
+
+The fidelity page is the one place the project makes a public quality claim, and
+the claim is only worth anything because each number comes from a committed
+artifact -- :file:`benchmarks/pmc/reference.json` and
+:file:`benchmarks/omnidocbench/baseline.json`. Nothing enforced that. The page
+and the artifacts were written in the same change and agreed on the day; the
+first time a pin moved they could silently stop agreeing, and a stale figure on
+that page reads exactly like a measured one.
+
+That is not hypothetical. This lane has already published a comparison between
+two runs covering different corpora, and issue #332 restored a withdrawn article
+precisely because a corpus can change under a page that still quotes the old
+reading.
+
+The check is deliberately built the strong way round. Rather than scraping
+numbers out of the prose and asking whether each looks plausible -- which cannot
+see a figure that should be there and is not, and needs an exemption for every
+incidental integer like "981 pages" -- each published claim is declared here as a
+*rendered snippet* built from the artifact, and the page must contain it
+verbatim. A value that drifts fails, and so does a stale line that was never
+updated, because the whole line is matched rather than the number alone.
+
+``test_the_figure_inventory_is_not_empty`` and
+``test_a_perturbed_artifact_is_caught`` exist because the obvious ways for this
+to break -- an artifact that fails to load, a renderer that returns ``""`` -- all
+produce a *passing* test.
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Callable
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+_REPO = Path(__file__).resolve().parents[2]
+_PAGE = _REPO / "docs" / "source" / "benchmarks.rst"
+_PMC = _REPO / "benchmarks" / "pmc" / "reference.json"
+_OMNI = _REPO / "benchmarks" / "omnidocbench" / "baseline.json"
+
+
+def _percent(value: float, places: int = 1) -> str:
+    return f"{value * 100:.{places}f}%"
+
+
+def _pmc_figures(pmc: dict[str, Any]) -> list[tuple[str, str]]:
+    corpus, recall, precision = pmc["corpus"], pmc["article_recall"], pmc["article_precision"]
+    kinds = recall["by_kind"]
+    rows: list[tuple[str, str]] = [
+        (
+            "corpus coverage",
+            f"It covers **{corpus['articles_scored']} articles and {corpus['pages_scored']} pages**.",
+        ),
+        (
+            "raw recall row",
+            f"   * - Raw recall\n     - {_percent(recall['recall'])}\n"
+            f"     - of {recall['scored']:,} ground-truth blocks",
+        ),
+        ("raw recall prose", f"Raw recall is {_percent(recall['recall'])},"),
+        ("attainable ceiling", f"     - {_percent(recall['ceiling'])}\n"),
+        ("recall of attainable", f"     - **{_percent(recall['attainable_recall'])}**\n"),
+        ("recall control", f"     - {_percent(recall['control_recall'])}\n"),
+        ("supported share", f"     - **{_percent(precision['precision'])}**\n"),
+        ("novel share", f"     - **{_percent(precision['novel_share'])}**\n"),
+        (
+            "emitted n-grams",
+            f"Over {precision['emitted']:,} emitted n-grams, {precision['novel']:,} are novel.",
+        ),
+        (
+            "tables",
+            f"**{corpus['tables_emitted']} emitted against {corpus['tables_expected']}\n"
+            f"expected**, on {corpus['pages_with_emitted_table']} of "
+            f"{corpus['pages_with_expected_table']} pages that should carry one.",
+        ),
+    ]
+    for label, kind in (("text blocks", "text_block"), ("titles", "title"), ("tables", "table")):
+        entry = kinds[kind]
+        rows.append(
+            (
+                f"by-kind row: {label}",
+                f"     - {entry['attainable']:,} of {entry['scored']:,}\n"
+                f"     - {entry['recovered']:,}\n"
+                f"     - **{_percent(entry['attainable_recall'])}**",
+            )
+        )
+    return rows
+
+
+def _omnidocbench_figures(omni: dict[str, Any]) -> list[tuple[str, str]]:
+    pages = omni["pages"]["scored"]
+    rows = []
+    for name in ("text_content_similarity", "reading_order_similarity", "block_structure_similarity"):
+        value = omni["dimensions"][name]["value"]
+        rows.append((f"omnidocbench {name}", f"   * - ``{name}``\n     - {value:.3f}\n"))
+    rows.append(("omnidocbench page count", f"The ``omnidocbench`` lane scores {pages} scanned pages"))
+    return rows
+
+
+def _figures() -> list[tuple[str, str]]:
+    pmc = json.loads(_PMC.read_bytes())
+    omni = json.loads(_OMNI.read_bytes())
+    return _pmc_figures(pmc) + _omnidocbench_figures(omni)
+
+
+def _page_text() -> str:
+    # The repo checks these blobs out as CRLF on Windows; normalise so the
+    # multi-line snippets above compare the same way on every platform.
+    return _PAGE.read_bytes().decode("utf-8").replace("\r\n", "\n")
+
+
+def _mismatches(render: Callable[[], list[tuple[str, str]]] = _figures) -> list[str]:
+    page = _page_text()
+    return [f"{label}: {snippet!r}" for label, snippet in render() if snippet not in page]
+
+
+def test_the_figure_inventory_is_not_empty() -> None:
+    """A loader that silently yields nothing would make every other test vacuous."""
+    figures = _figures()
+    assert len(figures) >= 15, f"expected the full published set, got {len(figures)}"
+    assert all(snippet.strip() for _label, snippet in figures), "a figure rendered as empty text"
+
+
+def test_published_figures_match_their_artifacts() -> None:
+    """Every number on the fidelity page comes from a committed artifact."""
+    mismatches = _mismatches()
+    assert not mismatches, "docs/source/benchmarks.rst disagrees with its artifacts:\n  " + "\n  ".join(mismatches)
+
+
+def test_a_perturbed_artifact_is_caught() -> None:
+    """Verify the judge can fail: move a figure and the check must go red.
+
+    Without this, every failure mode that produces an empty or unmatched
+    inventory reads as a pass -- which is the specific way the gates in this repo
+    have gone wrong before.
+    """
+    pmc = json.loads(_PMC.read_bytes())
+    pmc["corpus"]["pages_scored"] += 1
+    pmc["article_precision"]["novel_share"] += 0.05
+
+    def perturbed() -> list[tuple[str, str]]:
+        return _pmc_figures(pmc)
+
+    mismatches = _mismatches(perturbed)
+    assert len(mismatches) >= 2, f"a perturbed artifact still matched the page: {mismatches}"


### PR DESCRIPTION
Closes #332.

`PMC11000011.1` was withdrawn upstream (#329). Since #330 the lane degrades gracefully and scores 65 of 66 — right for an incident, wrong as a steady state. A permanently-false `complete_corpus` is a permanently-yellow test: the *second* withdrawal would be invisible against a run that already looks like that, and it quietly consumes the tolerance budget that exists for real incidents (the load aborts past a tenth of the selection).

## The replacement is drawn, not chosen

Re-walked **only** the `PMC11000000` seed through `build_manifest` with the committed `stride` (11), `per_seed` (3), candidate cap and filter. A hand-picked article would bias the corpus in a way nothing downstream could detect.

The walk also settles what kind of failure this is. The prefix **still lists** — only the PDF 404s — so it registers as a `pdf_missing` *rejection* rather than an outage, stride alignment is preserved, and the seed's two surviving members re-select **byte-for-byte identically** against the committed rows. Only the third slot moves:

| | before | after |
|---|---|---|
| seed members | `PMC11000000.1`, `PMC11000011.1`, `PMC11000022.1` | `PMC11000000.1`, `PMC11000022.1`, **`PMC11000033.1`** |
| articles | 66 (65 loadable) | 66 |
| pin | `34cc7c50` | `9ba5c0cd` |

The other 65 rows are preserved verbatim. `selection` metadata is updated so it doesn't describe a build that never happened — `candidates` 105 → 106, `pdf_missing` 7 → 8, plus a `rewalks` entry recording which seed was re-walked, why, and what it swapped. It lives inside `selection` because the loader validates the top-level key set exactly.

## Re-recorded on CI, not locally

`reference.json` was originally recorded on Linux from the lockfile, and the runner image and lockfile are part of the measurement — re-recording on a Windows dev box would have made the numbers incomparable with the ones they replace. Recorded from a full 66-article run ([run 31653012941](https://github.com/thomas-villani/all2md/actions/runs/31653012941)); `complete_corpus` is `true` again.

The readings barely move, which is what a representative corpus should do when one article of 66 is swapped:

| figure | before | after |
|---|---|---|
| recall of attainable | 95.3% | **95.3%** |
| novel n-grams | 1.0% | **1.0%** |
| raw recall | 60.1% | 60.2% |
| supported | 93.8% | 93.9% |
| tables | 88 / 117 | 92 / 121 |

## The check that was missing

Nothing tied the figures in `benchmarks.rst` to the artifacts behind them — the correspondence was asserted, not enforced, and this lane has already published a comparison between two runs covering different corpora. Added `tests/unit/test_published_benchmark_figures.py`:

- Each published claim is declared as a snippet **rendered from the artifact** and required to appear verbatim. That's the strong direction — scraping numbers out of prose cannot see a figure that should be there and is not, and would need an exemption for every incidental integer. Matching whole lines rather than bare numbers means a stale line fails too.
- `corpus_pin` must equal the SHA-256 of the committed `manifest.json`, so a manifest edit landing without a re-record fails immediately.
- The published reference must be a *complete* run covering every article the manifest names.
- `test_the_figure_inventory_is_not_empty` and `test_a_perturbed_artifact_is_caught` exist because a loader that yields nothing would make everything else vacuous.

**Verified the judge can fail** twice. Against the pre-update page it reports exactly the nine figures that moved, while the unchanged OmniDocBench readings still match. Changing one integer in the manifest fails the pin check with both digests and the instruction to re-record.

## Notes

- The pin change means a new digest-keyed cache directory. I warmed it by **copying** (never moving) from the existing one and `load` re-verified all 66 against the new pin, so no 148 MB re-download was needed — and `.cache/34cc7c503bba1468/` still holds the only surviving copy of the withdrawn article, per the issue's warning.
- All six fidelity-gated root docs still round-trip at 100.

🤖 Generated with [Claude Code](https://claude.com/claude-code)