### PR TITLE
ci: run the generative gates per PR, and make discovery actually discover

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -113,18 +113,17 @@ jobs:
           # They run on 3.12 — the same leg that uploads coverage, so the reported
           # figure still includes them.
           #
-          # The 3.12 leg additionally drops `generative`: the Hypothesis-drawn
-          # roundtrip gates are derandomized, so a per-PR run replays a fixed
-          # corpus for an answer that only moves when our code does. They run on
-          # a schedule instead (fuzz-corpus.yml). This is what took the leg from
-          # ~6 min to over 3 hours and made it the critical path for every PR.
+          # The generative gates run here too, on this one leg. They were pulled
+          # out in #230 when they took over 3 hours and made this the critical
+          # path for every PR; #341 found the cause (a verbose Hypothesis profile
+          # leaking into CI, nothing to do with the gates themselves) and they now
+          # finish in ~20s. Replaying a fixed corpus per PR is exactly the point of
+          # a ratchet: it fails the moment our code changes the answer.
           #
           # --durations is cheap and prints the 25 slowest tests, so the next
           # time a leg blows up the log says which test rather than which file.
           ARGS=(tests/ -v --durations=25 --cov=all2md --cov-report=xml --cov-report=term)
-          if [ "$PYTHON_VERSION" = "3.12" ]; then
-            ARGS+=(-m "not generative")
-          else
+          if [ "$PYTHON_VERSION" != "3.12" ]; then
             ARGS+=(-m "not matrix_single")
           fi
           pytest "${ARGS[@]}"

--- a/.github/workflows/fuzz-corpus.yml
+++ b/.github/workflows/fuzz-corpus.yml
@@ -46,13 +46,11 @@ name: Generative Roundtrip Discovery
 # slow runner can do, and invalid examples numbered 0-8 rather than thousands.
 # Keep the flag -- it is cheap, and it is the instrument that pays off here.
 
+# Dispatch only. When the cron returns it should be daily rather than weekly
+# (unlike corpus-gate): this corpus is generated locally and costs no
+# third-party downloads, and a one-day commit range is the cheapest thing to
+# bisect when a crash class appears.
 on:
-  schedule:
-    # 04:00 UTC daily. Nightly rather than weekly (unlike corpus-gate): this
-    # corpus is generated locally and costs no third-party downloads, and a
-    # one-day commit range is the cheapest thing to bisect when a crash class
-    # appears.
-    - cron: "0 4 * * *"
   workflow_dispatch:
 
 concurrency:
@@ -64,7 +62,7 @@ permissions:
 
 jobs:
   generative:
-    name: Generative Roundtrip Gates
+    name: Generative Roundtrip Discovery
     runs-on: ubuntu-latest
     # The runtime is understood now (see the header), so this is tightened from
     # 240 to a bound that still leaves generous headroom: the file runs in ~32s
@@ -104,7 +102,14 @@ jobs:
       # whether 863s of dokuwiki is 25 slow round trips or a generator thrashing
       # on rejected examples. Compare against the local baseline: 25 passing,
       # 5 invalid, ~74ms of an ~87ms example spent in generation.
+      # ALL2MD_FUZZ_DISCOVERY=1 is what makes this a sweep rather than a second
+      # copy of the per-PR run. Without it the gates keep `derandomize=True` and
+      # replay the exact corpus ci.yml already covered, which is the vacuous
+      # shape described in the header. If this line ever goes missing, the job
+      # still passes -- it just stops discovering anything.
       - name: Run the generative gates
+        env:
+          ALL2MD_FUZZ_DISCOVERY: "1"
         run: >
           pytest tests/unit/test_roundtrip_fuzzing.py -m generative -v
           --durations=0 --hypothesis-show-statistics

--- a/.github/workflows/fuzz-corpus.yml
+++ b/.github/workflows/fuzz-corpus.yml
@@ -13,12 +13,12 @@ name: Generative Roundtrip Discovery
 # replayed the same corpus the per-PR run already covers. `ALL2MD_FUZZ_DISCOVERY=1`
 # is what actually redraws (fingerprints differ every run, verified both ways).
 #
-# NOT on a schedule yet, deliberately. Discovery currently fails on its first
-# run -- e.g. the asciidoc renderer emits a nested list its own parser rejects
-# with "Cannot nest to level 2 without a parent item at level 1". A nightly that
-# is red every morning teaches people to ignore it. Restore the cron once the
-# findings it produces are triaged into KNOWN_CRASHES with repros and issues,
-# which is the process tests/unit/test_roundtrip_fuzzing.py documents.
+# NOT on a schedule yet, deliberately. Its first four runs turned up two crash
+# classes (#343). The asciidoc one is now in KNOWN_CRASHES with a repro, but the
+# PDF one ("Failed to render PDF: ValueError", 2 of 4 runs) is still
+# uncharacterised, so a nightly would be red on a coin flip -- and a job that is
+# red most mornings teaches people to ignore it. Restore the cron once #343 is
+# closed, which is the process tests/unit/test_roundtrip_fuzzing.py documents.
 #
 # What forced the earlier split: these took over 3 hours on the 3.12 leg against ~60s
 # locally. That is now understood and fixed, and it was never about CI at all.

