### PR TITLE
feat(benchmarks): record why a table region was rejected, and how many were

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **The born-digital lane records *why* a table region was rejected, and how many were**
+  (payload schema 4). The parser distinguishes nine reasons for rejecting a table region and
+  coalesces repeats of `(parser, kind, detail, severity)` while summing their counts. The
+  lane read back only `kind`, and then counted coalesced *event objects* — so an article
+  rejecting twelve regions and one rejecting a single region contributed identically, and
+  `table_rejected: 101` was neither a count of regions nor of articles but of event objects,
+  which is the least meaningful of the three. Nothing downstream could tell a corpus-wide
+  detection failure from one pathological document, and nothing could tell an improvement
+  from a regression, because some of those reasons are the parser *correctly* refusing to
+  grid a page of prose.
+  `degraded_events` now reports occurrences broken down by reason, with the number of
+  articles each reached beside it — the two answer different questions and diverge sharply
+  here, since a single article contributed twelve of the twenty-nine
+  `text_grid_splits_words` rejections measured across twelve articles. This is a benchmark
+  payload change only; no conversion behaviour changes, and no published figure moves.
+
 ### Fixed
 
 - **One rejected table region is no longer counted as two** (PDF). When the layout model

--- a/benchmarks/pmc/benchmark.py
+++ b/benchmarks/pmc/benchmark.py
@@ -44,7 +44,7 @@ from benchmarks.pmc.article import (
     measure_recall,
     summarize,
 )
-from benchmarks.pmc.convert import convert_article, pdf_options
+from benchmarks.pmc.convert import DegradedFact, convert_article, pdf_options
 from benchmarks.pmc.oracles import coverage, project_jats, to_projection
 from benchmarks.pmc.pages import ASSIGNMENTS, assign_pages, index_pages
 
@@ -53,7 +53,13 @@ from benchmarks.pmc.pages import ASSIGNMENTS, assign_pages, index_pages
 #: 3 adds ``corpus.articles_unavailable``. Under 2 a run that lost pinned articles was
 #: indistinguishable from one that scored them all, so every payload without this key has
 #: an unknown denominator rather than a complete one.
-SCHEMA_VERSION = 3
+#: 4 reshapes ``degraded_events`` from a flat count of coalesced event *objects* to
+#: occurrences broken down by reason and by how many articles each reached. Under 3 an
+#: article rejecting twelve regions counted the same as one rejecting a single region, and
+#: the nine reasons behind ``table_rejected`` were indistinguishable -- so the number could
+#: not tell an improvement from a regression, because some of those reasons are the parser
+#: correctly refusing to grid a page of prose.
+SCHEMA_VERSION = 4
 ORACLE_SCHEMA_VERSION = 1
 
 #: Fixed seed: a control that scrambles differently every run cannot be compared across
@@ -130,7 +136,7 @@ class ArticleEvaluation:
     excluded: Mapping[str, int]
     coverage: float
     ocr_page_fraction: float
-    degraded_kinds: tuple[str, ...]
+    degraded: tuple[DegradedFact, ...]
     duration_seconds: float
     ground_truth_blocks: int
     emitted_text: str = ""
@@ -138,6 +144,42 @@ class ArticleEvaluation:
     pdf_text: str = ""
     truth_blocks: tuple[tuple[str, str], ...] = field(default_factory=tuple)
     error: str | None = None
+
+
+def _degraded_summary(evaluations: Sequence[Any]) -> dict[str, Any]:
+    """Total each degraded-event kind by occurrence, and break it down by reason.
+
+    ``articles`` is reported beside ``occurrences`` because the two answer different
+    questions and diverge sharply here: one article contributed twelve
+    ``text_grid_splits_words`` rejections out of twenty-nine measured across twelve
+    articles, so a corpus total alone reads as a widespread failure when it can be a
+    single pathological document.
+    """
+    totals: Counter[str] = Counter()
+    articles: Counter[str] = Counter()
+    reasons: dict[str, Counter[str]] = {}
+    reason_articles: dict[str, Counter[str]] = {}
+    for result in evaluations:
+        for kind in {fact.kind for fact in result.degraded}:
+            articles[kind] += 1
+        for kind, reason in {(fact.kind, fact.reason) for fact in result.degraded}:
+            if reason is not None:
+                reason_articles.setdefault(kind, Counter())[reason] += 1
+        for fact in result.degraded:
+            totals[fact.kind] += fact.occurrences
+            if fact.reason is not None:
+                reasons.setdefault(fact.kind, Counter())[fact.reason] += fact.occurrences
+
+    summary: dict[str, Any] = {}
+    for kind in sorted(totals):
+        entry: dict[str, Any] = {"occurrences": totals[kind], "articles": articles[kind]}
+        if kind in reasons:
+            entry["by_reason"] = {
+                reason: {"occurrences": count, "articles": reason_articles[kind][reason]}
+                for reason, count in sorted(reasons[kind].items(), key=lambda item: (-item[1], item[0]))
+            }
+        summary[kind] = entry
+    return summary
 
 
 def _pdf_facts(pdf_path: Path) -> tuple[int, int, str]:
