### PR TITLE
fix(tests): stop the ci profile making every CI run verbose

### DIFF
--- a/.github/workflows/fuzz-corpus.yml
+++ b/.github/workflows/fuzz-corpus.yml
@@ -11,31 +11,31 @@ name: Generative Roundtrip Gates
 #
 #     HYPOTHESIS_PROFILE=ci pytest -m fuzzing --hypothesis-seed=random
 #
-# What forced the split: on the 3.12 leg these took over 3 hours, against ~60s
-# for the same file locally. That gap is still unexplained, and the list of
-# things it is NOT keeps growing -- each one measured, not argued:
+# What forced the split: these took over 3 hours on the 3.12 leg against ~60s
+# locally. That is now understood and fixed, and it was never about CI at all.
 #
-#   - example count: #216's per-format budget is real, but it is 10x of ~6s
-#   - coverage: 61s plain vs 59s under --cov=all2md
-#   - Hypothesis profile: CI never sets HYPOTHESIS_PROFILE, so it loads `dev`
-#     exactly as a dev box does
-#   - Hypothesis version: CI installs 6.164.0 against 6.155.7 locally, but
-#     shadowing 6.164.0 onto a local run leaves dokuwiki at ~1s
-#   - corpus luck: dokuwiki is flat at ~1.5s across five different seeds
+# The cause was a one-word setting in tests/conftest.py. Hypothesis ships a
+# built-in profile named `ci` and auto-loads it when it detects CI, and
+# `register_profile` re-loads a profile that is already active -- so our own
+# `register_profile("ci", ..., verbosity=Verbosity.verbose)` landed on the live
+# profile, and `dev` (registered next, and what actually runs) inherited the
+# verbosity. Verbose makes Hypothesis pretty-print every generated example
+# through a printer that calls ast.parse/inspect.getsource, which cost ~35s on
+# a structurally complex document. It could not reproduce locally because off
+# CI the active profile is `default` and nothing re-loads. `CI=true pytest ...`
+# reproduces it in one command; tests/unit/test_hypothesis_profiles.py now
+# fails if it comes back. With it gone the whole file runs in ~32s.
 #
-# The first --durations run ruled out a stall: the per-test durations sum to
-# 4938s against a 4993s job, so the time is real work spread over specific
-# tests. It is also wildly uneven -- dokuwiki 863s and asciidoc 557s in CI
-# against ~2s locally, while ipynb is only 6.5x. Locally those two are among
-# the *fastest* formats, so CI is not simply a slower machine: a constant
-# factor cannot invert the ordering.
+# Everything else this was blamed on was refuted by measurement -- do not
+# re-run these: example count (#216's budget is 10x of ~6s), coverage (61s vs
+# 59s under --cov), Hypothesis version (6.165.5 locally is ~1s), Python version
+# (3.12.2 locally is ~1s), the local example database (empty DB is ~1s), and
+# network I/O (there is none in parsers/ or renderers/).
 #
-# --hypothesis-show-statistics is the next instrument. Locally dokuwiki reports
-# 25 passing / 5 invalid examples with generation dominating (~74ms of an ~87ms
-# example). The CI numbers separate the live hypotheses: 25 examples at ~34s
-# each means execution is genuinely slow on this platform, while thousands of
-# invalid examples means Hypothesis is thrashing on generation and the finger
-# points away from our renderers entirely.
+# --hypothesis-show-statistics is what finally split it: generation cost the
+# same on CI as locally (~0-173ms) while execution ran 1000x apart, which no
+# slow runner can do, and invalid examples numbered 0-8 rather than thousands.
+# Keep the flag -- it is cheap, and it is the instrument that pays off here.
 
 on:
   schedule:
@@ -57,10 +57,11 @@ jobs:
   generative:
     name: Generative Roundtrip Gates
     runs-on: ubuntu-latest
-    # Deliberately above the ~3h these currently take, so a scheduled run still
-    # produces the --durations table instead of being killed just short of it.
-    # Tighten this once the runtime is understood.
-    timeout-minutes: 240
+    # The runtime is understood now (see the header), so this is tightened from
+    # 240 to a bound that still leaves generous headroom: the file runs in ~32s
+    # locally under CI settings. A run that reaches 30 minutes means something
+    # has regressed into a pathological path, and failing is the useful answer.
+    timeout-minutes: 30
 
     steps:
       - name: Check out code

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -14,8 +14,19 @@ from utils import cleanup_test_dir, create_test_temp_dir
 try:
     from hypothesis import Phase, Verbosity, settings
 
