### PR TITLE
fix: transform AST walkers, HTML loose body text, XLSX hyperlink cells

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -393,6 +393,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   sibling is reached — so the top-level walk now delegates to it instead of duplicating a
   narrower, buggy version of the same logic. Whitespace-only text between block elements
   still produces no paragraph.
+- **XLSX cell hyperlinks render as real links again, instead of escaped literal text.** The
+  parser built a markdown-syntax string (`[text](url)`) for a hyperlinked cell and handed it to
+  `build_table_ast()` as plain cell text, which wrapped it in a `Text` node — so every renderer
+  saw an ordinary string, not a link. The Markdown renderer escapes brackets in `Text` content,
+  so a hyperlinked cell rendered as `\[text\](http://x)` instead of a working link, and the HTML
+  renderer emitted the literal bracket syntax instead of an `<a>` tag. The parser now extracts
+  each cell's (text, hyperlink URL) pair and, for a hyperlinked cell, builds a real `Link` node
+  directly in the `TableCell` — the same thing the DOCX, PPTX and HTML parsers already do.
+  `build_table_ast()` (shared by CSV, ODS and XLSX) gained a second accepted cell shape for
+  this: a cell can still be a plain string, unchanged for every other caller, or a pre-built
+  `list[Node]` used as-is. ODS has no cell-hyperlink extraction at all yet, so it is unaffected
+  and left as-is.
 
 ## [1.12.0] - 2026-08-12
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -368,6 +368,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   and the published reference must be a *complete* run covering every article the manifest
   names, since `complete_corpus` going false is the right signal for a run and the wrong state
   for the artifact a public page quotes as its reading.
+- **Three AST walkers stopped dead at List and Table nodes.**
+  `AddAttachmentFootnotesTransform._collect_footnote_refs`,
+  `GenerateTocTransform._collect_headings`, and `GenerateTocTransform._inject_heading_ids`
+  recursed only through `hasattr(node, "children")` / `hasattr(node, "content")`, but `List`
+  stores its items in `.items`, `Table` in `.header`/`.rows`, `TableRow` in `.cells`, and
+  `DefinitionList` in `.items` tuples — none of which the check saw, so recursion silently
+  stopped the moment it reached one of those nodes. In practice, the CLI's
+  `add-attachment-footnotes` transform never emitted a `FootnoteDefinition` for an
+  empty-URL `Image`/`Link` nested in a list or table cell, and `GenerateTocTransform`
+  (Python-API-only) omitted headings nested the same way from the generated TOC and never
+  injected their ids. All three walkers now recurse via the shared `get_node_children()`
+  helper (`src/all2md/ast/nodes.py`) that every other AST walker in this codebase already
+  uses, so they see every node type uniformly. `_inject_heading_ids` also had to gain
+  a hand-rolled `DefinitionList` case, since `replace_node_children()` deliberately refuses
+  to rebuild that node's `(term, [descriptions])` tuple structure generically.
 
 ## [1.12.0] - 2026-08-12
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -383,6 +383,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   uses, so they see every node type uniformly. `_inject_heading_ids` also had to gain
   a hand-rolled `DefinitionList` case, since `replace_node_children()` deliberately refuses
   to rebuild that node's `(term, [descriptions])` tuple structure generically.
+- **HTML: bare text directly under `<body>` (or in a body-less fragment) is no longer
+  discarded.** The top-level walk only processed `Tag` children of `<body>`/root and skipped
+  every `NavigableString`, so `<body>Loose text. <p>Paragraph.</p>Trailing text.</body>` kept
+  only the `<p>`, and a pure fragment like `Just plain text with <b>bold</b> inside` parsed to
+  a `Document` containing just `Strong('bold')` with all the surrounding plain text deleted.
+  The rest of the parser already had a mechanism for this — `_process_block_container`
+  accumulates adjacent inline content and flushes it into a single `Paragraph` when a block
+  sibling is reached — so the top-level walk now delegates to it instead of duplicating a
+  narrower, buggy version of the same logic. Whitespace-only text between block elements
+  still produces no paragraph.
 
 ## [1.12.0] - 2026-08-12
 

