### PR TITLE
fix(api): infer markdown, not plaintext, from an unrecognized output extension

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Writing to `out.txt` no longer silently strips every piece of formatting.** When no
+  `target_format` was given, `convert()` inferred one from the output path — and
+  `registry.detect_format` answers `"plaintext"` for anything it does not recognise,
+  including a `.txt` extension and any unknown one. That answer is a *no-match* signal, but
+  it was used as a renderer choice, so `convert("in.md", "out.txt")` rendered through the
+  plaintext renderer: `# Title` became `Title`, `**bold**` became `bold`, and
+  `[a link](https://example.com)` lost its URL entirely. The code had a guard for exactly
+  this, comparing the inferred format against `"txt"` and substituting markdown, but
+  `detect_format` has returned `"plaintext"` — never `"txt"` — since it was rewritten, so
+  the guard had been dead the whole time and the documented "defaults to markdown"
+  behaviour never fired. All three sites (`convert()`, and the CLI's merge and
+  single-file conversion paths) now compare against `"plaintext"`. Only *inference* is
+  remapped: an explicit `target_format="plaintext"` or `--to plaintext` still selects the
+  plaintext renderer, and a recognised extension such as `.html` or `.docx` is still
+  honoured.
 - **A PDF figure caption is now taken from the layout model's `caption` region**, not
   guessed from a fixed band of text near the image. The old rule matched a figure cue
   (`Figure 3`) against a 50pt band above and below the image and, failing that, accepted