--- a/.github/workflows/fuzz-corpus.yml
+++ b/.github/workflows/fuzz-corpus.yml
@@ -1,17 +1,26 @@
-name: Generative Roundtrip Gates
+name: Generative Roundtrip Discovery
 
-# The Hypothesis-drawn roundtrip gates from tests/unit/test_roundtrip_fuzzing.py,
-# split off the per-PR run. See that file's header for which gates stay per-PR.
+# A *discovery* sweep of tests/unit/test_roundtrip_fuzzing.py: it draws a fresh
+# corpus every run and reports round trips that crash in a way KNOWN_CRASHES
+# does not already describe. The same gates now also run per PR (ci.yml, the
+# 3.12 leg) against their fixed corpus, which is the ratchet; this is the half
+# that finds new defects rather than re-proving old ones.
 #
-# Why they are not per-PR: every gate here is `derandomize=True`, so it draws the
-# same corpus every run. A PR replays a fixed set of documents to recompute an
-# answer that can only change when our code changes -- and the deterministic
-# half of the file (invariants, known-crash repros) already catches that in ~2s.
-# The discovery value is in a seeded sweep, which is a deliberate activity:
+# Why an env var and not a flag: `--hypothesis-seed=random` does NOT override
+# the explicit `derandomize=True` on these gates. Measured by fingerprinting the
+# drawn corpus -- with the flag and without it, the documents are identical. The
+# workflow this replaces used that flag and was therefore a vacuous sweep: it
+# replayed the same corpus the per-PR run already covers. `ALL2MD_FUZZ_DISCOVERY=1`
+# is what actually redraws (fingerprints differ every run, verified both ways).
 #
-#     HYPOTHESIS_PROFILE=ci pytest -m fuzzing --hypothesis-seed=random
+# NOT on a schedule yet, deliberately. Discovery currently fails on its first
+# run -- e.g. the asciidoc renderer emits a nested list its own parser rejects
+# with "Cannot nest to level 2 without a parent item at level 1". A nightly that
+# is red every morning teaches people to ignore it. Restore the cron once the
+# findings it produces are triaged into KNOWN_CRASHES with repros and issues,
+# which is the process tests/unit/test_roundtrip_fuzzing.py documents.
 #
-# What forced the split: these took over 3 hours on the 3.12 leg against ~60s
+# What forced the earlier split: these took over 3 hours on the 3.12 leg against ~60s
 # locally. That is now understood and fixed, and it was never about CI at all.
 #
 # The cause was a one-word setting in tests/conftest.py. Hypothesis ships a

--- a/pytest.ini
+++ b/pytest.ini
@@ -39,7 +39,7 @@ markers =
     security: Security-focused tests (SSRF, file access, ZIP bombs)
     fuzzing: Property-based and fuzz tests using Hypothesis
     matrix_single: Exercises library logic, not interpreter differences; CI runs it on one Python leg only
-    generative: Draws its corpus with Hypothesis; fixed-seed and expensive, so CI runs it on a schedule rather than per PR
+    generative: Draws its corpus with Hypothesis; fixed-seed per PR, set ALL2MD_FUZZ_DISCOVERY=1 to redraw and hunt new defects
     golden: Golden/snapshot regression tests
     asciidoc: Tests related to AsciiDoc conversion
     plaintext: Tests related to PlainText rendering

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -42,6 +42,31 @@ except ImportError:
     pass
 
 
+def pytest_report_header() -> list[str]:
+    """Print the Hypothesis profile and fuzz mode at the top of every run.
+
+    Both are invisible settings that change what the suite actually measures,
+    and both have already gone wrong silently: a profile inherited an unwanted
+    verbosity and cost 68 minutes per CI run, and the discovery sweep spent
+    months replaying the fixed corpus because its flag did not take. A run that
+    is not doing what its workflow name says should say so in its own log.
+    """
+    import os
+
+    lines = [
+        f"all2md fuzz discovery: {'on' if os.environ.get('ALL2MD_FUZZ_DISCOVERY') == '1' else 'off (fixed corpus)'}"
+    ]
+    try:
+        from hypothesis import settings as _settings
+
+        lines.append(
+            f"hypothesis profile: {os.getenv('HYPOTHESIS_PROFILE', 'dev')} (verbosity={_settings.default.verbosity!r})"
+        )
+    except ImportError:
+        pass
+    return lines
+
+
 def _setup_test_imports():
     """Setup imports needed for testing while maintaining lazy loading in production."""
     # Make pymupdf available for PDF tests that need to mock it

