### PR TITLE
test(fuzz): teach the generative strategies to build definition lists

### DIFF
--- a/tests/document_strategies.py
+++ b/tests/document_strategies.py
@@ -47,6 +47,9 @@ from all2md.ast.nodes import (
     BlockQuote,
     Code,
     CodeBlock,
+    DefinitionDescription,
+    DefinitionList,
+    DefinitionTerm,
     Document,
     Emphasis,
     FootnoteDefinition,
@@ -370,3 +373,84 @@ def documents_with_footnotes(draw: st.DrawFn, min_notes: int = 1, max_notes: int
 
     definitions = [draw(footnote_definitions(identifier)) for identifier in identifiers]
     return Document(children=[*body, *definitions])
+
+
+def definition_terms() -> st.SearchStrategy[DefinitionTerm]:
+    """Return a strategy for one term of a definition list.
+
+    A term is inline content on a single line in every target spelling, so it is
+    built from text rather than from blocks.
+    """
+    return st.builds(
+        DefinitionTerm,
+        content=st.lists(st.builds(Text, content=safe_words()), min_size=1, max_size=1),
+    )
+
+
+def definition_descriptions(max_paragraphs: int = 2) -> st.SearchStrategy[DefinitionDescription]:
+    """Return a strategy for one description of a definition list.
+
+    A description holds *blocks*, and generating more than one paragraph matters
+    for the same reason it does for footnotes: a multi-paragraph body is the
+    shape that collapses, and a strategy that only builds single-paragraph
+    descriptions cannot see that class of bug.
+
+    The paragraphs hold plain text rather than arbitrary inline content, so that
+    a failure here is attributable to definition lists. Drawing full
+    :func:`paragraphs` instead finds real bugs, but they are inline bugs: the
+    first run of this strategy crashed the AsciiDoc round trip on a nested
+    ``Strong`` wrapping a hard break, which reproduces from a bare paragraph
+    with no definition list anywhere near it. That belongs to the inline gates,
+    not to this one -- an allowlist entry blaming definition lists for it would
+    be a false attribution, and the reason string would send the next reader to
+    the wrong parser.
+    """
+    return st.builds(
+        DefinitionDescription,
+        content=st.lists(
+            st.builds(Paragraph, content=st.lists(st.builds(Text, content=safe_words()), min_size=1, max_size=1)),
+            min_size=1,
+            max_size=max_paragraphs,
+        ),
+    )
+
+
+@st.composite
+def definition_lists(draw: st.DrawFn, min_items: int = 1, max_items: int = 3) -> DefinitionList:
+    """Return a strategy for a definition list.
+
+    ``DefinitionList.items`` is a list of ``(term, [description, ...])`` tuples
+    rather than a flat child list, so it is built explicitly -- ``st.builds``
+    cannot infer that shape and a flat list of nodes would not type-check
+    against it.
+
+    A term is given one or two descriptions. Two matters: several formats spell
+    the second description by repeating the marker rather than nesting it, and a
+    term that only ever has one description never exercises that path.
+    """
+    count = draw(st.integers(min_value=min_items, max_value=max_items))
+    items = [
+        (
+            draw(definition_terms()),
+            draw(st.lists(definition_descriptions(), min_size=1, max_size=2)),
+        )
+        for _ in range(count)
+    ]
+    return DefinitionList(items=items)
+
+
+@st.composite
+def documents_with_definition_lists(draw: st.DrawFn) -> Document:
+    """Return a strategy for documents containing a definition list.
+
+    A paragraph precedes the list, because a definition list is the one block
+    here whose opening line is ordinary text: several formats mark a term only
+    by what follows it, so a list that starts the document cannot show whether
+    the preceding block was absorbed into the first term.
+    """
+    return Document(
+        children=[
+            Paragraph(content=[Text(content=draw(safe_words()))]),
+            draw(definition_lists()),
+        ]
+    )

--- a/tests/unit/test_roundtrip_fuzzing.py
+++ b/tests/unit/test_roundtrip_fuzzing.py
@@ -19,7 +19,7 @@ format. ``tests/document_strategies.py`` builds those documents.
 How the gates work
 ------------------
 
-Four gates, in increasing tightness:
+Five gates, in increasing tightness:
 
 ``test_ast_round_trip_is_lossless``
     The ``ast`` format must score exactly 100 on every generated document. This
@@ -48,6 +48,19 @@ Four gates, in increasing tightness:
     which is why "expand the fuzz tests" was answered with more coverage rather
     than more examples.
 
+``test_definition_lists_survive``
+    The second such gate, covering ``DefinitionList``/``Term``/``Description``.
+    It runs only over the five formats whose *parser* can build a definition
+    list: sixteen renderers emit one, and a round trip through the other eleven
+    would fill the allowlist with entries saying nothing but "this format has no
+    syntax we read back".
+
+    Its descriptions hold plain text rather than arbitrary inline content, on
+    purpose. Drawing full paragraphs found a real crash on the first run --- and
+    the crash was an inline defect (#353) reachable from a bare paragraph, which
+    an entry in this gate's allowlist would have misattributed to definition
+    lists. A gate should fail for the reason it is named after.
+
 Adding to the allowlists
 ------------------------
 
@@ -61,12 +74,22 @@ import io
 import os
 
 import pytest
-from document_strategies import documents, documents_of, documents_with_footnotes, lists, tables
+from document_strategies import (
+    documents,
+    documents_of,
+    documents_with_definition_lists,
+    documents_with_footnotes,
+    lists,
+    tables,
+)
 from hypothesis import HealthCheck, given, settings
 
 from all2md import from_ast, roundtrip_report, roundtrippable_formats, to_ast
 from all2md.ast.nodes import (
     CodeBlock,
+    DefinitionDescription,
+    DefinitionList,
+    DefinitionTerm,
     Document,
     FootnoteDefinition,
     FootnoteReference,
@@ -377,8 +400,19 @@ def _round_trip(doc: Document, fmt: str) -> Document:
 
 
 def _collect(node: object, cls: type, found: list | None = None) -> list:
-    """Return every descendant of ``node`` that is an instance of ``cls``."""
+    """Return every descendant of ``node`` that is an instance of ``cls``.
+
+    Tuples and lists inside a child attribute are walked through rather than
+    treated as leaves. ``DefinitionList.items`` is a list of
+    ``(term, [description, ...])`` tuples, and without this a search for a
+    `DefinitionTerm` finds nothing at all -- which made the first version of the
+    definition-list gate compare 0 against 0 and pass while measuring nothing.
+    """
     found = [] if found is None else found
+    if isinstance(node, (tuple, list)):
+        for element in node:
+            _collect(element, cls, found)
+        return found
     if isinstance(node, cls):
         found.append(node)
     for attr in ("children", "content", "items", "rows", "cells"):
@@ -681,6 +715,101 @@ class TestGeneratedFootnotes:
 
         @settings(deadline=None, max_examples=25, suppress_health_check=[HealthCheck.too_slow])
         @given(documents_with_footnotes())
+        def property_holds(doc: Document) -> None:
+            assert measure(_round_trip(doc, fmt)) == measure(doc)
+
+        property_holds()
+
+
+def _definition_shape(doc: Document) -> tuple[int, int, int]:
+    """Return ``(lists, terms, descriptions)`` in *doc*."""
+    return (
+        len(_collect(doc, DefinitionList)),
+        len(_collect(doc, DefinitionTerm)),
+        len(_collect(doc, DefinitionDescription)),
+    )
+
+
+def _description_paragraphs(doc: Document) -> int:
+    """Return the total number of paragraphs across every description."""
+    return sum(len(_collect(description, Paragraph)) for description in _collect(doc, DefinitionDescription))
+
+
+#: Formats the definition-list gate covers: the ones whose *parser* can produce a
+#: `DefinitionList` at all. Sixteen renderers emit one, but only five read one
+#: back, and a round trip through the other eleven measures a documented absence
+#: rather than a defect -- it would fill the allowlist with entries that say
+#: nothing except "this format has no definition-list syntax we parse".
+DEFINITION_FORMATS = ("ast", "markdown", "html", "rst", "org", "asciidoc")
+
+#: Known definition-list round-trip gaps, keyed by ``(format, property)``. Same
+#: ratchet as the other allowlists here: fixing one makes its test XPASS, which
+#: fails CI until the entry is deleted.
+#: Markdown and HTML round-trip all three shapes here correctly, so none of these
+#: is a spec ambiguity about what a definition list means -- two formats get it
+#: right and three do not.
+KNOWN_DEFINITION_GAPS: dict[tuple[str, str], str] = {
+    ("asciidoc", "shape"): (
+        "The AsciiDoc parser drops every description and splits one list into one list per "
+        "term. `t::\\ndesc` comes back as a DefinitionTerm with no DefinitionDescription, the "
+        "description text becoming a sibling paragraph, and an N-term list comes back as N "
+        "single-term lists. The text survives; the binding between term and description does "
+        "not. See #351."
+    ),
+    ("asciidoc", "description_paragraphs"): (
+        "Follows from the same defect as ('asciidoc', 'shape'): with no DefinitionDescription "
+        "surviving the trip there is nothing left to count paragraphs inside. See #351."
+    ),
+    ("rst", "shape"): (
+        "The reStructuredText renderer emits a term's several descriptions as consecutive "
+        "indented lines with nothing between them, so they parse back as one description. "
+        "See #352."
+    ),
+    ("rst", "description_paragraphs"): (
+        "The reStructuredText renderer concatenates a description's paragraphs with no "
+        "separator at all -- two paragraphs 'alpha' and 'beta' render as 'alphabeta', which "
+        "fuses a word boundary rather than merely losing a break. See #352."
+    ),
+    ("org", "shape"): (
+        "Same defect as ('rst', 'shape') in the Org renderer: a term's several descriptions "
+        "are emitted as continuation lines and parse back as one. See #352."
+    ),
+    ("org", "description_paragraphs"): (
+        "Same defect as ('rst', 'description_paragraphs') in the Org renderer: a description's "
+        "paragraphs are concatenated with no separator, fusing the words either side. See #352."
+    ),
+}
+
+DEFINITION_PROPERTIES = {
+    "shape": _definition_shape,
+    "description_paragraphs": _description_paragraphs,
+}
+
+
+def _definition_params() -> list:
+    """Build one parametrization per (format, property), xfailing known gaps."""
+    params = []
+    for fmt in DEFINITION_FORMATS:
+        for name in DEFINITION_PROPERTIES:
+            reason = KNOWN_DEFINITION_GAPS.get((fmt, name))
+            marks = [pytest.mark.xfail(strict=True, reason=reason)] if reason else []
+            params.append(pytest.param(fmt, name, id=f"{fmt}-{name}", marks=marks))
+    return params
+
+
+@pytest.mark.unit
+@pytest.mark.generative
+@pytest.mark.fuzzing
+class TestGeneratedDefinitionLists:
+    """Definition lists survive a round trip, or the gap is written down and attributed."""
+
+    @pytest.mark.parametrize(("fmt", "prop"), _definition_params())
+    def test_definition_lists_survive(self, fmt: str, prop: str) -> None:
+        """Property: a document's definition lists come back with the same shape."""
+        measure = DEFINITION_PROPERTIES[prop]
+
+        @settings(deadline=None, max_examples=25, suppress_health_check=[HealthCheck.too_slow])
+        @given(documents_with_definition_lists())
         def property_holds(doc: Document) -> None:
             assert measure(_round_trip(doc, fmt)) == measure(doc)
 


### PR DESCRIPTION
Second node-type group after footnotes (#348), same shape: widen the *strategy*, add a gate with a strict-xfail allowlist, attribute every gap to the side of the trip that caused it.

## The gate's own instrument was broken first

`_collect` walked a node's `items` but treated a tuple inside it as a leaf. `DefinitionList.items` is a list of `(term, [description, ...])` tuples, so the helper could not see a `DefinitionTerm` or a `DefinitionDescription` **at all** — it only ever counted the `DefinitionList` itself.

That made the `description_paragraphs` leg compare `0 == 0` and pass while measuring nothing. Fixing the walk turned **1 failure into 6**: the vacuous helper was hiding five real defects. Verified non-vacuous before trusting any result — a 3-term list now measures `(1, 3, 3)` and 3 description paragraphs, where it previously measured `(1, 0, 0)` and 0.

## Three defects, six allowlist entries

None is a spec ambiguity: **markdown and html round-trip all three shapes correctly.**

| defect | formats | issue |
|---|---|---|
| every description dropped; N-term list → N single-term lists | asciidoc | #351 |
| description paragraphs concatenated with **no separator** — `alpha`+`beta` → `alphabeta` | rst, org | #352 |
| a term's several descriptions collapse into one | rst, org | #352 |

The middle one is content corruption rather than structure loss: it destroys a word boundary, so the text that comes back is not the text that went in. The AsciiDoc one keeps the text (it reappears as a sibling paragraph) but loses the term↔description binding, which is the entire point of the node.

## Scope choice: descriptions hold plain text

Drawing full `paragraphs()` into descriptions found a **real crash** on the first run — but it was an inline defect reachable from a bare paragraph with no definition list anywhere near it:

```python
Document([Paragraph([Strong([Strong([LineBreak(soft=False)])])])])
  → asciidoc: '** +\n**'
  → ValueError: Cannot nest to level 2 without a parent item at level 1
```

`** ` at line start is an AsciiDoc level-2 list marker. Filed separately as **#353** with the full repro, including the nastier single-asterisk variant that does *not* crash and instead silently turns emphasis into a list item.

Putting that in `KNOWN_DEFINITION_GAPS` would have been a false attribution — the reason string would send the next reader to the wrong parser, which is exactly the failure mode recorded from the earlier fuzz batch. So the strategy is narrowed and the crash is tracked where it belongs. A gate should fail for the reason it is named after.

## Remaining coverage

Node types the strategies still cannot build: `Comment`, `CommentInline`, `HTMLBlock`, `HTMLInline`, `Mark`, `MathBlock`, `MathInline`, `Subscript`, `Superscript`, `Underline`.

Refs #351, #352, #353

🤖 Generated with [Claude Code](https://claude.com/claude-code)