@@ -187,7 +229,7 @@ def evaluate_article(article: Any, *, options: Any = None) -> ArticleEvaluation:
             excluded=dict(Counter(assignment.excluded)),
             coverage=coverage(whole, pdf_words),
             ocr_page_fraction=0.0,
-            degraded_kinds=(),
+            degraded=(),
             duration_seconds=time.perf_counter() - started,
             ground_truth_blocks=len(blocks),
             truth_blocks=truth_pairs,
@@ -228,7 +270,7 @@ def evaluate_article(article: Any, *, options: Any = None) -> ArticleEvaluation:
         excluded=dict(Counter(assignment.excluded)),
         coverage=coverage(whole, pdf_words),
         ocr_page_fraction=converted.ocr_page_fraction,
-        degraded_kinds=converted.degraded_kinds,
+        degraded=converted.degraded,
         duration_seconds=time.perf_counter() - started,
         ground_truth_blocks=len(blocks),
         emitted_text=" ".join(block for page in emitted for block in page.text_blocks),
@@ -445,9 +487,13 @@ def normalize_results(
         # Expected to be empty: this corpus was characterized as 0.0% scan-shaped. A
         # non-empty list means the corpus is not what the characterization says it is.
         "ocr_articles": ocr_articles,
-        "degraded_events": dict(
-            sorted(Counter(kind for result in evaluations for kind in result.degraded_kinds).items())
-        ),
+        # Occurrences, not event objects, and broken down by the guard that fired. The
+        # previous shape counted coalesced *events* -- one per (kind, reason) per article --
+        # so an article rejecting twelve regions and one rejecting a single region
+        # contributed identically, and the nine reasons behind `table_rejected` were
+        # indistinguishable. Neither number could tell an improvement from a regression,
+        # because some of those reasons are the parser correctly refusing to grid prose.
+        "degraded_events": _degraded_summary(evaluations),
     }
 
 

--- a/benchmarks/pmc/convert.py
+++ b/benchmarks/pmc/convert.py
@@ -36,6 +36,34 @@ class PageBoundaryError(RuntimeError):
 
 
 @dataclass(frozen=True, slots=True)
+class DegradedFact:
+    """One degraded-conversion event, with the two fields the lane used to discard.
+
+    The parser records nine distinct reasons for rejecting a table region alone, and
+    coalesces repeats of ``(parser, kind, detail, severity)`` while summing their counts.
+    Reading back only ``kind`` therefore threw away both halves of what the event says:
+    *which* guard fired, and *how many* regions it fired on. A run could report
+    ``table_rejected: 101`` with no way to tell one over-firing article from a corpus-wide
+    detection failure -- and no way to tell an improvement from a regression, since some of
+    those reasons are the parser correctly refusing to grid a page of prose.
+
+    Attributes
+    ----------
+    kind : str
+        Machine-readable event category, e.g. ``"table_rejected"``.
+    reason : str or None
+        The event's ``detail``, naming the specific guard that fired.
+    occurrences : int
+        How many times it fired, from the coalesced event's ``count``.
+
+    """
+
+    kind: str
+    reason: str | None
+    occurrences: int
+
+
+@dataclass(frozen=True, slots=True)
 class ConvertedArticle:
     """One article's AST, whole and split by page.
 
@@ -48,15 +76,16 @@ class ConvertedArticle:
     ocr_page_fraction : float
         Share of pages the parser OCR'd. Expected to be zero on a born-digital corpus, and
         reported rather than assumed so a non-zero is visible.
-    degraded_kinds : tuple[str, ...]
-        Degraded-conversion event kinds the parser recorded.
+    degraded : tuple[DegradedFact, ...]
+        Degraded-conversion events the parser recorded, with their reason and occurrence
+        count intact.
 
     """
 
     document: Document
     pages: tuple[Document, ...]
     ocr_page_fraction: float
