### PR TITLE
feat(benchmarks): measure whether figure captions reach their figures

### DIFF
--- a/benchmarks/pmc/article.py
+++ b/benchmarks/pmc/article.py
@@ -357,6 +357,156 @@ def measure_precision(
     )
 
 
+@dataclass(frozen=True, slots=True)
+class BindingReport:
+    """Whether a figure's caption reached the figure, rather than merely reaching the output.
+
+    This lane already reports that figure caption *text* survives at close to 100%, because
+    `benchmarks.pmc.oracles.walk` yields each ``<fig>``'s caption as an ordinary text block
+    and the parser does emit those words. That number is true and it is not the question:
+    a caption emitted as free-floating prose scores exactly like one attached to its image.
+    What is missing is the binding, and nothing measured it.
+
+    Three counts, because the interesting failures are distinguishable and a single ratio
+    would hide which one is happening:
+
+    * ``bound`` -- the caption is carried by an emitted figure. The number to move.
+    * ``misfiled`` -- the caption was *found* by the parser and written into the image's
+      ``alt_text`` instead. Alt text substitutes for an image for a reader who cannot see
+      it; a caption sits beside one. Counting these apart separates "the detector failed"
+      from "the detector worked and the AST had nowhere to put the result" (#338), which
+      are opposite kinds of defect with opposite fixes.
+    * ``present`` -- the caption's words are somewhere in the output. Expected to stay near
+      the top whatever the other two do, and reported so that a low ``bound`` cannot be
+      misread as lost text.
+
+    Attributes
+    ----------
+    bound : int
+        Ground-truth figures whose caption is carried by an emitted figure.
+    misfiled : int
+        Ground-truth figures whose caption reached an emitted figure's alt text instead.
+    present : int
+        Ground-truth figures whose caption text appears anywhere in the output.
+    scored : int
+        Ground-truth figures with enough n-grams to look for.
+    too_short : int
+        Figures whose caption is too short to test, reported rather than counted either way.
+    images_emitted : int
+        `Image` nodes emitted across the corpus. Compared against ``scored``, this is the
+        granularity gap: a tiled or multi-panel figure emits several images under one
+        caption, measured at 345 rasters for 231 figures on this corpus.
+    captioned_emitted : int
+        Emitted images carrying a caption at all -- the converse denominator. A parser that
+        captioned every image with the same string would score well on ``bound`` alone.
+    control_bound : int
+        Captions "bound" to a *different* article's figures. The instrument's noise floor.
+    control_scored : int
+        Captions scored against the mismatched article.
+
+    """
+
+    bound: int
+    misfiled: int
+    present: int
+    scored: int
+    too_short: int
+    images_emitted: int
+    captioned_emitted: int
+    control_bound: int
+    control_scored: int
+
+    @property
+    def binding_rate(self) -> float:
+        """Share of testable figures whose caption is attached to a figure in the output."""
+        return self.bound / self.scored if self.scored else 0.0
+
+    @property
+    def misfiled_rate(self) -> float:
+        """Share whose caption was detected but written to alt text instead."""
+        return self.misfiled / self.scored if self.scored else 0.0
+
+    @property
+    def caption_recall(self) -> float:
+        """Share whose caption text survived anywhere -- the number that is already high."""
+        return self.present / self.scored if self.scored else 0.0
+
+    @property
+    def control_binding_rate(self) -> float:
+        """Share of captions 'bound' to the wrong article's figures."""
+        return self.control_bound / self.control_scored if self.control_scored else 0.0
+
+
+def measure_binding(
+    articles: Iterable[tuple[str, Sequence[str], Sequence[tuple[str, str]], str]],
+) -> BindingReport:
+    """Measure whether figure captions are bound to figures.
+
+    Matching is n-gram containment at `RECALL_MIN`, the same rule and threshold
+    `measure_recall` uses, so a caption that counts as recovered there and as unbound here
+    differs only in where it ended up -- not in how generously it was matched.
+
+    **Scored per ground-truth figure, never per emitted image.** A figure tiled into fifteen
+    rasters that all carry the correct caption is one binding, not fifteen; scoring the
+    emitted side would report that article as a triumph and an article whose single image
+    carries no caption as an equal failure.
+
+    Parameters
+    ----------
+    articles : Iterable
+        ``(article_id, truth_captions, emitted_figures, emitted_text)`` tuples, where
+        ``emitted_figures`` are ``(caption, alt_text)`` pairs from the converted AST.
+
+    Returns
+    -------
+    BindingReport
+        Binding, misfiling and caption survival, with the mismatched-article control.
+
+    """
+    indexed = [
+        (
+            [ngrams(normalize(caption)) for caption in truth],
+            [(ngrams(normalize(caption)), ngrams(normalize(alt))) for caption, alt in figures],
+            ngrams(normalize(emitted_text)),
+            len(figures),
+            sum(1 for caption, _alt in figures if caption.strip()),
+        )
+        for _article_id, truth, figures, emitted_text in articles
+    ]
+
+    bound = misfiled = present = scored = too_short = 0
+    images = captioned = control_bound = control_scored = 0
+    for position, (truth, figures, haystack, image_count, captioned_count) in enumerate(indexed):
+        images += image_count
+        captioned += captioned_count
+        # Pair with the neighbour rather than a random article, so the control reproduces
+        # exactly on a re-run -- as `measure_recall` does.
+        other = indexed[(position + 1) % len(indexed)][1]
+        for caption in truth:
+            if len(caption) < MIN_NGRAMS:
+                too_short += 1
+                continue
+            scored += 1
+            bound += any(emitted and _contained(caption, emitted) for emitted, _alt in figures)
+            misfiled += any(alt and _contained(caption, alt) for _emitted, alt in figures)
+            present += _contained(caption, haystack)
+            if other is not figures:
+                control_scored += 1
+                control_bound += any(emitted and _contained(caption, emitted) for emitted, _alt in other)
+
+    return BindingReport(
+        bound=bound,
+        misfiled=misfiled,
+        present=present,
+        scored=scored,
+        too_short=too_short,
+        images_emitted=images,
+        captioned_emitted=captioned,
+        control_bound=control_bound,
+        control_scored=control_scored,
+    )
+
+
 def summarize(values: Sequence[float]) -> dict[str, float]:
     """Summarize a dimension's distribution, so a gate can see whether it discriminates.
 

--- a/benchmarks/pmc/benchmark.py
+++ b/benchmarks/pmc/benchmark.py
@@ -38,14 +38,16 @@ from benchmarks.omnidocbench.oracles import PageProjection, project_ast, score_p
 from benchmarks.pmc.alignment import TOKEN_PLACEMENT_MIN
 from benchmarks.pmc.article import (
     RECALL_MIN,
+    BindingReport,
     PrecisionReport,
     RecallReport,
+    measure_binding,
     measure_precision,
     measure_recall,
     summarize,
 )
 from benchmarks.pmc.convert import DegradedFact, convert_article, pdf_options
-from benchmarks.pmc.oracles import coverage, project_jats, to_projection
+from benchmarks.pmc.oracles import coverage, project_jats, to_projection, walk_figures
 from benchmarks.pmc.pages import ASSIGNMENTS, assign_pages, index_pages
 
 #: 2 adds ``article_precision``. A reader that expects 1 would silently see recall with no
@@ -59,7 +61,11 @@ from benchmarks.pmc.pages import ASSIGNMENTS, assign_pages, index_pages
 #: the nine reasons behind ``table_rejected`` were indistinguishable -- so the number could
 #: not tell an improvement from a regression, because some of those reasons are the parser
 #: correctly refusing to grid a page of prose.
-SCHEMA_VERSION = 4
+#: 5 adds ``figure_binding`` and turns image extraction on. Under 4 the lane inherited the
+#: default ``alt_text`` attachment mode, which returns before extraction runs, so it emitted
+#: no figures at all and no figure defect was observable -- and the ~100% caption text recall
+#: it did report was being read as though it said something about figures, which it does not.
+SCHEMA_VERSION = 5
 ORACLE_SCHEMA_VERSION = 1
 
 #: Fixed seed: a control that scrambles differently every run cannot be compared across
@@ -143,6 +149,9 @@ class ArticleEvaluation:
     #: The PDF's own text layer, which bounds what any parser could recover.
     pdf_text: str = ""
     truth_blocks: tuple[tuple[str, str], ...] = field(default_factory=tuple)
+    #: Ground-truth ``<fig>`` captions, and the ``(caption, alt_text)`` of every emitted image.
+    truth_captions: tuple[str, ...] = field(default_factory=tuple)
+    emitted_figures: tuple[tuple[str, str], ...] = field(default_factory=tuple)
     error: str | None = None
 
 
@@ -213,6 +222,7 @@ def evaluate_article(article: Any, *, options: Any = None) -> ArticleEvaluation:
     started = time.perf_counter()
     root, _ = _parse_jats(article.xml_path.read_bytes())
     blocks, whole = project_jats(root)
+    truth_captions = tuple(figure.caption for figure in walk_figures(root))
     page_count, pdf_words, pdf_text = _pdf_facts(article.pdf_path)
     indexed = index_pages(article.pdf_path)
     assignment = assign_pages(blocks, indexed)
@@ -233,6 +243,7 @@ def evaluate_article(article: Any, *, options: Any = None) -> ArticleEvaluation:
             duration_seconds=time.perf_counter() - started,
             ground_truth_blocks=len(blocks),
             truth_blocks=truth_pairs,
+            truth_captions=truth_captions,
             error=f"{type(exc).__name__}: {exc}",
         )
 
@@ -276,6 +287,8 @@ def evaluate_article(article: Any, *, options: Any = None) -> ArticleEvaluation:
         emitted_text=" ".join(block for page in emitted for block in page.text_blocks),
         pdf_text=pdf_text,
         truth_blocks=truth_pairs,
+        truth_captions=truth_captions,
+        emitted_figures=tuple((figure.caption, figure.alt_text) for figure in converted.figures),
     )
 
 
@@ -333,6 +346,7 @@ def normalize_results(
     evaluations: Sequence[ArticleEvaluation],
     recall: RecallReport,
     precision: PrecisionReport,
+    binding: BindingReport,
     all2md_commit: str,
     worktree_dirty: bool = False,
     parser_runtime: Mapping[str, str],
@@ -349,6 +363,8 @@ def normalize_results(
         Whole-article content recall with its control.
     precision : PrecisionReport
         Whether the output says anything the document does not, with its control.
+    binding : BindingReport
+        Whether figure captions reached the figures they belong to.
     all2md_commit : str
         Commit the parser was scored at.
     worktree_dirty : bool
@@ -395,6 +411,9 @@ def normalize_results(
                 "layout_analysis_mode": "enabled",
                 "include_page_numbers": True,
                 "ocr": {"enabled": True, "mode": "auto", "engine": "tesseract", "dpi": 200},
+                # Part of the measurement, not an incidental: under the default `alt_text`
+                # the parser emits no images and `figure_binding` is zero by construction.
+                "attachment_mode": "base64",
             },
             "placement_config": {
                 "token_placement_min": TOKEN_PLACEMENT_MIN,
@@ -482,6 +501,35 @@ def normalize_results(
             "control_emitted": precision.control_emitted,
             "discrimination": precision.precision - precision.control_precision,
         },
+        # Whether a figure's caption reached the figure, as opposed to reaching the output.
+        # Separate from `article_recall` because that instrument already scores these same
+        # captions as text blocks and passes them at close to 100% -- which says nothing
+        # about binding, and had been standing in for an answer nobody had measured.
+        "figure_binding": {
+            "binding_rate": binding.binding_rate,
+            "bound": binding.bound,
+            "scored": binding.scored,
+            "too_short": binding.too_short,
+            # The caption was found and written to alt text instead. A different defect from
+            # not finding it, with a different fix, so it is counted apart rather than
+            # folded into the failures.
+            "misfiled_rate": binding.misfiled_rate,
+            "misfiled": binding.misfiled,
+            # Expected to stay high whatever the rest does. Present so a low binding rate
+            # cannot be misread as the caption text having been lost.
+            "caption_recall": binding.caption_recall,
+            "present": binding.present,
+            # Emitted images against ground-truth figures: the granularity gap. Multi-panel
+            # and tiled figures emit several images under one caption, so these two are not
+            # expected to be equal and a ratio of 1 would be the surprising reading.
+            "images_emitted": binding.images_emitted,
+            "captioned_emitted": binding.captioned_emitted,
+            "control_binding_rate": binding.control_binding_rate,
+            # As with recall and precision: reported so a zero control cannot be misread as
+            # passing when it is really an absent denominator.
+            "control_scored": binding.control_scored,
+            "discrimination": binding.binding_rate - binding.control_binding_rate,
+        },
         "dimensions": dimensions,
         "conversion_failures": failures,
         # Expected to be empty: this corpus was characterized as 0.0% scan-shaped. A
@@ -526,11 +574,19 @@ def run(snapshot: Any, *, all2md_commit: str = "unknown", worktree_dirty: bool =
     ]
     recall = measure_recall(scored)
     precision = measure_precision(scored)
+    binding = measure_binding(
+        [
+            (result.article_id, result.truth_captions, result.emitted_figures, result.emitted_text)
+            for result in evaluations
+            if result.error is None
+        ]
+    )
     return normalize_results(
         snapshot=snapshot,
         evaluations=evaluations,
         recall=recall,
         precision=precision,
+        binding=binding,
         all2md_commit=all2md_commit,
         worktree_dirty=worktree_dirty,
         parser_runtime={

--- a/benchmarks/pmc/convert.py
+++ b/benchmarks/pmc/convert.py
@@ -64,6 +64,30 @@ class DegradedFact:
 
 
 @dataclass(frozen=True, slots=True)
+class EmittedFigure:
+    """One `Image` node the parser emitted, and whatever caption it carries.
+
+    ``caption`` is read through `getattr` because `all2md.ast.nodes.Image` has no caption
+    field yet -- that is the defect this instrument exists to measure (#338). Reading it
+    defensively means the oracle ships before the field and reports the honest zero, rather
+    than the two having to land together and the baseline being unobservable.
+
+    Attributes
+    ----------
+    alt_text : str
+        The node's alt text. Today the PDF parser writes a detected caption here, which
+        conflates an accessibility description with visible page content; recorded so the
+        instrument can see a caption that was found but misfiled.
+    caption : str
+        The node's caption, once it has one. Empty until then.
+
+    """
+
+    alt_text: str
+    caption: str
+
+
+@dataclass(frozen=True, slots=True)
 class ConvertedArticle:
     """One article's AST, whole and split by page.
 
@@ -79,6 +103,8 @@ class ConvertedArticle:
     degraded : tuple[DegradedFact, ...]
         Degraded-conversion events the parser recorded, with their reason and occurrence
         count intact.
+    figures : tuple[EmittedFigure, ...]
+        Every `Image` node the parser emitted, in document order.
 
     """
 
@@ -86,6 +112,7 @@ class ConvertedArticle:
     pages: tuple[Document, ...]
     ocr_page_fraction: float
     degraded: tuple[DegradedFact, ...]
+    figures: tuple[EmittedFigure, ...] = ()
 
 
 def pdf_options(**overrides: Any) -> PdfOptions:
@@ -94,6 +121,19 @@ def pdf_options(**overrides: Any) -> PdfOptions:
     OCR is left **enabled in auto mode** rather than switched off. Disabling it would make
     "no page needed OCR" true by construction; leaving it on means the reported OCR fraction
     is a measurement that can fail, and a corpus that is not born-digital would say so.
+
+    **Image extraction is enabled for the same reason.** The default ``alt_text`` mode
+    returns early before extraction runs, so a lane that inherited the default would report
+    "no figures" by construction and could never see a figure defect at all. ``base64`` is
+    chosen over ``save`` because it needs no temporary directory to create and clean up on
+    a CI runner.
+
+    This costs the text instruments nothing, which is why it can be turned on without
+    disturbing the published figures: the shared oracle's ``_node_text`` returns ``""`` for
+    an `Image` -- the node has no ``content`` and no children -- so extracted images add
+    empty entries to the block stream and contribute not one word to recall or precision.
+    They do add ``text_block`` kinds, which moves ``block_structure_similarity``; that
+    dimension is already declared ungateable here for unrelated reasons.
 
     Parameters
     ----------
@@ -114,6 +154,7 @@ def pdf_options(**overrides: Any) -> PdfOptions:
         "include_page_numbers": True,
         "page_separator_template": PAGE_SEPARATOR_TEMPLATE,
         "ocr": OCROptions(enabled=True, mode="auto", engine="tesseract", languages="eng", dpi=200),
+        "attachment_mode": "base64",
     }
     settings.update(overrides)
     return PdfOptions(**settings)
@@ -228,4 +269,38 @@ def convert_article(pdf_path: Path, expected_pages: int, *, options: PdfOptions 
         pages=split_pages(document, expected_pages),
         ocr_page_fraction=fraction,
         degraded=tuple(sorted(events, key=lambda fact: (fact.kind, fact.reason or ""))),
+        figures=collect_figures(document),
+    )
+
+
+def collect_figures(document: Any) -> tuple[EmittedFigure, ...]:
+    """Return every `Image` node in a converted document, in document order.
+
+    Uses `NodeCollector` rather than recursing ``.children``: images live inside paragraphs
+    and other inline containers, and a ``.children`` walk misses whole node types on this
+    AST -- it finds 170 of 5,233 nodes on a real article.
+
+    Parameters
+    ----------
+    document : Document
+        Converted article.
+
+    Returns
+    -------
+    tuple[EmittedFigure, ...]
+        Emitted figures in document order.
+
+    """
+    from all2md.ast.nodes import Image
+    from all2md.ast.transforms import NodeCollector
+
+    collector = NodeCollector(lambda node: isinstance(node, Image))
+    document.accept(collector)
+    images = [node for node in collector.collected if isinstance(node, Image)]
+    return tuple(
+        EmittedFigure(
+            alt_text=image.alt_text if isinstance(image.alt_text, str) else "",
+            caption=caption if isinstance(caption := getattr(image, "caption", ""), str) else "",
+        )
+        for image in images
     )

--- a/benchmarks/pmc/oracles.py
+++ b/benchmarks/pmc/oracles.py
@@ -353,6 +353,57 @@ def to_projection(blocks: tuple[JatsBlock, ...]) -> PageProjection:
     )
 
 
+@dataclass(frozen=True, slots=True)
+class JatsFigure:
+    """One ``<fig>``: the ground truth for caption-to-figure binding.
+
+    Kept apart from `JatsBlock` on purpose. `walk` already yields a figure's caption as a
+    ``text_block``, which is what makes caption *text* score ~100% on this corpus -- and that
+    number says nothing about whether the caption was bound to the figure it belongs to,
+    because a caption emitted as free-floating prose scores identically to one attached to
+    its image. The two questions need two instruments.
+
+    Attributes
+    ----------
+    label : str
+        The figure's ``<label>``, e.g. ``"Figure 3"``. Empty when unlabelled.
+    caption : str
+        Label and caption text joined as the page renders them, matching what `walk` puts
+        into the text stream so the two instruments describe the same string.
+
+    """
+
+    label: str
+    caption: str
+
+
+def walk_figures(root: Any) -> Iterator[JatsFigure]:
+    """Yield every ``<fig>`` in document order, respecting `SKIPPED`.
+
+    Parameters
+    ----------
+    root : xml.etree.ElementTree.Element
+        Parsed JATS article element or any subtree of one.
+
+    Yields
+    ------
+    JatsFigure
+        Figures in the order the article declares them.
+
+    """
+    tag = _tag(root)
+    if tag in SKIPPED:
+        return
+    if tag == "fig":
+        label = next((_all_text(child) for child in root if _tag(child) == "label"), "")
+        caption = _caption_of(root)
+        if caption:
+            yield JatsFigure(label=label, caption=caption)
+        return
+    for child in root:
+        yield from walk_figures(child)
+
+
 def project_jats(root: Any) -> tuple[tuple[JatsBlock, ...], PageProjection]:
     """Project a whole article, returning its blocks and their comparable projection.
 

--- a/benchmarks/pmc/reference.json
+++ b/benchmarks/pmc/reference.json
@@ -96,20 +96,20 @@
   },
   "dimensions": {
     "block_structure_similarity": {
-      "control_mean": 0.444966651809884,
+      "control_mean": 0.444062500305806,
       "count": 706.0,
       "direction": "higher",
-      "discrimination": 0.10894954604621127,
+      "discrimination": 0.09821699469080908,
       "maximum": 1.0,
-      "mean": 0.5539161978560952,
-      "median": 0.5714285714285714,
+      "mean": 0.5422794949966151,
+      "median": 0.563858695652174,
       "minimum": 0.016393442622950838,
       "mutation_drop": {
-        "halved": 0.08100948154670065,
-        "reversed": 0.008751660091300871,
-        "shuffled": 0.02068652727439497
+        "halved": 0.0660754154821242,
+        "reversed": 0.007900606406820655,
+        "shuffled": 0.019971909881816467
       },
-      "stdev": 0.20297905026461505,
+      "stdev": 0.2060450206343589,
       "ungateable": "compares kind sequences without inspecting the text under a block, so content-free output scores 1.0 (issue #256); eleven text categories collapse to `text_block`, so fully reversed output scores exactly 1.0 on 153 of the 981 pinned pages; and on the born-digital lane it separates own-page from wrong-page output by only ~0.06 while *rising* when half the emitted content is deleted, which rewards dropping blocks"
     },
     "reading_order_similarity": {
@@ -124,7 +124,7 @@
       "mutation_drop": {
         "halved": 0.32680517032583656,
         "reversed": 0.43991109322823835,
-        "shuffled": 0.20385363703260995
+        "shuffled": 0.21344156351079682
       },
       "stdev": 0.2183936420081225
     },
@@ -172,10 +172,25 @@
       "mutation_drop": {
         "halved": 0.24829681578792712,
         "reversed": 0.18663777322996467,
-        "shuffled": 0.1228484750939727
+        "shuffled": 0.12969326210192544
       },
       "stdev": 0.23081827781970696
     }
