### PR TITLE
fix(pdf): stop counting one rejected table region twice

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **One rejected table region is no longer counted as two** (PDF). When the layout model
+  predicts a table region and a grid is found there but then refused, the refusing guard
+  records its own specific reason — `text_grid_splits_words`, `degenerate_grid`,
+  `mostly_empty`. The method that owns this already carried a note forbidding the vaguer
+  `layout_region_not_tabular` from being added on top, because that counts the same region
+  twice and takes a second bite out of the confidence score. The flag the note relies on did
+  not work for the case it was written for: `found_grid` was set *after* the split-word
+  guard, and that guard `continue`s, so the flag was only ever true for grids that
+  *survived* — never for a grid found and then rejected.
+  The signature is unmistakable on the born-digital corpus. Across 12 articles the two
+  reasons appear in exact 1:1 correspondence in every affected article — 1/1, 4/4, 6/6,
+  12/12, 29 each in total — which is one region counted twice rather than two regions
+  rejected. So the confidence score was penalised twice for a single refusal, and the
+  benchmark's headline `table_rejected` count roughly doubles its dominant case, which
+  matters because that number is read as "tables we threw away". The flag is now set when a
+  grid is *found*, which is what its name and the note both already said it meant.
+  The existing regression test asserted this property but only on the arm that satisfied it:
+  it drives `lines_strict` with a degenerate grid, reaching the foot of the method with the
+  flag already set. The new one drives the text-alignment arm where the defect lived, and
+  asserts the recorded *reasons* rather than the counter — a counter cannot see one region
+  rejected under two names.
 - **The PMC born-digital corpus is back to 66 articles.** `PMC11000011.1` was withdrawn
   upstream (#329), and since #330 the lane degraded gracefully and scored 65 of 66. That is
   the right behaviour for an incident and the wrong steady state: a permanently-false

--- a/src/all2md/parsers/pdf.py
+++ b/src/all2md/parsers/pdf.py
@@ -3453,6 +3453,12 @@ class PdfToAstConverter(BaseParser):
                 continue
             if not tabs.tables:
                 continue
+            # Set before the guards below, not after them. This flag answers "was anything
+            # tabular found here at all", which is true of a grid that was found and then
+            # rejected -- and the rejection paths below `continue`, so setting it after them
+            # meant it was only ever true for grids that survived. See the double-count note
+            # at the foot of this method.
+            found_grid = True
             # Text alignment has no ruling lines corroborating it, so it is held to one
             # extra test the line strategies are not: its columns must not cut through
             # words. See MAX_SPLIT_WORD_RATIO -- without this, a mis-predicted region
@@ -3470,7 +3476,6 @@ class PdfToAstConverter(BaseParser):
                     )
                     self._record_table_rejection("text_grid_splits_words")
                     continue
-            found_grid = True
             table = self._process_table_to_ast(tabs.tables[0], page, page_num)
             if isinstance(table, AstTable):
                 return table

--- a/tests/unit/formats/pdf/test_pdf_layout_region_tables.py
+++ b/tests/unit/formats/pdf/test_pdf_layout_region_tables.py
@@ -77,6 +77,16 @@ def converter() -> PdfToAstConverter:
     return conv
 
 
+def _rejection_reasons(converter: PdfToAstConverter) -> list[str]:
+    """The ``detail`` of every ``table_rejected`` event, in the order recorded.
+
+    Asserting on the counter alone cannot see a region rejected twice under two different
+    reasons, which is precisely the defect these tests pin.
+    """
+    events = converter.__dict__.get("_degraded_events", [])
+    return [event.detail for event in events if event.kind == "table_rejected"]
+
+
 def _rect(*values: float):
     import pymupdf
 
@@ -182,3 +192,26 @@ class TestLayoutRegionExtraction:
         converter._extract_table_from_layout_region(page, _rect(0, 0, 100, 50), page_num=0)
 
         assert converter._tables_rejected == 1, "the degenerate-grid guard already recorded this region"