-    degraded_kinds: tuple[str, ...]
+    degraded: tuple[DegradedFact, ...]
 
 
 def pdf_options(**overrides: Any) -> PdfOptions:
@@ -178,15 +207,25 @@ def convert_article(pdf_path: Path, expected_pages: int, *, options: PdfOptions 
     fraction = 0.0
     if isinstance(raw_fraction, (int, float)) and not isinstance(raw_fraction, bool):
         fraction = float(raw_fraction)
-    events = confidence.get("degraded_events") if isinstance(confidence, Mapping) else None
-    kinds = (
-        tuple(sorted(str(event["kind"]) for event in events if isinstance(event, Mapping) and "kind" in event))
-        if isinstance(events, list)
-        else ()
-    )
+    raw_events = confidence.get("degraded_events") if isinstance(confidence, Mapping) else None
+    events: list[DegradedFact] = []
+    if isinstance(raw_events, list):
+        for event in raw_events:
+            if not isinstance(event, Mapping) or "kind" not in event:
+                continue
+            raw_count = event.get("count", 1)
+            count = raw_count if isinstance(raw_count, int) and not isinstance(raw_count, bool) else 1
+            detail = event.get("detail")
+            events.append(
+                DegradedFact(
+                    kind=str(event["kind"]),
+                    reason=None if detail is None else str(detail),
+                    occurrences=max(count, 1),
+                )
+            )
     return ConvertedArticle(
         document=document,
         pages=split_pages(document, expected_pages),
         ocr_page_fraction=fraction,
-        degraded_kinds=kinds,
+        degraded=tuple(sorted(events, key=lambda fact: (fact.kind, fact.reason or ""))),
     )

--- a/benchmarks/pmc/reference.json
+++ b/benchmarks/pmc/reference.json
@@ -67,7 +67,32 @@
     "tables_expected": 121
   },
   "degraded_events": {
-    "table_rejected": 101
+    "table_rejected": {
+      "articles": 45,
+      "by_reason": {
+        "degenerate_grid": {
+          "articles": 16,
+          "occurrences": 24
+        },
+        "layout_region_not_tabular": {
+          "articles": 1,
+          "occurrences": 2
+        },
+        "mostly_empty": {
+          "articles": 20,
+          "occurrences": 118
+        },
+        "oversized_grid": {
+          "articles": 1,
+          "occurrences": 1
+        },
+        "text_grid_splits_words": {
+          "articles": 32,
+          "occurrences": 92
+        }
+      },
+      "occurrences": 237
+    }
   },
   "dimensions": {
     "block_structure_similarity": {
@@ -174,11 +199,11 @@
     "unsplit_spans": 42
   },
   "provenance": {
-    "all2md_commit": "200e74677c89edc5b1186061f712648b7a65d174",
+    "all2md_commit": "da3591364cb1251642d2b324408fada42395fa98",
     "bucket": "pmc-oa-opendata",
     "complete_corpus": true,
     "corpus_pin": "9ba5c0cd59067bda102b9e27a7c1e613987c145f9fb61a4c26b811d9fd24dc58",
-    "created_at": "2026-08-13T00:27:44.499597+00:00",
+    "created_at": "2026-08-13T01:56:56.338282+00:00",
     "oracle_schema_version": 1,
     "parser_config": {
       "include_page_numbers": true,
@@ -202,5 +227,5 @@
     "python": "3.12.3 (main, Jun 19 2026, 12:46:00) [GCC 13.3.0]",
     "worktree_dirty": false
   },
-  "schema_version": 3
+  "schema_version": 4
 }

--- a/tests/unit/test_pmc_oracle.py
+++ b/tests/unit/test_pmc_oracle.py
@@ -492,7 +492,7 @@ def test_page_scores_and_the_error_budget_come_from_the_same_run(tmp_path: Path)
                 excluded={"missing": 1},
                 coverage=1.0,
                 ocr_page_fraction=0.0,
-                degraded_kinds=(),
+                degraded=(),
                 duration_seconds=0.1,
                 ground_truth_blocks=10,
             )