+  },
+  "figure_binding": {
+    "binding_rate": 0.0,
+    "bound": 0,
+    "caption_recall": 0.8325581395348837,
+    "captioned_emitted": 0,
+    "control_binding_rate": 0.0,
+    "control_scored": 215,
+    "discrimination": 0.0,
+    "images_emitted": 433,
+    "misfiled": 0,
+    "misfiled_rate": 0.0,
+    "present": 179,
+    "scored": 215,
+    "too_short": 13
   },
   "ocr_articles": [
     "PMC10500011.1",
@@ -199,13 +214,14 @@
     "unsplit_spans": 42
   },
   "provenance": {
-    "all2md_commit": "da3591364cb1251642d2b324408fada42395fa98",
+    "all2md_commit": "e2e8ff38b1e507ca2ba10a38a1062792016258fb",
     "bucket": "pmc-oa-opendata",
     "complete_corpus": true,
     "corpus_pin": "9ba5c0cd59067bda102b9e27a7c1e613987c145f9fb61a4c26b811d9fd24dc58",
-    "created_at": "2026-08-13T01:56:56.338282+00:00",
+    "created_at": "2026-08-13T03:37:43.750812+00:00",
     "oracle_schema_version": 1,
     "parser_config": {
+      "attachment_mode": "base64",
       "include_page_numbers": true,
       "layout_analysis_mode": "enabled",
       "ocr": {
@@ -227,5 +243,5 @@
     "python": "3.12.3 (main, Jun 19 2026, 12:46:00) [GCC 13.3.0]",
     "worktree_dirty": false
   },
-  "schema_version": 4
+  "schema_version": 5
 }

--- a/tests/unit/test_pmc_oracle.py
+++ b/tests/unit/test_pmc_oracle.py
@@ -79,8 +79,7 @@ def test_jats_and_html_tables_are_counted_identically() -> None:
     from benchmarks.omnidocbench.oracles import _html_table
 
     markup = (
-        "<table><tr><th colspan='2'>Head</th></tr>"
-        "<tr><td rowspan='2'>A</td><td>B</td></tr><tr><td>C</td></tr></table>"
+        "<table><tr><th colspan='2'>Head</th></tr><tr><td rowspan='2'>A</td><td>B</td></tr><tr><td>C</td></tr></table>"
     )
     jats = oracles._jats_table(ElementTree.fromstring(markup))
     html = _html_table(markup)
@@ -499,6 +498,7 @@ def test_page_scores_and_the_error_budget_come_from_the_same_run(tmp_path: Path)
         ],
         recall=article.measure_recall([]),
         precision=article.measure_precision([]),