-    # Register custom Hypothesis profiles
-    settings.register_profile("ci", max_examples=100, verbosity=Verbosity.verbose)
+    # Register custom Hypothesis profiles.
+    #
+    # Do NOT set ``verbosity`` on the "ci" profile. Hypothesis ships its own
+    # profile of that exact name and auto-loads it when it detects CI, and
+    # ``register_profile`` re-loads a profile that is already the active one.
+    # So registering "ci" here lands on the live profile in CI, and every
+    # profile registered *after* it -- including "dev", which is what actually
+    # runs -- inherits whatever we set. A stray ``verbosity=Verbosity.verbose``
+    # therefore made CI, and only CI, pretty-print every generated example;
+    # that printer calls ``ast.parse``/``inspect.getsource`` per example and
+    # cost ~35s on a complex document, turning a ~40s fuzz run into 68 minutes.
+    # Use ``--hypothesis-verbosity=verbose`` for a one-off noisy run instead.
+    settings.register_profile("ci", max_examples=100)
     settings.register_profile("dev", max_examples=20)
     settings.register_profile(
         "debug", max_examples=10, verbosity=Verbosity.verbose, phases=[Phase.explicit, Phase.reuse, Phase.generate]

--- a/tests/unit/test_hypothesis_profiles.py
+++ b/tests/unit/test_hypothesis_profiles.py
@@ -1,0 +1,53 @@
+"""Guards on the Hypothesis profiles registered in ``tests/conftest.py``.
+
+Why this file exists
+--------------------
+
+Hypothesis ships a built-in profile named ``ci`` and auto-loads it when it
+detects a CI environment (``CI=true``, which GitHub Actions always sets).
+``tests/conftest.py`` registers a profile under that same name -- and
+``settings.register_profile`` re-loads a profile if it is the one currently
+active. So in CI, and *only* in CI, our registration lands on the live profile,
+and every profile registered after it inherits whatever we put there. ``dev`` is
+registered after ``ci`` and is what actually runs, so a setting meant for the
+``ci`` profile silently became the setting for every test.
+
+That is not hypothetical: a ``verbosity=Verbosity.verbose`` on the ``ci``
+profile made CI pretty-print every generated example. That printer calls
+``ast.parse``/``inspect.getsource`` per example, which cost ~35s on a
+structurally complex document and turned the ~40s generative fuzz run into 68
+minutes. It survived weeks of investigation because it cannot reproduce locally
+-- off CI the active profile is ``default``, the re-registration does not
+re-load, and ``dev`` inherits nothing.
+
+These tests are cheap insurance against the same shape of mistake.
+"""
+
+import os
+
+import pytest
+from hypothesis import Verbosity, settings
+
+
+@pytest.mark.unit
+def test_the_ci_profile_does_not_request_verbose_output() -> None:
+    """Verbose output in CI is not free -- it is a ~100x runtime multiplier.
+
+    Anyone who wants a noisy run has ``--hypothesis-verbosity=verbose`` for a
+    single invocation, which costs nothing when it is not passed.
+    """
+    assert settings.get_profile("ci").verbosity < Verbosity.verbose
+
+
+@pytest.mark.unit
+def test_the_active_profile_is_not_verbose() -> None:
+    """The profile that actually runs must not be verbose unless asked for.
+
+    This is the assertion that would have caught the original defect. It passes
+    trivially off CI, where nothing re-loads the active profile; it fails in CI
+    the moment a profile registered before ``dev`` sets verbosity. ``debug`` is
+    exempt because being verbose is the entire point of asking for it.
+    """
+    if os.getenv("HYPOTHESIS_PROFILE") == "debug":
+        pytest.skip("the debug profile is verbose on purpose")
+    assert settings.default.verbosity < Verbosity.verbose


### PR DESCRIPTION
## What

The generative fuzz gates took **68 minutes** on CI against ~40s locally. The cause was ours, and it was one keyword argument in `tests/conftest.py`.

Hypothesis ships a built-in profile named `ci` and auto-loads it when it detects a CI environment. `settings.register_profile` **re-loads a profile if it is the one currently active** — so our own `register_profile("ci", ..., verbosity=Verbosity.verbose)` landed on the live profile in CI, and `dev` (registered on the next line, inheriting from the then-current default) silently picked up the verbosity. `dev` is what actually runs.

```
1. after hypothesis import        : ci  | verbosity = Verbosity.normal
2. after conftest re-registers ci : ci  | verbosity = Verbosity.verbose
3. after conftest loads dev       : dev | verbosity = Verbosity.verbose   <-- every test
```

Verbose makes Hypothesis pretty-print every generated example through a printer that calls `ast.parse`/`inspect.getsource`, which cost ~35s on a structurally complex document. Off CI the active profile is `default`, the re-registration does not re-load, and nothing inherits anything — which is why it never reproduced on a dev box.

## Measured

| | before | after |
|---|---|---|
| whole generative file | 4069s (CI run 31670388038) | **32s** locally under `CI=true`, 22 passed |
| `dokuwiki` alone | >600s locally under `CI=true` | **0.86s** |
| whole `-m fuzzing` suite | — | 127 passed, 1 skipped in 43.6s under `CI=true` |

`CI=true pytest ...` reproduces the original slowness in one command, which is what finally made it tractable.

## The ratchet

`tests/unit/test_hypothesis_profiles.py` — both tests were confirmed to fail against the restored defect:

- `test_the_ci_profile_does_not_request_verbose_output` fails anywhere.
- `test_the_active_profile_is_not_verbose` fails **only** under `CI=true`, which is the environment-sensitive guard that was missing.

## Also

Tightens the workflow timeout 240 → 30 minutes and rewrites the `fuzz-corpus.yml` header, which documented this at length as unexplained. The refuted theories are kept there so nobody re-runs them: example count, coverage, Hypothesis version, Python version, the local example database, and network I/O. Two of those were re-refuted today with CI's exact versions (Python 3.12.2 + Hypothesis 6.165.5 → 0.88s).

No `src/` changes, so no CHANGELOG entry.

## Follow-up, not in this PR

These gates were moved off the per-PR run by #230 *because* of the 2h39m runtime. That constraint is gone — the full file is now ~32s. Whether they return to per-PR is a separate call; `fuzz-corpus.yml`'s header also argues for nightly on discovery grounds, independent of speed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)