### PR TITLE
feat(ast): give figures a caption of their own

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,40 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Figures carry a caption: `Image.caption`.** `Image` had `url`, `alt_text`, `title`,
+  `width` and `height` and no way to record the text printed *beside* a figure, so two
+  parsers had independently worked around the gap by writing captions into `alt_text`.
+  Those are different things — alt text substitutes for an image nobody can see, a caption
+  sits next to one everybody can — and an image with both had to give one up. The field is
+  typed `str | None` to match `Table.caption` and sits in the same position on the node.
+  Formats with a native spelling now use it: AsciiDoc's block title, reStructuredText's
+  `figure` directive (an image directive is promoted when it has a caption), HTML's
+  `<figure>`/`<figcaption>`, and MediaWiki's trailing caption field. Markdown has no caption
+  syntax, so it reuses the two-part device built for table captions in
+  [#237](https://github.com/thomas-villani/all2md/issues/237) — a visible italic line plus a
+  marker comment naming it a caption — with the caption placed *below* the figure, since
+  that is where a figure's caption is conventionally set. The AsciiDoc and HTML parsers read
+  their own spelling back, so those round-trip too.
+  The PDF parser does **not** populate the field yet. Its caption detector is a regex over
+  a fixed 50pt band whose fallback accepts any capitalised text under 200 characters, and
+  on 20 cached research PDFs only 44 of the 155 strings it returned even begin with a
+  figure cue — the rest are author names, running heads and fragments of body text. Since
+  `include_image_captions` defaults to `True`, binding that output to a field the renderers
+  now print would put spurious italic caption lines under most extracted images. Routing it
+  waits on the detector work in [#338](https://github.com/thomas-villani/all2md/issues/338),
+  measured against the figure-binding oracle rather than assumed.
+  ([#338](https://github.com/thomas-villani/all2md/issues/338))
+
 ### Changed
 
+- **An HTML `<figcaption>` no longer overwrites the image's alt text** under
+  `figures_parsing="image_with_caption"`. It binds to `Image.caption`, so a figure that
+  carries both a real `alt` attribute and a caption keeps both. Previously the caption was
+  only absorbed when the image had no meaningful alt text of its own, and absorbing it
+  destroyed the alt text when it did. A caption with no image to bind to is still emitted as
+  its own paragraph rather than dropped.
 - **The born-digital lane records *why* a table region was rejected, and how many were**
   (payload schema 4). The parser distinguishes nine reasons for rejecting a table region and
   coalesces repeats of `(parser, kind, detail, severity)` while summing their counts. The

--- a/src/all2md/ast/nodes.py
+++ b/src/all2md/ast/nodes.py
@@ -1188,6 +1188,13 @@ class Image(Node):
         Optional width in pixels
     height : int or None, default = None
         Optional height in pixels
+    caption : str or None, default = None
+        Optional caption: text printed *beside* the image on the page, such as a
+        journal figure's "Figure 1. ..." line or an HTML ``<figcaption>``. Distinct
+        from ``alt_text``, which substitutes *for* the image when it cannot be seen.
+        Conflating the two loses that distinction, and two parsers had independently
+        worked around the missing field by writing captions into ``alt_text``.
+        Placed last, beside ``Table.caption``, so the two read alike. See #338.
     metadata : dict, default = empty dict
         Image metadata
     source_location : SourceLocation or None, default = None
@@ -1200,6 +1207,7 @@ class Image(Node):
     title: Optional[str] = None
     width: Optional[int] = None
     height: Optional[int] = None
+    caption: Optional[str] = None
     metadata: dict[str, Any] = field(default_factory=dict)
     source_location: Optional[SourceLocation] = None
 

--- a/src/all2md/ast/serialization.py
+++ b/src/all2md/ast/serialization.py
@@ -362,6 +362,8 @@ def _serialize_image(node: Image) -> dict[str, Any]:
         result["width"] = node.width
     if node.height:
         result["height"] = node.height
+    if node.caption:
+        result["caption"] = node.caption
     _add_metadata_and_source(result, node)
     return result
 
@@ -855,6 +857,7 @@ def _deserialize_image(data: dict[str, Any]) -> Image:
         title=data.get("title"),
         width=data.get("width"),
         height=data.get("height"),
+        caption=data.get("caption"),
         metadata=_opt(data, "metadata", {}),
         source_location=_deserialize_source_location(data.get("source_location")),
     )

--- a/src/all2md/ast/transforms.py
+++ b/src/all2md/ast/transforms.py
@@ -335,6 +335,7 @@ class NodeTransformer(NodeVisitor):
             title=node.title,
             width=node.width,
             height=node.height,
+            caption=node.caption,
             metadata=node.metadata.copy(),
             source_location=node.source_location,
         )
@@ -1060,6 +1061,7 @@ class LinkRewriter(NodeTransformer):
             title=node.title,
             width=node.width,
             height=node.height,
+            caption=node.caption,
             metadata=node.metadata.copy(),
             source_location=node.source_location,
         )

--- a/src/all2md/constants.py
+++ b/src/all2md/constants.py
@@ -402,6 +402,12 @@ DEFAULT_MARKDOWN_HTML_PASSTHROUGH_MODE: HtmlPassthroughMode = "pass-through"
 # caption text, so editing the visible line edits the caption. See #237.
 MARKDOWN_TABLE_CAPTION_MARKER = "all2md:table-caption"
 
+# The same device for figure captions (#338). The one difference is placement: a
+# table's caption is conventionally set above it and a figure's below it, so this
+# marker follows the caption paragraph rather than preceding the content. The
+# triple is therefore image-paragraph, caption-paragraph, marker.
+MARKDOWN_IMAGE_CAPTION_MARKER = "all2md:image-caption"
+
 # Boilerplate text removal patterns (used by RemoveBoilerplateTextTransform)
 DEFAULT_BOILERPLATE_PATTERNS = [
     r"^CONFIDENTIAL$",

--- a/src/all2md/parsers/asciidoc.py
+++ b/src/all2md/parsers/asciidoc.py
@@ -790,21 +790,33 @@ class AsciiDocParser(BaseParser):
             return None
         return stripped[1:].strip() or None
 
-    def _is_table_block_title(self) -> bool:
-        """Return whether the cursor sits on a `.Title` line belonging to a table.
+    def _block_title_target(self) -> str | None:
+        """Return what a `.Title` line at the cursor titles, if it titles anything.
 
-        Recognized only directly above a table, with nothing but block
-        attributes in between, so an ordinary paragraph opening with a period
-        stays a paragraph. Both ``_parse_block`` and the list-item loop have to
-        agree on this, or a caption would be swallowed as an item's text.
+        Recognized only directly above a block that can carry a caption, with
+        nothing but block attributes in between, so an ordinary paragraph opening
+        with a period stays a paragraph. Both ``_parse_block`` and the list-item
+        loop have to agree on this, or a caption would be swallowed as an item's
+        text.
+
+        Returns
+        -------
+        str or None
+            ``"table"``, ``"image"``, or None if this is not a block title
+
         """
         token = self._current_token()
         if token.type != TokenType.TEXT_LINE or not self._block_title_match(token.content):
-            return False
+            return None
         offset = 1
         while self._peek_token(offset).type == TokenType.BLOCK_ATTRIBUTE:
             offset += 1
-        return self._peek_token(offset).type == TokenType.TABLE_DELIMITER
+        following = self._peek_token(offset)
+        if following.type == TokenType.TABLE_DELIMITER:
+            return "table"
+        if following.type == TokenType.TEXT_LINE and self.image_block_pattern.match(following.content.strip()):
+            return "image"
+        return None
 
     def _parse_block(self) -> Node | list[Node] | None:
         """Parse a single block-level element.
@@ -825,9 +837,9 @@ class AsciiDocParser(BaseParser):
         # A block title -- `.My caption` on the line above a block. The renderer has
         # always emitted one for a table's caption; nothing here read it back, so the
         # caption made the trip out and not the trip in. Recognized only directly above
-        # a table, and only with the delimiter or a block attribute in between, so an
-        # ordinary paragraph opening with a period is still a paragraph.
-        if self._is_table_block_title():
+        # a block that can carry one, so an ordinary paragraph opening with a period is
+        # still a paragraph.
+        if self._block_title_target() is not None:
             self.pending_block_attrs["title"] = self._block_title_match(token.content)
             self._advance()
             return None
@@ -1047,6 +1059,13 @@ class AsciiDocParser(BaseParser):
                 break
 
         content = self._inline_from_lines(lines)
+
+        # `.Caption` above a block image is that figure's caption, the same way it is
+        # a table's. Only a lone image takes it: a title above a line that merely
+        # happens to contain an image has no unambiguous owner, and guessing one
+        # would move text the author put somewhere specific.
+        if "title" in attrs and len(content) == 1 and isinstance(content[0], Image):
+            content[0].caption = attrs["title"]
 
         # Apply metadata if present
         metadata = {}
@@ -1585,7 +1604,7 @@ class AsciiDocParser(BaseParser):
             while self._current_token().type == TokenType.TEXT_LINE and not self._is_list_continuation():
                 # A `.Caption` line directly above a table is a block title, not
                 # this item's text. Same guard `_parse_block` applies.
-                if self._is_table_block_title():
+                if self._block_title_target() is not None:
                     break
                 item_lines.append(self._advance().content)
 

--- a/src/all2md/parsers/html.py
+++ b/src/all2md/parsers/html.py
@@ -1314,13 +1314,17 @@ class HtmlToAstConverter(BaseParser):
             )
 
         if mode == "image_with_caption" and caption_text:
-            # Fold the caption into the image's alt text instead of emitting it as its own
-            # paragraph -- but only if there is an image to carry it and that image has no
-            # meaningful alt text of its own. A caption that cannot be absorbed falls
-            # through below and is emitted as a paragraph, rather than being dropped.
+            # Bind the caption to the image instead of emitting it as its own paragraph.
+            # This used to overwrite the image's alt text, which conflated two different
+            # things -- alt text stands in for an image nobody can see, a caption is
+            # printed beside one everybody can -- and meant a figure with real alt text
+            # had to choose between them. `Image.caption` ends that (#338), so the alt
+            # text is now left exactly as the page wrote it. A caption with no image to
+            # carry it still falls through below and is emitted as a paragraph, rather
+            # than being dropped.
             image = self._find_first_image(content)
-            if image is not None and (not image.alt_text or image.alt_text == "Image"):
-                image.alt_text = caption_text
+            if image is not None:
+                image.caption = caption_text
                 caption_text = None
 
         if caption_text:

--- a/src/all2md/parsers/markdown.py
+++ b/src/all2md/parsers/markdown.py
@@ -62,7 +62,7 @@ from all2md.ast import (
     Underline,
 )
 from all2md.ast.utils import extract_text
-from all2md.constants import DEPS_MARKDOWN, MARKDOWN_TABLE_CAPTION_MARKER
+from all2md.constants import DEPS_MARKDOWN, MARKDOWN_IMAGE_CAPTION_MARKER, MARKDOWN_TABLE_CAPTION_MARKER
 from all2md.converter_metadata import ConverterMetadata
 from all2md.options.markdown import MarkdownParserOptions
 from all2md.parsers.base import BaseParser
@@ -476,7 +476,7 @@ class MarkdownToAstConverter(BaseParser):
 
         # Convert tokens to AST (tokens should always be a list for our configuration)
         if isinstance(tokens, list):
-            children = self._reattach_table_captions(self._process_tokens(tokens))
+            children = self._reattach_captions(self._process_tokens(tokens))
         else:
             # Fallback for unexpected token format
             children = []
@@ -1216,15 +1216,16 @@ class MarkdownToAstConverter(BaseParser):
 
         return self._fold_underline_html(nodes)
 
-    def _reattach_table_captions(self, nodes: list[Node]) -> list[Node]:
-        """Fold ``*caption*`` + marker comment + table back into ``Table.caption``.
+    def _reattach_captions(self, nodes: list[Node]) -> list[Node]:
+        """Fold rendered caption groups back into ``Table.caption`` and ``Image.caption``.
 
         Markdown has no caption syntax, so the renderer emits the caption twice
         over: an italic paragraph a reader can see, and a marker comment that
         says the paragraph was a caption rather than prose (#237). Without the
         marker there is nothing to distinguish the two on the way back in, and a
         round trip both lost the caption *and* gained a paragraph node -- a
-        structural change, not just a missing attribute.
+        structural change, not just a missing attribute. Figures use the same
+        device with the caption below rather than above (#338).
 
         Deliberately conservative. Only the exact triple folds, and only when the
         paragraph holds a single Emphasis; a bare marker, a marker with no table
@@ -1254,7 +1255,7 @@ class MarkdownToAstConverter(BaseParser):
             for attribute in ("children", "items"):
                 container = getattr(node, attribute, None)
                 if isinstance(container, list) and container and all(isinstance(c, Node) for c in container):
-                    setattr(node, attribute, self._reattach_table_captions(container))
+                    setattr(node, attribute, self._reattach_captions(container))
 
         result: list[Node] = []
         index = 0
@@ -1267,6 +1268,15 @@ class MarkdownToAstConverter(BaseParser):
                 result.append(table)
                 index += 3
                 continue
+
+            image_caption = self._image_caption_from_triple(nodes, index)
+            if image_caption is not None:
+                image, text = image_caption
+                image.caption = text
+                result.append(nodes[index])
+                index += 3
+                continue
+
             result.append(nodes[index])
             index += 1
         return result
@@ -1288,6 +1298,46 @@ class MarkdownToAstConverter(BaseParser):
 
         text = extract_text(paragraph.content[0], joiner="").strip()
         return text or None
+
+    def _image_caption_from_triple(self, nodes: list[Node], index: int) -> tuple[Image, str] | None:
+        """Return the image and its caption if ``nodes[index:index + 3]`` is a figure triple.
+
+        The mirror of :meth:`_caption_from_triple` for figures, and deliberately
+        just as conservative. The order differs because the rendered order does:
+        a figure's caption sits *below* it, so the triple runs image, caption,
+        marker rather than caption, marker, table.
+
+        Parameters
+        ----------
+        nodes : list of Node
+            Block-level nodes, in document order
+        index : int
+            Position to test as the start of a triple
+
+        Returns
+        -------
+        tuple of (Image, str), or None
+            The image to caption and the text to give it, or None if this is not
+            a figure triple
+
+        """
+        if index + 2 >= len(nodes):
+            return None
+
+        figure, caption, comment = nodes[index], nodes[index + 1], nodes[index + 2]
+        if not (isinstance(figure, Paragraph) and isinstance(caption, Paragraph) and isinstance(comment, Comment)):
+            return None
+        if comment.content.strip() != MARKDOWN_IMAGE_CAPTION_MARKER:
+            return None
+        if len(figure.content) != 1 or not isinstance(figure.content[0], Image):
+            return None
+        if figure.content[0].caption:
+            return None
+        if len(caption.content) != 1 or not isinstance(caption.content[0], Emphasis):
+            return None
+
+        text = extract_text(caption.content[0], joiner="").strip()
+        return (figure.content[0], text) if text else None
 
     def _fold_underline_html(self, nodes: list[Node]) -> list[Node]:
         """Fold ``<u>``/``<ins>`` HTMLInline pairs back into Underline nodes.

--- a/src/all2md/renderers/asciidoc.py
+++ b/src/all2md/renderers/asciidoc.py
@@ -763,7 +763,10 @@ class AsciiDocRenderer(NodeVisitor, InlineContentMixin, BaseRenderer):
             Image to render
 
         """
-        # Block image by default
+        # Block image by default. A caption is AsciiDoc's block title, the same
+        # `.Text` line this renderer already writes above a table (#338).
+        if node.caption:
+            self._output.append(f".{node.caption}\n")
         self._output.append(f"image::{node.url}[{node.alt_text}]")
 
     def visit_line_break(self, node: LineBreak) -> None:

--- a/src/all2md/renderers/html.py
+++ b/src/all2md/renderers/html.py
@@ -800,6 +800,17 @@ hr {
             Paragraph to render
 
         """
+        # A captioned image gets the element HTML has for exactly this, which is also
+        # what our own parser reads back as a figure. It has to be decided here rather
+        # than in visit_image because <figure> is flow content and would be invalid
+        # inside the <p> that visit_image renders into (#338).
+        if len(node.content) == 1 and isinstance(node.content[0], Image) and node.content[0].caption:
+            caption = escape_html(node.content[0].caption, enabled=self.options.escape_html)
+            self._output.append(f"<figure{self._get_custom_css_class('Image')}>\n")
+            node.content[0].accept(self)
+            self._output.append(f"\n<figcaption>{caption}</figcaption>\n</figure>\n")
+            return
+
         content = self._render_inline_content(node.content)
         css_class = self._get_custom_css_class("Paragraph")
         self._output.append(f"<p{css_class}>{content}</p>\n")

--- a/src/all2md/renderers/markdown.py
+++ b/src/all2md/renderers/markdown.py
@@ -57,7 +57,7 @@ from all2md.ast.nodes import (
     Underline,
 )
 from all2md.ast.visitors import NodeVisitor
-from all2md.constants import MARKDOWN_TABLE_CAPTION_MARKER
+from all2md.constants import MARKDOWN_IMAGE_CAPTION_MARKER, MARKDOWN_TABLE_CAPTION_MARKER
 from all2md.options.markdown import MarkdownRendererOptions
 from all2md.renderers.base import BaseRenderer, InlineContentMixin
 from all2md.utils.flavors import (
@@ -628,9 +628,41 @@ class MarkdownRenderer(NodeVisitor, InlineContentMixin, BaseRenderer):
             content = content.replace("\n", "\n" + indent)
         self._output.append(f"{indent}{content}")
 
+        # A figure's caption is set below it, so it is emitted here rather than in
+        # visit_image: Image is an inline node and a caption is a block, and only
+        # the paragraph knows the image stands alone. Same two-part device as table
+        # captions -- a visible italic line plus a marker comment naming it a
+        # caption (#237, #338). A captioned image sharing its paragraph with other
+        # content has no unambiguous place to put the caption, so it keeps it in
+        # the AST and simply does not render it here.
+        image = self._sole_captioned_image(node)
+        if image is not None and image.caption:
+            self._output.append(f"\n\n{indent}*{image.caption}*")
+            if self.options.comment_mode != "ignore":
+                self._output.append(f"\n\n{indent}<!-- {MARKDOWN_IMAGE_CAPTION_MARKER} -->")
+
         # Emit block references if using after_block placement
         if self.options.link_style == "reference" and self.options.reference_link_placement == "after_block":
             self._emit_block_references()
+
+    @staticmethod
+    def _sole_captioned_image(node: Paragraph) -> Image | None:
+        """Return the paragraph's image if it is the only thing in it.
+
+        Parameters
+        ----------
+        node : Paragraph
+            Paragraph to inspect
+
+        Returns
+        -------
+        Image or None
+            The lone image, or None if the paragraph holds anything else
+
+        """
+        if len(node.content) == 1 and isinstance(node.content[0], Image):
+            return node.content[0]
+        return None
 
     def visit_code_block(self, node: CodeBlock) -> None:
         """Render a CodeBlock node.

--- a/src/all2md/renderers/mediawiki.py
+++ b/src/all2md/renderers/mediawiki.py
@@ -515,8 +515,10 @@ class MediaWikiRenderer(NodeVisitor, InlineContentMixin, BaseRenderer):
         if self.options.image_thumb:
             parts.append("thumb")
 
-            # Handle caption rendering based on mode
-            caption_text = node.title if hasattr(node, "title") and node.title else node.alt_text
+            # Handle caption rendering based on mode. A real caption wins over the
+            # two things this had to guess from before it existed (#338) -- MediaWiki's
+            # trailing field *is* a caption, so an actual one is what belongs there.
+            caption_text = node.caption or node.title or node.alt_text
 
             if self.options.image_caption_mode == "auto" and caption_text:
                 # Auto mode: render both alt attribute and caption text

--- a/src/all2md/renderers/rst.py
+++ b/src/all2md/renderers/rst.py
@@ -678,10 +678,15 @@ class RestructuredTextRenderer(NodeVisitor, InlineContentMixin, BaseRenderer):
             Image to render
 
         """
-        # RST image directive
-        self._output.append(f".. image:: {node.url}\n")
+        # RST image directive -- or `figure`, which is the same thing plus a caption.
+        # The caption is the directive's body, so it needs the blank line and the
+        # indent that separates a body from the option block above it (#338).
+        directive = "figure" if node.caption else "image"
+        self._output.append(f".. {directive}:: {node.url}\n")
         if node.alt_text:
             self._output.append(f"   :alt: {node.alt_text}\n")
+        if node.caption:
+            self._output.append(f"\n   {node.caption}\n")
 
     def visit_line_break(self, node: LineBreak) -> None:
         r"""Render a LineBreak node.

--- a/src/all2md/utils/parser_helpers.py
+++ b/src/all2md/utils/parser_helpers.py
@@ -256,7 +256,7 @@ def append_attachment_footnotes(
 
 def attachment_result_to_image_node(
     attachment_result: dict[str, Any], fallback_alt_text: str = "image"
-) -> "Node | None":
+) -> "Image | None":
     """Convert process_attachment result dict to Image AST node.
 
     This helper eliminates the need for parsers to manually parse markdown
@@ -277,7 +277,7 @@ def attachment_result_to_image_node(
 
     Returns
     -------
-    Node or None
+    Image or None
         Image AST node, or None if attachment result is empty/invalid
 
     Examples

--- a/tests/unit/formats/html/test_html_enhancements.py
+++ b/tests/unit/formats/html/test_html_enhancements.py
@@ -55,10 +55,13 @@ def test_figure_image_with_caption_rendering():
     para = doc.children[0]
     assert isinstance(para, Paragraph)
 
-    # Check for image with caption as alt text (when no alt text exists)
+    # The caption binds to the image's own caption field. It used to be written into
+    # alt text for want of anywhere else to put it; that field now exists (#338), and
+    # alt text is left as the page wrote it -- here, absent.
     image = para.content[0]
     assert isinstance(image, Image)
-    assert image.alt_text == "A beautiful photo"
+    assert image.caption == "A beautiful photo"
+    assert image.alt_text == ""
 
 
 def test_details_blockquote_rendering():

--- a/tests/unit/parsers/test_html_figure_content.py
+++ b/tests/unit/parsers/test_html_figure_content.py
@@ -197,15 +197,20 @@ class TestFiguresParsingModes:
         assert len(html_blocks) == 1
         assert "<table" in html_blocks[0].content
 
-    def test_image_with_caption_folds_caption_into_alt_text(self):
+    def test_image_with_caption_binds_the_caption_to_the_image(self):
         doc = self._parse("image_with_caption")
         images = [n for n in _walk(doc) if isinstance(n, Image)]
-        assert images[0].alt_text == "Cap"
+        assert images[0].caption == "Cap"
         # ...and the table is still not dropped
         assert [n for n in _walk(doc) if isinstance(n, Table)]
 
-    def test_image_with_caption_keeps_a_caption_it_cannot_absorb(self):
-        """If the image already has alt text, the caption has nowhere to go -- emit it."""
+    def test_a_caption_no_longer_overwrites_real_alt_text(self):
+        """Both survive now. They are different things and the figure has both (#338).
+
+        This used to be a forced choice: the caption went into ``alt_text``, so an
+        image describing itself for a screen reader had to give that up to keep the
+        text printed under it. The image had no field for the second one.
+        """
         doc = to_ast(
             b"<figure><img src='x.png' alt='real alt'><figcaption>Cap</figcaption></figure>",
             source_format="html",
@@ -213,5 +218,15 @@ class TestFiguresParsingModes:
         )
         images = [n for n in _walk(doc) if isinstance(n, Image)]
         assert images[0].alt_text == "real alt"
+        assert images[0].caption == "Cap"
+
+    def test_a_caption_with_no_image_is_still_emitted(self):
+        """A caption that has nothing to bind to must not simply vanish."""
+        doc = to_ast(
+            b"<figure><p>not an image</p><figcaption>Cap</figcaption></figure>",
+            source_format="html",
+            parser_options=HtmlOptions(figures_parsing="image_with_caption"),
+        )
+        assert not [n for n in _walk(doc) if isinstance(n, Image)]
         text = " ".join(n.content for n in _walk(doc) if hasattr(n, "content") and isinstance(n.content, str))
         assert "Cap" in text, "caption was dropped instead of being emitted as a paragraph"

--- a/tests/unit/parsers/test_image_caption.py
+++ b/tests/unit/parsers/test_image_caption.py
@@ -1,0 +1,209 @@
+#  Copyright (c) 2025 Tom Villani, Ph.D.
+"""Figures carry their caption on the node, and it survives a round trip (#338).
+
+``Image`` had ``url``, ``alt_text``, ``title``, ``width`` and ``height`` -- and no
+caption. Two parsers had independently worked around that by writing the caption
+into ``alt_text``, which conflates two different things: alt text stands in for an
+image nobody can see, a caption is text printed beside one everybody can. A figure
+that had both had to choose.
+
+``Image.caption`` ends the choice. On the way out, formats with a native spelling
+use it (AsciiDoc's block title, reST's ``figure`` directive, HTML's ``<figure>``);
+Markdown, which has none, borrows the two-part device #237 built for table
+captions -- a visible italic line plus a marker comment naming it a caption. The
+difference from tables is placement, because the typographic convention differs: a
+table's caption is set above it, a figure's below.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from all2md import to_ast
+from all2md.ast.nodes import Document, Image, Paragraph, Text
+from all2md.ast.serialization import ast_to_dict, dict_to_ast
+from all2md.constants import MARKDOWN_IMAGE_CAPTION_MARKER
+from all2md.options import MarkdownRendererOptions
+from all2md.renderers.markdown import MarkdownRenderer
+
+pytestmark = [pytest.mark.unit, pytest.mark.image]
+
+CAPTION = "Figure 1. Growth over time."
+
+
+def _figure(caption: str | None = CAPTION, alt: str = "a plot") -> Paragraph:
+    return Paragraph(content=[Image(url="fig1.png", alt_text=alt, caption=caption)])
+
+
+def _render(document: Document, **options: object) -> str:
+    return MarkdownRenderer(MarkdownRendererOptions(**options)).render_to_string(document)  # type: ignore[arg-type]
+
+
+def _images(document: Document) -> list[Image]:
+    return [
+        node
+        for child in document.children
+        if isinstance(child, Paragraph)
+        for node in child.content
+        if isinstance(node, Image)
+    ]
+
+
+class TestMarkdownRoundTrip:
+    def test_caption_survives_and_adds_no_node(self) -> None:
+        parsed = to_ast(_render(Document(children=[_figure()])).encode(), source_format="markdown")
+
+        assert [type(node).__name__ for node in parsed.children] == ["Paragraph"]
+        assert _images(parsed)[0].caption == CAPTION
+
+    def test_the_caption_does_not_displace_the_alt_text(self) -> None:
+        """The whole point of the field: a figure can have both, and keeps both."""
+        parsed = to_ast(_render(Document(children=[_figure()])).encode(), source_format="markdown")
+
+        image = _images(parsed)[0]
+        assert image.caption == CAPTION
+        assert image.alt_text == "a plot"
+
+    def test_the_caption_is_still_visible_to_a_reader(self) -> None:
+        assert f"*{CAPTION}*" in _render(Document(children=[_figure()]))
+
+    def test_rendering_is_idempotent(self) -> None:
+        once = _render(Document(children=[_figure()]))
+        twice = _render(to_ast(once.encode(), source_format="markdown"))
+        assert once == twice
+
+    def test_editing_the_visible_line_edits_the_caption(self) -> None:
+        """The marker deliberately carries no copy of the text."""
+        rendered = _render(Document(children=[_figure()])).replace(CAPTION, "Figure 1. Revised.")
+        parsed = to_ast(rendered.encode(), source_format="markdown")
+        assert _images(parsed)[0].caption == "Figure 1. Revised."
+
+    def test_an_uncaptioned_image_gains_neither_marker_nor_paragraph(self) -> None:
+        rendered = _render(Document(children=[_figure(caption=None)]))
+
+        assert MARKDOWN_IMAGE_CAPTION_MARKER not in rendered
+        parsed = to_ast(rendered.encode(), source_format="markdown")
+        assert [type(node).__name__ for node in parsed.children] == ["Paragraph"]
+        assert _images(parsed)[0].caption is None
+
+    def test_a_following_block_is_not_absorbed(self) -> None:
+        document = Document(children=[_figure(), Paragraph(content=[Text(content="Body prose.")])])
+        parsed = to_ast(_render(document).encode(), source_format="markdown")
+
+        assert [type(node).__name__ for node in parsed.children] == ["Paragraph", "Paragraph"]
+        assert _images(parsed)[0].caption == CAPTION
+
+
+class TestItIsConservative:
+    """Each of these is more likely someone's real content than a caption to rewrite."""
+
+    def test_an_italic_paragraph_after_an_image_is_left_alone(self) -> None:
+        """The control that matters: without the marker, nothing is swallowed."""
+        parsed = to_ast(b"![a](f.png)\n\n*Just some emphasis.*\n", source_format="markdown")
+
+        assert [type(node).__name__ for node in parsed.children] == ["Paragraph", "Paragraph"]
+        assert _images(parsed)[0].caption is None
+
+    def test_a_marker_with_no_image_before_it_is_left_alone(self) -> None:
+        source = f"Some prose.\n\n*Cap*\n\n<!-- {MARKDOWN_IMAGE_CAPTION_MARKER} -->\n".encode()
+        parsed = to_ast(source, source_format="markdown")
+        assert [type(node).__name__ for node in parsed.children] == ["Paragraph", "Paragraph", "Comment"]
+
+    def test_an_image_sharing_its_paragraph_is_not_captioned(self) -> None:
+        """A caption has no unambiguous owner when the paragraph holds other content."""
+        source = f"see ![a](f.png)\n\n*Cap*\n\n<!-- {MARKDOWN_IMAGE_CAPTION_MARKER} -->\n".encode()
+        parsed = to_ast(source, source_format="markdown")
+
+        assert [type(node).__name__ for node in parsed.children] == ["Paragraph", "Paragraph", "Comment"]
+        assert _images(parsed)[0].caption is None
+
+    def test_a_mixed_paragraph_is_not_treated_as_a_caption(self) -> None:
+        source = f"![a](f.png)\n\nLead in *Cap*\n\n<!-- {MARKDOWN_IMAGE_CAPTION_MARKER} -->\n".encode()
+        parsed = to_ast(source, source_format="markdown")
+        assert [type(node).__name__ for node in parsed.children] == ["Paragraph", "Paragraph", "Comment"]
+
+
+class TestCommentMode:
+    def test_ignore_suppresses_the_marker_and_says_so_by_losing_the_caption(self) -> None:
+        """``comment_mode="ignore"`` asks for no comments; the caption degrades to prose."""
+        rendered = _render(Document(children=[_figure()]), comment_mode="ignore")
+
+        assert MARKDOWN_IMAGE_CAPTION_MARKER not in rendered
+        assert f"*{CAPTION}*" in rendered
+
+        parsed = to_ast(rendered.encode(), source_format="markdown")
+        assert [type(node).__name__ for node in parsed.children] == ["Paragraph", "Paragraph"]
+        assert _images(parsed)[0].caption is None
+
+    @pytest.mark.parametrize("mode", ["html", "blockquote"])
+    def test_every_other_comment_mode_keeps_the_round_trip(self, mode: str) -> None:
+        parsed = to_ast(_render(Document(children=[_figure()]), comment_mode=mode).encode(), source_format="markdown")
+        assert _images(parsed)[0].caption == CAPTION
+
+
+class TestOtherFormats:
+    """Formats with a native caption spelling should use it rather than drop it."""
+
+    def test_asciidoc_round_trips_through_the_block_title(self) -> None:
+        from all2md.parsers.asciidoc import AsciiDocParser
+        from all2md.renderers.asciidoc import AsciiDocRenderer
+
+        document = Document(children=[_figure()])
+        rendered = AsciiDocRenderer().render_to_string(document)
+
+        assert rendered.startswith(f".{CAPTION}\n")
+        assert AsciiDocParser().parse(rendered).children == document.children
+
+    def test_a_period_leading_paragraph_is_still_a_paragraph(self) -> None:
+        """The AsciiDoc control: a block title is only a block title above a block."""
+        from all2md.parsers.asciidoc import AsciiDocParser
+
+        parsed = AsciiDocParser().parse(".Just a sentence. And another.\n")
+        assert [type(node).__name__ for node in parsed.children] == ["Paragraph"]
+        assert not _images(parsed)
+
+    def test_rst_promotes_the_image_directive_to_a_figure(self) -> None:
+        from all2md.renderers.rst import RestructuredTextRenderer
+
+        rendered = RestructuredTextRenderer().render_to_string(Document(children=[_figure()]))
+
+        assert ".. figure:: fig1.png" in rendered
+        assert f"\n\n   {CAPTION}" in rendered, "the caption must be a blank line below the options, and indented"
+
+    def test_rst_stays_an_image_directive_without_a_caption(self) -> None:
+        from all2md.renderers.rst import RestructuredTextRenderer
+
+        rendered = RestructuredTextRenderer().render_to_string(Document(children=[_figure(caption=None)]))
+        assert ".. image:: fig1.png" in rendered
+        assert "figure" not in rendered
+
+    def test_html_emits_a_figure_and_reads_it_back(self) -> None:
+        from all2md.options.html import HtmlOptions
+        from all2md.parsers.html import HtmlToAstConverter
+        from all2md.renderers.html import HtmlRenderer
+
+        rendered = HtmlRenderer().render_to_string(Document(children=[_figure()]))
+        assert "<figure" in rendered and f"<figcaption>{CAPTION}</figcaption>" in rendered
+
+        parsed = HtmlToAstConverter(HtmlOptions(figures_parsing="image_with_caption")).parse(rendered)
+        image = _images(parsed)[0]
+        assert image.caption == CAPTION
+        assert image.alt_text == "a plot"
+
+    def test_an_uncaptioned_image_is_not_wrapped_in_a_figure(self) -> None:
+        from all2md.renderers.html import HtmlRenderer
+
+        rendered = HtmlRenderer().render_to_string(Document(children=[_figure(caption=None)]))
+        assert "<figure" not in rendered
+        assert "<img" in rendered
+
+
+class TestSerialization:
+    def test_the_caption_survives_a_dict_round_trip(self) -> None:
+        """A field the serializer does not know about is a field that silently vanishes."""
+        restored = dict_to_ast(ast_to_dict(Document(children=[_figure()])))
+        assert _images(restored)[0].caption == CAPTION
+
+    def test_an_absent_caption_is_not_serialized(self) -> None:
+        payload = ast_to_dict(Document(children=[_figure(caption=None)]))
+        assert "caption" not in payload["children"][0]["content"][0]


### PR DESCRIPTION
Closes the first half of #338: figures get a caption field, and the two parsers that were writing captions into `alt_text` stop.

## The problem

`Image` had `url`, `alt_text`, `title`, `width`, `height` — and no caption. Only `Table` had one. So two parsers arrived independently at the same workaround (`parsers/pdf.py`, `parsers/html.py`): put the caption in `alt_text`.

Those are different things. Alt text substitutes *for* an image nobody can see; a caption is printed *beside* one everybody can. A figure carrying both had to give one up — and in HTML's `image_with_caption` mode it did, silently overwriting a real `alt` attribute.

## What this does

- **`Image.caption`**, typed `str | None`, positioned last-before-`metadata` to match `Table.caption` (which also shifts the fewest positional slots).
- **Native spellings where they exist** — AsciiDoc block title, reST `figure` (an `image` directive is promoted when it has a caption), HTML `<figure>`/`<figcaption>`, MediaWiki's trailing caption field.
- **Markdown reuses the #237 device**: a visible italic line plus a marker comment naming it a caption. Difference from tables is placement — a table's caption is set above it, a figure's below — so the triple is image, caption, marker.
- **AsciiDoc and HTML read their own spelling back**, so both round-trip. The AsciiDoc block-title recogniser was already there for tables and is generalised rather than copied, keeping #343's list-item guard in agreement with `_parse_block`.
- **Serialization and the two `Image`-rebuilding transforms** carry the field.

## What this deliberately does *not* do

**The PDF parser is untouched.** Its detected caption was passed as `fallback_alt_text`, which only applies when the extracted alt text is empty — and the extractor always writes an `Image from page N` placeholder, so it could never fire. No PDF caption has ever reached output.

Binding it to a field the renderers now *print* would make the detector's precision everyone's problem. Measured over 20 cached research PDFs: **155 strings returned, 44 begin with a figure cue, 111 do not** — author names, running heads, query fragments, body text with embedded newlines. `include_image_captions` defaults to `True`, so that would land under most extracted images. Routing waits on the detector work in #338, measured against the figure-binding oracle rather than assumed.

## Verification

- unit + golden: 7516 passed. integration + e2e: 1595 passed. ruff, black, mypy clean.
- **Mutation-tested**, because a passing test proves nothing until it can fail: dropping the marker emission fails 6 round-trip tests; restoring the alt-text conflation fails 4; deleting the serializer's caption line fails the round-trip test. The first attempt at that last one hit `_serialize_table`'s identical block instead and passed — worth knowing the check itself needed checking.
- **PDF output byte-compared** before/after (goldens skip on Windows): all 5 default-mode outputs identical.
- Two flakes seen under `-n 3` (`test_watch_mode_debounce_rapid_changes`, `test_a_withdrawn_article_does_not_disturb_the_others`); both pass alone and both fail-free on clean `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)