@@ -532,3 +532,80 @@ def test_recall_and_precision_are_reported_together() -> None:
     assert payload["article_recall"]["attainable_recall"] > 0.0
     assert payload["article_precision"]["precision"] == pytest.approx(1.0)
     assert payload["article_precision"]["control_emitted"] > 0
+
+
+class _FakeEvaluation:
+    """Only the field `_degraded_summary` reads. The real one needs a scored corpus."""
+
+    def __init__(self, degraded: tuple[convert.DegradedFact, ...]) -> None:
+        self.degraded = degraded
+
+
+def _fact(kind: str, reason: str | None, occurrences: int) -> convert.DegradedFact:
+    return convert.DegradedFact(kind=kind, reason=reason, occurrences=occurrences)
+
+
+def test_degraded_events_count_occurrences_rather_than_coalesced_events() -> None:
+    """The parser coalesces repeats and sums their `count`; reading the event alone loses it.
+
+    Twelve regions rejected in one article is a different fact from one region rejected, and
+    under the old shape the two were identical.
+    """
+    evaluations = [_FakeEvaluation((_fact("table_rejected", "text_grid_splits_words", 12),))]
+
+    summary = benchmark._degraded_summary(evaluations)
+
+    assert summary["table_rejected"]["occurrences"] == 12
+    assert summary["table_rejected"]["by_reason"]["text_grid_splits_words"]["occurrences"] == 12
+
+
+def test_degraded_events_separate_a_pathological_article_from_a_corpus_wide_failure() -> None:
+    """`articles` is why the corpus total cannot be misread.
+
+    Twenty-nine rejections spread over nine articles is a detection gap; the same total from
+    one article is one bad document, and the work those two imply is not the same.
+    """
+    concentrated = [_FakeEvaluation((_fact("table_rejected", "text_grid_splits_words", 29),))]
+    spread = [_FakeEvaluation((_fact("table_rejected", "text_grid_splits_words", 1),)) for _ in range(29)]
+
+    one = benchmark._degraded_summary(concentrated)["table_rejected"]
+    many = benchmark._degraded_summary(spread)["table_rejected"]
+
+    assert one["occurrences"] == many["occurrences"] == 29, "the totals are deliberately identical"
+    assert one["articles"] == 1
+    assert many["articles"] == 29, "which is the only thing that tells them apart"
+
+
+def test_degraded_events_keep_the_reasons_apart() -> None:
+    """Nine guards reject a table region, and some of those rejections are correct.
+
+    Collapsing them into one number cannot distinguish the parser refusing to grid a page of
+    prose -- which is the behaviour we want -- from a real table lost.
+    """
+    evaluations = [
+        _FakeEvaluation(
+            (
+                _fact("table_rejected", "text_grid_splits_words", 6),
+                _fact("table_rejected", "mostly_empty", 6),
+            )
+        ),
+        _FakeEvaluation((_fact("table_rejected", "degenerate_grid", 1),)),
+    ]
+
+    entry = benchmark._degraded_summary(evaluations)["table_rejected"]
+
+    assert entry["occurrences"] == 13
+    assert entry["articles"] == 2
+    assert list(entry["by_reason"]) == [
+        "mostly_empty",
+        "text_grid_splits_words",
+        "degenerate_grid",
+    ], "ordered by occurrences, so the dominant cause leads"
+    assert entry["by_reason"]["degenerate_grid"] == {"occurrences": 1, "articles": 1}
+
+
+def test_an_event_with_no_reason_still_totals() -> None:
+    """Not every degraded event carries a detail; those must not vanish from the total."""
+    summary = benchmark._degraded_summary([_FakeEvaluation((_fact("ocr_failed", None, 3),))])
+
+    assert summary["ocr_failed"] == {"occurrences": 3, "articles": 1}

--- a/tests/unit/test_published_benchmark_figures.py
+++ b/tests/unit/test_published_benchmark_figures.py
@@ -151,6 +151,23 @@ def test_the_reference_was_recorded_against_the_committed_manifest() -> None:
     )
 
 
