### PR TITLE
fix(detection): stop reading inline content strings as filenames

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Format detection no longer reads a sentence as a filename.** `registry.detect_format`
+  ran `os.path.splitext` over *any* `str` it was given, so a string holding document
+  content was extension-matched on its tail: `to_markdown("Reminder: check results.csv")`
+  detected `csv` and returned the one-cell table `| Reminder: check results.csv |`, and
+  `to_markdown("Payload attached as invoice.pdf")` raised `FileNotFoundError` naming a path
+  the caller never passed — the failure class [#233](https://github.com/thomas-villani/all2md/issues/233)
+  fixed in the input loader, resurfacing one layer down because detection ran *before* the
+  loader and derived its own answer. Detection now applies the loader's own
+  `looks_like_path_attempt` rule, so the two agree: a `Path`, an openable `str`, and a
+  path-shaped `str` (short, single-line, no whitespace, no `://`, ending in an extension
+  all2md knows) all keep extension and MIME matching, and everything else is content. Path-ness
+  is deliberately *not* gated on the file existing, since `detect_format` is also called on
+  output paths that have not been written yet.
+  Such a string is now also handed to the content detectors, which never saw it before —
+  `content` stayed `None` for any `str` that was not an openable file. Inline string content
+  therefore detects identically to the same content passed as `bytes`: HTML, JSON, XML and
+  the rest are now recognised, and the structured-text detectors claim the same strings they
+  already claimed on the `bytes` path (`"- a\n- b"` is YAML there and is YAML here). Where no
+  detector matches, the fallback to `plaintext` is unchanged.
 - **A PDF figure caption is now taken from the layout model's `caption` region**, not
   guessed from a fixed band of text near the image. The old rule matched a figure cue
   (`Figure 3`) against a 50pt band above and below the image and, failing that, accepted

--- a/src/all2md/converter_registry.py
+++ b/src/all2md/converter_registry.py
@@ -44,6 +44,31 @@ def _sanitize_for_log(value: str) -> str:
     return value.replace("\n", "\\n").replace("\r", "\\r")
 
 
+def _looks_like_path_attempt(value: str) -> bool:
+    """Return whether an ambiguous ``str`` was plausibly meant as a file path.
+
+    Thin wrapper over :func:`all2md.utils.inputs.looks_like_path_attempt` so that
+    format detection and the input loader share one rule instead of each deriving
+    its own. Imported lazily because ``all2md.utils.inputs`` imports this module
+    back, and because module import cost is a tracked budget.
+
+    Parameters
+    ----------
+    value : str
+        The ambiguous string.
+
+    Returns
+    -------
+    bool
+        True if the string should be treated as a (possibly nonexistent) path
+        rather than as inline document content.
+
+    """
+    from all2md.utils.inputs import looks_like_path_attempt
+
+    return looks_like_path_attempt(value)
+
+
 def check_package_installed(import_name: str) -> bool:
     """Check if a package is installed and importable.
 
@@ -585,17 +610,9 @@ class ConverterRegistry:
         if hint and hint in self._converters:
             return hint
 
-        # Get filename for extension-based detection
-        filename: str | None = None
-        if isinstance(input_data, (str, Path)):
-            filename = str(input_data)
-        elif hasattr(input_data, "name") or hasattr(input_data, "filename"):
-            file_obj_name: str | None = getattr(input_data, "name", None) or getattr(input_data, "filename", None)
-            if file_obj_name and file_obj_name != "unknown":
-                filename = file_obj_name
-
         # Get content for validation
         content: bytes | str | None = None
+        opened_as_file = False
         if isinstance(input_data, bytes):
             content = input_data
         elif isinstance(input_data, (str, Path)):
@@ -603,6 +620,7 @@ class ConverterRegistry:
             try:
                 with open(input_data, "rb") as f:
                     content = f.read(1024)
+                opened_as_file = True
             except Exception:
                 pass
         elif isinstance(input_data, io.IOBase) or (
@@ -619,6 +637,26 @@ class ConverterRegistry:
                 input_data.seek(pos)
             except Exception as e:
                 logger.debug(f"Error reading input as file: {e!r}")
+
+        # Get filename for extension-based detection
+        filename: str | None = None
+        if isinstance(input_data, str) and not opened_as_file and not _looks_like_path_attempt(input_data):
+            # The input loader would read this ``str`` as inline document content, not
+            # as a path (see ``all2md.utils.inputs.looks_like_path_attempt``), so it must
+            # not be filename/extension/MIME-matched: ``"Reminder: check results.csv"``
+            # is prose, and matching its tail turned it into a one-cell CSV table, while
+            # ``"Payload attached as invoice.pdf"`` raised FileNotFoundError naming a path
+            # the caller never passed. Hand the string to content-based detection instead
+            # -- the only detector entitled to claim it -- and fall back as before if
+            # nothing matches. A ``Path``, an openable ``str``, and a path-looking ``str``
+            # such as an as-yet-nonexistent output path all keep extension matching.
+            content = input_data
+        elif isinstance(input_data, (str, Path)):
+            filename = str(input_data)
+        elif hasattr(input_data, "name") or hasattr(input_data, "filename"):
+            file_obj_name: str | None = getattr(input_data, "name", None) or getattr(input_data, "filename", None)
+            if file_obj_name and file_obj_name != "unknown":
+                filename = file_obj_name
 
         # Normalize content to bytes if it's a string (from text streams)
         if isinstance(content, str):

--- a/tests/unit/core/test_converter_registry_new_api.py
+++ b/tests/unit/core/test_converter_registry_new_api.py
@@ -186,6 +186,63 @@ class TestRegistryNewAPI:
         f.write_bytes(content)
         assert registry.detect_format(str(f)) == "markdown"
 
+    @pytest.mark.parametrize(
+        "prose",
+        [
+            "Reminder: check results.csv",
+            "Payload attached as invoice.pdf",
+            "Please read the attached notes.docx",
+        ],
+    )
+    def test_inline_content_str_is_not_extension_matched(self, prose):
+        """Prose that merely mentions a filename is content, not that file's format.
+
+        ``detect_format`` used to treat *every* ``str`` as a filename and run
+        ``os.path.splitext`` over it, so "Reminder: check results.csv" detected as
+        ``csv`` and came back as a bogus one-cell table, and "Payload attached as
+        invoice.pdf" raised ``FileNotFoundError`` naming a path the caller never
+        passed. The input loader already rules these out (they contain whitespace,
+        see ``looks_like_path_attempt``); detection now applies the same rule.
+        """
+        assert registry.detect_format(prose) != prose.rsplit(".", 1)[-1]
+        assert registry.detect_format(prose) == "plaintext"
+
+    def test_inline_content_str_reaches_content_detection(self):
+        """Inline string content is offered to the content detectors.
+
+        Previously ``content`` stayed ``None`` for any ``str`` that was not an
+        openable file, so magic bytes and content detectors never saw it. A string
+        now detects exactly as the same bytes would.
+        """
+        html = "<html><body><h1>hi</h1></body></html>"
+        assert registry.detect_format(html) == "html"
+        assert registry.detect_format(html) == registry.detect_format(html.encode("utf-8"))
+
+        payload = '{"a": 1}'
+        assert registry.detect_format(payload) == registry.detect_format(payload.encode("utf-8"))
+
+    @pytest.mark.parametrize("value", ["notes.md", "docs/guide.rst", "out.txt"])
+    def test_path_shaped_str_still_extension_matched(self, value):
+        """A path-shaped ``str`` keeps extension matching even when it does not exist.
+
+        ``detect_format`` is also called on *output* paths, which by definition have
+        not been written yet, so path-ness must not be gated on file existence.
+        """
+        expected = {"notes.md": "markdown", "docs/guide.rst": "rst", "out.txt": "plaintext"}[value]
+        assert registry.detect_format(value) == expected
+
+    def test_existing_path_with_spaces_still_extension_matched(self, tmp_path):
+        """A real path containing whitespace is still detected from its extension.
+
+        ``looks_like_path_attempt`` says False for anything containing whitespace, so
+        existence has to be checked too or every "My Documents" path would be read as
+        prose.
+        """
+        source = tmp_path / "my report file.md"
+        source.write_text("plain body text", encoding="utf-8")
+
+        assert registry.detect_format(str(source)) == "markdown"
+
     def test_markdown_beats_sourcecode_for_md_extension(self):
         """Guard the latent markdown/sourcecode extension overlap.
 

--- a/tests/unit/parsers/test_str_input_disambiguation.py
+++ b/tests/unit/parsers/test_str_input_disambiguation.py
@@ -152,6 +152,40 @@ class TestResolveStrInput:
 
 
 @pytest.mark.unit
+class TestFormatDetectionAgreesWithTheLoader:
+    """Auto-detection must classify a ``str`` the same way the loader does.
+
+    The #233 rule lived only in the input loader. ``registry.detect_format`` still
+    treated every ``str`` as a filename, so the two disagreed and the same failure
+    class resurfaced one layer down: ``to_markdown`` picked a parser off the tail
+    of a sentence before the loader ever got to classify it.
+    """
+
+    def test_prose_mentioning_a_csv_is_not_parsed_as_a_table(self) -> None:
+        from all2md import to_markdown
+
+        result = to_markdown("Reminder: check results.csv")
+
+        assert "|" not in result, "prose was routed to the CSV parser and became a table"
+        assert "Reminder: check results.csv" in result
+
+    def test_prose_mentioning_a_pdf_does_not_raise_file_not_found(self) -> None:
+        """The caller passed content, so no path can be reported as missing."""
+        from all2md import to_markdown
+
+        result = to_markdown("Payload attached as invoice.pdf")
+
+        assert "Payload attached as invoice.pdf" in result
+
+    def test_a_mistyped_filename_still_raises(self) -> None:
+        """The #233 behaviour is preserved: no whitespace + known extension = a path."""
+        from all2md import to_markdown
+
+        with pytest.raises(All2MdFileNotFoundError):
+            to_markdown("does_not_exist.md")
+
+
+@pytest.mark.unit
 def test_prose_ending_in_a_dotted_word_still_parses() -> None:
     """Regression: ``.com`` is not an all2md extension, so this stays content.
 


### PR DESCRIPTION
Fixes audit finding #2 (high) from the 2026-08-13 codebase review.

`detect_format()` treated ANY `str` as a filename, so prose ending in a known extension was misrouted: `to_markdown('Reminder: check results.csv')` returned a bogus one-cell CSV table, and `to_markdown('Payload attached as invoice.pdf')` raised `FileNotFoundError` blaming a path the caller never passed (the issue #233 error class, resurfacing one layer down). Meanwhile inline string content was never fed to content-based detection at all.

- Detection now reuses the input loader's own rule (`looks_like_path_attempt`) instead of re-deriving its own: a `str` is a path if it opens as a file **or** looks like a path attempt; otherwise it is inline content and goes to the content detectors.
- Openable-first matters: real paths containing spaces (`C:\My Documents\report.pdf`) still extension-match, and nonexistent *output* paths (`out.txt`) keep extension matching since they contain no whitespace.

One deliberate behavior note: inline strings now reach the same content detectors the bytes path already uses, so e.g. `'a, b\n1, 2'` detects as csv exactly as the equivalent `bytes` input already did — the str path is now at parity with the bytes path rather than inventing a new rule.

## Testing
- New tests: both repros above, path-shaped strings still matched, existing path with spaces still matched, `to_markdown("does_not_exist.md")` still raises (#233 preserved).
- New tests verified to fail against the unfixed code.
- 2209 + 888 tests pass across unit/golden/integration; ruff/black/mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)