--- a/src/all2md/parsers/html.py
+++ b/src/all2md/parsers/html.py
@@ -1037,8 +1037,17 @@ class HtmlToAstConverter(BaseParser):
             List of block nodes (Paragraph, Heading, List, etc.)
 
         """
+        from bs4.element import Comment, NavigableString
+
         children: list[Node] = []
         inline_buffer: list[Node] = []
+        # A whitespace-only text child yields no node, but between two inline
+        # siblings it is still a separator -- HTML collapses it to one space, it
+        # does not delete it. Dropping it fused adjacent inline elements
+        # (``<img>``/newline/``<img>`` became two images with nothing between
+        # them). It only ever separates: at a block boundary or the end of the
+        # container it goes back to being ignorable formatting.
+        pending_space = False
 
         for child in node.children:
             if skip is not None and child is skip:
@@ -1049,6 +1058,7 @@ class HtmlToAstConverter(BaseParser):
                 if inline_buffer:
                     children.append(Paragraph(content=inline_buffer))
                     inline_buffer = []
+                pending_space = False
 
                 # Process block element
                 block_node = self._process_node_to_ast(child)
@@ -1061,10 +1071,20 @@ class HtmlToAstConverter(BaseParser):
                 # Inline element or text: add to buffer
                 inline_nodes = self._process_node_to_ast(child)
                 if inline_nodes:
+                    if pending_space:
+                        inline_buffer.append(Text(content=" "))
+                        pending_space = False
                     if isinstance(inline_nodes, list):
                         inline_buffer.extend(inline_nodes)
                     else:
                         inline_buffer.append(inline_nodes)
+                elif (
+                    inline_buffer
+                    and isinstance(child, NavigableString)
+                    and not isinstance(child, Comment)
+                    and not str(child).strip()
+                ):
+                    pending_space = True
 
         # Flush remaining inline content
         if inline_buffer:

--- a/src/all2md/parsers/html.py
+++ b/src/all2md/parsers/html.py
@@ -283,23 +283,23 @@ class HtmlToAstConverter(BaseParser):
         return None
 
     def _process_body_children(self, soup: Any) -> list[Node]:
-        """Process body or root element children to AST nodes."""
+        """Process body or root element children to AST nodes.
+
+        Delegates to :meth:`_process_block_container`, which already knows how to
+        interleave block and inline content: adjacent inline content (bare text,
+        inline tags) is accumulated and wrapped in a single ``Paragraph`` when a
+        block-level sibling is reached (or at the end of the walk), and
+        whitespace-only text between block elements produces no node at all.
+        Without this, bare text directly under ``<body>`` -- or in a parser-fed
+        HTML fragment with no ``<body>`` at all -- was silently discarded, since
+        the old implementation only processed ``Tag`` children and skipped every
+        ``NavigableString``.
+        """
         from bs4.element import Tag
 
         body = soup.find("body")
         root = body if isinstance(body, Tag) else soup
-        children: list[Node] = []
-
-        for child in root.children:
-            if not isinstance(child, Tag):
-                continue
-            nodes = self._process_node_to_ast(child)
-            if nodes:
-                if isinstance(nodes, list):
-                    children.extend(nodes)
-                else:
-                    children.append(nodes)
-        return children
+        return self._process_block_container(root)
 
     def convert_to_ast(self, html_content: str) -> Document:
         """Convert HTML string to AST Document.

