### PR TITLE
fix(parsers): Org greater blocks, list continuation lines, AsciiDoc ';;' description lists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **An Org greater block containing a blank line is no longer torn apart.** The Org
+  parser split a heading's body on blank lines and only *then* looked for
+  `#+BEGIN_`/`#+END_` delimiters, so a block whose contents contained a blank line — an
+  ordinary thing to write in source code, and the only way to write two paragraphs in a
+  `#+BEGIN_QUOTE` — was cut into fragments before anything could see it was one element.
+  The fragment holding `#+BEGIN_SRC` had no end delimiter, the fragments after it
+  re-parsed as prose (complete with Org inline markup applied to code), and the fragment
+  holding `#+END_SRC` printed that delimiter verbatim as body text: `#+BEGIN_SRC python`
+  / `x = 1` / blank / `y = 2` / `#+END_SRC` produced a `CodeBlock` of just `x = 1`
+  followed by a paragraph reading `y = 2 #+END_SRC`. Body segmentation is now aware of
+  open blocks, the same way the file-property filter above it already was: a blank line
+  inside a `#+BEGIN_x` region is content, and only a matching `#+END_x` closes it, so
+  code that itself contains `#+`-prefixed lines stays intact. Because a greater block is
+  an element in its own right, a delimiter now also bounds the elements around it when no
+  blank line separates them — which additionally recovers text written directly after
+  `#+END_SRC`, previously swallowed by the block and dropped. Affiliated keywords such as
+  `#+CAPTION:` still attach to the block beneath them.
 - **Words no longer fuse across a formatting change in run-based formats.**
   `group_and_format_runs` — the shared helper that turns a paragraph's runs into inline
   nodes for PPTX (and available to any run-based parser) — joined each same-format group

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   flattened to a single level — the loop strips each line before matching it, so the
   indentation that marks a sub-item is gone before the marker is read — and that is
   unchanged by this fix.
+- **A single `;` in AsciiDoc prose no longer creates a description list.** The lexer's
+  description-list pattern was `^(.+?);(?:\s+(.*))?$`, which matches an enormous amount
+  of ordinary writing: `Alpha; beta gamma.` was lexed as the term `Alpha` with the
+  description `beta gamma.`, a line merely ending in `;` became a bare term with no
+  description, and a semicolon anywhere on a wrapped line broke the paragraph it belonged
+  to in two — the text before the wrap staying a paragraph and the rest becoming a
+  definition list. AsciiDoc has no such marker; its description lists are written `::`,
+  `:::`, `::::` or `;;`. The pattern now requires the doubled `;;`, which parses exactly
+  as `::` does, and the class docstring's `term::` or `term;` has been corrected. One
+  existing test asserted the single-semicolon behaviour and has been updated: it encoded
+  the defect rather than the language.
 - **Words no longer fuse across a formatting change in run-based formats.**
   `group_and_format_runs` — the shared helper that turns a paragraph's runs into inline
   nodes for PPTX (and available to any run-based parser) — joined each same-format group

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   blank line separates them — which additionally recovers text written directly after
   `#+END_SRC`, previously swallowed by the block and dropped. Affiliated keywords such as
   `#+CAPTION:` still attach to the block beneath them.