+def test_the_reference_was_produced_by_the_current_payload_shape() -> None:
+    """A payload change without a re-record leaves the artifact describing an older run.
+
+    ``corpus_pin`` catches a *corpus* that moved underneath the reference; this catches the
+    *measurement* moving underneath it. Both matter, and neither implies the other -- the
+    schema bump that added this check reshaped ``degraded_events`` without touching a single
+    figure on the page, so nothing else here would have noticed.
+    """
+    from benchmarks.pmc.benchmark import SCHEMA_VERSION
+
+    recorded = json.loads(_PMC.read_bytes())["schema_version"]
+    assert recorded == SCHEMA_VERSION, (
+        f"benchmarks/pmc/reference.json is a schema {recorded} payload but the lane now emits "
+        f"{SCHEMA_VERSION} -- re-record the reference"
+    )
+
+
 def test_the_reference_covers_the_whole_corpus() -> None:
     """A partial run must not sit behind figures the page presents as the corpus.
 


### PR DESCRIPTION
Follow-up to #336, and the "instrument before tuning" half of the table work.

## The number was less meaningful than it looked

The parser distinguishes **nine** reasons for rejecting a table region, and coalesces repeats of `(parser, kind, detail, severity)` while summing their `count`. The lane read back only `kind`, then counted coalesced **event objects** — so `table_rejected: 101` was neither a count of regions nor of articles but of event objects, the least meaningful of the three. An article rejecting twelve regions and one rejecting a single region contributed identically.

That number is naturally read as "tables we threw away", and it could not support that reading or any other. Worse, it could not tell an improvement from a regression, because some of those reasons are the parser **correctly** refusing to grid a page of prose.

## What it reports now

```json
"table_rejected": {
  "occurrences": 237, "articles": 45,
  "by_reason": {
    "mostly_empty":              {"occurrences": 118, "articles": 20},
    "text_grid_splits_words":    {"occurrences":  92, "articles": 32},
    "degenerate_grid":           {"occurrences":  24, "articles": 16},
    "layout_region_not_tabular": {"occurrences":   2, "articles":  1},
    "oversized_grid":            {"occurrences":   1, "articles":  1}
  }
}
```

`articles` sits beside `occurrences` because they answer different questions and diverge here: `mostly_empty` averages 5.9 rejections per affected article and `text_grid_splits_words` 2.9 — one concentrated, one widespread. A corpus total alone reads as a systemic failure when it can be a handful of documents.

**It immediately corrected a conclusion.** From a 12-article sample I had `text_grid_splits_words` as the dominant cause. Over all 66 it is second; `mostly_empty` leads. The sample had `mostly_empty` at six.

It also confirms #336 corpus-wide: `layout_region_not_tabular` falls to **2 occurrences in 1 article**, from being half of every sampled rejection. Genuine "no grid found at all" regions are now rare rather than routine, which is what that reason was always supposed to mean.

## Reference re-recorded

Payload schema 3 → 4. Recorded from a full 66-article run on CI ([run 31657951890](https://github.com/thomas-villani/all2md/actions/runs/31657951890)) against this branch's own head, with #336 already on `main`.

**No published figure moved** — stated in advance as a falsifiable prediction, since both changes are accounting-only. The only difference outside `provenance` and `degraded_events` is `schema_version` itself. The parity test from #332 confirms `benchmarks.rst` still matches.

## A gap in that parity test, now closed

It verified the reference was recorded against the committed **corpus**, but not that it was produced by the current **payload builder**. This schema bump reshaped the payload without moving a single published figure, so nothing else here would have noticed. The new invariant fired immediately on the stale artifact:

```
benchmarks/pmc/reference.json is a schema 3 payload but the lane now emits 4 -- re-record the reference
```

## Notes

- Benchmark payload only — **no conversion behaviour changes**.
- Four unit tests cover the aggregation, including that occurrences and articles are deliberately identical in total for the concentrated and spread cases and only `articles` tells them apart.
- This is the same defect as the OCR adapter returning `str` and destroying boxes it was handed, one level down: a lossy result type at an internal boundary, where the tempting fix is a feature and the valuable one is the type.

🤖 Generated with [Claude Code](https://claude.com/claude-code)