### PR TITLE
fix(pptx): recurse into grouped shapes and wire run hyperlinks into output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **PPTX run hyperlinks are no longer discarded.** `_process_paragraph_runs_to_inline` built
+  a `Link` node for every hyperlinked run into a local `result` list, but both of the
+  function's exit paths returned `inline_nodes` (the output of `group_and_format_runs`,
+  which never captures hyperlinks) instead — the hyperlink loop was dead code, so every
+  PPTX hyperlink's URL was silently dropped and only the anchor text survived. Runs are now
+  split into consecutive stretches by hyperlink address; each stretch is formatted
+  independently (so bold/italic inside a link's text still applies) and hyperlinked
+  stretches are wrapped in a `Link` node, preserving run order relative to surrounding plain
+  text.
 - **PPTX grouped shapes no longer drop all of their contents.** `_process_shape_to_ast`
   handled text frames, tables, images, and charts and then fell through to `None` for
   everything else. A `GroupShape` has none of those attributes itself — its content lives

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **PPTX grouped shapes no longer drop all of their contents.** `_process_shape_to_ast`
+  handled text frames, tables, images, and charts and then fell through to `None` for
+  everything else. A `GroupShape` has none of those attributes itself — its content lives
+  entirely in its member shapes — so slides with a grouped diagram, SmartArt-converted
+  shapes, or manually grouped callouts (all extremely common in real decks) lost that
+  content with no warning and no degraded-content signal. The parser now recurses into
+  `shape.shapes` for any `GroupShape`, in document order, and handles groups nested inside
+  groups.
 - **A PDF figure caption is now taken from the layout model's `caption` region**, not
   guessed from a fixed band of text near the image. The old rule matched a figure cue
   (`Figure 3`) against a 50pt band above and below the image and, failing that, accepted

--- a/src/all2md/parsers/pptx.py
+++ b/src/all2md/parsers/pptx.py
@@ -905,43 +905,51 @@ class PptxToAstConverter(BaseParser):
             lambda nodes: Underline(content=nodes),  # Index 5 - applied first (innermost)
         )
 
-        # Process runs with formatting
-        inline_nodes = group_and_format_runs(
-            runs=paragraph.runs,
-            text_extractor=text_extractor,
-            format_extractor=format_extractor,
-            format_builders=format_builders,
-        )
+        def format_run_segment(runs_segment: list[Any]) -> list[Node]:
+            return group_and_format_runs(
+                runs=runs_segment,
+                text_extractor=text_extractor,
+                format_extractor=format_extractor,
+                format_builders=format_builders,
+            )
 
-        # Post-process to extract hyperlinks
-        # PPTX hyperlinks are on runs, not separate nodes
+        # PPTX hyperlinks live on individual runs rather than as separate
+        # inline nodes, so split the paragraph's runs into consecutive
+        # stretches that share the same hyperlink address (None meaning "no
+        # link"). Each stretch is formatted independently via
+        # group_and_format_runs so bold/italic/etc. inside a link's text is
+        # preserved, and hyperlinked stretches are wrapped in a Link node.
+        # Run order (and therefore the order links appear relative to plain
+        # text) is preserved throughout.
         result: list[Node] = []
+        segment: list[Any] = []
+        segment_url: str | None = None
+
+        def flush_segment() -> None:
+            nonlocal segment
+            if not segment:
+                return
+            formatted = format_run_segment(segment)
+            if formatted:
+                if segment_url:
+                    result.append(Link(url=segment_url, content=cast(list[Node], formatted)))
+                else:
+                    result.extend(formatted)
+            segment = []
+
         for run in paragraph.runs:
-            # Check if this run has a hyperlink
+            run_url: str | None = None
             if hasattr(run, "hyperlink") and run.hyperlink and hasattr(run.hyperlink, "address"):