+- **An Org list item's wrapped continuation line is no longer deleted.** `_parse_list`
+  kept only the lines that matched a bullet or number marker and had no branch for
+  anything else, so a line continuing an item's text onto the next line — how any
+  reasonably long item is written — simply vanished. `- item one continues` /
+  `  onto a wrapped line` / `- item two` produced a two-item list in which
+  `onto a wrapped line` appeared nowhere at all, with nothing to indicate text had been
+  dropped. A non-marker line now joins the preceding item's principal text separated by
+  a single space, which is the rule the AsciiDoc parser was given for the same defect in
+  [#343](https://github.com/thomas-villani/all2md/issues/343); a wrapped item and the
+  same item written on one line now parse to equal documents. Nested items are still
+  flattened to a single level — the loop strips each line before matching it, so the
+  indentation that marks a sub-item is gone before the marker is read — and that is
+  unchanged by this fix.
 - **Words no longer fuse across a formatting change in run-based formats.**
   `group_and_format_runs` — the shared helper that turns a paragraph's runs into inline
   nodes for PPTX (and available to any run-based parser) — joined each same-format group

--- a/src/all2md/parsers/asciidoc.py
+++ b/src/all2md/parsers/asciidoc.py
@@ -151,9 +151,16 @@ class AsciiDocLexer:
         self.heading_pattern = re.compile(r"^(={1,6})\s+(.+?)(?:\s+\1)?$")
         self.ul_pattern = re.compile(r"^(\*{1,5})\s+(.*)$")
         self.ol_pattern = re.compile(r"^(\.{1,5})\s+(.*)$")
-        # Description list: supports both :: and ; delimiters
+        # Description list: supports both :: and ;; delimiters.
+        #
+        # The marker is a doubled semicolon, never a single one. Matching a single ';'
+        # turned ordinary prose into a definition list: "Alpha; beta gamma." became the
+        # term "Alpha" with the description "beta gamma.", a line merely ending in ';'
+        # became a bare term, and a semicolon anywhere on a wrapped line split the
+        # paragraph it belonged to. Nothing in AsciiDoc spells a description list that
+        # way -- the markers are '::', ':::', '::::' and ';;'.
         self.desc_pattern_double_colon = re.compile(r"^(.+?)::(?:\s+(.*))?$")
-        self.desc_pattern_semicolon = re.compile(r"^(.+?);(?:\s+(.*))?$")
+        self.desc_pattern_semicolon = re.compile(r"^(.+?);;(?:\s+(.*))?$")
         self.checklist_pattern = re.compile(r"^(\*+)\s+\[([ x*])\]\s+(.*)$")
         self.attribute_pattern = re.compile(r"^:([^:!]+)(!)?:\s*(.*)$")
         self.block_attr_pattern = re.compile(r"^\[([^\]]+)\]$")
@@ -351,7 +358,7 @@ class AsciiDocParser(BaseParser):
       - Unordered (\* through \*****)
       - Ordered (. through .....)
       - Checklists (\* [x] or \* [ ])
-      - Description lists (term:: or term;)
+      - Description lists (term:: or term;;)
     - Code blocks (----) with language support via [source,lang]
     - Literal blocks (....) for preformatted text
     - Block quotes (____)

--- a/src/all2md/parsers/org.py
+++ b/src/all2md/parsers/org.py
@@ -1106,6 +1106,12 @@ class OrgParser(BaseParser):
         List or None
             List AST node
 
+        Notes
+        -----
+        Nested items are still flattened to a single level: the loop strips a line
+        before matching it, so a sub-item's indentation -- the only thing marking it as
+        one -- is gone by the time the marker is read.
+
         """
         lines = block.split("\n")
         items: list[ListItem] = []
@@ -1122,33 +1128,42 @@ class OrgParser(BaseParser):
             # the number was present in the document and discarded on the way in.
             start = int(first_number.group(1))
 
+        # Match list item. The content group is optional: a bullet with nothing
+        # after it is still an item, and requiring content silently deleted it --
+        # `- \n- b` came back as a one-item list. An empty item carries no
+        # Paragraph, which is the shape the Markdown parser already produces.
+        marker = re.compile(r"^\d+[\.\)](?:\s+(.*))?$" if ordered else r"^[\-\+\*](?:\s+(.*))?$")
+
+        # Group the block's lines into one text per item. A line carrying no marker is
+        # not a line to discard: it is the previous item's principal text wrapping onto
+        # the next line. The loop kept only matching lines and had no other branch, so
+        # `- item one continues` / `  onto a wrapped line` lost the second line
+        # entirely. The AsciiDoc parser joins an item's run-on lines the same way,
+        # separated by a single space (#343).
+        item_texts: list[str] = []
         for line in lines:
             line_stripped = line.strip()
             if not line_stripped:
                 continue
 
-            # Match list item. The content group is optional: a bullet with nothing
-            # after it is still an item, and requiring content silently deleted it --
-            # `- \n- b` came back as a one-item list. An empty item carries no
-            # Paragraph, which is the shape the Markdown parser already produces.
-            if ordered:
-                match = re.match(r"^\d+[\.\)](?:\s+(.*))?$", line_stripped)
-            else:
-                match = re.match(r"^[\-\+\*](?:\s+(.*))?$", line_stripped)
-
+            match = marker.match(line_stripped)
             if match:
-                item_text = (match.group(1) or "").strip()
-                # `[@N]` is Org's own counter set, and it wins over the literal number
-                # it follows -- that is the whole point of writing it.
-                counter = re.match(r"^\[@(\d+)\]\s*(.*)$", item_text, re.DOTALL)
-                if counter:
-                    if not items:
-                        start = int(counter.group(1))
-                    item_text = counter.group(2).strip()
-                if item_text:
-                    items.append(ListItem(children=[Paragraph(content=self._parse_inline(item_text))]))
-                else:
-                    items.append(ListItem(children=[]))
+                item_texts.append((match.group(1) or "").strip())
+            elif item_texts:
+                item_texts[-1] = f"{item_texts[-1]} {line_stripped}".strip()
+
+        for item_text in item_texts:
+            # `[@N]` is Org's own counter set, and it wins over the literal number
+            # it follows -- that is the whole point of writing it.
+            counter = re.match(r"^\[@(\d+)\]\s*(.*)$", item_text, re.DOTALL)
+            if counter:
+                if not items:
+                    start = int(counter.group(1))
+                item_text = counter.group(2).strip()
+            if item_text:
+                items.append(ListItem(children=[Paragraph(content=self._parse_inline(item_text))]))
+            else:
+                items.append(ListItem(children=[]))
 
         return List(ordered=ordered, start=start, items=items)
 

--- a/src/all2md/parsers/org.py
+++ b/src/all2md/parsers/org.py
@@ -645,6 +645,61 @@ class OrgParser(BaseParser):
 
         return Heading(level=level, content=content, metadata=heading_metadata)
 
+    @staticmethod
+    def _split_body_blocks(body_text: str) -> list[str]:
+        """Split body text into blocks, keeping each greater block in one piece.
+
+        Blank lines separate Org elements, but not inside a greater block: a
+        ``#+BEGIN_SRC``/``#+END_SRC`` pair runs to its own delimiter no matter how many
+        blank lines the code between them contains. Splitting on blank lines first cut
+        such a block into fragments -- the one holding ``#+BEGIN_SRC`` had no end, the
+        middle ones re-parsed as prose, and the last printed ``#+END_SRC`` verbatim as
+        body text. So the segmentation has to know where a block is open, the same way
+        the file-property filter above already does.
+
+        A greater block also starts and ends an element of its own, so a delimiter that
+        follows or precedes ordinary text without a blank line between them still marks
+        a boundary. The one exception is an affiliated keyword such as ``#+CAPTION:``,
+        which belongs to the block written underneath it and therefore stays attached.
+        """
+        blocks: list[str] = []
+        current: list[str] = []
+        open_kind: str | None = None
+
+        def flush() -> None:
+            if current:
+                blocks.append("\n".join(current))
+                current.clear()
+
+        for line in body_text.split("\n"):
+            stripped = line.strip()
+
+            if open_kind is not None:
+                current.append(line)
+                if re.match(rf"^#\+END_{re.escape(open_kind)}\b", stripped, re.IGNORECASE):
+                    open_kind = None
+                    flush()
+                continue
+
+            begin = re.match(r"^#\+BEGIN_(\w+)", stripped, re.IGNORECASE)
+            if begin:
+                # Affiliated keywords belong to the block below them; anything else is a
+                # separate element that the block must not swallow.
+                if not all(re.match(r"^#\+[\w-]+:", pending.strip()) for pending in current):
+                    flush()
+                open_kind = begin.group(1)
+                current.append(line)
+                continue
+
+            if not stripped:
+                flush()
+                continue
+
+            current.append(line)
+
+        flush()
+        return blocks
+
     def _process_body(self, body_text: str) -> list[Node]:
         """Process body text into AST nodes.
 
@@ -666,8 +721,8 @@ class OrgParser(BaseParser):
         """
         result: list[Node] = []
 
-        # Split into blocks (separated by blank lines)
-        blocks = re.split(r"\n\n+", body_text)
+        # Split into blocks (separated by blank lines), keeping greater blocks whole
+        blocks = self._split_body_blocks(body_text)
 
         # Track footnote definitions for later
         footnote_defs: list[FootnoteDefinition] = []

--- a/tests/unit/parsers/test_asciidoc_parser_improvements.py
+++ b/tests/unit/parsers/test_asciidoc_parser_improvements.py
@@ -282,12 +282,18 @@ class TestAsciiDocTableHeaderExplicit:
 
 
 class TestAsciiDocSemicolonDescriptionLists:
-    """Tests for semicolon description list syntax."""
+    """Tests for semicolon description list syntax.
+
+    AsciiDoc's description-list markers are ``::``, ``:::``, ``::::`` and ``;;`` -- never
+    a single ``;``. This class asserted the single-semicolon form, which was the lexer's
+    behaviour and not the language's: it turned any prose containing a semicolon into a
+    definition list.
+    """
 
     def test_semicolon_description_list(self) -> None:
-        """Test term; description syntax."""
-        asciidoc = """CPU; Central Processing Unit
-RAM; Random Access Memory"""
+        """Test term;; description syntax."""
+        asciidoc = """CPU;; Central Processing Unit
+RAM;; Random Access Memory"""
         parser = AsciiDocParser()
         doc = parser.parse(asciidoc)
 
@@ -301,6 +307,39 @@ RAM; Random Access Memory"""
         assert term1.content[0].content == "CPU"
         assert len(descs1) == 1
         assert isinstance(descs1[0], DefinitionDescription)
+
+    def test_prose_with_a_mid_sentence_semicolon_stays_one_paragraph(self) -> None:
+        """``Alpha; beta gamma.`` is a sentence, and used to become a definition list."""
+        parser = AsciiDocParser()
+
+        doc = parser.parse("Alpha; beta gamma.")
+
+        assert [type(node) for node in doc.children] == [Paragraph]
+        assert doc.children[0].content[0].content == "Alpha; beta gamma."
+
+    def test_a_line_ending_in_a_semicolon_stays_prose(self) -> None:
+        """The description group is optional, so such a line became a bare term."""
+        parser = AsciiDocParser()
+
+        doc = parser.parse("A sentence ending in a semicolon;")
+
+        assert [type(node) for node in doc.children] == [Paragraph]
+        assert doc.children[0].content[0].content == "A sentence ending in a semicolon;"
+
+    def test_a_semicolon_on_a_wrapped_line_does_not_split_the_paragraph(self) -> None:
+        """The line was lexed on its own, so the paragraph broke in two mid-sentence."""
+        parser = AsciiDocParser()
+
+        doc = parser.parse("Some prose that wraps\nand continues; with more text here.")
+
+        assert [type(node) for node in doc.children] == [Paragraph]
+        assert doc.children[0].content[0].content == "Some prose that wraps and continues; with more text here."
+
+    def test_the_doubled_marker_behaves_like_the_double_colon_one(self) -> None:
+        """``;;`` and ``::`` are the same construct, so they must parse the same."""
+        parser = AsciiDocParser()
+
+        assert parser.parse("Term;; Definition") == parser.parse("Term:: Definition")
 
     def test_double_colon_still_works(self) -> None:
         """Test that traditional :: syntax still works."""

--- a/tests/unit/parsers/test_org_parser.py
+++ b/tests/unit/parsers/test_org_parser.py
@@ -1265,6 +1265,68 @@ class TestGreaterBlocks:
 
 
 @pytest.mark.unit
+class TestGreaterBlocksWithBlankLines:
+    """A blank line inside a greater block must not break the block apart.
+
+    The body was split on blank lines before any block was recognized, so the fragment
+    holding ``#+BEGIN_SRC`` had no end, the middle fragments re-parsed as prose, and the
+    fragment holding ``#+END_SRC`` printed that delimiter verbatim as body text.
+    """
+
+    def test_source_block_keeps_an_internal_blank_line(self) -> None:
+        """``#+BEGIN_SRC`` with a blank line in the code stayed one code block."""
+        doc = OrgParser().parse("* H\n#+BEGIN_SRC python\nx = 1\n\ny = 2\n#+END_SRC\n")
+
+        blocks = [node for node in doc.children if isinstance(node, CodeBlock)]
+        assert [type(node) for node in doc.children] == [Heading, CodeBlock]
+        assert blocks[0].language == "python"
+        assert blocks[0].content == "x = 1\n\ny = 2"
+
+    def test_source_block_keeps_several_internal_blank_lines(self) -> None:
+        """More than one blank line is still code, not a run of paragraphs."""
+        doc = OrgParser().parse("#+BEGIN_SRC python\na = 1\n\n\nb = 2\n\nc = 3\n#+END_SRC\n")
+
+        assert [type(node) for node in doc.children] == [CodeBlock]
+        assert doc.children[0].content == "a = 1\n\n\nb = 2\n\nc = 3"
+
+    def test_example_block_keeps_an_internal_blank_line(self) -> None:
+        """An example block is verbatim, so its blank lines survive too."""
+        doc = OrgParser().parse("#+BEGIN_EXAMPLE\nfirst\n\nsecond\n#+END_EXAMPLE\n")
+
+        assert [type(node) for node in doc.children] == [CodeBlock]
+        assert doc.children[0].content == "first\n\nsecond"
+
+    def test_quote_block_keeps_both_paragraphs_and_no_delimiter_text(self) -> None:
+        """A quote block's blank line separates paragraphs within the quote."""
+        doc = OrgParser().parse("#+BEGIN_QUOTE\nOne.\n\nTwo.\n#+END_QUOTE\n")
+
+        assert [type(node) for node in doc.children] == [BlockQuote]
+        quoted = doc.children[0].children
+        assert [type(node) for node in quoted] == [Paragraph, Paragraph]
+        assert [node.content[0].content for node in quoted] == ["One.", "Two."]
+
+    def test_code_containing_hash_plus_lines_is_not_mistaken_for_a_delimiter(self) -> None:
+        """Only a matching ``#+END_`` closes a block; other ``#+`` lines are code."""
+        doc = OrgParser().parse("#+BEGIN_SRC org\n#+TITLE: x\n\n#+OPTIONS: toc:nil\n#+END_SRC\n")
+
+        assert [type(node) for node in doc.children] == [CodeBlock]
+        assert doc.children[0].content == "#+TITLE: x\n\n#+OPTIONS: toc:nil"
+
+    def test_text_around_a_block_without_blank_lines_stays_separate(self) -> None:
+        """A greater block begins and ends an element of its own.
+
+        Text on the line after ``#+END_SRC`` used to be swallowed by the block and
+        dropped entirely, since the code extractor stops at the end delimiter.
+        """
+        doc = OrgParser().parse("Intro text\n#+BEGIN_SRC python\nz = 1\n#+END_SRC\nAfter text\n")
+
+        assert [type(node) for node in doc.children] == [Paragraph, CodeBlock, Paragraph]
+        assert doc.children[0].content[0].content == "Intro text"
+        assert doc.children[1].content == "z = 1"
+        assert doc.children[2].content[0].content == "After text"
+
+
+@pytest.mark.unit
 class TestEmptyListItems:
     """A bullet with no content is an item, not a line to discard."""
 

--- a/tests/unit/parsers/test_org_parser.py
+++ b/tests/unit/parsers/test_org_parser.py
@@ -1359,3 +1359,67 @@ class TestEmptyListItems:
         items = doc.children[0].items
         assert items[0].children == []
         assert [type(child) for child in items[1].children] == [Paragraph]
+
+
+@pytest.mark.unit
+class TestListItemRunOnLines:
+    """An item's text wrapping onto the next line must join it, not disappear.
+
+    The loop kept only lines matching a marker and had no other branch, so a wrapped
+    continuation line was silently deleted. The AsciiDoc parser joins run-on lines the
+    same way (#343).
+    """
+
+    @pytest.mark.parametrize(
+        ("wrapped", "flat"),
+        [
+            (
+                "- item one continues\n  onto a wrapped line\n- item two\n",
+                "- item one continues onto a wrapped line\n- item two\n",
+            ),
+            (
+                "1. first\n   wrapped on\n2. second\n",
+                "1. first wrapped on\n2. second\n",
+            ),
+            (
+                "- only item\n  line two\n  line three\n",
+                "- only item line two line three\n",
+            ),
+        ],
+        ids=["unordered", "ordered", "several-lines"],
+    )
+    def test_a_wrapped_item_parses_the_same_as_the_unwrapped_one(self, wrapped: str, flat: str) -> None:
+        """Parity, not a hand-written node list, so the two paths cannot drift."""
+        parser = OrgParser()
+
+        assert parser.parse(wrapped) == parser.parse(flat)
+
+    def test_the_continuation_text_is_present_at_all(self) -> None:
+        """The reported symptom: the wrapped line appeared nowhere in the document."""
+        parser = OrgParser()
+
+        doc = parser.parse("- item one continues\n  onto a wrapped line\n- item two\n")
+
+        lists = [node for node in doc.children if isinstance(node, List)]
+        assert len(lists) == 1
+        assert len(lists[0].items) == 2
+        assert lists[0].items[0].children[0].content[0].content == "item one continues onto a wrapped line"
+
+    def test_a_continuation_line_does_not_leak_into_the_next_item(self) -> None:
+        """Joining stops at the next marker."""
+        parser = OrgParser()
+
+        doc = parser.parse("- one\n  more of one\n- two\n  more of two\n")
+
+        items = doc.children[0].items
+        assert [item.children[0].content[0].content for item in items] == ["one more of one", "two more of two"]
+
+    def test_a_continuation_line_after_an_empty_item_becomes_that_item_s_text(self) -> None:
+        """An empty bullet with a following line is an item whose text wrapped."""
+        parser = OrgParser()
+
+        doc = parser.parse("- a\n-\n  text below the bare marker\n- b\n")
+
+        items = doc.children[0].items
+        assert len(items) == 3
+        assert items[1].children[0].content[0].content == "text below the bare marker"


### PR DESCRIPTION
Fixes three verified findings from the 2026-08-13 codebase audit (Leg 3, findings #10, #24, #22).

## Org: greater blocks torn apart by internal blank lines (#10, high)

`_process_body` split on blank lines before recognizing `#+BEGIN_x`/`#+END_x`, so a source block with an internal blank line fragmented: code leaked out as prose and `#+END_SRC` printed verbatim. Body segmentation is now block-aware (mirroring `_strip_file_properties`' in-block tracking). A delimiter also bounds adjacent elements when no blank line separates them — recovering text written directly after `#+END_SRC`, which was previously dropped — while affiliated keywords (`#+CAPTION:`) stay attached to their block.

## Org: list item continuation lines deleted (#24, medium)

`_parse_list` kept only marker-matching lines with no else branch, so a wrapped continuation line vanished silently. A non-marker line now joins the previous item's principal text with a single space — the same rule AsciiDoc got in #343 — asserted as parity (`parse(wrapped) == parse(flat)`). Nested-item flattening is pre-existing and out of scope; documented in the method's Notes.

## AsciiDoc: single `;` created description lists (#22, medium)

The lexer pattern `^(.+?);(?:\s+(.*))?$` restructured ordinary prose ("Alpha; beta gamma.") into definition lists and split wrapped paragraphs at any semicolon. AsciiDoc's markers are `::`, `:::`, `::::`, and `;;` — never single `;`. The pattern now requires `;;` (which also fixes genuine `;;` lists previously parsing with a trailing `;` in the term) and the class docstring is corrected. One existing test encoded the single-`;` behavior and was updated deliberately.

## Verification

- 12 new regression tests across `test_org_parser.py` and `test_asciidoc_parser_improvements.py`; org/asciidoc unit + integration suites green.
- `tests/golden` at documented pre-existing Windows state (121 passed, 1 unused, PDF skips); no snapshot changes needed.
- Roundtrip-fuzz slice for definition lists/footnotes: no XPASS, no allowlist changes needed.
- black / ruff / mypy clean; docstrings verified RST-safe with docutils.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