--- a/src/all2md/parsers/xlsx.py
+++ b/src/all2md/parsers/xlsx.py
@@ -21,6 +21,7 @@ from all2md.ast import (
     Heading,
     HTMLInline,
     Image,
+    Link,
     Node,
     Paragraph,
     Table,
@@ -39,51 +40,52 @@ from all2md.utils.inputs import validate_and_convert_input
 from all2md.utils.metadata import DocumentMetadata
 from all2md.utils.parser_helpers import attachment_result_to_image_node
 from all2md.utils.spreadsheet import (
+    CellValue,
     build_table_ast,
     sanitize_cell_text,
     transform_header_case,
-    trim_columns,
-    trim_rows,
 )
 
 logger = logging.getLogger(__name__)
 
 
-def _format_link_or_text(cell: Any, text: str, preserve_newlines: bool = False) -> str:
-    """Get cell text, checking for hyperlinks.
+def _cell_hyperlink_url(cell: Any) -> Optional[str]:
+    """Extract a cell's hyperlink target, if it has one.
 
     Parameters
     ----------
     cell : Any
         Cell object (openpyxl)
-    text : str
-        Cell text value
-    preserve_newlines : bool
-        Whether to preserve newlines in cells
 
     Returns
     -------
-    str
-        Cell text with hyperlinks formatted as markdown links if present
+    str or None
+        The hyperlink's URL (or ``#location`` for an internal link), or None
+        if the cell has no hyperlink.
 
     """
-    # Check if cell has a hyperlink
-    if hasattr(cell, "hyperlink") and cell.hyperlink:
-        # Extract the URL from the hyperlink
-        url = None
-        if hasattr(cell.hyperlink, "target") and cell.hyperlink.target:
-            url = cell.hyperlink.target
-        elif hasattr(cell.hyperlink, "location") and cell.hyperlink.location:
-            # Internal link (cell reference)
-            url = f"#{cell.hyperlink.location}"
+    hyperlink = getattr(cell, "hyperlink", None)
+    if not hyperlink:
+        return None
+    if getattr(hyperlink, "target", None):
+        return cast(str, hyperlink.target)
+    if getattr(hyperlink, "location", None):
+        # Internal link (cell reference)
+        return f"#{hyperlink.location}"
+    return None
 
-        if url:
-            # Format as markdown link: [text](url)
-            sanitized_text = sanitize_cell_text(text, preserve_newlines)
-            return f"[{sanitized_text}]({url})"
 
-    # No hyperlink, return sanitized text
-    return sanitize_cell_text(text, preserve_newlines)
+def _paired_cell(text: str, url: Optional[str]) -> CellValue:
+    """Build a build_table_ast() cell value from cell text and an optional hyperlink.
+
+    A hyperlinked cell becomes a real ``Link`` node (rather than a markdown-syntax
+    string, which a renderer's Text-escaping would turn into a literal, escaped
+    bracket-and-parens sequence); a plain cell stays a bare string.
+
+    """
+    if url:
+        return [Link(url=url, content=[Text(content=text)])]
+    return text
 
 
 def _alignment_for_cell(cell: Any) -> Alignment:
@@ -118,6 +120,72 @@ def _alignment_for_cell(cell: Any) -> Alignment:
         pass
 
     return "center"
+
+
+def _trim_paired_rows(
+    rows: list[list[tuple[str, Optional[str]]]], trim_mode: str
+) -> list[list[tuple[str, Optional[str]]]]:
+    """Trim empty leading/trailing rows from (text, url) cell pairs.
+
+    Mirrors :func:`all2md.utils.spreadsheet.trim_rows`, whose emptiness test
+    (``cell == ""``) only makes sense for plain text. XLSX cells carry a
+    parallel hyperlink URL that must survive the same trim decisions, so this
+    is a small local duplicate of that logic operating on the text half of
+    each pair.
+
+    """
+    if not rows or trim_mode == "none":
+        return rows
+
+    if trim_mode in ("leading", "both"):
+        while rows and all(text == "" for text, _ in rows[0]):
+            rows.pop(0)
+
+    if trim_mode in ("trailing", "both"):
+        while rows and all(text == "" for text, _ in rows[-1]):
+            rows.pop()
+
+    return rows
+
+
+def _trim_paired_columns(
+    rows: list[list[tuple[str, Optional[str]]]], trim_mode: str
+) -> list[list[tuple[str, Optional[str]]]]:
+    """Trim empty leading/trailing columns from (text, url) cell pairs.
+
+    See :func:`_trim_paired_rows` for why this duplicates
+    :func:`all2md.utils.spreadsheet.trim_columns` instead of reusing it.
+
+    """
+    if not rows or trim_mode == "none":
+        return rows
+
+    if not rows[0]:
+        return rows
+
+    num_cols = len(rows[0])
+
+    leading_empty = 0
+    if trim_mode in ("leading", "both"):
+        for col_idx in range(num_cols):
+            if all((row[col_idx][0] == "") if col_idx < len(row) else True for row in rows):
+                leading_empty += 1
+            else:
+                break
+
+    trailing_empty = 0
+    if trim_mode in ("trailing", "both"):
+        for col_idx in range(num_cols - 1, -1, -1):
+            if all((row[col_idx][0] == "") if col_idx < len(row) else True for row in rows):
+                trailing_empty += 1
+            else:
+                break
+
+    if leading_empty > 0 or trailing_empty > 0:
+        end_col = num_cols - trailing_empty
+        return [row[leading_empty:end_col] for row in rows]
+
+    return rows
 
 
 def _xlsx_iter_rows(sheet: Any, max_rows: int | None, max_cols: int | None) -> Iterable[list[Any]]:
@@ -519,8 +587,10 @@ class XlsxToAstConverter(BaseParser):
             return [n for n in sheet_names if pattern.search(n)]
         return sheet_names
 
-    def _convert_rows_to_strings(self, raw_rows: list[list[Any]], merged_map: dict[str, str]) -> list[list[str]]:
-        """Convert raw cell rows to string rows, handling merged cells.
+    def _convert_rows_to_cells(
+        self, raw_rows: list[list[Any]], merged_map: dict[str, str]
+    ) -> list[list[tuple[str, Optional[str]]]]:
+        """Convert raw cell rows to (text, hyperlink_url) pairs, handling merged cells.
 
         Parameters
         ----------
@@ -531,13 +601,13 @@ class XlsxToAstConverter(BaseParser):
 
         Returns
         -------
-        list[list[str]]
-            Rows as string values
+        list[list[tuple[str, str | None]]]
+            Rows of (cell text, hyperlink URL or None) pairs
 
         """
-        str_rows: list[list[str]] = []
+        cell_rows: list[list[tuple[str, Optional[str]]]] = []
         for row in raw_rows:
-            out: list[str] = []
+            out: list[tuple[str, Optional[str]]] = []
             for cell in row:
                 coord = getattr(cell, "coordinate", None)
                 # Only apply merged cell logic if mode is "flatten"
@@ -547,11 +617,12 @@ class XlsxToAstConverter(BaseParser):
                     and coord in merged_map
                     and merged_map[coord] != coord
                 ):
-                    out.append("")
+                    out.append(("", None))
                 else:
-                    out.append(_format_link_or_text(cell, cell.value, self.options.preserve_newlines_in_cells))
-            str_rows.append(out)
-        return str_rows
+                    text = sanitize_cell_text(cell.value, self.options.preserve_newlines_in_cells)
+                    out.append((text, _cell_hyperlink_url(cell)))
+            cell_rows.append(out)
+        return cell_rows
 
     def _compute_alignments(self, sheet: Any, num_cols: int) -> list[Alignment]:
         """Compute column alignments from header cells.
@@ -614,23 +685,30 @@ class XlsxToAstConverter(BaseParser):
         if not raw_rows:
             return children
 
-        # Convert to strings
-        str_rows = self._convert_rows_to_strings(raw_rows, merged_map)
+        # Convert to (text, hyperlink_url) pairs
+        cell_rows = self._convert_rows_to_cells(raw_rows, merged_map)
 
-        # Trim empty rows and columns
-        str_rows = trim_rows(str_rows, cast(Any, self.options.trim_empty))
-        if not str_rows:
+        # Trim empty rows and columns (mirrors trim_rows/trim_columns, but keeps
+        # each cell's hyperlink URL alongside its text through the trim)
+        cell_rows = _trim_paired_rows(cell_rows, cast(Any, self.options.trim_empty))
+        if not cell_rows:
             return children
 
-        str_rows = trim_columns(str_rows, cast(Any, self.options.trim_empty))
-        if not str_rows or not any(str_rows):
+        cell_rows = _trim_paired_columns(cell_rows, cast(Any, self.options.trim_empty))
+        if not cell_rows or not any(cell_rows):
             return children
 
-        # Build table
-        header = str_rows[0]
-        data = str_rows[1:] if len(str_rows) > 1 else []
-        header = transform_header_case(header, self.options.header_case)
-        alignments = self._compute_alignments(sheet, len(header))
+        # Build table: transform_header_case operates on plain text, so split
+        # text/url apart for the header row and re-pair them afterward.
+        header_pairs = cell_rows[0]
+        data_pairs = cell_rows[1:] if len(cell_rows) > 1 else []
+
+        header_text = transform_header_case([text for text, _ in header_pairs], self.options.header_case)
+        header_urls = [url for _, url in header_pairs]
+        alignments = self._compute_alignments(sheet, len(header_text))
+
+        header: list[CellValue] = [_paired_cell(text, url) for text, url in zip(header_text, header_urls, strict=True)]
+        data: list[list[CellValue]] = [[_paired_cell(text, url) for text, url in row] for row in data_pairs]
 
         table = build_table_ast(header, data, alignments)
         children.append(table)

--- a/src/all2md/transforms/builtin.py
+++ b/src/all2md/transforms/builtin.py
@@ -59,6 +59,9 @@ from datetime import datetime, timezone
 from typing import cast
 
 from all2md.ast.nodes import (
+    DefinitionDescription,
+    DefinitionList,
+    DefinitionTerm,
     Document,
     FootnoteDefinition,
     Heading,
@@ -69,6 +72,7 @@ from all2md.ast.nodes import (
     Node,
     Paragraph,
     Text,
+    get_node_children,
     replace_node_children,
 )
 from all2md.ast.transforms import NodeTransformer
@@ -1081,15 +1085,10 @@ class AddAttachmentFootnotesTransform(NodeTransformer):
             # Use helper to add label with automatic duplicate handling
             self._add_footnote_label(base_label, source_text)
 
-        # Recurse into children
-        if hasattr(node, "children") and isinstance(node.children, list):
-            for child in node.children:
-                self._collect_footnote_refs(child)
-
-        # Recurse into content
-        if hasattr(node, "content") and isinstance(node.content, list):
-            for child in node.content:
-                self._collect_footnote_refs(child)
+        # Recurse into all children, regardless of the attribute they're
+        # stored under (children/content/items/header/rows/cells/...).
+        for child in get_node_children(node):
+            self._collect_footnote_refs(child)
 
     def _add_footnote_label(self, base_label: str, source_text: str) -> None:
         """Add a footnote label with automatic duplicate handling.
@@ -1321,16 +1320,14 @@ class GenerateTocTransform(NodeTransformer):
                     self._heading_id_map[heading_idx] = heading_id
 
             self._headings.append((node.level, text, heading_id))
+            # Headings never nest inside other headings; no need to recurse
+            # into their own content.
+            return
 
-        # Recurse into children
-        if hasattr(node, "children") and isinstance(node.children, list):
-            for child in node.children:
-                self._collect_headings(child)
-
-        # Recurse into content
-        if hasattr(node, "content") and isinstance(node.content, list):
-            for child in node.content:
-                self._collect_headings(child)
+        # Recurse into all children, regardless of the attribute they're
+        # stored under (children/content/items/header/rows/cells/...).
+        for child in get_node_children(node):
+            self._collect_headings(child)
 
     def _generate_id(self, text: str) -> str:
         """Generate a slugified ID from heading text.
@@ -1393,24 +1390,29 @@ class GenerateTocTransform(NodeTransformer):
             else:
                 return node
 
-        # Recurse into children
-        if hasattr(node, "children") and isinstance(node.children, list):
-            new_children = []
-            for child in node.children:
-                updated_child = self._inject_heading_ids(child)
-                new_children.append(updated_child)
+        # DefinitionList has a (term, [descriptions]) structure that
+        # replace_node_children cannot rebuild generically, so handle it here.
+        if isinstance(node, DefinitionList):
+            new_items = [
+                (
+                    cast(DefinitionTerm, self._inject_heading_ids(term)),
+                    [
+                        cast(DefinitionDescription, self._inject_heading_ids(description))
+                        for description in descriptions
+                    ],
+                )
+                for term, descriptions in node.items
+            ]
+            return DefinitionList(items=new_items, metadata=node.metadata, source_location=node.source_location)
 
-            # Rebuild node with updated children
-            if isinstance(node, Document):
-                return Document(children=new_children, metadata=node.metadata, source_location=node.source_location)
-            elif isinstance(node, Paragraph):
-                return node  # Paragraphs can't have Heading children
-            else:
-                # For other node types, try to update children if they have that attribute
-                if hasattr(node, "children"):
-                    return replace_node_children(node, new_children)
+        # Recurse into all children, regardless of the attribute they're
+        # stored under (children/content/items/header/rows/cells/...).
+        children = get_node_children(node)
+        if not children:
+            return node
 
-        return node
+        new_children = [self._inject_heading_ids(child) for child in children]
+        return replace_node_children(node, new_children)
 
     def _generate_toc(self) -> list[Node]:
         """Generate TOC nodes from collected headings.

