### PR TITLE
fix(api,chunking): honor the kwargs warn-and-drop contract beside options objects; keep chunk spans on the section basis

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **An unknown keyword argument passed beside an options object now warns instead of
+  raising `TypeError`.** `to_ast`, `from_ast`, `to_markdown`, `convert` and `roundtrip`
+  document a single rule for a keyword argument no options class has a field for: warn
+  and drop it. That rule only ever ran on the branch where the caller passed *no* options
+  object. Pass one — `to_ast(src, parser_options=MarkdownParserOptions(), bogus=1)` — and
+  the kwargs went straight to `create_updated`, which is `dataclasses.replace`, so the
+  same typo escaped as `MarkdownParserOptions.__init__() got an unexpected keyword
+  argument 'bogus'` instead. The same branch could not reach a field of a *nested* options
+  dataclass either: `network_timeout` lives on `options.network`, the no-options branch
+  has always folded it in, and the with-options branch raised on it even though it is a
+  perfectly valid option for that format. Both are now handled the same way on both
+  branches, with the existing warning categories and wording.
+  Related: the kwargs that `to_markdown`/`convert` pre-split were checked against the
+  *detected format's* options class rather than the class of the options instance that
+  actually receives them. Options classes inherit (`MboxOptions` is an `EmlOptions`) and
+  parsers accept any subclass of what they expect, so a caller could legitimately pass an
+  instance whose class is not the format's own — and a field of *that* class, such as
+  `max_messages` on an eml parse, was dropped as "not for the formats in this conversion"
+  and silently applied nothing. The split now uses the receiving instance's class when one
+  is given.
 - **Words no longer fuse across a formatting change in run-based formats.**
   `group_and_format_runs` — the shared helper that turns a paragraph's runs into inline
   nodes for PPTX (and available to any run-based parser) — joined each same-format group

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Chunk character spans stay on the basis they claim under `--avoid-table-split` /
+  `--avoid-code-split`.** Every chunk is stamped `char_basis="section_text"` — the span
+  indexes the section's rendered Markdown — and that held only while a section was
+  chunked in one piece. Segmenting a section around an atomic table or code block
+  computed each segment's offsets against *that segment's* own text: the atomic piece
+  got the constant span `(0, len(text))` and each prose segment restarted at 0. On a
+  prose/table/prose section every chunk after the first therefore reported a span that
+  overlapped its predecessors and, sliced out of the section text as documented,
+  returned the wrong text — 45 of 119 chunks over this repository's README across five
+  strategies. Each segment is now located in the section's own rendering and its windows
+  shifted by that offset, so the spans are true, ordered and non-overlapping. Searching
+  forward from the previous segment's end keeps two identically-rendered segments (two
+  tables with the same cells) in document order. Rendering a fragment is not guaranteed
+  to reproduce a substring of rendering the whole — footnote definitions, for one, are
+  collected at the end of whatever document they are rendered in — so a segment that
+  cannot be located keeps its segment-relative span and says so with a new
+  `char_basis="segment_text"`, rather than reporting a section offset that is wrong.
+  Check `char_basis` before slicing.
 - **An unknown keyword argument passed beside an options object now warns instead of
   raising `TypeError`.** `to_ast`, `from_ast`, `to_markdown`, `convert` and `roundtrip`
   document a single rule for a keyword argument no options class has a field for: warn

--- a/docs/source/cli.rst
+++ b/docs/source/cli.rst
@@ -743,7 +743,10 @@ Each line is a flat object: ``chunk_id``, ``index``, ``text``, ``token_count``,
 ``source_line_start``, ``source_line_end``, ``char_start``, ``char_end``,
 ``char_basis``, ``prev_chunk_id``, ``next_chunk_id``. Character spans index into
 the chunk's rendered section text (``char_basis="section_text"``), and ``page``
-fields are populated only for formats that track pages.
+fields are populated only for formats that track pages. Check ``char_basis``
+before slicing: under ``--avoid-table-split`` / ``--avoid-code-split`` a chunk
+whose segment could not be located in the section text reports
+``char_basis="segment_text"``, with the span relative to that segment instead.
 
 Python API
 ~~~~~~~~~~

--- a/src/all2md/api.py
+++ b/src/all2md/api.py
@@ -7,7 +7,7 @@ import warnings
 from collections.abc import Iterator
 from contextlib import contextmanager
 from contextvars import ContextVar
-from dataclasses import fields, is_dataclass
+from dataclasses import fields, is_dataclass, replace
 from pathlib import Path
 from typing import IO, TYPE_CHECKING, Any, Optional, TypeVar, Union, cast, get_type_hints
 
@@ -52,6 +52,10 @@ def _transforms() -> Any:
 
 # TypeVar for generic options creation
 OptionsT = TypeVar("OptionsT", BaseParserOptions, BaseRendererOptions)