+        assert _rejection_reasons(converter) == ["degenerate_grid"]
+
+    def test_the_split_word_guard_rejection_is_not_counted_twice(self, converter):
+        """The sibling arm of the test above, and the one where the double count really happened.
+
+        The test above reaches the bottom of the method with ``found_grid`` already set,
+        because ``lines_strict`` returned a grid that ``_process_table_to_ast`` then rejected.
+        The split-word guard ``continue``s *before* that assignment, so the flag stayed false
+        and every guarded rejection also recorded the vaguer ``layout_region_not_tabular`` --
+        the exact case the note at the foot of the method forbids.
+
+        The signature on the born-digital corpus is unmistakable: the two reasons appeared in
+        exact 1:1 correspondence in every affected article (1/1, 4/4, 6/6, 12/12), which is
+        one region counted twice rather than two regions rejected.
+        """
+        page = _FakePage(PROSE_TEXT, {"text": [_FakeTable(SHREDDED_PROSE, (0, 0, 100, 50))]})
+        node = converter._extract_table_from_layout_region(page, _rect(0, 0, 100, 50), page_num=0)
+
+        assert isinstance(node, AstParagraph), "the region's text must still survive as prose"
+        assert _rejection_reasons(converter) == [
+            "text_grid_splits_words"
+        ], "the specific guard reports; the vaguer layout_region_not_tabular must not pile on"
+        assert converter._tables_rejected == 1, "one region, one rejection, one hit to confidence"


### PR DESCRIPTION
Found while instrumenting table detection for the next batch. `_extract_table_from_layout_region` already ends with a note forbidding exactly this:

> *Only when nothing tabular was found at all. If a grid was found and then rejected, that guard has already recorded its own, more specific reason — adding this vaguer one on top counts the same region twice and takes a second bite out of the confidence score.*

**The flag that note relies on did not work for the case it was written for.** `found_grid` was set *after* the split-word guard, and that guard `continue`s — so the flag was only ever true for grids that **survived**, never for a grid found and then rejected. Every split-word rejection therefore recorded a second, vaguer `layout_region_not_tabular` for the same region.

## The signature

Histogramming rejection *reasons* over 12 born-digital articles, the two appear in exact 1:1 correspondence in every affected article — `1/1`, `4/4`, `6/6`, `12/12`, 29 each in total. That is one region counted twice, not two regions rejected.

| reason | before | after |
|---|---|---|
| `text_grid_splits_words` | 29 | 29 |
| `layout_region_not_tabular` | 29 | **0** |
| `mostly_empty` | 6 | 6 |
| `degenerate_grid` | 3 | 3 |
| total | 67 | **38** |
| **tables emitted** | 12 | **12** |

Tables emitted is unchanged, which is the point: this is an accounting fix, not a behaviour change.

## Why it matters beyond tidiness

- **The confidence score was penalised twice for one refusal** — user-facing, and precisely what the note existed to prevent.
- **The benchmark's headline `table_rejected` count roughly doubles its dominant case**, and that number is naturally read as "tables we threw away".

The fix sets the flag when a grid is *found* rather than when one survives, which is what its name and the note both already said it meant. The degenerate-grid path was unaffected and stays unaffected.

## The test that should have caught this

There was already a `test_a_guard_rejection_is_not_counted_twice` — but it drives `lines_strict` with a degenerate grid, which reaches the foot of the method with `found_grid` **already set**. It asserted the right property on the one arm that satisfied it, and the defect lived in the sibling arm.

The new test drives the text-alignment arm, and asserts the recorded **reasons** rather than the counter — a counter cannot see one region rejected under two names. I also extended the existing test to assert its reason, for the same reason.

**Verified the judge can fail:** against the unfixed parser the new test fails naming the extra `layout_region_not_tabular`, and the other eleven pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)