--- a/src/all2md/utils/spreadsheet.py
+++ b/src/all2md/utils/spreadsheet.py
@@ -9,9 +9,35 @@ to reduce code duplication and improve maintainability.
 
 from __future__ import annotations
 
-from typing import Any, Literal
+from typing import Any, Literal, Sequence
 
-from all2md.ast import Alignment, Table, TableCell, TableRow, Text
+from all2md.ast import Alignment, Node, Table, TableCell, TableRow, Text
+
+# A cell's content for build_table_ast(): either plain text (the common case,
+# used by CSV/ODS) or a pre-built list of inline nodes (used by XLSX for a
+# hyperlinked cell, which needs a real Link node rather than a markdown-syntax
+# string that a renderer's Text-escaping would mangle).
+CellValue = str | list[Node]
+
+
+def _cell_content(cell: CellValue) -> list[Node]:
+    """Build TableCell inline content from a cell value.
+
+    Parameters
+    ----------
+    cell : str or list of Node
+        Plain text, wrapped in a single Text node, or a pre-built list of
+        inline nodes used as-is.
+
+    Returns
+    -------
+    list of Node
+        Inline content for a TableCell.
+
+    """
+    if isinstance(cell, str):
+        return [Text(content=cell)]
+    return cell
 
 
 def sanitize_cell_text(text: Any, preserve_newlines: bool = False) -> str:
@@ -49,14 +75,21 @@ def sanitize_cell_text(text: Any, preserve_newlines: bool = False) -> str:
     return s
 
 
-def build_table_ast(header: list[str], rows: list[list[str]], alignments: list[Alignment]) -> Table:
+def build_table_ast(
+    header: Sequence[CellValue], rows: Sequence[Sequence[CellValue]], alignments: list[Alignment]
+) -> Table:
     """Build an AST Table from header, rows, and alignments.
 
     Parameters
     ----------
-    header : list[str]
-        Header row cells
-    rows : list[list[str]]
+    header : sequence of (str or list of Node)
+        Header row cells. Most callers pass plain strings; a cell needing
+        richer inline content (e.g. a hyperlink) can pass a pre-built
+        ``list[Node]`` instead (see :data:`CellValue`). Declared as
+        ``Sequence`` rather than ``list`` so a plain ``list[str]`` -- what
+        every caller besides XLSX passes -- remains assignable despite
+        ``list`` being invariant in its element type.
+    rows : sequence of sequence of (str or list of Node)
         Data rows
     alignments : list[Alignment]
         Column alignments ('left', 'center', 'right')
@@ -69,7 +102,7 @@ def build_table_ast(header: list[str], rows: list[list[str]], alignments: list[A
     """
     # Build header row
     header_cells = [
-        TableCell(content=[Text(content=cell)], alignment=alignments[i] if i < len(alignments) else "center")
+        TableCell(content=_cell_content(cell), alignment=alignments[i] if i < len(alignments) else "center")
         for i, cell in enumerate(header)
     ]
     header_row = TableRow(cells=header_cells, is_header=True)