+
+# TypeVar for updating an existing options instance. Bound rather than value-restricted
+# so the caller's concrete class (e.g. MarkdownRendererOptions) survives the round trip.
+OptionsInstanceT = TypeVar("OptionsInstanceT", bound=Union[BaseParserOptions, BaseRendererOptions])
 
 
 def _resolve_document_source(
@@ -421,6 +425,74 @@ def _create_options_from_kwargs(
     return options_class(**valid_kwargs)
 
 
+def _nested_dataclass_type(field_type: Any) -> type[Any] | None:
+    """Return the options dataclass an annotation refers to, unwrapping ``Optional``.
+
+    Returns ``None`` when the annotation is not (or does not contain) a dataclass.
+    """
+    if field_type is None:
+        return None
+    if isinstance(field_type, type) and is_dataclass(field_type):
+        return field_type
+    for arg in getattr(field_type, "__args__", ()):
+        if arg is not type(None) and isinstance(arg, type) and is_dataclass(arg):
+            return arg
+    return None
+
+
+def _merge_kwargs_into_options(options: OptionsInstanceT, kwargs: dict[str, Any], stacklevel: int) -> OptionsInstanceT:
+    """Apply loose keyword arguments on top of an options object the caller built.
+
+    ``create_updated`` is :func:`dataclasses.replace`, so on its own it fails two ways
+    that are routine at the API surface, where kwargs arrive beside a pre-built options
+    instance: a name the dataclass has no field for raises ``TypeError`` instead of the
+    documented warn-and-drop, and a field of a *nested* options dataclass
+    (``network_timeout`` lives on ``options.network``) raises even though it is a
+    perfectly good option for that format. The no-options branch
+    (``_create_options_from_kwargs``) handles both, so this makes the with-options
+    branch behave the same way (#12).
+
+    ``stacklevel`` is counted from the caller's frame, as if it had called
+    ``warnings.warn`` itself.
+    """
+    options_class = cast("type[BaseParserOptions] | type[BaseRendererOptions]", type(options))
+    nested_info = _collect_nested_dataclass_kwargs(options_class, kwargs)
+    type_hints = _option_type_hints(options_class)
+
+    updates: dict[str, Any] = {}
+    dropped: list[str] = []
+
+    # Fold nested names into the nested instance already on ``options`` so unrelated
+    # fields of that nested object survive; build a fresh one only if it is absent.
+    for nested_field_name, nested_kwargs in nested_info["nested"].items():
+        current: Any = getattr(options, nested_field_name, None)
+        if current is not None and is_dataclass(type(current)):
+            updates[nested_field_name] = replace(current, **nested_kwargs)
+            continue
+        nested_class = _nested_dataclass_type(type_hints.get(nested_field_name))
+        if nested_class is not None:
+            updates[nested_field_name] = nested_class(**nested_kwargs)
+        else:  # pragma: no cover - defensive, the field was resolved as a dataclass
+            dropped.extend(nested_kwargs)
+
+    option_names = {field.name for field in fields(options_class)}
+    for name, value in nested_info["remaining"].items():
+        if name in option_names:
+            updates[name] = value
+        else:
+            dropped.append(name)
+
+    if dropped:
+        logger.debug(f"Skipping unknown {options_class.__name__} options: {dropped}")
+        _warn_dropped_kwargs(dropped, stacklevel=stacklevel)
+
+    if not updates:
+        return options
+    # ``create_updated`` returns ``Self``, which mypy resolves against the TypeVar's
+    # union bound rather than the concrete class the caller passed.
+    return cast(OptionsInstanceT, options.create_updated(**updates))
+
+
 def _create_parser_options_from_kwargs(format: DocumentFormat, **kwargs: Any) -> BaseParserOptions | None:
     """Create format-specific parser options object from keyword arguments.
 
@@ -462,7 +534,12 @@ def _create_renderer_options_from_kwargs(format: DocumentFormat, **kwargs: Any) 
 
 
 def _split_kwargs_for_parser_and_renderer(
-    parser_format: DocumentFormat, renderer_format: DocumentFormat, kwargs: dict
+    parser_format: DocumentFormat,
+    renderer_format: DocumentFormat,
+    kwargs: dict,
+    *,
+    parser_options: BaseParserOptions | None = None,
+    renderer_options: BaseRendererOptions | None = None,
 ) -> tuple[dict, dict]:
     """Split kwargs between parser and renderer based on their field names.
 
@@ -474,15 +551,37 @@ def _split_kwargs_for_parser_and_renderer(
         Renderer format to determine which kwargs belong to renderer
     kwargs : dict
         Keyword arguments to split
+    parser_options : BaseParserOptions, optional
+        The options instance the parser kwargs will actually be merged into. When
+        given, its own class decides which names are parser names -- see Notes.
+    renderer_options : BaseRendererOptions, optional
+        The options instance the renderer kwargs will actually be merged into.
 
     Returns
     -------
     tuple[dict, dict]
         (parser_kwargs, renderer_kwargs)
 
+    Notes
+    -----
+    The formats are only a stand-in for "the class that will receive these kwargs".
+    When the caller also passed an options *instance*, that instance is what receives
+    them, and it need not be the detected format's own options class -- parsers accept
+    any subclass of what they expect, and detection can land on a neighbouring format.
+    Validating against the format's class then splits by the wrong field list: a name
+    the instance accepts is dropped as unmatched, and a name it does not accept is
+    routed onward to a bare ``dataclasses.replace`` that raises ``TypeError`` instead
+    of warning (#12).
+
     """
-    parser_class = _get_parser_options_class_for_format(parser_format)
-    renderer_class = _get_renderer_options_class_for_format(renderer_format)
+    parser_class = (
+        type(parser_options) if parser_options is not None else _get_parser_options_class_for_format(parser_format)
+    )
+    renderer_class = (
+        type(renderer_options)
+        if renderer_options is not None
+        else _get_renderer_options_class_for_format(renderer_format)
+    )
 
     parser_kwargs = {}
     renderer_kwargs = {}
@@ -650,11 +749,13 @@ def to_markdown(
             kwargs["flavor"] = flavor
 
         # Split kwargs for renderer (parser kwargs are irrelevant for AST input)
-        _, renderer_kwargs = _split_kwargs_for_parser_and_renderer("markdown", "markdown", kwargs)
+        _, renderer_kwargs = _split_kwargs_for_parser_and_renderer(
+            "markdown", "markdown", kwargs, renderer_options=renderer_options
+        )
 
         final_renderer_options: MarkdownRendererOptions
         if renderer_kwargs and renderer_options:
-            final_renderer_options = renderer_options.create_updated(**renderer_kwargs)
+            final_renderer_options = _merge_kwargs_into_options(renderer_options, renderer_kwargs, stacklevel=3)
         elif renderer_kwargs:
             result = _create_renderer_options_from_kwargs("markdown", **renderer_kwargs)
             assert result is None or isinstance(result, MarkdownRendererOptions)
@@ -695,12 +796,18 @@ def to_markdown(
         actual_format = registry.detect_format(detection_input, hint=None)  # type: ignore[arg-type,assignment]
 
     # Split kwargs between parser and renderer
-    parser_kwargs, renderer_kwargs = _split_kwargs_for_parser_and_renderer(actual_format, "markdown", kwargs)
+    parser_kwargs, renderer_kwargs = _split_kwargs_for_parser_and_renderer(
+        actual_format,
+        "markdown",
+        kwargs,
+        parser_options=parser_options,
+        renderer_options=renderer_options,
+    )
 
     # Prepare parser options
     final_parser_options: BaseParserOptions | None
     if parser_kwargs and parser_options:
-        final_parser_options = parser_options.create_updated(**parser_kwargs)
+        final_parser_options = _merge_kwargs_into_options(parser_options, parser_kwargs, stacklevel=3)
     elif parser_kwargs:
         final_parser_options = _create_parser_options_from_kwargs(actual_format, **parser_kwargs)
     else:
@@ -711,7 +818,7 @@ def to_markdown(
         renderer_kwargs["flavor"] = flavor
 
     if renderer_kwargs and renderer_options:
-        final_renderer_options = renderer_options.create_updated(**renderer_kwargs)
+        final_renderer_options = _merge_kwargs_into_options(renderer_options, renderer_kwargs, stacklevel=3)
     elif renderer_kwargs:
         result = _create_renderer_options_from_kwargs("markdown", **renderer_kwargs)
         assert result is None or isinstance(result, MarkdownRendererOptions)
@@ -869,7 +976,7 @@ def to_ast(
     # Prepare parser options
     final_parser_options: BaseParserOptions | None
     if kwargs and parser_options:
-        final_parser_options = parser_options.create_updated(**kwargs)
+        final_parser_options = _merge_kwargs_into_options(parser_options, kwargs, stacklevel=3)
     elif kwargs:
         opts = _create_parser_options_from_kwargs(actual_format, **kwargs)
         if opts is None:
@@ -1224,7 +1331,7 @@ def roundtrip_report(
             raise FormatError("Cannot auto-detect format from text-mode stream. Please specify source_format.")
 
         parser_kwargs, _ = _split_kwargs_for_parser_and_renderer(
-            cast(DocumentFormat, actual_source_format), via, dict(kwargs)
+            cast(DocumentFormat, actual_source_format), via, dict(kwargs), parser_options=parser_options
         )
         original = to_ast(
             cast(Union[str, Path, IO[bytes], bytes], resolved_payload),
@@ -1235,11 +1342,11 @@ def roundtrip_report(
         )
 
     _, renderer_kwargs = _split_kwargs_for_parser_and_renderer(
-        cast(DocumentFormat, actual_source_format), via, dict(kwargs)
+        cast(DocumentFormat, actual_source_format), via, dict(kwargs), renderer_options=renderer_options
     )
     final_renderer_options: Optional[BaseRendererOptions]
     if renderer_kwargs and renderer_options:
-        final_renderer_options = renderer_options.create_updated(**renderer_kwargs)
+        final_renderer_options = _merge_kwargs_into_options(renderer_options, renderer_kwargs, stacklevel=3)
     elif renderer_kwargs:
         final_renderer_options = _create_renderer_options_from_kwargs(via, **renderer_kwargs)
     else:
@@ -1546,7 +1653,7 @@ def from_ast(
     # Prepare renderer options
     final_renderer_options: Optional[BaseRendererOptions]
     if kwargs and renderer_options:
-        final_renderer_options = renderer_options.create_updated(**kwargs)
+        final_renderer_options = _merge_kwargs_into_options(renderer_options, kwargs, stacklevel=3)
     elif kwargs:
         final_renderer_options = _create_renderer_options_from_kwargs(target_format, **kwargs)
     else:
@@ -1823,12 +1930,14 @@ def convert(
         cast(DocumentFormat, actual_source_format),
         cast(DocumentFormat, actual_target_format),
         kwargs,
+        parser_options=parser_options,
+        renderer_options=renderer_options,
     )
 
     # Parse to AST
     final_parser_options: Optional[BaseParserOptions]
     if parser_kwargs and parser_options:
-        final_parser_options = parser_options.create_updated(**parser_kwargs)
+        final_parser_options = _merge_kwargs_into_options(parser_options, parser_kwargs, stacklevel=3)
     elif parser_kwargs:
         final_parser_options = _create_parser_options_from_kwargs(
             cast(DocumentFormat, actual_source_format), **parser_kwargs
@@ -1864,7 +1973,7 @@ def convert(
     final_renderer_options: Optional[BaseRendererOptions]
     with library_injected_options(*injected_by_shorthand):
         if renderer_kwargs and renderer_options:
-            final_renderer_options = renderer_options.create_updated(**renderer_kwargs)
+            final_renderer_options = _merge_kwargs_into_options(renderer_options, renderer_kwargs, stacklevel=3)
         elif renderer_kwargs:
             final_renderer_options = _create_renderer_options_from_kwargs(
                 cast(DocumentFormat, actual_target_format), **renderer_kwargs

--- a/src/all2md/chunking/provenance.py
+++ b/src/all2md/chunking/provenance.py
@@ -22,7 +22,9 @@ Rendering each unit to Markdown (rather than flattening with ``extract_text``)
 preserves the blank-line/structure boundaries the paragraph/line/section
 chunkers depend on, and yields clean, RAG-friendly chunk text. Character spans
 are therefore into that rendered section text (``char_basis="section_text"``),
-not the original binary.
+not the original binary -- including when ``avoid_table_split`` /
+``avoid_code_split`` chunk a section one segment at a time; see
+:func:`_build_pieces` for the one case that cannot hold the basis and says so.
 """
 
 from __future__ import annotations
@@ -379,7 +381,7 @@ def _emit_unit(
     running index.
     """
     pieces = _build_pieces(chunker, unit_nodes, provenance_nodes, opts)
-    for chunk_in_unit, (text, tokens, char_start, char_end, prov_nodes) in enumerate(pieces, start=1):
+    for chunk_in_unit, (text, tokens, char_start, char_end, prov_nodes, char_basis) in enumerate(pieces, start=1):
         page, page_end, line_start, line_end = _node_provenance(prov_nodes)
         chunks.append(
             ProvenanceChunk(
@@ -400,7 +402,7 @@ def _emit_unit(
                 source_line_end=line_end,
                 char_start=char_start,
                 char_end=char_end,
-                char_basis="section_text",
+                char_basis=char_basis,
             )
         )
         running_index += 1
@@ -408,8 +410,8 @@ def _emit_unit(
 
 
 # A renderable chunk before id/provenance assignment:
-# (text, token_count, char_start, char_end, provenance_nodes).
-_Piece = tuple[str, int, int, int, list[Node]]
+# (text, token_count, char_start, char_end, provenance_nodes, char_basis).
+_Piece = tuple[str, int, int, int, list[Node], str]
 
 
 def _build_pieces(
@@ -418,29 +420,80 @@ def _build_pieces(
     provenance_nodes: list[Node],
     opts: _UnitOpts,
 ) -> list[_Piece]:
-    """Render and chunk a unit into pieces, keeping atomic nodes whole when asked."""
+    """Render and chunk a unit into pieces, keeping atomic nodes whole when asked.
+
+    Every piece carries a span *into the unit's own rendered Markdown* -- the string a
+    consumer gets by rendering the section, which is what ``char_basis="section_text"``
+    promises. The segmented path renders each segment separately, so its windows count
+    from 0 within that segment; each segment is located in the whole-unit rendering and
+    its windows are shifted by that offset. A segment that cannot be located (rendering
+    a fragment is not always a substring of rendering the whole -- footnote definitions,
+    for one, are collected at the end of whatever document they are rendered in) keeps
+    its segment-relative span and says so with ``char_basis="segment_text"``, rather
+    than reporting a section offset that is wrong.
+    """
     pieces: list[_Piece] = []
 
     if opts.atomic_types and any(isinstance(n, opts.atomic_types) for n in unit_nodes):
+        # One extra render of the whole unit, only on this path, to have the string the
+        # spans are documented to index into.
+        section_text = _render_markdown(unit_nodes, opts.elide_data_uris)
+        cursor = 0
         for seg_nodes, is_atomic in _segment_atomic(unit_nodes, opts.atomic_types):
             text = _render_markdown(seg_nodes, opts.elide_data_uris)
             if not text.strip():
                 continue
+            offset = _locate_segment(section_text, text, cursor)
+            basis = "section_text" if offset is not None else "segment_text"
+            base = offset if offset is not None else 0
+            if offset is not None:
+                cursor = offset + len(text)
             if is_atomic:
                 # Whole atomic node is one chunk; allowed to exceed max_tokens.
-                pieces.append((text, chunker.counter.count(text), 0, len(text), seg_nodes))
+                pieces.append((text, chunker.counter.count(text), base, base + len(text), seg_nodes, basis))
             else:
                 for window in chunker.chunk(text):
                     pieces.append(
-                        (window.content, window.tokens, window.position.start, window.position.end, seg_nodes)
+                        (
+                            window.content,
+                            window.tokens,
+                            base + window.position.start,
+                            base + window.position.end,
+                            seg_nodes,
+                            basis,
+                        )
                     )
         return pieces
 
     text = _render_markdown(unit_nodes, opts.elide_data_uris)
     if text.strip():
         for window in chunker.chunk(text):
-            pieces.append((window.content, window.tokens, window.position.start, window.position.end, provenance_nodes))
+            pieces.append(
+                (
+                    window.content,
+                    window.tokens,
+                    window.position.start,
+                    window.position.end,
+                    provenance_nodes,
+                    "section_text",
+                )
+            )
     return pieces
+
+
+def _locate_segment(section_text: str, segment_text: str, cursor: int) -> Optional[int]:
+    """Return where ``segment_text`` starts in ``section_text``, or None if it does not.
+
+    Searching forward from ``cursor`` (the end of the previous segment) keeps the
+    segments in document order when two of them render identically -- two tables with
+    the same cells, say -- which a plain search would collapse onto the first match.
+    Falls back to a search from the start so one unlocatable segment does not strand
+    every segment after it.
+    """
+    offset = section_text.find(segment_text, cursor)
+    if offset < 0:
+        offset = section_text.find(segment_text)
+    return offset if offset >= 0 else None
 
 
 def _segment_atomic(nodes: list[Node], atomic_types: tuple[type, ...]) -> list[tuple[list[Node], bool]]:

--- a/src/all2md/chunking/records.py
+++ b/src/all2md/chunking/records.py
@@ -55,8 +55,14 @@ class ProvenanceChunk:
         Character span of this chunk. By default these index into the
         section's extracted text (see ``char_basis``), not the original binary.
     char_basis : str
-        What ``char_start``/``char_end`` index into. ``"section_text"`` for
-        fine-grained strategies; ``"document"`` is reserved for future
+        What ``char_start``/``char_end`` index into -- always check it before
+        slicing. ``"section_text"`` (the usual value) is the section's rendered
+        Markdown, the string you get by rendering the section's nodes.
+        ``"segment_text"`` appears only under ``avoid_table_split`` /
+        ``avoid_code_split``, for a chunk whose atomic segment could not be
+        located in that section text (rendering a fragment is not always a
+        substring of rendering the whole); the span is then relative to that
+        segment's own rendered Markdown. ``"document"`` is reserved for future
         binary-accurate spans.
     prev_chunk_id, next_chunk_id : str or None
         Neighbor ids, for reconstructing reading order downstream.

--- a/src/all2md/skills/all2md/references/chunk.md
+++ b/src/all2md/skills/all2md/references/chunk.md
@@ -110,7 +110,7 @@ Each line is a flat object with these keys:
 `chunk_id`, `index`, `text`, `token_count`, `token_counter`, `strategy`, `document_id`, `document_path`, `section_heading`, `section_level`, `section_index`, `page`, `page_end`, `source_line_start`, `source_line_end`, `char_start`, `char_end`, `char_basis`, `prev_chunk_id`, `next_chunk_id`.
 
 Notes:
-- `char_start`/`char_end` index into the chunk's rendered **section text** (`char_basis="section_text"`), not the original binary.
+- `char_start`/`char_end` index into the chunk's rendered **section text** (`char_basis="section_text"`), not the original binary. Check `char_basis` before slicing: under `--avoid-table-split`/`--avoid-code-split`, a chunk whose segment could not be located in the section text reports `char_basis="segment_text"` and its span is relative to that segment.
 - `page`/`page_end` are populated only for formats that track pages (PDF and similar); otherwise `null`.
 - `section_index` is `-1` for preamble / pre-heading content.
 - `prev_chunk_id`/`next_chunk_id` chain chunks in reading order within a document.

--- a/tests/unit/chunking/test_provenance.py
+++ b/tests/unit/chunking/test_provenance.py
@@ -223,6 +223,143 @@ class TestAvoidCodeSplit:
         assert len(code_chunks) >= 2
 
 
+class TestCharSpansIndexTheSectionText:
+    """``char_start``/``char_end`` must mean what ``char_basis`` says they mean.
+
+    Every chunk is stamped ``char_basis="section_text"``: an index into the section's
+    rendered Markdown. The segmented path (``avoid_table_split`` / ``avoid_code_split``)
+    used to compute its offsets against each *segment's* text instead -- atomic pieces
+    got the constant span ``(0, len(text))`` and each prose segment restarted at 0 -- so
+    a consumer slicing the section text by those spans got the wrong text for every
+    chunk after the first segment, and the spans overlapped.
+    """
+
+    def _section_text(self, nodes):
+        """The string the spans are documented to index into."""
+        from all2md.chunking.provenance import _render_markdown
+
+        return _render_markdown(list(nodes))
+
+    def _doc_with_table(self):
+        """A section shaped prose / table / prose."""
+        return Document(
+            children=[
+                Heading(level=1, content=[Text(content="Data")]),
+                Paragraph(content=[Text(content="Intro paragraph with several words to chunk.")]),
+                _table(8),
+                Paragraph(content=[Text(content="Trailing paragraph after the table here.")]),
+            ]
+        )
+
+    def _doc_with_code(self):
+        """A section shaped prose / code / prose."""
+        code = "\n".join(f"line_{i} = compute(value_{i}, other_{i})" for i in range(12))
+        return Document(
+            children=[
+                Heading(level=1, content=[Text(content="Code")]),
+                Paragraph(content=[Text(content="Intro paragraph before the code block here.")]),
+                CodeBlock(content=code, language="python"),
+                Paragraph(content=[Text(content="Trailing paragraph after the code here.")]),
+            ]
+        )
+
+    @pytest.mark.parametrize("strategy", ["paragraph", "word", "line", "sentence"])
+    def test_each_span_slices_its_own_text_out_of_the_section(self, strategy):
+        doc = self._doc_with_table()
+        section_text = self._section_text(doc.children)
+
+        chunks = chunk_ast(doc, strategy=strategy, max_tokens=8, avoid_table_split=True, token_counter="whitespace")
+
+        assert len(chunks) > 1, "this document must segment for the test to mean anything"
+        for chunk in chunks:
+            assert chunk.char_basis == "section_text"
+            assert section_text[chunk.char_start : chunk.char_end] == chunk.text
+
+    def test_spans_advance_and_do_not_overlap(self):
+        doc = self._doc_with_table()
+        chunks = chunk_ast(doc, strategy="paragraph", max_tokens=8, avoid_table_split=True, token_counter="whitespace")
+
+        starts = [c.char_start for c in chunks]
+        assert starts == sorted(starts)
+        for earlier, later in zip(chunks, chunks[1:], strict=False):
+            assert later.char_start >= earlier.char_end
+
+    def test_the_atomic_chunk_is_not_pinned_to_zero(self):
+        """The atomic piece used to be stamped ``(0, len(text))`` whatever preceded it."""
+        doc = self._doc_with_table()
+        chunks = chunk_ast(doc, strategy="paragraph", max_tokens=8, avoid_table_split=True, token_counter="whitespace")
+
+        table_chunk = next(c for c in chunks if "|" in c.text)
+        assert table_chunk.char_start > 0
+        assert self._section_text(doc.children)[table_chunk.char_start : table_chunk.char_end] == table_chunk.text
+
+    def test_code_segmentation_too(self):
+        doc = self._doc_with_code()
+        section_text = self._section_text(doc.children)
+
+        chunks = chunk_ast(doc, strategy="paragraph", max_tokens=8, avoid_code_split=True, token_counter="whitespace")
+
+        assert any("compute(" in c.text for c in chunks)
+        for chunk in chunks:
+            assert section_text[chunk.char_start : chunk.char_end] == chunk.text
+
+    def test_two_identical_segments_get_different_spans(self):
+        """Searching from the previous segment's end keeps repeats in document order."""
+        doc = Document(
+            children=[
+                Heading(level=1, content=[Text(content="Twice")]),
+                Paragraph(content=[Text(content="Between the first and second copy.")]),
+                _table(2),
+                Paragraph(content=[Text(content="Between the first and second copy.")]),
+                _table(2),
+            ]
+        )
+        section_text = self._section_text(doc.children)
+
+        chunks = chunk_ast(doc, strategy="paragraph", max_tokens=8, avoid_table_split=True, token_counter="whitespace")
+
+        table_chunks = [c for c in chunks if "|" in c.text]
+        assert len(table_chunks) == 2
+        assert table_chunks[0].char_start != table_chunks[1].char_start
+        for chunk in chunks:
+            assert section_text[chunk.char_start : chunk.char_end] == chunk.text
+
+    def test_the_unsegmented_path_is_unchanged(self):
+        """Control: the path that already honoured the contract still does."""
+        doc = self._doc_with_table()
+        section_text = self._section_text(doc.children)
+
+        chunks = chunk_ast(doc, strategy="paragraph", max_tokens=8, token_counter="whitespace")
+
+        for chunk in chunks:
+            assert chunk.char_basis == "section_text"
+            assert section_text[chunk.char_start : chunk.char_end] == chunk.text
+
+    def test_an_unlocatable_segment_admits_its_basis(self, monkeypatch):
+        """Rendering a fragment is not always a substring of rendering the whole.
+
+        Footnote definitions, for one, are collected at the end of whatever document
+        they are rendered in. Rather than report a section offset that is wrong, such a
+        chunk keeps its segment-relative span and renames the basis.
+        """
+        from all2md.chunking import provenance
+
+        doc = self._doc_with_table()
+        whole = len(doc.children)
+        original = provenance._render_markdown
+
+        def render_fragments_differently(nodes, elide_data_uris=True):
+            text = original(nodes, elide_data_uris)
+            return text if len(nodes) == whole else f"<<<{text}"
+
+        monkeypatch.setattr(provenance, "_render_markdown", render_fragments_differently)
+        chunks = chunk_ast(doc, strategy="paragraph", max_tokens=8, avoid_table_split=True, token_counter="whitespace")
+
+        assert chunks
+        assert {c.char_basis for c in chunks} == {"segment_text"}
+        assert chunks[0].char_start == 0
+
+
 class TestDataUriElision:
     """Long base64 data URIs are elided from chunk text by default."""
 

--- a/tests/unit/core/test_api_kwarg_validation.py
+++ b/tests/unit/core/test_api_kwarg_validation.py
@@ -14,6 +14,7 @@ import warnings
 import pytest
 
 from all2md import from_ast, to_ast, to_markdown
+from all2md.options import HtmlOptions, MarkdownParserOptions, MarkdownRendererOptions
 
 MARKDOWN_SRC = "# Heading\n\nBody text.\n"
 
@@ -234,3 +235,133 @@ class TestUnknownKwargsStillApplyTheGoodOnes:
             warnings.simplefilter("ignore")
             out = to_markdown(MARKDOWN_SRC, source_format="markdown", flavor="commonmark", bogus_xyz=1)
         assert "Heading" in out
+
+
+@pytest.mark.unit
+class TestKwargsBesideAnOptionsInstance:
+    """The warn-and-drop contract held only when no options object was passed (#12).
+
+    With one, the kwargs went to ``create_updated`` -- a bare ``dataclasses.replace``
+    -- so an unknown name raised ``TypeError`` from inside the library instead of
+    warning, and a field of a nested options dataclass raised too even though it is a
+    real option for that format.
+    """
+
+    def test_to_ast_warns_instead_of_raising(self):
+        found = _warnings_matching(
+            TYPO, to_ast, MARKDOWN_SRC, source_format="markdown", parser_options=MarkdownParserOptions(), bogus_xyz=1
+        )
+        assert found, "to_ast with parser_options did not warn about an unknown kwarg"
+        assert "bogus_xyz" in str(found[0].message)
+
+    def test_from_ast_warns_instead_of_raising(self):
+        doc = to_ast(MARKDOWN_SRC, source_format="markdown")
+        found = _warnings_matching(
+            TYPO, from_ast, doc, "markdown", renderer_options=MarkdownRendererOptions(), bogus_xyz=1
+        )
+        assert found, "from_ast with renderer_options did not warn about an unknown kwarg"
+        assert "bogus_xyz" in str(found[0].message)
+
+    def test_to_markdown_warns_instead_of_raising(self):
+        found = _warnings_matching(
+            TYPO,
+            to_markdown,
+            MARKDOWN_SRC,
+            source_format="markdown",
+            parser_options=MarkdownParserOptions(),
+            bogus_xyz=1,
+        )
+        assert found, "to_markdown with parser_options did not warn about an unknown kwarg"
+        assert "bogus_xyz" in str(found[0].message)
+
+    @pytest.mark.parametrize("entry_point", [to_ast, to_markdown])
+    def test_the_two_branches_agree(self, entry_point):
+        """Parity, not an ideal: passing options must not change what a bad name does."""
+        without = [
+            str(w.message) for w in _warnings_from(entry_point, MARKDOWN_SRC, source_format="markdown", bogus_xyz=1)
+        ]
+        with_options = [
+            str(w.message)
+            for w in _warnings_from(
+                entry_point,
+                MARKDOWN_SRC,
+                source_format="markdown",
+                parser_options=MarkdownParserOptions(),
+                bogus_xyz=1,
+            )
+        ]
+        assert with_options == without
+
+    def test_a_nested_option_field_still_lands_on_the_nested_object(self):
+        """``network_timeout`` lives on ``options.network``; replace() cannot see it."""
+        from all2md.api import _merge_kwargs_into_options
+
+        options = HtmlOptions()
+        merged = _merge_kwargs_into_options(options, {"network_timeout": 5}, stacklevel=3)
+
+        assert merged.network.network_timeout == 5
+        assert options.network.network_timeout != 5, "the caller's options object was mutated"
+        # Sibling fields of the nested object survive the merge.
+        assert merged.network.max_redirects == options.network.max_redirects
+
+    def test_a_nested_option_field_does_not_raise_through_the_api(self):
+        assert not _warnings_from(
+            to_markdown, "<p>x</p>", source_format="html", parser_options=HtmlOptions(), network_timeout=5
+        )
+
+    def test_the_good_kwargs_beside_the_bad_one_still_apply(self):
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            out = to_markdown(
+                "Some *emph* text.\n",
+                source_format="markdown",
+                renderer_options=MarkdownRendererOptions(),
+                emphasis_symbol="_",
+                bogus_xyz=1,
+            )
+        assert "_emph_" in out
+
+
+@pytest.mark.unit
+class TestKwargsAreCheckedAgainstTheInstanceThatReceivesThem:
+    """The kwargs go onto the options object passed, so that object sets the field list.
+
+    Options classes inherit (``MboxOptions`` is an ``EmlOptions``) and parsers accept
+    any subclass of what they expect, so the instance a caller hands in need not be the
+    detected format's own options class. Splitting kwargs by the *format's* class then
+    dropped a name the receiving object accepts -- silently applying nothing (#12).
+    """
+
+    EML_SRC = b"From: a@b.com\nSubject: Hi\n\nBody text here.\n"
+
+    def test_a_field_of_the_passed_class_is_not_dropped(self):
+        from all2md.options import MboxOptions
+
+        found = _warnings_from(
+            to_markdown, self.EML_SRC, source_format="eml", parser_options=MboxOptions(), max_messages=5
+        )
+        assert not found, f"a field of the options object passed was dropped: {[str(w.message) for w in found]}"
+
+    def test_it_reaches_the_options_object(self, monkeypatch):
+        from all2md import api
+        from all2md.options import MboxOptions
+
+        received = {}
+        original = api._merge_kwargs_into_options
+
+        def spy(options, kwargs, stacklevel):
+            received["class"] = type(options).__name__
+            received["kwargs"] = dict(kwargs)
+            return original(options, kwargs, stacklevel)
+
+        monkeypatch.setattr(api, "_merge_kwargs_into_options", spy)
+        to_markdown(self.EML_SRC, source_format="eml", parser_options=MboxOptions(), max_messages=5)
+
+        assert received == {"class": "MboxOptions", "kwargs": {"max_messages": 5}}
+
+    def test_a_name_the_passed_class_lacks_is_still_diagnosed(self):
+        """The other direction: it is dropped with the usual warning, not raised."""
+        found = _warnings_from(
+            to_markdown, MARKDOWN_SRC, source_format="markdown", parser_options=MarkdownParserOptions(), pages="1-3"
+        )
+        assert found and "pages" in str(found[0].message)


### PR DESCRIPTION
Fixes two verified findings from the 2026-08-13 codebase audit (Leg 3, findings #12, #14).

## #12: options+kwargs merge bypassed the warn-and-drop filter (medium)

`to_ast`'s documented contract is that an unrecognized kwarg warns and is dropped — but only the no-options branch honored it. With an options instance also passed, `create_updated(**kwargs)` is a bare `dataclasses.replace`, so an unknown name raised a raw `TypeError`. A new `_merge_kwargs_into_options` helper does for an existing instance what `_create_options_from_kwargs` does for a constructed one — nested-field kwargs merge into the nested object already on the instance, unknown names route through `_warn_dropped_kwargs` with the same categories and stacklevel — and replaces all seven `create_updated(**kwargs)` sites (`to_ast`, `from_ast`, `to_markdown` ×2, `convert` ×2, `roundtrip_report`).

`_split_kwargs_for_parser_and_renderer` now validates against the class of the options **instance** actually passed, not the detected format's class. Scope correction found while fixing: the raw-TypeError direction of that mismatch was effectively unreachable (parsers reject foreign options via `_validate_options_type` anyway) — the reachable defect was the opposite direction: `to_markdown(eml, parser_options=MboxOptions(), max_messages=5)` silently dropped `max_messages` because `MboxOptions` subclasses `EmlOptions` and the split checked the parent class. It now applies. Bonus fix: nested-field kwargs beside an options instance (e.g. `network_timeout` with `HtmlOptions()`) previously raised on every entry point; they now merge.

## #14: chunk char spans silently changed basis under atomic segmentation (medium)

`ProvenanceChunk` documents `char_basis="section_text"`, but when `avoid_table_split`/`avoid_code_split` segmentation kicked in, offsets were computed per segment — atomic pieces got `(0, len(text))` and prose windows restarted at 0 per segment, so spans overlapped and slicing the section text extracted wrong content for everything after the first segment.

The segmented path now renders the whole unit once, locates each segment's rendering inside it (searching forward from the previous segment's end, so identically-rendered segments — two same-cell tables — keep document order), and shifts that segment's windows by the offset. A segment that genuinely cannot be located (rendering a fragment isn't always a substring of rendering the whole) keeps its segment-relative span and honestly reports a new `char_basis="segment_text"` instead of a wrong section offset — probing found no real input that trips this today, so it's defensive and covered by a monkeypatched test. Docs updated in `records.py`, the module docstring, `docs/source/cli.rst`, and the chunk skill reference.

Measured on this repo's README across 5 strategies with both avoid-split flags: **45 of 119 chunks sliced wrong before, 0 of 119 after**, no overlaps.

## Verification

- 15 new api-kwargs tests (7 fail pre-fix) incl. a with/without-options warning-parity test; 9 new provenance tests (all 9 fail pre-fix; un-segmented control passes throughout).
- `tests/unit/{chunking,core,options,cli}` + `tests/integration/test_cli_chunk.py`: 288 passed.
- Full Sphinx `-W` build succeeds; black / ruff / mypy clean.
- Pre-existing (not from this diff, identical on main): two tests emit `Keyword arguments were ignored: ['attachment_mode']` — the library-injected-options mark doesn't cover those call paths; possibly worth its own finding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
