### PR TITLE
fix(benchmarks): parse third-party XML with defusedxml

### DIFF
--- a/benchmarks/corpus/download.py
+++ b/benchmarks/corpus/download.py
@@ -4,7 +4,12 @@ Each source fetches documents from a public HTTP endpoint and caches them under
 ``benchmarks/corpus/.cache/<source>/``. A per-source ``_index.json`` records what
 was fetched, so re-running ``download`` is a no-op once the cache is populated.
 
-All fetchers use stdlib only (urllib, tarfile, zipfile, xml.etree, json).
+All fetchers use stdlib only (urllib, tarfile, zipfile, json), with one exception:
+XML arrives from third-party endpoints, so it is parsed with ``defusedxml`` rather
+than ``xml.etree``. Stdlib's parser expands external entities and nested entity
+definitions, which turns a hostile or compromised feed into local file disclosure
+or a memory exhaustion. ``defusedxml`` is already a dependency of the ``all``
+extra, so this costs nothing to require here.
 """
 
 from __future__ import annotations
@@ -19,11 +24,12 @@ import time
 import urllib.error
 import urllib.parse
 import urllib.request
-import xml.etree.ElementTree as ET
 import zipfile
 from dataclasses import asdict, dataclass
 from pathlib import Path
 from typing import Any, Callable, Iterable
+
+import defusedxml.ElementTree as ET
 
 USER_AGENT = "all2md-corpus-benchmark/1.0 (mailto:thomas.villani@njii.com)"
 DEFAULT_TIMEOUT = 60

--- a/benchmarks/pmc/corpus.py
+++ b/benchmarks/pmc/corpus.py
@@ -44,7 +44,17 @@ from pathlib import Path
 from typing import Any, Callable, Iterator, Sequence
 from urllib.parse import quote
 from uuid import uuid4
-from xml.etree import ElementTree
+
+# The JATS and S3 listing payloads both come from third-party endpoints, so
+# parsing goes through defusedxml: stdlib's parser expands external entities and
+# nested entity definitions, which turns a hostile payload into local file
+# disclosure or memory exhaustion. `Element` is imported from the stdlib because
+# defusedxml does not re-export it -- it is the node type, not a parser, and
+# nothing here constructs one, it is only used in annotations.
+from xml.etree.ElementTree import Element
+
+from defusedxml import ElementTree
+from defusedxml.common import EntitiesForbidden
 
 BUCKET = "pmc-oa-opendata"
 BUCKET_BASE = f"https://{BUCKET}.s3.amazonaws.com"
@@ -721,11 +731,23 @@ def _neutralize_entities(payload: bytes) -> bytes:
     )
 
 
-def _parse_jats(payload: bytes) -> tuple[ElementTree.Element, bool]:
+def _parse_jats(payload: bytes) -> tuple[Element, bool]:
     """Parse JATS bytes, reporting whether entity neutralization was needed.
 
     Strict parsing is tried first so a well-formed article is never rewritten, and the
     fallback is counted rather than applied invisibly.