@@ -78,7 +111,7 @@ def build_table_ast(header: list[str], rows: list[list[str]], alignments: list[A
     data_rows = []
     for row in rows:
         row_cells = [
-            TableCell(content=[Text(content=cell)], alignment=alignments[i] if i < len(alignments) else "center")
+            TableCell(content=_cell_content(cell), alignment=alignments[i] if i < len(alignments) else "center")
             for i, cell in enumerate(row)
         ]
         data_rows.append(TableRow(cells=row_cells, is_header=False))

--- a/tests/golden/__snapshots__/test_html_golden.ambr
+++ b/tests/golden/__snapshots__/test_html_golden.ambr
@@ -54,9 +54,7 @@
   '''
   ## Images
   
-  ![First image](https://example.com/image1.png)
-  
-  ![Second image](https://example.com/image2.jpg)
+  ![First image](https://example.com/image1.png) ![Second image](https://example.com/image2.jpg)
   '''
 # ---
 # name: TestHTMLGolden.test_html_with_lists

--- a/tests/golden/__snapshots__/test_textual_formats_golden.ambr
+++ b/tests/golden/__snapshots__/test_textual_formats_golden.ambr
@@ -345,6 +345,8 @@
           return a + b
   ```
   
+   def multiply(self, a, b): return a \* b 
+  
   Use the `Calculator` class for basic arithmetic.
   
   ## Important Information

--- a/tests/unit/parsers/test_html_parser.py
+++ b/tests/unit/parsers/test_html_parser.py
@@ -840,6 +840,66 @@ class TestEdgeCases:
         # Div should create a paragraph-like structure
         assert isinstance(doc.children[0], Paragraph)
 
+    def test_loose_leading_text_becomes_paragraph(self) -> None:
+        """Bare text directly under <body>, before any block element, is not dropped."""
+        html = "<html><body>Loose text at top. <p>In a paragraph.</p></body></html>"
+        converter = HtmlToAstConverter()
+        doc = converter.convert_to_ast(html)
+
+        assert len(doc.children) == 2
+        assert isinstance(doc.children[0], Paragraph)
+        assert doc.children[0].content[0].content == "Loose text at top. "
+        assert isinstance(doc.children[1], Paragraph)
+        assert doc.children[1].content[0].content == "In a paragraph."
+
+    def test_loose_trailing_text_becomes_paragraph(self) -> None:
+        """Bare text directly under <body>, after a block element, is not dropped."""
+        html = "<html><body><p>In a paragraph.</p>Trailing loose text.</body></html>"
+        converter = HtmlToAstConverter()
+        doc = converter.convert_to_ast(html)
+
+        assert len(doc.children) == 2
+        assert isinstance(doc.children[0], Paragraph)
+        assert doc.children[0].content[0].content == "In a paragraph."
+        assert isinstance(doc.children[1], Paragraph)
+        assert doc.children[1].content[0].content == "Trailing loose text."
+
+    def test_pure_fragment_with_inline_markup_keeps_all_content(self) -> None:
+        """A body-less fragment mixing bare text and inline tags is not discarded.
+
+        Regression test for a bug where the top-level walk only processed Tag
+        children of <body>/root and silently dropped every NavigableString, so
+        this fragment parsed to a Document containing only the Strong('bold')
+        node with all surrounding plain text deleted.
+        """
+        html = "Just plain text with <b>bold</b> inside"
+        converter = HtmlToAstConverter()
+        doc = converter.convert_to_ast(html)
+
+        assert len(doc.children) == 1
+        para = doc.children[0]
+        assert isinstance(para, Paragraph)
+        # Loose text before and after the inline tag must form ONE paragraph together
+        # with the inline element, not separate fragments.
+        assert len(para.content) == 3
+        assert isinstance(para.content[0], Text)
+        assert para.content[0].content == "Just plain text with "
+        assert isinstance(para.content[1], Strong)
+        assert para.content[1].content[0].content == "bold"
+        assert isinstance(para.content[2], Text)
+        assert para.content[2].content == " inside"
+
+    def test_whitespace_only_text_between_blocks_produces_no_paragraph(self) -> None:
+        """Whitespace-only text nodes between block elements must not become paragraphs."""
+        html = "<p>A</p>\n  \n<p>B</p>"
+        converter = HtmlToAstConverter()
+        doc = converter.convert_to_ast(html)
+
+        assert len(doc.children) == 2
+        assert all(isinstance(child, Paragraph) for child in doc.children)
+        assert doc.children[0].content[0].content == "A"
+        assert doc.children[1].content[0].content == "B"
+
 
 @pytest.mark.unit
 class TestNetworkOptionsForwarding:

--- a/tests/unit/parsers/test_xlsx_parser.py
+++ b/tests/unit/parsers/test_xlsx_parser.py
@@ -192,6 +192,92 @@ class TestXlsxBasicConversion:
 
 @pytest.mark.unit
 @pytest.mark.skipif(not HAS_OPENPYXL, reason="openpyxl not installed")
+class TestXlsxHyperlinks:
+    """Tests for cell hyperlinks in XLSX files.
+
+    Regression tests: a hyperlinked cell used to be flattened into a
+    markdown-syntax string ('[text](url)') that flowed into a plain Text
+    node, so the Markdown renderer's Text-escaping turned every hyperlinked
+    cell into a literal, escaped bracket-and-parens sequence instead of a
+    working link.
+    """
+
+    def test_hyperlinked_cell_produces_link_node(self) -> None:
+        """A cell with a hyperlink should produce a Link node in the TableCell, not escaped markdown text."""
+        from all2md.ast import Link, Text
+
+        wb = openpyxl.Workbook()
+        ws = wb.active
+        ws["A1"] = "Name"
+        ws["B1"] = "Site"
+        ws["A2"] = "Example"
+        ws["B2"] = "Click here"
+        ws["B2"].hyperlink = "http://example.com"
+
+        output = BytesIO()
+        wb.save(output)
+        output.seek(0)
+
+        converter = XlsxToAstConverter()
+        ast_doc = converter.parse(output)
+
+        table = next(child for child in ast_doc.children if isinstance(child, Table))
+        link_cell = table.rows[0].cells[1]
+
+        assert len(link_cell.content) == 1
+        link_node = link_cell.content[0]
+        assert isinstance(link_node, Link)
+        assert link_node.url == "http://example.com"
+        assert isinstance(link_node.content[0], Text)
+        assert link_node.content[0].content == "Click here"
+
+    def test_hyperlinked_cell_renders_unescaped_markdown_link(self) -> None:
+        """The rendered markdown for a hyperlinked cell must contain a real, unescaped link."""
+        from all2md import to_markdown
+
+        wb = openpyxl.Workbook()
+        ws = wb.active
+        ws["A1"] = "Name"
+        ws["B1"] = "Site"
+        ws["A2"] = "Example"
+        ws["B2"] = "Click here"
+        ws["B2"].hyperlink = "http://example.com"
+
+        output = BytesIO()
+        wb.save(output)
+        output.seek(0)
+
+        markdown = to_markdown(output, source_format="xlsx")
+
+        assert "[Click here](http://example.com)" in markdown
+        assert r"\[Click here\]" not in markdown
+
+    def test_non_hyperlinked_cell_stays_plain_text(self) -> None:
+        """A cell with no hyperlink is unaffected and still produces a plain Text node."""
+        from all2md.ast import Text
+
+        wb = openpyxl.Workbook()
+        ws = wb.active
+        ws["A1"] = "Name"
+        ws["A2"] = "Plain value"
+
+        output = BytesIO()
+        wb.save(output)
+        output.seek(0)
+
+        converter = XlsxToAstConverter()
+        ast_doc = converter.parse(output)
+
+        table = next(child for child in ast_doc.children if isinstance(child, Table))
+        cell = table.rows[0].cells[0]
+
+        assert len(cell.content) == 1
+        assert isinstance(cell.content[0], Text)
+        assert cell.content[0].content == "Plain value"
+
+
+@pytest.mark.unit
+@pytest.mark.skipif(not HAS_OPENPYXL, reason="openpyxl not installed")
 class TestXlsxImageExtraction:
     """Tests for image extraction from XLSX files."""
 

--- a/tests/unit/transforms/test_builtin_transforms.py
+++ b/tests/unit/transforms/test_builtin_transforms.py
@@ -773,6 +773,58 @@ class TestAddAttachmentFootnotesTransform:
         footnote_defs = [n for n in result.children if isinstance(n, FootnoteDefinition)]
         assert len(footnote_defs) == 1
 
+    def test_finds_footnote_ref_image_nested_in_list_item(self):
+        """Test that a footnote-ref image nested inside a list item is still found.
+
+        Regression test: the walker used to recurse only via
+        ``hasattr(node, "children"/"content")``, which stops dead at List
+        nodes (children live in ``.items``) and ListItem nodes have
+        ``.children`` but the List itself does not expose a plain
+        ``children`` attribute the walker recognized transitively through
+        List -> ListItem -> Paragraph -> Image.
+        """
+        from all2md.ast.nodes import FootnoteDefinition, ListItem
+        from all2md.ast.nodes import List as ListNode
+
+        doc = Document(
+            children=[
+                ListNode(
+                    ordered=False,
+                    items=[
+                        ListItem(
+                            children=[Paragraph(content=[Image(url="", alt_text="nested.png")])],
+                        )
+                    ],
+                )
+            ]
+        )
+
+        transform = AddAttachmentFootnotesTransform()
+        result = transform.transform(doc)
+
+        footnote_defs = [n for n in result.children if isinstance(n, FootnoteDefinition)]
+        assert len(footnote_defs) == 1
+        assert footnote_defs[0].identifier == "nested"
+
+    def test_finds_footnote_ref_image_nested_in_table_cell(self):
+        """Test that a footnote-ref image nested inside a table cell is still found."""
+        from all2md.ast.nodes import FootnoteDefinition, Table, TableCell, TableRow
+
+        doc = Document(
+            children=[
+                Table(
+                    rows=[TableRow(cells=[TableCell(content=[Image(url="", alt_text="in_table.png")])])],
+                )
+            ]
+        )
+
+        transform = AddAttachmentFootnotesTransform()
+        result = transform.transform(doc)
+
+        footnote_defs = [n for n in result.children if isinstance(n, FootnoteDefinition)]
+        assert len(footnote_defs) == 1
+        assert footnote_defs[0].identifier == "in_table"
+
 
 # GenerateTocTransform tests
 
@@ -1183,6 +1235,74 @@ class TestGenerateTocTransform:
 
         assert doc2_headings[0].metadata.get("id") == "heading-a"
         assert doc2_headings[1].metadata.get("id") == "heading-b"
+
+    def test_toc_finds_heading_nested_in_list_item(self):
+        """Test that a heading nested inside a list item is collected into the TOC.
+
+        Regression test: the walker used to recurse only via
+        ``hasattr(node, "children"/"content")``, which stops dead at List
+        nodes since children live in ``.items``.
+        """
+        from all2md.ast.nodes import List as ListNode
+        from all2md.ast.nodes import ListItem
+
+        doc = Document(
+            children=[
+                Heading(level=1, content=[Text(content="Top Heading")]),
+                ListNode(
+                    ordered=False,
+                    items=[
+                        ListItem(children=[Heading(level=2, content=[Text(content="Nested Heading")])]),
+                    ],
+                ),
+            ]
+        )
+
+        transform = GenerateTocTransform(add_links=True, set_ids_if_missing=True)
+        result = transform.transform(doc)
+
+        toc_list = result.children[1]
+        # Top heading plus its nested sub-item for "Nested Heading"
+        assert len(toc_list.items) == 1
+        nested_lists = [child for child in toc_list.items[0].children if isinstance(child, ListNode)]
+        assert len(nested_lists) == 1
+        nested_urls = [item.children[0].content[0].url for item in nested_lists[0].items]
+        assert "#nested-heading" in nested_urls
+
+        # The nested heading should also have had its id injected into the document.
+        list_node = result.children[3]
+        nested_heading = list_node.items[0].children[0]
+        assert isinstance(nested_heading, Heading)
+        assert nested_heading.metadata.get("id") == "nested-heading"
+
+    def test_toc_finds_heading_nested_in_table_cell(self):
+        """Test that a heading nested inside a table cell is collected and id-injected."""
+        from all2md.ast.nodes import Table, TableCell, TableRow
+
+        doc = Document(
+            children=[
+                Table(
+                    rows=[
+                        TableRow(cells=[TableCell(content=[Heading(level=2, content=[Text(content="Cell Heading")])])])
+                    ],
+                )
+            ]
+        )
+
+        transform = GenerateTocTransform(add_links=True, set_ids_if_missing=True)
+        result = transform.transform(doc)
+
+        toc_list = result.children[1]
+        assert len(toc_list.items) == 1
+        para = toc_list.items[0].children[0]
+        link = para.content[0]
+        assert link.url == "#cell-heading"
+
+        # Id should be injected back into the heading inside the table cell.
+        table_node = result.children[2]
+        injected_heading = table_node.rows[0].cells[0].content[0]
+        assert isinstance(injected_heading, Heading)
+        assert injected_heading.metadata.get("id") == "cell-heading"
 
 
 # TitlePromotionTransform tests

--- a/tests/unit/utils/test_spreadsheet_utils.py
+++ b/tests/unit/utils/test_spreadsheet_utils.py
@@ -1,7 +1,7 @@
 #  Copyright (c) 2025 Tom Villani, Ph.D.
 """Tests for shared spreadsheet utility functions."""
 
-from all2md.ast import Table, TableCell
+from all2md.ast import Link, Table, TableCell, Text
 from all2md.utils.spreadsheet import (
     build_table_ast,
     create_table_cell,
@@ -80,6 +80,28 @@ class TestBuildTableAst:
         assert len(table.rows) == 2
         assert table.rows[0].cells[0].content[0].content == "Data1"
         assert table.rows[1].cells[0].content[0].content == "Data2"
+
+    def test_cell_accepts_prebuilt_node_list(self):
+        """A cell value may be a pre-built list[Node] (e.g. a hyperlink's Link node).
+
+        Regression test for the seam XLSX uses to emit real Link nodes for
+        hyperlinked cells instead of a markdown-syntax string. Plain-string
+        cells (used by CSV/ODS) must keep working exactly as before.
+        """
+        header = ["Name", "Site"]
+        rows = [["Example", [Link(url="https://example.com", content=[Text(content="Click here")])]]]
+        alignments = ["left", "left"]
+
+        table = build_table_ast(header, rows, alignments)
+
+        # Plain string cells still become a single Text node.
+        assert table.rows[0].cells[0].content == [Text(content="Example")]
+
+        # A cell given a pre-built node list is used as-is.
+        link_cell_content = table.rows[0].cells[1].content
+        assert len(link_cell_content) == 1
+        assert isinstance(link_cell_content[0], Link)
+        assert link_cell_content[0].url == "https://example.com"
 
 
 class TestCreateTableCell:


### PR DESCRIPTION
Fixes three verified findings from the 2026-08-13 codebase audit (Leg 3, findings #3, #9, #16).

## Transforms: AST walkers stopped dead at List/Table nodes (#3, medium)

`AddAttachmentFootnotesTransform._collect_footnote_refs`, `GenerateTocTransform._collect_headings`, and `_inject_heading_ids` recursed via `hasattr(node, 'children')`/`hasattr(node, 'content')` — which List (`.items`), Table (`.header`/`.rows`), TableRow (`.cells`), and DefinitionList all fail, so nested footnote refs and headings were silently missed. All three now use the canonical `get_node_children()` helper (the repo's known fix for this recurring bug class). `_inject_heading_ids` gets a hand-written DefinitionList case since `replace_node_children` deliberately refuses that node's `(term, [descriptions])` structure.

## HTML: bare text directly under `<body>` silently discarded (#9, high)

`_process_body_children` skipped every non-`Tag` child, so loose text at the top level of a body or fragment vanished ("Just plain text with `<b>`bold`</b>` inside" parsed to just `Strong('bold')`). It now delegates to the existing `_process_block_container`, which already accumulates adjacent inline content into single Paragraphs, flushes at block boundaries, and drops whitespace-only strings — no duplicated logic, and top-level HTML comments are now handled consistently too.

## XLSX: cell hyperlinks emitted as escaped markdown literals (#16, medium)

`_format_link_or_text` baked `[text](url)` markdown syntax into Text nodes, which every renderer then mangled (Markdown escapes it to `\[text\](url)`; HTML emits the literal string). Hyperlinked cells now become real `Link` AST nodes: cells flow through the pipeline as `(text, url)` pairs, and `build_table_ast` in the shared spreadsheet util accepts `CellValue = str | list[Node]` (typed `Sequence` for covariance, so CSV/ODS `list[str]` callers are unaffected). Trimming uses local paired variants of `trim_rows`/`trim_columns` so a hyperlink survives trim decisions attached to its cell. ODS checked: it has no hyperlink extraction at all, so unaffected.

## Verification

- New tests: nested-in-List/TableCell coverage for all three walkers (footnote refs, TOC collection, id injection); loose leading/trailing/fragment/whitespace-only HTML text; xlsx Link node + unescaped render + `build_table_ast` list-of-nodes cells.
- Targeted suites green: transforms (251), html sweep, xlsx/csv/ods/spreadsheet-utils (~85). The one `-k html` failure (`test_random_binary_as_pdf`) is a pre-existing Hypothesis deadline flake, reproduced standalone on main.
- Golden xlsx snapshot in `test_other_formats_golden.ambr` unchanged (fixture has no hyperlinks).
- black / ruff / mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