-                hyperlink_url = run.hyperlink.address
-                if hyperlink_url:
-                    # Find the corresponding text node(s) for this run
-                    # For simplicity, wrap the run's text in a Link node
-                    run_text = run.text.strip() if run.text else ""
-                    if run_text:
-                        # Create link with the formatted content
-                        link_content = [Text(content=run_text)]
-                        result.append(Link(url=hyperlink_url, content=cast(list[Node], link_content)))
-                        continue
+                run_url = run.hyperlink.address or None
 
-            # No hyperlink - use the nodes from group_and_format_runs
-            # Note: This is a simplified approach - ideally we'd match runs to nodes
-            # For now, if there are no hyperlinks in any runs, just return inline_nodes
+            if run_url != segment_url:
+                flush_segment()
+                segment_url = run_url
+            segment.append(run)
 
-        # If no hyperlinks were found, return the formatted nodes as-is
-        if not result:
-            return inline_nodes
+        flush_segment()
 
-        # Otherwise, we have a mix - this is complex, so for now just return inline_nodes
-        # and log that hyperlinks might not be fully integrated with formatting
-        # A full solution would require matching runs to nodes in group_and_format_runs result
-        return inline_nodes
+        return result
 
     def _process_table_to_ast(self, table: Any) -> AstTable | None:
         """Process a PPTX table to AST Table node.

--- a/src/all2md/parsers/pptx.py
+++ b/src/all2md/parsers/pptx.py
@@ -324,6 +324,24 @@ class PptxToAstConverter(BaseParser):
         if isinstance(shape, GraphicFrame) and hasattr(shape, "has_chart") and shape.has_chart:
             return self._process_chart_to_ast(shape.chart)
 
+        from pptx.shapes.group import GroupShape
+
+        if isinstance(shape, GroupShape):
+            # Grouped shapes (e.g. SmartArt-converted diagrams or manually grouped
+            # callouts) contain no text/table/image/chart of their own - their
+            # content lives entirely in the member shapes. Recurse into them in
+            # document order so nested text, tables, and images are not silently
+            # dropped. Nested groups are handled by the recursive call itself.
+            group_nodes: list[Node] = []
+            for member_shape in shape.shapes:
+                member_nodes = self._process_shape_to_ast(member_shape)
+                if member_nodes:
+                    if isinstance(member_nodes, list):
+                        group_nodes.extend(member_nodes)
+                    else:
+                        group_nodes.append(member_nodes)
+            return group_nodes
+
         # For other shapes, skip or handle as needed
         return None
 

--- a/src/all2md/parsers/pptx.py
+++ b/src/all2md/parsers/pptx.py
@@ -920,21 +920,32 @@ class PptxToAstConverter(BaseParser):
         # group_and_format_runs so bold/italic/etc. inside a link's text is
         # preserved, and hyperlinked stretches are wrapped in a Link node.
         # Run order (and therefore the order links appear relative to plain
-        # text) is preserved throughout.
+        # text) is preserved throughout. group_and_format_runs strips each
+        # group's edges, so whitespace at a segment boundary ("...to " before
+        # a linked run) must be re-emitted here or adjacent words fuse.
         result: list[Node] = []
         segment: list[Any] = []
         segment_url: str | None = None
+        pending_space = False
 
         def flush_segment() -> None:
-            nonlocal segment
+            nonlocal segment, pending_space
             if not segment:
                 return
+            raw = "".join(run.text or "" for run in segment)
             formatted = format_run_segment(segment)
             if formatted:
+                if result and (pending_space or raw[:1].isspace()):
+                    result.append(Text(content=" "))
                 if segment_url:
                     result.append(Link(url=segment_url, content=cast(list[Node], formatted)))
                 else:
                     result.extend(formatted)
+                pending_space = raw[-1:].isspace()
+            elif raw and result:
+                # Whitespace-only segment between content-bearing segments:
+                # keep a single separating space.
+                pending_space = True
             segment = []
 
         for run in paragraph.runs:

--- a/tests/golden/__snapshots__/test_other_formats_golden.ambr
+++ b/tests/golden/__snapshots__/test_other_formats_golden.ambr
@@ -137,7 +137,7 @@
   * And the second
   * Third
   * And back out
-  * Here’s a hyperlink to http://www.example.com
+  * Here’s a hyperlink to [http://www.example.com](http://www.example.com/)
   
   ---
   

--- a/tests/unit/parsers/test_pptx_parser.py
+++ b/tests/unit/parsers/test_pptx_parser.py
@@ -1734,6 +1734,7 @@ class TestHyperlinkExtraction:
         assert len(strong_nodes) == 1
         assert strong_nodes[0].content[0].content == "Click here"
 
-        # Surrounding plain text must remain intact and in order.
+        # Surrounding plain text must remain intact and in order, with the
+        # run-boundary whitespace preserved so words do not fuse around the link.
         texts = [node.content for node in extract_nodes(ast_doc, Text)]
-        assert texts == ["Before", "Click here", "after"]
+        assert texts == ["Before", " ", "Click here", " ", "after"]

--- a/tests/unit/parsers/test_pptx_parser.py
+++ b/tests/unit/parsers/test_pptx_parser.py
@@ -1692,13 +1692,48 @@ class TestHyperlinkExtraction:
         converter = PptxToAstConverter()
         ast_doc = converter.convert_to_ast(prs)
 
-        # Note: Current implementation may not fully integrate hyperlinks with formatting
-        # This test verifies the parser handles hyperlinks when present
-        # Full integration would require matching runs to formatted nodes
         assert isinstance(ast_doc, Document)
 
-        # Try to find link nodes (may or may not be present depending on implementation)
         links = list(extract_nodes(ast_doc, Link))
-        # If links are extracted, verify URL
-        if links:
-            assert links[0].url == "https://www.example.com"
+        assert len(links) == 1
+        assert links[0].url == "https://www.example.com"
+        link_text = "".join(node.content for node in extract_nodes(links[0], Text))
+        assert link_text == "Click here"
+
+    def test_hyperlink_with_surrounding_text_and_formatting(self) -> None:
+        """Hyperlinked run mixed with plain runs keeps the URL, surrounding text, and inner formatting."""
+        prs = Presentation()
+        layout = prs.slide_layouts[6]
+        slide = prs.slides.add_slide(layout)
+
+        textbox = slide.shapes.add_textbox(Inches(1), Inches(1), Inches(5), Inches(1))
+        tf = textbox.text_frame
+        p = tf.paragraphs[0]
+
+        before_run = p.add_run()
+        before_run.text = "Before "
+
+        link_run = p.add_run()
+        link_run.text = "Click here"
+        link_run.hyperlink.address = "https://www.example.com"
+        link_run.font.bold = True
+
+        after_run = p.add_run()
+        after_run.text = " after"
+
+        converter = PptxToAstConverter()
+        ast_doc = converter.convert_to_ast(prs)
+
+        # The URL must survive.
+        links = list(extract_nodes(ast_doc, Link))
+        assert len(links) == 1
+        assert links[0].url == "https://www.example.com"
+
+        # Bold formatting inside the link text must survive.
+        strong_nodes = list(extract_nodes(links[0], Strong))
+        assert len(strong_nodes) == 1
+        assert strong_nodes[0].content[0].content == "Click here"
+
+        # Surrounding plain text must remain intact and in order.
+        texts = [node.content for node in extract_nodes(ast_doc, Text)]
+        assert texts == ["Before", "Click here", "after"]

--- a/tests/unit/parsers/test_pptx_parser.py
+++ b/tests/unit/parsers/test_pptx_parser.py
@@ -462,6 +462,60 @@ class TestImages:
 
 
 @pytest.mark.unit
+class TestGroupedShapes:
+    """Tests for grouped shapes (python-pptx GroupShape)."""
+
+    def test_grouped_textboxes_are_not_dropped(self) -> None:
+        """Text inside a grouped shape should still be extracted."""
+        prs = Presentation()
+        layout = prs.slide_layouts[6]
+        slide = prs.slides.add_slide(layout)
+
+        tb1 = slide.shapes.add_textbox(Inches(1), Inches(1), Inches(2), Inches(1))
+        tb1.text_frame.text = "Alpha text"
+        tb2 = slide.shapes.add_textbox(Inches(3), Inches(1), Inches(2), Inches(1))
+        tb2.text_frame.text = "Beta text"
+
+        # Group the two textboxes into a single top-level shape, mirroring
+        # SmartArt-converted diagrams or manually grouped callouts.
+        slide.shapes.add_group_shape([tb1, tb2])
+
+        converter = PptxToAstConverter()
+        ast_doc = converter.convert_to_ast(prs)
+
+        texts = [node.content for node in extract_nodes(ast_doc, Text)]
+        assert "Alpha text" in texts
+        assert "Beta text" in texts
+
+    def test_nested_group_shapes_are_not_dropped(self) -> None:
+        """Text inside a group nested within another group should be extracted."""
+        prs = Presentation()
+        layout = prs.slide_layouts[6]
+        slide = prs.slides.add_slide(layout)
+
+        tb1 = slide.shapes.add_textbox(Inches(1), Inches(1), Inches(2), Inches(1))
+        tb1.text_frame.text = "Inner text"
+        tb2 = slide.shapes.add_textbox(Inches(3), Inches(1), Inches(2), Inches(1))
+        tb2.text_frame.text = "Sibling text"
+        inner_group = slide.shapes.add_group_shape([tb1, tb2])
+
+        tb3 = slide.shapes.add_textbox(Inches(5), Inches(1), Inches(2), Inches(1))
+        tb3.text_frame.text = "Outer text"
+
+        # Group the inner group together with another shape, producing a
+        # group-within-a-group.
+        slide.shapes.add_group_shape([inner_group, tb3])
+
+        converter = PptxToAstConverter()
+        ast_doc = converter.convert_to_ast(prs)
+
+        texts = [node.content for node in extract_nodes(ast_doc, Text)]
+        assert "Inner text" in texts
+        assert "Sibling text" in texts
+        assert "Outer text" in texts
+
+
+@pytest.mark.unit
 class TestBulletLists:
     """Tests for bullet list conversion."""
 


### PR DESCRIPTION
Fixes two verified findings from the 2026-08-13 codebase audit (findings #6 and #17).

## Grouped shapes were silently dropped (audit #6, high)

`_process_shape_to_ast` handled text frames, tables, images, and charts, then returned `None` for everything else. `GroupShape` has none of those attributes, so a grouped shape — SmartArt-converted diagrams, manually grouped callouts — fell through and none of its member shapes were ever visited. All of that text/table/image content vanished with no warning.

Now the parser detects `GroupShape` and recurses into `shape.shapes` in document order, merging member results. Nested groups work via the same recursive branch.

## Run hyperlinks were dead code (audit #17, medium)

`_process_paragraph_runs_to_inline` built `Link` nodes into a `result` list that both exit branches ignored — every PPTX hyperlink URL was silently discarded, keeping only the anchor text.

Rewritten to segment the paragraph's runs into consecutive stretches sharing a hyperlink address; each stretch is formatted via `group_and_format_runs` (so bold/italic inside link text survives) and linked stretches are wrapped in `Link(url=...)`, preserving run order.

## Testing

- New `TestGroupedShapes` (flat + nested groups) in `tests/unit/parsers/test_pptx_parser.py`
- `test_run_with_hyperlink` tightened from a permissive `if links:` check (which this bug had forced) to strict assertions; new mixed plain/bold-hyperlink ordering test
- 72 unit + 106 integration/renderer pptx tests pass; ruff, black, mypy clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)