+        binding=article.measure_binding([]),
         all2md_commit="deadbeef",
         parser_runtime={},
     )
@@ -526,12 +526,122 @@ def test_recall_and_precision_are_reported_together() -> None:
         evaluations=[],
         recall=article.measure_recall(scored),
         precision=article.measure_precision(scored),
+        binding=article.measure_binding([]),
         all2md_commit="deadbeef",
         parser_runtime={},
     )
     assert payload["article_recall"]["attainable_recall"] > 0.0
     assert payload["article_precision"]["precision"] == pytest.approx(1.0)
     assert payload["article_precision"]["control_emitted"] > 0
+
+
+# ---------------------------------------------------------------------------
+# Figure-to-caption binding
+# ---------------------------------------------------------------------------
+
+_CAPTION = "Figure 1 mean response amplitude across the four experimental conditions shown"
+_OTHER_CAPTION = "Figure 2 electrode placement viewed from above with the reference channel marked"
+
+
+def test_a_figure_caption_is_ground_truth_separate_from_the_text_stream() -> None:
+    """`walk` already yields the caption as prose; binding needs it as a figure of its own."""
+    root = _jats(f"<fig><label>Figure 1</label><caption><p>{_CAPTION}</p></caption></fig>")
+
+    figures = tuple(oracles.walk_figures(root))
+
+    assert len(figures) == 1
+    assert figures[0].label == "Figure 1"
+    assert _CAPTION in figures[0].caption
+    # The same figure still reaches the text stream, unchanged: the two instruments read the
+    # same article and must not disagree about what it contains.
+    assert any(_CAPTION in block.text for block in oracles.walk(root))
+
+
+def test_unrendered_subtrees_hold_no_figures() -> None:
+    """A `<fig>` under a skipped element would be ground truth the page never prints."""
+    root = _jats(f"<counts><fig><caption><p>{_CAPTION}</p></caption></fig></counts>")
+
+    assert tuple(oracles.walk_figures(root)) == ()
+
+
+def test_a_bound_caption_is_recognised() -> None:
+    """Verify the judge can pass: the instrument must report a correct binding as correct.
+
+    This lane's binding rate is **zero by construction** until `Image` gains a caption field
+    (#338), and a gate whose only observable value is zero is indistinguishable from one
+    that cannot fire at all. Every other test here would pass against an instrument that
+    always returns zero; this one would not.
+    """
+    report = article.measure_binding([("A", [_CAPTION], [(_CAPTION, "")], _CAPTION)])
+
+    assert report.scored == 1
+    assert report.binding_rate == pytest.approx(1.0)
+    assert report.misfiled == 0
+
+
+def test_a_caption_that_reached_only_the_prose_is_not_counted_as_bound() -> None:
+    """The whole point: caption text surviving is not the caption being bound.
+
+    On this corpus caption text recall is close to 100% while nothing is bound at all, and
+    an instrument that could not tell those apart would report the parser as already correct.
+    """
+    report = article.measure_binding([("A", [_CAPTION], [("", "")], f"prose {_CAPTION} prose")])
+
+    assert report.binding_rate == pytest.approx(0.0)
+    assert report.caption_recall == pytest.approx(1.0)
+
+
+def test_a_caption_written_into_alt_text_is_counted_apart() -> None:
+    """Detector worked, AST had nowhere to put the result -- a different defect from a miss."""
+    report = article.measure_binding([("A", [_CAPTION], [("", _CAPTION)], _CAPTION)])
+
+    assert report.binding_rate == pytest.approx(0.0)
+    assert report.misfiled_rate == pytest.approx(1.0)
+
+
+def test_a_tiled_figure_counts_once_rather_than_once_per_panel() -> None:
+    """Measured: 231 ground-truth figures emit 345 rasters, one of them tiled fifteen ways.
+
+    Scoring the emitted side would let a single tiled figure outweigh whole articles.
+    """
+    panels = [(_CAPTION, "")] * 15
+    report = article.measure_binding([("A", [_CAPTION], panels, _CAPTION)])
+
+    assert report.bound == 1
+    assert report.scored == 1
+    assert report.images_emitted == 15
+    assert report.captioned_emitted == 15
+
+
+def test_binding_collapses_against_a_different_article() -> None:
+    """Without the control, a high binding rate might only mean captions look alike."""
+    report = article.measure_binding(
+        [
+            ("A", [_CAPTION], [(_CAPTION, "")], _CAPTION),
+            ("B", [_OTHER_CAPTION], [(_OTHER_CAPTION, "")], _OTHER_CAPTION),
+        ]
+    )
+
+    assert report.binding_rate == pytest.approx(1.0)
+    assert report.control_binding_rate == pytest.approx(0.0)
+    assert report.control_scored == 2
+
+
+def test_a_single_article_reports_no_binding_control_rather_than_a_flattering_zero() -> None:
+    """With one article there is no other to score against, as for recall and precision."""
+    report = article.measure_binding([("A", [_CAPTION], [(_CAPTION, "")], _CAPTION)])
+
+    assert report.control_scored == 0
+    assert report.control_binding_rate == pytest.approx(0.0)
+
+
+def test_the_lane_extracts_images_so_a_figure_defect_is_observable() -> None:
+    """Under the default `alt_text` mode the parser emits none, making the oracle vacuous.
+
+    The same argument the lane already makes for leaving OCR enabled: a policy that switches
+    the subsystem off makes its own clean result true by construction.
+    """
+    assert convert.pdf_options().attachment_mode == "base64"
 
 
 class _FakeEvaluation:


### PR DESCRIPTION
Step 1 of #338: build the instrument before touching the detector.

## Why the number we had was not an answer

The lane already reports that figure caption *text* survives at close to 100%, and that was
standing in for a measurement nobody had made. It cannot say anything about binding —
`oracles.walk` yields each `<fig>`'s caption as an ordinary text block, so a caption emitted
as free-floating prose scores exactly like one attached to its image.

## What this adds

`figure_binding`, with three counts rather than one ratio, because the failures are
distinguishable and have different fixes:

| count | question |
|---|---|
| `bound` | is the caption carried by an emitted figure? |
| `misfiled` | was it found and written into `alt_text` instead? |
| `present` | are the words anywhere in the output? |

`present` ships so a low binding rate cannot be misread as lost text. `misfiled` ships
because "the detector failed" and "the detector worked and the AST had nowhere to put the
result" are opposite defects.

**Scored per ground-truth figure, never per emitted image.** A figure tiled into fifteen
rasters that all carry the correct caption is one binding, not fifteen. Measured on this
corpus, 231 ground-truth figures emit 345 rasters above 50×50 pt, so scoring the emitted
side would let one tiled article outweigh several others.

## Image extraction is now on

The lane inherited the default `alt_text` attachment mode, which returns before extraction
runs — so it emitted no figures at all and no figure defect was observable. That is the same
argument the lane already makes for leaving OCR enabled: a policy that switches the subsystem
off makes its own clean result true by construction.