--- a/tests/unit/test_roundtrip_fuzzing.py
+++ b/tests/unit/test_roundtrip_fuzzing.py
@@ -60,6 +60,7 @@ from all2md.ast.nodes import (
     CodeBlock,
     Document,
     Heading,
+    LineBreak,
     List,
     ListItem,
     Paragraph,
@@ -142,7 +143,13 @@ LOSSLESS_FORMATS = ("ast",)
 #: output its own parser rejects is always a bug. They are listed so the gate can
 #: distinguish "already known" from "newly introduced". Minimal reproductions for
 #: every entry are pinned in :class:`TestKnownCrashRepros` below.
-KNOWN_CRASHES: dict[tuple[str, str], str] = {}
+KNOWN_CRASHES: dict[tuple[str, str], str] = {
+    ("asciidoc", "Cannot nest to level 2 without a parent item at level 1"): (
+        "#343: an item whose paragraph opens with a hard line break renders as "
+        "`*  +` -- marker and continuation on one line -- and the asciidoc parser "
+        "does not read that back as a level-1 item, so a nested `**` has no parent."
+    ),
+}
 
 
 def is_known(fmt: str, exc: BaseException) -> bool:
@@ -323,6 +330,42 @@ NESTED_TASK_ITEM = Document(
 )
 
 
+#: An outer list item whose paragraph opens with a *hard* line break and then has
+#: text, wrapping a nested empty item that carries a task status. asciidoc writes
+#: this as::
+#:
+#:     *  +
+#:     0
+#:       ** [x]
+#:
+#: and its own parser rejects the `**` for want of a level-1 parent. All three
+#: parts are load-bearing, measured by removing each in turn: without the line
+#: break, without the text after it, with a soft break, with a non-empty inner
+#: item, or with the inner ``task_status`` dropped, the round trip succeeds.
+#: `unchecked` fails the same way as `checked`. #343.
+LINEBREAK_OPENS_LIST_ITEM = Document(
+    children=[
+        List(
+            ordered=False,
+            tight=False,
+            items=[
+                ListItem(
+                    task_status=None,
+                    children=[
+                        Paragraph(content=[LineBreak(soft=False), Text(content="0")]),
+                        List(
+                            ordered=False,
+                            tight=False,
+                            items=[ListItem(children=[], task_status="checked")],
+                        ),
+                    ],
+                )
+            ],
+        )
+    ]
+)
+
+
 @pytest.mark.unit
 @pytest.mark.fuzzing
 class TestKnownCrashRepros:
@@ -336,7 +379,14 @@ class TestKnownCrashRepros:
 
     @pytest.mark.parametrize(
         ("doc", "fmt"),
-        [],
+        [
+            pytest.param(
+                LINEBREAK_OPENS_LIST_ITEM,
+                "asciidoc",
+                marks=pytest.mark.xfail(strict=True, reason="#343"),
+                id="asciidoc-hard-break-opens-item",
+            ),
+        ],
     )
     def test_known_crash_still_reproduces(self, doc: Document, fmt: str) -> None:
         """Each known crash reproduces from a minimal document.

--- a/tests/unit/test_roundtrip_fuzzing.py
+++ b/tests/unit/test_roundtrip_fuzzing.py
@@ -49,6 +49,7 @@ than leaving it as documentation.
 """
 
 import io
+import os
 
 import pytest
 from document_strategies import documents, documents_of, lists, tables
@@ -77,15 +78,24 @@ from all2md.ast.nodes import (
 #: nothing while thinning the security coverage.
 #:
 #: The gates that draw their corpus with Hypothesis carry a second marker,
-#: ``generative``, and per-PR CI deselects it: those run on a schedule instead
-#: (see .github/workflows/fuzz-corpus.yml). They are ``derandomize=True``, so a
-#: PR run recomputes a fixed answer over a fixed corpus and can only change when
-#: our code does -- the discovery value is in a seeded sweep, not in the 300th
-#: identical replay. What stays per-PR is everything deterministic and cheap:
-#: the classification check, the structural invariants, and the known-crash
-#: repros, whose strict xfails are what fail the moment someone fixes a bug and
-#: leaves the allowlist entry behind.
+#: ``generative``. They run per PR on the same single leg: they are
+#: ``derandomize=True``, so a PR replays a fixed corpus to recompute an answer
+#: that only moves when our code does, which is what a ratchet is for. They were
+#: briefly moved to a nightly schedule when they took over three hours, but that
+#: was a verbose Hypothesis profile leaking into CI (#341), not the gates; they
+#: cost ~20s.
 pytestmark = pytest.mark.matrix_single
+
+#: Draw a fresh corpus instead of replaying the fixed one. This is the *discovery*
+#: mode, run nightly by .github/workflows/fuzz-corpus.yml, and anything it finds
+#: belongs in :data:`KNOWN_CRASHES` with a reproduction.
+#:
+#: It needs an environment variable because ``--hypothesis-seed=random`` cannot do
+#: it: an explicit ``derandomize=True`` in ``@settings`` beats the flag, so that
+#: sweep silently replays the same documents. Measured, by fingerprinting the
+#: drawn corpus -- with and without the flag the fingerprints are identical. Do
+#: not put ``--hypothesis-seed=random`` in a workflow and call it discovery.
+DISCOVERY = os.environ.get("ALL2MD_FUZZ_DISCOVERY") == "1"
 
 # --------------------------------------------------------------------------- #
 # Format groups
@@ -208,12 +218,16 @@ class TestNoUnrecognisedCrash:
     which reads as a flaky test and trains people to re-run CI until it passes.
 
     The cost is that these gates stop discovering new defects once the seed is
-    fixed. Discovery is a separate activity, run on purpose rather than on every
-    commit::
+    fixed. Discovery is a separate activity, run nightly and on purpose rather
+    than on every commit::
 
-        HYPOTHESIS_PROFILE=ci python -m pytest -m fuzzing --hypothesis-seed=random
+        ALL2MD_FUZZ_DISCOVERY=1 python -m pytest -m generative
 
     Anything that finds belongs in :data:`KNOWN_CRASHES` with a reproduction.
+
+    Use that variable, not ``--hypothesis-seed=random``: the flag loses to the
+    explicit ``derandomize`` here and quietly replays the same corpus, so a
+    sweep built on it is vacuous. See :data:`DISCOVERY`.
 
     The format comes from ``parametrize`` rather than from ``sampled_from``
     inside the strategy, so ``max_examples`` is a budget *per format* instead of
@@ -231,7 +245,7 @@ class TestNoUnrecognisedCrash:
     @settings(
         deadline=None,
         max_examples=25,
-        derandomize=True,
+        derandomize=not DISCOVERY,
         suppress_health_check=[HealthCheck.too_slow],
     )
     @given(documents())
@@ -254,7 +268,7 @@ class TestNoUnrecognisedCrash:
     @settings(
         deadline=None,
         max_examples=10,
-        derandomize=True,
+        derandomize=not DISCOVERY,
         suppress_health_check=[HealthCheck.too_slow],
     )
     @given(documents(max_blocks=3))


### PR DESCRIPTION
Follows #341, which removed the reason these gates were pulled off the per-PR run.

## Per-PR

The 3.12 leg (the one that already runs `matrix_single`) now runs the whole file. Locally under CI settings: **59 passed, 1 skipped, 25.8s**. Replaying a fixed corpus on every PR is precisely what a ratchet is for — it fails the moment our code changes the answer.

## The nightly was vacuous

Removing the deselection leaves the nightly replaying the same corpus the PR run now covers. But it was worse than redundant: the discovery command this project has recommended for months does not work.

**`--hypothesis-seed=random` does not override an explicit `derandomize=True` in `@settings`.** Measured by fingerprinting the drawn documents (memory addresses normalised out, database disabled):

```
CI, derandomized 1: 9ad489fc8e92adaa
CI, derandomized 2: 9ad489fc8e92adaa
CI, seed=random  1: 9ad489fc8e92adaa     <-- identical
CI, seed=random  2: 9ad489fc8e92adaa
```

So `ALL2MD_FUZZ_DISCOVERY=1` gates `derandomize` instead. Verified in both directions, which is the part that matters:

| mode | run 1 | run 2 | |
|---|---|---|---|
| default | `64567303f7da` | `64567303f7da` | still a ratchet |
| discovery | `2b4c96a0e261` | `ef4a8a37dc45` | genuinely redraws |

## Discovery is dispatch-only, not nightly

It fails on its first run, and a nightly that is red every morning teaches people to ignore it. Two crash classes in four runs, both new — filed as #343:

- **asciidoc**, 4/4 runs — renders a nested list its own parser rejects: `Cannot nest to level 2 without a parent item at level 1`
- **pdf**, 2/4 runs — `RenderingError: Failed to render PDF: ValueError`

Restore the cron once those are triaged into `KNOWN_CRASHES` with repros, which is the process `tests/unit/test_roundtrip_fuzzing.py` already documents.

## Note

Editing the `@settings` decorators changes Hypothesis's `function_digest`, so the fixed corpus is not the same set of documents it was before this PR. It still passes — but that is why the diff is not purely additive in effect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
