### PR TITLE
fix(pdf): take a figure's caption from the layout model, not a band of nearby text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,14 +23,42 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   marker comment naming it a caption — with the caption placed *below* the figure, since
   that is where a figure's caption is conventionally set. The AsciiDoc and HTML parsers read
   their own spelling back, so those round-trip too.
-  The PDF parser does **not** populate the field yet. Its caption detector is a regex over
-  a fixed 50pt band whose fallback accepts any capitalised text under 200 characters, and
-  on 20 cached research PDFs only 44 of the 155 strings it returned even begin with a
-  figure cue — the rest are author names, running heads and fragments of body text. Since
-  `include_image_captions` defaults to `True`, binding that output to a field the renderers
-  now print would put spurious italic caption lines under most extracted images. Routing it
-  waits on the detector work in [#338](https://github.com/thomas-villani/all2md/issues/338),
-  measured against the figure-binding oracle rather than assumed.
+  The PDF parser does **not** populate the field yet. Its caption detector was, at the time
+  this field landed, a regex over a fixed 50pt band whose fallback accepted any capitalised
+  text under 200 characters — on 20 cached research PDFs only 44 of the 155 strings it
+  returned even began with a figure cue. Since `include_image_captions` defaults to `True`,
+  binding that output to a field the renderers now print would have put spurious italic
+  caption lines under most extracted images. The detector has since been rebuilt on the
+  layout model's `caption` regions (see **Fixed**); routing its result into this field is
+  the remaining step, and will be graded against the figure-binding oracle rather than
+  assumed.
+  ([#338](https://github.com/thomas-villani/all2md/issues/338))
+
+### Fixed
+
+- **A PDF figure caption is now taken from the layout model's `caption` region**, not
+  guessed from a fixed band of text near the image. The old rule matched a figure cue
+  (`Figure 3`) against a 50pt band above and below the image and, failing that, accepted
+  *any* text under 200 characters beginning with a capital letter — which on a journal page
+  is a running head, an author list, or an ordinary sentence. Scored against JATS figure
+  captions over 12 PMC articles, it returned 32 strings of which 19 were captions (59%
+  precision, 50% recall). Reading the `caption` regions the layout model already predicts
+  and binding the nearest one below the figure — below rather than above, which is the
+  convention for figures and the opposite of a table's — returns 31 strings of which 27 are
+  captions (87% precision, 74% recall). Where `pymupdf-layout` is not installed the cue
+  match still applies but the catch-all fallback is gone, which trades 6 points of recall
+  for 20 of precision (79%/44%). Requiring a cue *on top of* a layout region was measured
+  and rejected: 0.9 points of precision for 8.8 of recall, because real captions do not all
+  open with the word "Figure". No output changes yet — the detector's result still reaches
+  nothing, and routing it into `Image.caption` is the next step.
+  ([#338](https://github.com/thomas-villani/all2md/issues/338))
+- **An image next to a blank line is no longer silently dropped from a PDF.** The caption
+  detector checked a text band for content *before* stripping it, so a band holding only
+  whitespace became an empty string and then raised `IndexError` on `text[0]`. Image
+  extraction wraps each image in `except Exception: continue`, so the crash never surfaced
+  as an error — it discarded the whole image, after it had been successfully decoded and
+  encoded. Measured at 1 image in 70 across 20 PMC articles, in `save` and `base64` modes
+  with `include_image_captions` left at its default of `True`.
   ([#338](https://github.com/thomas-villani/all2md/issues/338))
 
 ### Changed

--- a/src/all2md/constants.py
+++ b/src/all2md/constants.py
@@ -802,6 +802,17 @@ DEFAULT_IMAGE_QUALITY = 90  # JPEG quality (1-100)
 # tiny (≈4×10pt) decorative glyphs and signature-line slivers that DocuSign-
 # stamped PDFs scatter through the page-header strip.
 DEFAULT_MIN_IMAGE_DIMENSION = 20.0
+# How far from an image's edge a caption may sit, in points. Applies to the layout
+# model's `caption` regions and to the cue-matched text band alike; a caption further
+# away than this belongs to something else on the page.
+PDF_CAPTION_SEARCH_GAP = 80.0
+# Width of the text band searched when no layout `caption` region is available, and
+# how far it may overhang the image horizontally.
+PDF_CAPTION_BAND_HEIGHT = 50.0
+PDF_CAPTION_BAND_OVERHANG = 20.0
+# A caption is long-form prose, but not unbounded. Bounds the text handed to the cue
+# pattern so a runaway region cannot turn matching into a ReDoS surface.
+PDF_CAPTION_MAX_LENGTH = 500
 # When the layout model is available, also drop images that fall inside a
 # page-header / page-footer region (recurring logos, signature blocks).
 DEFAULT_FILTER_HEADER_FOOTER_IMAGES = True

--- a/src/all2md/parsers/_pdf_images.py
+++ b/src/all2md/parsers/_pdf_images.py
@@ -13,6 +13,12 @@ from __future__ import annotations
 import re
 from typing import TYPE_CHECKING, Any, Callable
 
+from all2md.constants import (
+    PDF_CAPTION_BAND_HEIGHT,
+    PDF_CAPTION_BAND_OVERHANG,
+    PDF_CAPTION_MAX_LENGTH,
+    PDF_CAPTION_SEARCH_GAP,
+)
 from all2md.options.pdf import PdfOptions
 from all2md.utils.attachments import generate_attachment_filename, process_attachment
 
@@ -39,55 +45,116 @@ def _bbox_in_any_region(bbox: Any, regions: list[Any], coverage: float = 0.7) ->
     return False
 
 
-def detect_image_caption(page: "pymupdf.Page", image_bbox: "pymupdf.Rect") -> str | None:
-    """Detect caption text near an image.
+#: Openings that mark a line as a figure caption rather than body text. Used only when the
+#: layout model is unavailable, where there is nothing better to go on.
+_CAPTION_CUE = re.compile(
+    r"^(Figure|Fig\.?|Image|Picture|Photo|Illustration|Scheme|Chart|Graph|Table)\s*\.?\s*(\d+|[A-Z]\b)",
+    re.IGNORECASE,
+)
 
-    Looks for text blocks immediately below or above the image
-    that might be captions (e.g., starting with "Figure", "Fig.", etc.).
+
+def _region_text(page: "pymupdf.Page", rect: Any) -> str:
+    """Return the text inside a rect as a single whitespace-collapsed line."""
+    return " ".join(page.get_textbox(rect).split())[:PDF_CAPTION_MAX_LENGTH]
+
+
+def _caption_from_layout(
+    page: "pymupdf.Page",
+    image_bbox: "pymupdf.Rect",
+    caption_regions: list[Any],
+) -> str | None:
+    """Return the text of the layout ``caption`` region bound to this image, if any.
+
+    Below beats above at equal distance, which is the convention for figures -- and the
+    opposite of a table's, whose caption is set above it. Ties are broken by distance so a
+    page with two figures does not give both the same caption.
+    """
+    import pymupdf
+
+    best: tuple[float, str] | None = None
+    for region in caption_regions:
+        rect = pymupdf.Rect(region.bbox)
+        # A caption sits under the figure it belongs to, not beside it in the next column.
+        if min(image_bbox.x1, rect.x1) - max(image_bbox.x0, rect.x0) <= 0:
+            continue
+        if rect.y0 >= image_bbox.y1 - 2:
+            gap, rank = rect.y0 - image_bbox.y1, rect.y0 - image_bbox.y1
+        elif rect.y1 <= image_bbox.y0 + 2:
+            # Ranked behind every below-candidate by adding a whole gap's worth.
+            gap = image_bbox.y0 - rect.y1
+            rank = gap + PDF_CAPTION_SEARCH_GAP
+        else:
+            continue
+        if gap > PDF_CAPTION_SEARCH_GAP:
+            continue
+        text = _region_text(page, rect)
+        if text and (best is None or rank < best[0]):
+            best = (rank, text)
+    return best[1] if best else None
+
+
+def detect_image_caption(
+    page: "pymupdf.Page",
+    image_bbox: "pymupdf.Rect",
+    caption_regions: list[Any] | None = None,
+) -> str | None:
+    """Detect the caption belonging to an image.
+
+    Prefers the layout model's ``caption`` regions, which are what the model was trained to
+    find, and falls back to matching a figure cue (``Figure 3``, ``Fig. 2b``) against a
+    fixed band above and below the image when the model is unavailable.
+
+    The fallback is deliberately narrower than the band search it replaces. That search also
+    accepted *any* text under 200 characters beginning with a capital, which on a journal
+    page means running heads, author names and ordinary sentences: measured against JATS
+    figure captions over 12 PMC articles, it returned 32 strings of which 19 were captions.
+    The rules here return 31 of which 27 are captions with the model, and 19 of which 15 are
+    with only the cue. Requiring the cue *on top of* a layout region was tried and rejected:
+    it bought 0.9 points of precision for 8.8 points of recall, because real captions do not
+    all open with the word "Figure".
 
     Parameters
     ----------
     page : PyMuPDF Page
-        PDF page containing the image
+        PDF page containing the image.
     image_bbox : PyMuPDF Rect
-        Bounding box of the image
+        Bounding box of the image.
+    caption_regions : list of LayoutPrediction or None
+        The page's layout regions labelled ``caption``. Empty or None falls back to the cue.
 
     Returns
     -------
     str or None
-        Detected caption text or None if no caption found
+        The caption text, or None when nothing near the image looks like one.
 
     """
-    # Define search region below and above image
-    caption_patterns = [
-        r"^(Figure|Fig\.?|Image|Picture|Photo|Illustration|Table)\s+\d+",
-        r"^(Figure|Fig\.?|Image|Picture|Photo|Illustration|Table)\s+[A-Z]\.",
-    ]
-
     import pymupdf
 
-    # Search below image
-    search_below = pymupdf.Rect(image_bbox.x0 - 20, image_bbox.y1, image_bbox.x1 + 20, image_bbox.y1 + 50)
+    if caption_regions:
+        found = _caption_from_layout(page, image_bbox, caption_regions)
+        if found:
+            return found
 
-    # Search above image (less common)
-    search_above = pymupdf.Rect(image_bbox.x0 - 20, image_bbox.y0 - 50, image_bbox.x1 + 20, image_bbox.y0)
-
-    for search_rect in [search_below, search_above]:
-        text = page.get_textbox(search_rect)
-        if text:
-            text = text.strip()
-            # Limit text length to prevent ReDoS attacks
-            # Captions should be short, so 500 chars is reasonable
-            if len(text) > 500:
-                text = text[:500]
-            # Check if text matches caption pattern
-            for pattern in caption_patterns:
-                if re.match(pattern, text, re.IGNORECASE):
-                    return text
-
-            # Also check for short text that might be a caption
-            if len(text) < 200 and text[0].isupper():
-                return text
+    below = pymupdf.Rect(
+        image_bbox.x0 - PDF_CAPTION_BAND_OVERHANG,
+        image_bbox.y1,
+        image_bbox.x1 + PDF_CAPTION_BAND_OVERHANG,
+        image_bbox.y1 + PDF_CAPTION_BAND_HEIGHT,
+    )
+    above = pymupdf.Rect(
+        image_bbox.x0 - PDF_CAPTION_BAND_OVERHANG,
+        image_bbox.y0 - PDF_CAPTION_BAND_HEIGHT,
+        image_bbox.x1 + PDF_CAPTION_BAND_OVERHANG,
+        image_bbox.y0,
+    )
+    for search_rect in (below, above):
+        # Truncated by _region_text before matching, so the pattern never sees an
+        # unbounded string. A whitespace-only band collapses to "" and is skipped --
+        # it used to reach `text[0]` and raise IndexError, which the caller swallowed
+        # as "skip this image", silently deleting 1 image in 70 on the PMC corpus.
+        text = _region_text(page, search_rect)
+        if text and _CAPTION_CUE.match(text):
+            return text
 
     return None
 
@@ -99,6 +166,7 @@ def extract_page_images(
     base_filename: str = "document",
     attachment_sequencer: Callable | None = None,
     excluded_regions: list[Any] | None = None,
+    caption_regions: list[Any] | None = None,
 ) -> tuple[list[dict], dict[str, str]]:
     """Extract images from a PDF page with their positions.
 
@@ -121,6 +189,9 @@ def extract_page_images(
         Regions on the page where images should be skipped (e.g. page-header
         and page-footer zones from layout analysis). An image is dropped if
         its bbox is mostly contained in any excluded region.
+    caption_regions : list of LayoutPrediction, optional
+        The page's layout regions labelled ``caption``. When absent, caption detection
+        falls back to matching a figure cue near the image.
 
     Returns
     -------
@@ -245,7 +316,7 @@ def extract_page_images(
             # Try to detect caption
             caption = None
             if options.include_image_captions:
-                caption = detect_image_caption(page, bbox)
+                caption = detect_image_caption(page, bbox, caption_regions)
 
             # Store the process_attachment result dict instead of just markdown string
             images.append({"bbox": bbox, "result": result, "caption": caption})

--- a/src/all2md/parsers/pdf.py
+++ b/src/all2md/parsers/pdf.py
@@ -2020,6 +2020,9 @@ class PdfToAstConverter(BaseParser):
                 base_filename,
                 attachment_sequencer,
                 excluded_regions=excluded_regions,
+                # The model's own caption regions beat guessing from a fixed band: 87%
+                # of what they return is a real caption against 59% for the band.
+                caption_regions=layout.get_predictions_by_label("caption") if layout else None,
             )
             self._attachment_footnotes.update(page_footnotes)
 

--- a/tests/unit/parsers/test_pdf_caption_detector.py
+++ b/tests/unit/parsers/test_pdf_caption_detector.py
@@ -1,0 +1,192 @@
+"""What `detect_image_caption` will and will not call a caption.
+
+The detector had no tests at all, which is some of how it drifted to accepting any text
+under 200 characters that began with a capital -- on a journal page that is a running head,
+an author list, or an ordinary sentence. Measured against JATS figure captions over 12 PMC
+articles it returned 32 strings of which 19 were captions; the rules here return 31 of which
+27 are, when the layout model is available.
+
+The layout tests pass regions in directly rather than running the model, so they exercise
+the binding rule on every platform -- `pymupdf-layout` is an optional extra and is not
+installed in the unit lane.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+import pytest
+
+from all2md.parsers._pdf_images import detect_image_caption
+
+pytestmark = [pytest.mark.unit, pytest.mark.pdf, pytest.mark.image]
+
+CAPTION = "Figure 1. Growth of the assay over twelve weeks."
+#: A column-spanning figure, so the fallback band is wide enough to hold CAPTION whole.
+#: A *narrower* figure clips it -- see `test_a_caption_wider_than_the_band_is_clipped`.
+IMAGE_RECT = (72.0, 120.0, 400.0, 240.0)
+
+
+@dataclass(frozen=True)
+class FakeRegion:
+    """Stands in for a `LayoutPrediction`; the detector only reads ``bbox``."""
+
+    bbox: tuple[float, float, float, float]
+
+
+def _page(tmp_path: Path, lines: dict[float, str], *, name: str = "page.pdf"):
+    """A one-page PDF with an image at IMAGE_RECT and text at the given baselines."""
+    pymupdf = pytest.importorskip("pymupdf")
+    source = pymupdf.open()
+    source_page = source.new_page()
+    source_page.draw_rect(pymupdf.Rect(0, 0, 100, 100), fill=(0.5, 0.5, 0.5))
+    pixmap = source_page.get_pixmap(dpi=36)
+    source.close()
+
+    document = pymupdf.open()
+    page = document.new_page()
+    page.insert_image(pymupdf.Rect(*IMAGE_RECT), pixmap=pixmap)
+    for baseline, text in lines.items():
+        page.insert_text((72, baseline), text, fontsize=9)
+    path = tmp_path / name
+    document.save(path)
+    document.close()
+
+    opened = pymupdf.open(path)
+    return opened, opened[0], pymupdf.Rect(*IMAGE_RECT)
+
+
+class TestTheCue:
+    """With no layout regions, only a figure cue counts."""
+
+    def test_a_cue_below_the_image_is_the_caption(self, tmp_path: Path) -> None:
+        document, page, bbox = _page(tmp_path, {250.0: CAPTION})
+        try:
+            assert detect_image_caption(page, bbox) == CAPTION
+        finally:
+            document.close()
+
+    def test_a_cue_above_the_image_is_the_caption(self, tmp_path: Path) -> None:
+        document, page, bbox = _page(tmp_path, {110.0: CAPTION})
+        try:
+            assert detect_image_caption(page, bbox) == CAPTION
+        finally:
+            document.close()
+
+    def test_ordinary_prose_below_the_image_is_not_a_caption(self, tmp_path: Path) -> None:
+        """The rule this replaces returned this string, because it is short and capitalised."""
+        document, page, bbox = _page(tmp_path, {250.0: "The assay was repeated in triplicate."})
+        try:
+            assert detect_image_caption(page, bbox) is None
+        finally:
+            document.close()
+
+    def test_a_running_head_is_not_a_caption(self, tmp_path: Path) -> None:
+        document, page, bbox = _page(tmp_path, {110.0: "APPELLETTI ET AL."})
+        try:
+            assert detect_image_caption(page, bbox) is None
+        finally:
+            document.close()
+
+    def test_text_beyond_the_band_is_not_a_caption(self, tmp_path: Path) -> None:
+        document, page, bbox = _page(tmp_path, {700.0: CAPTION})
+        try:
+            assert detect_image_caption(page, bbox) is None
+        finally:
+            document.close()
+
+    def test_a_caption_wider_than_the_band_is_clipped(self, tmp_path: Path) -> None:
+        """A known limit of the cue path, pinned rather than hidden.
+
+        The band is the image's width plus a small overhang, so a caption set to the
+        column width under a narrow figure loses its tail. The layout region does not
+        have this problem, because the model draws the box around the caption itself.
+        """
+        pymupdf = pytest.importorskip("pymupdf")
+        document, page, _ = _page(tmp_path, {250.0: CAPTION}, name="narrow.pdf")
+        try:
+            narrow = pymupdf.Rect(72.0, 120.0, 220.0, 240.0)
+            clipped = detect_image_caption(page, narrow)
+            assert clipped is not None
+            assert CAPTION.startswith(clipped)
+            assert clipped != CAPTION
+
+            region = [FakeRegion((72.0, 244.0, 400.0, 256.0))]
+            assert detect_image_caption(page, narrow, region) == CAPTION
+        finally:
+            document.close()
+
+    def test_an_empty_band_yields_no_caption_rather_than_crashing(self, tmp_path: Path) -> None:
+        """A whitespace-only band used to reach ``text[0]`` and raise IndexError.
+
+        The caller wraps image extraction in ``except Exception: continue``, so the crash
+        did not surface -- it silently dropped the whole image, 1 in 70 on the PMC corpus.
+        """
+        document, page, bbox = _page(tmp_path, {250.0: "   "})
+        try:
+            assert detect_image_caption(page, bbox) is None
+        finally:
+            document.close()
+
+
+class TestTheLayoutRegion:
+    """A `caption` region beats the cue, and is not required to carry one."""
+
+    def test_a_caption_region_below_the_image_wins(self, tmp_path: Path) -> None:
+        document, page, bbox = _page(tmp_path, {250.0: "Growth over twelve weeks, by cohort."})
+        try:
+            regions = [FakeRegion((72.0, 244.0, 320.0, 256.0))]
+            # No figure cue anywhere: the cue-only path returns nothing here, so this
+            # asserts the region is what recovered it.
+            assert detect_image_caption(page, bbox) is None
+            assert detect_image_caption(page, bbox, regions) == "Growth over twelve weeks, by cohort."
+        finally:
+            document.close()
+
+    def test_a_region_in_the_next_column_is_not_this_figures_caption(self, tmp_path: Path) -> None:
+        document, page, bbox = _page(tmp_path, {250.0: CAPTION})
+        try:
+            regions = [FakeRegion((420.0, 244.0, 560.0, 256.0))]
+            assert detect_image_caption(page, bbox, regions) == CAPTION  # falls back to the cue
+        finally:
+            document.close()
+
+    def test_a_distant_region_is_not_this_figures_caption(self, tmp_path: Path) -> None:
+        document, page, bbox = _page(tmp_path, {600.0: "Growth over twelve weeks, by cohort."})
+        try:
+            regions = [FakeRegion((72.0, 594.0, 320.0, 606.0))]
+            assert detect_image_caption(page, bbox, regions) is None
+        finally:
+            document.close()
+
+    def test_the_nearer_region_wins_when_two_are_in_range(self, tmp_path: Path) -> None:
+        document, page, bbox = _page(tmp_path, {250.0: "Nearest below.", 290.0: "Further below."})
+        try:
+            regions = [
+                FakeRegion((72.0, 284.0, 320.0, 296.0)),
+                FakeRegion((72.0, 244.0, 320.0, 256.0)),
+            ]
+            assert detect_image_caption(page, bbox, regions) == "Nearest below."
+        finally:
+            document.close()
+
+    def test_below_beats_above_at_equal_distance(self, tmp_path: Path) -> None:
+        """A figure's caption is set below it; a table's above. This is the figure rule."""
+        document, page, bbox = _page(tmp_path, {110.0: "Above the figure.", 250.0: "Below the figure."})
+        try:
+            regions = [
+                FakeRegion((72.0, 104.0, 320.0, 116.0)),
+                FakeRegion((72.0, 244.0, 320.0, 256.0)),
+            ]
+            assert detect_image_caption(page, bbox, regions) == "Below the figure."
+        finally:
+            document.close()
+
+    def test_an_empty_region_falls_through_to_the_cue(self, tmp_path: Path) -> None:
+        document, page, bbox = _page(tmp_path, {250.0: CAPTION})
+        try:
+            regions = [FakeRegion((400.0, 400.0, 500.0, 420.0))]
+            assert detect_image_caption(page, bbox, regions) == CAPTION
+        finally:
+            document.close()


### PR DESCRIPTION
Step 3 of #338: fix the caption detector's precision *before* routing its output into `Image.caption`.

## Why this is the order

`Image.caption` shipped in #345 with the PDF parser deliberately left unwired. The reason was a measurement: `include_image_captions` defaults to `True`, and routing a detector this imprecise into a field the renderers now *print* would put spurious italic caption lines under most extracted images. Fixing the detector is a precondition for the routing, not a follow-up to it.

## What the detector did

It matched a figure cue (`Figure 3`) against a fixed 50pt band above and below the image and, failing that, accepted **any** text under 200 characters beginning with a capital letter. On a journal page that clause matches running heads, author lists and ordinary sentences.

## Measurement

Scored against JATS `<fig>` captions over 12 PMC articles, using the same n-gram containment rule at the same threshold the figure-binding oracle uses — so "matched here" and "bound there" mean the same thing.

| rule | precision | recall |
|---|---|---|
| current (band + "capitalised, <200 chars") | 59.4% | 50.0% |
| **layout `caption` region** | **87.1%** | **73.5%** |
| cue only, no layout — the no-extra path | 78.9% | 44.1% |
| cue required *on top of* a layout region | 88.0% | 64.7% |

The `caption` label was the obvious thing to reach for: the layout-label inventory measured 45 predictions across 111 pages at a 96% block-match rate, and **nothing in the parser read them**.

Two alternatives measured and rejected:

- **Cue on top of layout** — buys 0.9 points of precision for 8.8 of recall. Real captions do not all open with the word "Figure".
- **Cue as a fallback when layout finds nothing near an image** — byte-identical to layout alone. The cue rule never fires where the model is silent, so chaining them costs nothing and adds nothing; it survives only because it *is* the whole rule when `pymupdf-layout` isn't installed, which `layout_analysis_mode="auto"` makes a real configuration.

## The crash it also fixes

`detect_image_caption` tested a band for content *before* stripping it, so a whitespace-only band became `""` and then raised `IndexError` on `text[0]`. `extract_page_images` wraps each image in `except Exception: continue` — so this never surfaced as an error. It **discarded the whole image**, after it had been decoded and encoded. Measured at 1 image in 70 across 20 PMC articles, in `save`/`base64` mode at the default `include_image_captions=True`.

## Verification

- **No output change.** The detector's result is still discarded downstream (`parser_helpers.py:313` is `match.group(1) or fallback_alt_text`, and the placeholder alt text guarantees `group(1)` is never empty). Converting both PDF fixtures in `alt_text` and `base64` gives byte-identical output before and after.
- **The tests can fail.** The function had **no tests at all**. 13 now cover it; 10 fail against the old code, and the 3 that pass are the cue behaviours this preserves.
- `tests/unit` (pdf/image), `tests/golden` and `tests/integration` green locally; mypy, ruff and black clean. PDF goldens skip on Windows, hence the byte-comparison above.

## What this does not do

The figure-binding oracle will **not** move on this PR — it measures `Image.caption`, which the PDF parser still does not populate. Baseline recorded on current `main` for comparison when routing lands: 64 ground-truth figures, **0 bound**, 0 misfiled, 55 caption texts present (86%), 106 images emitted, 0 carrying a caption.

Refs #338

🤖 Generated with [Claude Code](https://claude.com/claude-code)