It costs the text instruments nothing, which is why it can be turned on without disturbing
the published figures: the shared oracle's `_node_text` returns `""` for an `Image` (no
`content`, no children), so extracted images contribute not one word to recall or precision.
They do add `text_block` kinds, which moves `block_structure_similarity` — already declared
ungateable here for unrelated reasons.

## Verifying the judge can fail

The binding rate is **zero by construction** until `Image` gains a caption field, and a gate
whose only observable value is zero is indistinguishable from one that cannot fire at all.
`test_a_bound_caption_is_recognised` is the positive control: every other test in this set
would pass against an instrument that always returns zero, and that one would not.

## Baseline, measured on three articles

```
binding_rate   0.0    (0/13)
misfiled_rate  0.0    (0/13)
caption_recall 1.0    (13/13)
images_emitted 21     for 13 ground-truth figures
control        0.0    (n=13, so the zero has a denominator)
```

Two things worth reading here. The structure-not-text story is now measured rather than
asserted. And **`misfiled` is 0, not positive** — every emitted image carries
`"Image from page N"`, so the caption detector is not firing at all rather than firing and
misfiling. That narrows where the work goes and is a finding this instrument existed to
produce.

## Follow-up required

`SCHEMA_VERSION` 4 → 5, so `test_the_reference_was_produced_by_the_current_payload_shape`
fails until `benchmarks/pmc/reference.json` is re-recorded on CI. That is the guard working.
`block_structure_similarity` will move when it is re-recorded, and
`docs/source/benchmarks.rst` will need the new value — the parity test will name it.

Refs #338

🤖 Generated with [Claude Code](https://claude.com/claude-code)