+
+    The two shapes this fallback exists for -- a reference to an entity declared in a DTD
+    the bucket does not ship, and one declared nowhere at all -- raise ``ParseError`` under
+    defusedxml exactly as they did under stdlib, so the swap does not change them.
+
+    An article that *declares* entities in an internal subset is deliberately **not**
+    neutralized.  Stdlib accepted those; defusedxml raises ``EntitiesForbidden``, and that
+    is the whole point of the swap, since a nested declaration is the entity-expansion
+    vector.  Neutralization could not rescue one anyway -- it rewrites references and
+    leaves the declaration in place, so the parse fails again.  The caller records such an
+    article as ``xml_unparsable``, which is a recorded rejection rather than a silent loss.
+    No article in the pinned corpus takes either path today.
     """
     try:
         return ElementTree.fromstring(payload), False
@@ -733,7 +755,7 @@ def _parse_jats(payload: bytes) -> tuple[ElementTree.Element, bool]:
         return ElementTree.fromstring(_neutralize_entities(payload)), True
 
 
-def _count_local(root: ElementTree.Element, tag: str) -> int:
+def _count_local(root: Element, tag: str) -> int:
     return sum(1 for element in root.iter() if _local_name(element.tag) == tag)
 
 
@@ -741,7 +763,7 @@ def _local_name(tag: Any) -> str:
     return tag.rsplit("}", 1)[-1] if isinstance(tag, str) else ""
 
 
-def _extract_licence(root: ElementTree.Element) -> str:
+def _extract_licence(root: Element) -> str:
     """Read the article licence out of the JATS itself, in decreasing order of precision."""
     for reference in root.iter(_ALI_LICENSE_REF):
         if reference.text and reference.text.strip():
@@ -1056,7 +1078,10 @@ def _evaluate_candidate(article_id: str, workspace: Path) -> tuple[ManifestArtic
         return drop("xml_missing", False)
     try:
         root, neutralized = _parse_jats(xml_bytes)
-    except ElementTree.ParseError:
+    except (ElementTree.ParseError, EntitiesForbidden):
+        # EntitiesForbidden is defusedxml refusing an internal entity declaration -- the
+        # entity-expansion vector. Recorded as a rejection like any other unparsable
+        # article rather than allowed to abort the whole walk.
         return drop("xml_unparsable", False)
     paragraphs = _count_local(root, "p")
     if paragraphs <= 0:


### PR DESCRIPTION
The part of #328 worth doing on its own merits, independent of the suppress-or-scope decision for the rest of the Semgrep findings.

## Why

Both corpus fetchers parse XML that arrives over the network from endpoints we don't control — arXiv's Atom feed and the S3 listing in `corpus/download.py`, JATS articles in `pmc/corpus.py`. Stdlib's ElementTree expands nested entity declarations.

Demonstrated rather than asserted:

| payload | stdlib | defusedxml |
|---|---|---|
| entity expansion (billion laughs) | **ACCEPTED** | rejected (`EntitiesForbidden`) |
| external entity (`file:///etc/passwd`) | rejected | rejected |

So one of the two halves is a real change and the other was already safe — worth saying, rather than claiming the whole class.

`defusedxml` is already a dependency of the `all` extra, so this costs nothing to require.

## The part that would have broken silently

`_parse_jats` falls back to neutralising entity references when a strict parse fails, so articles referencing entities from a DTD the bucket doesn't ship are kept rather than dropped — the fallback exists specifically to avoid biasing the corpus toward publishers who avoid them.

I checked each entity shape against both parsers instead of assuming the swap was a drop-in:

| shape | stdlib | defusedxml |
|---|---|---|
| undeclared reference, no DOCTYPE | `ParseError` | `ParseError` |
| external DTD, referenced entity | `ParseError` | `ParseError` |
| **internal entity declaration** | **ok** | `EntitiesForbidden` |

The two the fallback was written for are unchanged. The third is new, and it's the entity-expansion vector, so refusing it is the point.

My first fix was to catch `EntitiesForbidden` in `_parse_jats` alongside `ParseError`. That's wrong: neutralisation rewrites *references* and leaves the *declaration* in place, so the retry fails identically. The catch belongs at the caller, where the article is recorded as `xml_unparsable` — an existing per-article rejection reason. **Without it the exception escapes and aborts the whole manifest walk.**

`Element` now comes from the stdlib, since defusedxml doesn't re-export it. It's the node type, not a parser, and only appears in annotations.

## Verification

- All **132** cached JATS articles still parse; none needed neutralisation, so the fallback isn't exercised by the current corpus — which is exactly why the break would have been silent.
- Undeclared-reference fallback still routes to neutralisation and returns the article.
- The declaring case raises for the caller to record rather than crashing the walk.
- 258 corpus/benchmark tests pass. ruff, black, mypy clean on `benchmarks/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)