--- a/src/all2md/api.py
+++ b/src/all2md/api.py
@@ -690,10 +690,9 @@ def to_markdown(
         actual_format: DocumentFormat = source_format
         logger.debug(f"Using explicitly specified format: {actual_format}")
     else:
-        detected = registry.detect_format(detection_input, hint=None)  # type: ignore[arg-type]
-        if detected is None:
-            raise ValueError("Could not detect format from source")
-        actual_format = detected  # type: ignore[assignment]
+        # ``detect_format`` always returns a name (it falls back to "plaintext"),
+        # so there is no "undetected" case to guard against here.
+        actual_format = registry.detect_format(detection_input, hint=None)  # type: ignore[arg-type,assignment]
 
     # Split kwargs between parser and renderer
     parser_kwargs, renderer_kwargs = _split_kwargs_for_parser_and_renderer(actual_format, "markdown", kwargs)
@@ -1807,8 +1806,15 @@ def convert(
     elif isinstance(renderer, str):
         actual_target_format = renderer
     elif isinstance(output, (str, Path)):
+        # ``detect_format`` falls back to "plaintext" when it recognises nothing,
+        # so an inferred "plaintext" means "no target format could be read off the
+        # output path" -- not "the caller asked for the plaintext renderer". Writing
+        # markdown there matches the documented default and keeps ``out.txt`` from
+        # silently stripping headings, emphasis and link URLs. An explicit
+        # ``target_format="plaintext"`` is handled above and still selects the
+        # plaintext renderer.
         inferred = registry.detect_format(output)
-        actual_target_format = inferred if inferred != "txt" else "markdown"
+        actual_target_format = inferred if inferred != "plaintext" else "markdown"
     else:
         actual_target_format = "markdown"
 

--- a/src/all2md/cli/processors.py
+++ b/src/all2md/cli/processors.py
@@ -1887,7 +1887,11 @@ def _determine_output_format(args: argparse.Namespace, output_path: Optional[Pat
     if output_path:
         try:
             detected_target = registry.detect_format(output_path)
-            return detected_target if detected_target != "txt" else "markdown"
+            # "plaintext" is ``detect_format``'s no-match fallback, so it means the
+            # extension carried no target format -- fall back to markdown rather
+            # than rendering through the plaintext renderer. ``--output-format
+            # plaintext`` is handled above and still wins.
+            return detected_target if detected_target != "plaintext" else "markdown"
         except Exception:
             return "markdown"
 
@@ -2644,7 +2648,10 @@ def _detect_renderer_hint(target_format: str, output_path: Optional[Path]) -> st
 
     try:
         detected_target = registry.detect_format(output_path)
-        if detected_target and detected_target != "txt":
+        # "plaintext" is ``detect_format``'s no-match fallback: the output extension
+        # told us nothing, so leave the hint at "auto" and let the caller apply its
+        # markdown default instead of routing through the plaintext renderer.
+        if detected_target and detected_target != "plaintext":
             return detected_target
     except Exception:
         # Format detection is best-effort; fall through to the caller's

--- a/src/all2md/converter_registry.py
+++ b/src/all2md/converter_registry.py
@@ -639,7 +639,7 @@ class ConverterRegistry:
                 return format_name
 
         # Default fallback
-        logger.debug("No format detected, defaulting to txt")
+        logger.debug("No format detected, defaulting to plaintext")
         return "plaintext"
 
     def _detect_by_filename(self, filename: str, content: Optional[bytes] = None) -> Optional[str]:

--- a/tests/integration/api/test_api.py
+++ b/tests/integration/api/test_api.py
@@ -456,6 +456,39 @@ class TestConvert:
         content = output_file.read_text()
         assert "Test" in content
 
+    @pytest.mark.parametrize("output_name", ["output.txt", "output.zzunknownext"])
+    def test_convert_infers_markdown_for_unrecognized_output_extension(self, tmp_path, output_name):
+        """An output extension carrying no target format writes Markdown, not plaintext.
+
+        ``registry.detect_format`` answers "plaintext" when nothing matches, so
+        treating that answer as a renderer choice silently stripped headings,
+        emphasis and link URLs from ``convert(src, "notes.txt")``.
+        """
+        md_file = tmp_path / "input.md"
+        md_file.write_text("# Title\n\nSome **bold** text and [a link](https://example.com).\n")
+        output_file = tmp_path / output_name
+
+        convert(str(md_file), output=output_file, source_format="markdown")
+
+        content = output_file.read_text(encoding="utf-8")
+        assert "# Title" in content
+        assert "**bold**" in content
+        assert "[a link](https://example.com)" in content
+
+    def test_convert_explicit_plaintext_target_still_renders_plaintext(self, tmp_path):
+        """An explicit ``target_format="plaintext"`` is untouched by the inference fix."""
+        md_file = tmp_path / "input.md"
+        md_file.write_text("# Title\n\nSome **bold** text and [a link](https://example.com).\n")
+        output_file = tmp_path / "output.txt"
+
+        convert(str(md_file), output=output_file, source_format="markdown", target_format="plaintext")
+
+        content = output_file.read_text(encoding="utf-8")
+        assert "Title" in content
+        assert "#" not in content
+        assert "**" not in content
+        assert "https://example.com" not in content
+
     def test_convert_with_parser_and_renderer_options(self, tmp_path):
         """Test convert with both parser and renderer options."""
         md_file = tmp_path / "test.md"

--- a/tests/unit/cli/test_cli_processors.py
+++ b/tests/unit/cli/test_cli_processors.py
@@ -630,6 +630,67 @@ def test_determine_output_format_explicit_to_overrides_extension() -> None:
 
 
 @pytest.mark.unit
+@pytest.mark.parametrize("output_name", ["out.txt", "out.zzunknownext"])
+def test_determine_output_format_falls_back_to_markdown(output_name: str) -> None:
+    """An output extension carrying no target format defaults to markdown.
+
+    ``registry.detect_format`` answers "plaintext" when nothing matches, which is
+    a no-match signal rather than a request for the plaintext renderer. Treating
+    it as the latter silently stripped headings, emphasis and link URLs.
+    """
+    from pathlib import Path
+
+    from all2md.cli.builder import create_parser
+    from all2md.cli.processors import _determine_output_format
+
+    parser = create_parser()
+    args = parser.parse_args(["doc.md"])
+
+    assert _determine_output_format(args, Path(output_name)) == "markdown"
+
+
+@pytest.mark.unit
+def test_determine_output_format_honors_explicit_plaintext() -> None:
+    """An explicit ``--to plaintext`` still selects the plaintext renderer."""
+    from pathlib import Path
+
+    from all2md.cli.builder import create_parser
+    from all2md.cli.processors import _determine_output_format
+
+    parser = create_parser()
+    args = parser.parse_args(["doc.md", "--to", "plaintext"])
+
+    assert _determine_output_format(args, Path("out.txt")) == "plaintext"
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("output_name", ["out.txt", "out.zzunknownext"])
+def test_detect_renderer_hint_leaves_unknown_extension_auto(output_name: str) -> None:
+    """A .txt (or unknown) output path leaves the hint at "auto", not plaintext.
+
+    ``_handle_normal_conversion`` maps "auto" to markdown, so this is the seam
+    that keeps ``all2md doc.md --out notes.txt`` writing Markdown.
+    """
+    from pathlib import Path
+
+    from all2md.cli.processors import _detect_renderer_hint
+
+    assert _detect_renderer_hint("auto", Path(output_name)) == "auto"
+
+
+@pytest.mark.unit
+def test_detect_renderer_hint_still_reads_known_extensions() -> None:
+    """A recognised output extension is still inferred as the renderer hint."""
+    from pathlib import Path
+
+    from all2md.cli.processors import _detect_renderer_hint
+
+    assert _detect_renderer_hint("auto", Path("out.html")) == "html"
+    # An explicit target short-circuits inference entirely.
+    assert _detect_renderer_hint("plaintext", Path("out.html")) == "plaintext"
+
+
+@pytest.mark.unit
 def test_validation_outline_and_extract_mutually_exclusive() -> None:
     """Test validation catches when both --outline and --extract are used."""
     from all2md.cli.validation import ValidationSeverity, collect_argument_problems


### PR DESCRIPTION
Fixes audit findings #1 (high) and #34 (low) from the 2026-08-13 codebase review.

`convert(src, output="out.txt")` silently routed through the PlainTextRenderer, destroying headings, emphasis, and link URLs. The intended remap `inferred if inferred != "txt" else "markdown"` was dead code: `detect_format` has returned `"plaintext"` (never `"txt"`) since cb1a6fb0. The same dead comparison existed at two CLI sites (`_determine_output_format`, `_detect_renderer_hint`), so `all2md doc.pdf --out out.txt` had the same silent formatting loss.

- All three sites now compare against `"plaintext"`, so `.txt` and unknown output extensions write markdown (the documented default). An explicit `target_format="plaintext"` / `--output-format plaintext` still selects the plaintext renderer.
- Dropped the unreachable `if detected is None` branch in `to_markdown` (finding #34) and fixed the stale `"defaulting to txt"` debug message.

Before → after for `convert("in.md", "out.txt")`:
`'Title\n\nSome bold text and a link.'` → `'# Title\n\nSome **bold** text and [a link](https://example.com).'`

## Testing
- New API tests: `.txt`/unknown-extension output preserves formatting; explicit plaintext target unchanged. New CLI tests cover both processor seams plus `--to plaintext` and `.html` guards.
- New tests verified to fail against the unfixed code.
- 1876 unit + 131 e2e tests pass; ruff/black/mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)