### PR TITLE
fix(pdf): audit cluster — dead pipeline, ruling-line text loss, grid caps, silent page drops, list nesting order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   included: it means "detect the region, don't build a table from it", and the region's
   text has already been excluded by the time it is honoured — but it is not counted as a
   table rejection, because nothing was rejected.
+- **A framed text box no longer becomes a one-cell PDF "table".** `_pdf_tables` states
+  that its caps "apply to both PyMuPDF's `find_tables()` output and our ruling-line
+  detector since both can fire on the same false-positive shapes", and the `find_tables()`
+  path enforces `MIN_TABLE_ROWS` x `MIN_TABLE_COLS` accordingly. The ruling-line detector
+  did not: it asked only for two horizontal and two vertical lines, which is a *single
+  cell*, so a stroked callout box that cleared the sparsity guard came out as one cell of
+  prose wrapped in pipes — the exact shape those constants exist to reject. It now applies
+  the same minimum to the grid the lines actually bound (`len(lines) - 1` per axis), and
+  demotes what it rejects to a paragraph like every other guard. The same function had also
+  re-hardcoded two shared thresholds as bare literals — `> 0.70` beside the imported
+  `MAX_TABLE_EMPTY_RATIO`, `>= 5` beside `MIN_FILLED_FOR_UNIFORMITY_CHECK` — which happened
+  to agree with them and would have drifted silently the first time either was retuned;
+  both now read the constant.
 - **Words no longer fuse across a formatting change in run-based formats.**
   `group_and_format_runs` — the shared helper that turns a paragraph's runs into inline
   nodes for PPTX (and available to any run-based parser) — joined each same-format group

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   included: it means "detect the region, don't build a table from it", and the region's
   text has already been excluded by the time it is honoured — but it is not counted as a
   table rejection, because nothing was rejected.
+- **A PDF list no longer nests a parent item underneath its own child.**
+  `_determine_list_level_from_x` assigned each newly seen indent the level
+  `len(x_levels)` — arrival order — and never compared the x-coordinates to each other.
+  The first list item of a run was therefore level 0 whatever its indent, and every new
+  indent after it was one level *deeper* whether it lay to the right or to the left. A
+  nested list that continues at the top of a column or page begins on a sub-bullet, which
+  is routine in two-column typesetting; the sub-bullet took level 0, the genuine top-level
+  bullet after it took level 1, and since the list builder reads a larger level as deeper,
+  the parent list ended up nested inside its own child. Levels are now assigned by
+  comparing x: within tolerance of an established indent is that indent's level, further
+  right than all of them opens a deeper one, further left than all of them opens a
+  shallower one, and an indent arriving between two known ones lands between their levels.
+  The numbers are no longer 0-based or contiguous — they are an ordering key, and
+  renumbering them would strand the levels the list builder has already recorded on its
+  stack. A list run that starts on a sub-bullet now emits that sub-list in its own right
+  rather than dropping it when the stack unwinds past its bottom. **Not** addressed: this
+  is still blind to columns, so the first item of a right-hand column reads as deeper than
+  anything in the left one.
 - **A PDF page whose text cannot be read no longer disappears without a trace.**
   `_process_page_to_ast` wrapped its `page.get_text("dict", ...)` call in
   `except (AttributeError, KeyError, Exception): return []` — no log line, no degraded

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **A PDF's ruling-line table fallback no longer deletes the text of any region it
+  rejects.** Text that falls inside a detected table's bounding box is removed from the
+  page's ordinary text blocks *before* the table is validated, so that it is not emitted
+  twice. The `find_tables()` path knows this and hands the region's text back as a
+  paragraph from every one of its rejection branches. The ruling-line fallback —
+  `_extract_table_from_ruling_rect`, which reads a page's stroked lines directly — did
+  not: it returned bare `None` when extraction was switched off, when fewer than 2x2
+  ruling lines were found, and from each of its sparsity, uniformity and dot-leader/TOC
+  guards. Every one of those deleted the framed region's prose outright, and the
+  conversion still reported success. On a synthetic page holding a stroked frame with one
+  internal rule and a sentence inside it, `table_detection_mode="ruling"` produced *no
+  output at all* — the 2x2 grid was 75% empty, the sparsity guard rejected it, and the
+  sentence went with it. All five paths now return the region's text as a paragraph, the
+  same way the `find_tables()` path does. `table_fallback_extraction_mode="none"` is
+  included: it means "detect the region, don't build a table from it", and the region's
+  text has already been excluded by the time it is honoured — but it is not counted as a
+  table rejection, because nothing was rejected.
 - **Words no longer fuse across a formatting change in run-based formats.**
   `group_and_format_runs` — the shared helper that turns a paragraph's runs into inline
   nodes for PPTX (and available to any run-based parser) — joined each same-format group

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   assumed.
   ([#338](https://github.com/thomas-villani/all2md/issues/338))
 
+### Changed
+
+- **Removed an unreachable second block-processing pipeline from the PDF parser.**
+  `_process_text_region_to_ast` and the five helpers it alone called
+  (`_process_text_blocks_to_nodes`, `_process_blocks_line_text`,
+  `_process_blocks_line_monospace`, `_apply_column_detection` and
+  `_merge_columns_for_reading_order`) had no callers anywhere in the package or the test
+  suite. They were a near-duplicate of the live per-block path that had drifted away from
+  it — same responsibilities, different rotated-text, code-block and heading handling — so
+  reading them gave a misleading picture of what the parser actually does, and any fix
+  applied to one copy silently missed the other. No behaviour changes: nothing called them.
+
 ### Fixed
 
 - **Words no longer fuse across a formatting change in run-based formats.**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   included: it means "detect the region, don't build a table from it", and the region's
   text has already been excluded by the time it is honoured — but it is not counted as a
   table rejection, because nothing was rejected.
+- **A PDF page whose text cannot be read no longer disappears without a trace.**
+  `_process_page_to_ast` wrapped its `page.get_text("dict", ...)` call in
+  `except (AttributeError, KeyError, Exception): return []` — no log line, no degraded
+  event, no progress event. A page that failed to extract was indistinguishable in the
+  output from a page that was genuinely blank, and the conversion still reported success;
+  worse, if every page tripped it, the document-level OCR safety net saw an empty document
+  and could put a perfectly good text PDF through OCR. The failure is now logged at
+  `WARNING` with the page number and the underlying exception, and recorded as a
+  `page_text_extraction_failed` degraded event at `error` severity so it reaches the
+  confidence report. The tolerance itself is unchanged and deliberate — one unreadable
+  page must not cost the other four hundred, and the parser is driven with mock pages that
+  cannot answer `get_text()` at all — so the page is still skipped rather than raising.
+  The in-place `dehyphenate_blocks()` call, which had drifted inside the same `try`, has
+  been hoisted out of it: it runs on blocks that were already read successfully, so a
+  failure there is a bug in all2md rather than an unreadable page, and it was being
+  laundered into the same silent empty page.
 - **A framed text box no longer becomes a one-cell PDF "table".** `_pdf_tables` states
   that its caps "apply to both PyMuPDF's `find_tables()` output and our ruling-line
   detector since both can fire on the same false-positive shapes", and the `find_tables()`

--- a/src/all2md/parsers/pdf.py
+++ b/src/all2md/parsers/pdf.py
@@ -3119,13 +3119,6 @@ class PdfToAstConverter(BaseParser):
         h_lines_sorted = sorted(h_lines, key=lambda line: line[1])  # Sort by y-coordinate
         v_lines_sorted = sorted(v_lines, key=lambda line: line[0])  # Sort by x-coordinate
 
-        if len(h_lines_sorted) < 2 or len(v_lines_sorted) < 2:
-            # Need at least 2 horizontal and 2 vertical lines to form cells
-            return self._region_text_as_paragraph(page, table_rect, page_num)
-
-        # Create grid cells from line intersections
-        rows: list[TableRow] = []
-
         # Extract y-coordinates for rows (between consecutive h_lines)
         row_y_coords = [(h_lines_sorted[i][1], h_lines_sorted[i + 1][1]) for i in range(len(h_lines_sorted) - 1)]
 
@@ -3135,6 +3128,23 @@ class PdfToAstConverter(BaseParser):
         n_rows = len(row_y_coords)
         n_cols = len(col_x_coords)
         n_cells = n_rows * n_cols
+
+        # The same degenerate-grid cap the find_tables() path applies, on the grid the
+        # ruling lines actually bound: n lines on an axis bound n-1 cells, so the old
+        # ">= 2 lines on each axis" test admitted a 1x1 "table" -- a framed text box that
+        # cleared the sparsity guard came out as a single cell of prose wrapped in pipes.
+        # Fewer than two lines on an axis bounds no cells at all and lands here too.
+        if n_rows < MIN_TABLE_ROWS or n_cols < MIN_TABLE_COLS:
+            logger.debug(
+                f"Rejecting ruling-line table on page {page_num + 1}: "
+                f"{n_rows}x{n_cols} is not a grid (needs at least "
+                f"{MIN_TABLE_ROWS}x{MIN_TABLE_COLS})"
+            )
+            self._record_table_rejection("degenerate_grid")
+            return self._region_text_as_paragraph(page, table_rect, page_num)
+
+        # Create grid cells from line intersections
+        rows: list[TableRow] = []
 
         import pymupdf
 
@@ -3165,9 +3175,9 @@ class PdfToAstConverter(BaseParser):
         if not rows:
             return self._region_text_as_paragraph(page, table_rect, page_num)
 
-        # Sparsity guard: real tables are not mostly empty. A "table" with
-        # >70% empty cells is almost always a misfire on a bordered region.
-        if n_cells > 0 and n_empty / n_cells > 0.70:
+        # Sparsity guard: real tables are not mostly empty. A "table" past
+        # MAX_TABLE_EMPTY_RATIO is almost always a misfire on a bordered region.
+        if n_cells > 0 and n_empty / n_cells > MAX_TABLE_EMPTY_RATIO:
             logger.debug(
                 f"Rejecting ruling-line table on page {page_num + 1}: "
                 f"{n_empty}/{n_cells} ({n_empty / n_cells:.0%}) cells empty"
@@ -3179,7 +3189,7 @@ class PdfToAstConverter(BaseParser):
         # content is the prompt-callout pattern (decorative box with a
         # repeated title fragment scattered across cells).
         n_filled = n_cells - n_empty
-        if len(unique_texts) == 1 and n_filled >= 5:
+        if len(unique_texts) == 1 and n_filled >= MIN_FILLED_FOR_UNIFORMITY_CHECK:
             logger.debug(
                 f"Rejecting ruling-line table on page {page_num + 1}: "
                 f"all {n_filled} non-empty cells have identical content"

--- a/src/all2md/parsers/pdf.py
+++ b/src/all2md/parsers/pdf.py
@@ -1981,13 +1981,35 @@ class PdfToAstConverter(BaseParser):
         # Detect tables on the page
         table_info, _, _ = self._detect_page_tables(page, page_num, total_pages)
 
-        # Extract all text blocks from the page
+        # Extract all text blocks from the page.
+        #
+        # A page whose text cannot be read at all is tolerated rather than fatal: one
+        # broken page should not cost the other 400, and the test suite drives this
+        # method with mock pages that cannot answer get_text() at all. But it is no
+        # longer silent. A page that vanished without a trace was indistinguishable in
+        # the output from a page that was genuinely blank, the conversion still reported
+        # success, and if every page tripped it the document-level OCR safety net saw an
+        # empty document and could re-run a perfectly good text PDF through OCR.
         try:
             all_blocks = page.get_text("dict", flags=pymupdf.TEXTFLAGS_TEXT, sort=False)["blocks"]
-            if self.options.merge_hyphenated_words:
-                dehyphenate_blocks(all_blocks)
-        except (AttributeError, KeyError, Exception):
+        except Exception as e:
+            logger.warning(
+                "Text extraction failed on page %d (%s); the page is dropped from the output.", page_num + 1, e
+            )
+            self._record_degraded(
+                "page_text_extraction_failed",
+                detail=f"page {page_num + 1}: {type(e).__name__}: {e}",
+                severity="error",
+            )
             return []
+
+        # Deliberately outside the try. dehyphenate_blocks() is defensive internally and
+        # operates on blocks we have already read successfully, so an exception from it
+        # is a bug in our own code, not an unreadable page -- and the catch above would
+        # have turned it into the same silent empty page. (It was moved inside the try in
+        # 0e2d5927, which predates this method's error handling meaning anything.)
+        if self.options.merge_hyphenated_words:
+            dehyphenate_blocks(all_blocks)
 
         # Run layout analysis if enabled (before any filtering so indices match).
         # Done before image extraction so that page-header / page-footer regions

--- a/src/all2md/parsers/pdf.py
+++ b/src/all2md/parsers/pdf.py
@@ -3528,27 +3528,72 @@ class PdfToAstConverter(BaseParser):
         x_coord : float
             The x-coordinate of the list item
         x_levels : dict
-            Dictionary mapping level numbers to representative x-coordinates
+            Level number -> the x-coordinate anchoring it. Mutated in place as new
+            indents are seen; the caller clears it whenever a non-list node ends the run.
 
         Returns
         -------
         int
-            The nesting level (0-based)
+            The nesting level: an ordering key, not a count. A larger ``x`` always
+            yields a larger level, but the numbers are neither 0-based nor contiguous.
+            See the notes.
 
         Notes
         -----
-        X-coordinates within 5 points of each other are considered the same level.
+        X-coordinates within 5 points of an established indent are that indent's level.
+
+        Levels used to be handed out in *arrival* order (``len(x_levels)``), so the first
+        item seen was level 0 whatever its indent, and each new indent after it was one
+        level deeper whether it lay to the right or to the left. A nested list that
+        continues at the top of a column or page begins on a sub-bullet -- routine in
+        two-column typesetting -- so the sub-bullet took level 0 and the genuine
+        top-level bullet after it took level 1. The caller reads a larger level as
+        "deeper", so it nested the parent underneath its own child.
+
+        An indent shallower than everything seen so far consequently has to be able to
+        become a shallower *level* after the fact, and one arriving between two known
+        indents has to be able to land between their levels. Renumbering would strand
+        the level numbers the caller has already recorded on its list stack, so instead
+        the numbers are only ever compared, never counted: a shallower indent takes
+        ``min(...) - LEVEL_STRIDE``, a deeper one ``max(...) + LEVEL_STRIDE``, and one in
+        between takes the midpoint of its two neighbours' levels. The stride is what
+        leaves room for that midpoint; ten successive insertions into the same gap
+        exhaust it, at which point the indent joins the nearer of the two rather than
+        colliding with one of them.
+
+        Known limitation, deliberately out of scope: this is blind to columns. The first
+        item of a right-hand column sits at a larger ``x`` than anything in the left one,
+        so it still reads as deeper. Fixing that needs to know which column each item
+        came from, which this helper is not given.
 
         """
         LEVEL_THRESHOLD = 5.0
+        LEVEL_STRIDE = 1024
 
-        # Check if x_coord matches an existing level
-        for level, level_x in x_levels.items():
-            if abs(x_coord - level_x) < LEVEL_THRESHOLD:
-                return level
+        if not x_levels:
+            x_levels[0] = x_coord
+            return 0
 
-        # New level - assign it the next available level number
-        new_level = len(x_levels)
+        # Compare against the *nearest* indent rather than the first one within
+        # tolerance: with several levels established, "first match wins" is arrival order
+        # again, by way of the dict's insertion order.
+        nearest_level = min(x_levels, key=lambda level: abs(x_coord - x_levels[level]))
+        if abs(x_coord - x_levels[nearest_level]) < LEVEL_THRESHOLD:
+            return nearest_level
+
+        if x_coord > max(x_levels.values()):
+            new_level = max(x_levels) + LEVEL_STRIDE
+        elif x_coord < min(x_levels.values()):
+            new_level = min(x_levels) - LEVEL_STRIDE
+        else:
+            # Between two established indents. Level order tracks indent order, so the
+            # neighbouring levels can be picked out by number.
+            below = max(level for level, level_x in x_levels.items() if level_x < x_coord)
+            above = min(level for level, level_x in x_levels.items() if level_x > x_coord)
+            new_level = (below + above) // 2
+            if new_level in (below, above):
+                return nearest_level
+
         x_levels[new_level] = x_coord
         return new_level
 
@@ -4026,6 +4071,14 @@ class PdfToAstConverter(BaseParser):
                 parent_items = list_stack[-1][2]
                 if parent_items:
                     parent_items[-1].children.append(nested_list)
+            else:
+                # Nothing shallower left to nest under. Reachable since
+                # _determine_list_level_from_x learned to place a later, shallower indent
+                # *below* the level the stack was opened at: the sub-bullet-first case,
+                # where the run's own first item is a nested one. Its items have no parent
+                # in this document -- the parent came before them, or not at all -- so the
+                # list stands on its own. Dropping it here would delete them.
+                result.append(nested_list)
 
         # Check if we're at the same level and type
         if list_stack and list_stack[-1][1] == level:

--- a/src/all2md/parsers/pdf.py
+++ b/src/all2md/parsers/pdf.py
@@ -3070,7 +3070,7 @@ class PdfToAstConverter(BaseParser):
         h_lines: list[tuple],
         v_lines: list[tuple],
         page_num: int,
-    ) -> AstTable | None:
+    ) -> Node | None:
         """Extract table content from a bounding box using ruling lines.
 
         Implements basic grid-based cell segmentation using detected horizontal
@@ -3091,17 +3091,29 @@ class PdfToAstConverter(BaseParser):
 
         Returns
         -------
-        AstTable or None
-            Table node if extraction successful
+        Node or None
+            A table when the ruling lines really bound one; a paragraph carrying the
+            region's text when the detection is rejected or extraction is switched
+            off; ``None`` only when the region holds no text at all.
 
         Notes
         -----
         This method uses grid-based cell segmentation. It may not work well
         for tables without clear ruling lines or with merged cells.
 
+        Every path out of here that is *not* a table returns the region's text as a
+        paragraph rather than ``None``. The region's text was removed from the ordinary
+        text blocks before this ran (see :meth:`_region_text_as_paragraph`), so this
+        method is the only remaining copy of it: ``None`` deletes it, it does not demote
+        it. The caller, :meth:`_process_table_item`, appends whatever comes back and
+        adds nothing of its own, so there is no risk of emitting the text twice.
+
         """
         if self.options.table_fallback_extraction_mode == "none":
-            return None
+            # "Detect only, don't extract". The region was still detected, so its text is
+            # already out of the text blocks -- hand it back as prose. Not recorded as a
+            # rejection: nothing was rejected, the caller configured extraction off.
+            return self._region_text_as_paragraph(page, table_rect, page_num)
 
         # Sort lines for grid creation
         h_lines_sorted = sorted(h_lines, key=lambda line: line[1])  # Sort by y-coordinate
@@ -3109,7 +3121,7 @@ class PdfToAstConverter(BaseParser):
 
         if len(h_lines_sorted) < 2 or len(v_lines_sorted) < 2:
             # Need at least 2 horizontal and 2 vertical lines to form cells
-            return None
+            return self._region_text_as_paragraph(page, table_rect, page_num)
 
         # Create grid cells from line intersections
         rows: list[TableRow] = []
@@ -3151,7 +3163,7 @@ class PdfToAstConverter(BaseParser):
             rows.append(TableRow(cells=cells, is_header=is_header))
 
         if not rows:
-            return None
+            return self._region_text_as_paragraph(page, table_rect, page_num)
 
         # Sparsity guard: real tables are not mostly empty. A "table" with
         # >70% empty cells is almost always a misfire on a bordered region.
@@ -3161,7 +3173,7 @@ class PdfToAstConverter(BaseParser):
                 f"{n_empty}/{n_cells} ({n_empty / n_cells:.0%}) cells empty"
             )
             self._record_table_rejection("mostly_empty")
-            return None
+            return self._region_text_as_paragraph(page, table_rect, page_num)
 
         # Uniformity guard: a "table" where every non-empty cell has the same
         # content is the prompt-callout pattern (decorative box with a
@@ -3173,7 +3185,7 @@ class PdfToAstConverter(BaseParser):
                 f"all {n_filled} non-empty cells have identical content"
             )
             self._record_table_rejection("uniform_cells")
-            return None
+            return self._region_text_as_paragraph(page, table_rect, page_num)
 
         if n_filled and n_dot_leader / n_filled > MAX_DOT_LEADER_CELL_RATIO:
             logger.debug(
@@ -3182,7 +3194,7 @@ class PdfToAstConverter(BaseParser):
                 f"dot-leader noise (looks like TOC region)"
             )
             self._record_table_rejection("dot_leader_toc")
-            return None
+            return self._region_text_as_paragraph(page, table_rect, page_num)
 
         # Separate header and data rows
         header_row = rows[0] if rows else TableRow(cells=[])

--- a/src/all2md/parsers/pdf.py
+++ b/src/all2md/parsers/pdf.py
@@ -56,7 +56,6 @@ from all2md.ast import (
 )
 from all2md.ast.transforms import InlineFormattingConsolidator, extract_nodes
 from all2md.constants import (
-    DEFAULT_OVERLAP_THRESHOLD_PX,
     DEPS_PDF,
     DEPS_PDF_LAYOUT,
     PDF_MIN_PYMUPDF_VERSION,
@@ -2109,47 +2108,6 @@ class PdfToAstConverter(BaseParser):
 
         return nodes
 
-    def _apply_column_detection(self, blocks: list[dict]) -> list[dict]:
-        """Apply column detection to text blocks based on options.
-
-        Parameters
-        ----------
-        blocks : list[dict]
-            List of text blocks from PyMuPDF
-
-        Returns
-        -------
-        list[dict]
-            Processed blocks in reading order
-
-        """
-        if not self.options.detect_columns:
-            return blocks
-
-        # Check column_detection_mode option
-        if self.options.column_detection_mode in ("disabled", "force_single"):
-            # Force single column (no detection)
-            return blocks
-
-        # Apply column detection for force_multi or auto modes
-        if self.options.column_detection_mode == "force_multi":
-            columns: list[list[dict]] = detect_columns(
-                blocks,
-                self.options.column_gap_threshold,
-                use_clustering=self.options.use_column_clustering,
-                force_multi_column=True,
-            )
-        else:  # "auto" mode (default)
-            columns = detect_columns(
-                blocks,
-                self.options.column_gap_threshold,
-                use_clustering=self.options.use_column_clustering,
-                force_multi_column=False,
-            )
-
-        # Process blocks in proper reading order: top-to-bottom, left-to-right
-        return self._merge_columns_for_reading_order(columns)
-
     def _calculate_blocks_average_line_height(self, blocks: list[dict]) -> float | None:
         """Calculate average line height across multiple blocks."""
         line_heights = []
@@ -2165,173 +2123,6 @@ class PdfToAstConverter(BaseParser):
             logger.debug(f"Calculated average line height for page: {avg:.2f} points")
             return avg
         return None
-
-    def _process_blocks_line_monospace(self, spans: list, text: str, block: dict, state: _BlockProcessingState) -> bool:
-        """Handle monospace line in blocks processing. Returns True if handled."""
-        all_mono = all(s["flags"] & 8 for s in spans)
-        if not all_mono:
-            return False
-
-        state.in_code_block = True
-        span_size = spans[0]["size"]
-        delta = int((spans[0]["bbox"][0] - block["bbox"][0]) / (span_size * 0.5)) if span_size > 0 else 0
-        state.code_block_lines.append(" " * delta + text)
-        return True
-
-    def _process_blocks_line_text(
-        self,
-        spans: list,
-        links: list[dict],
-        page_num: int,
-        average_line_height: float | None,
-        state: _BlockProcessingState,
-    ) -> None:
-        """Process text line (heading or paragraph) in blocks processing."""
-        header_level = 0
-        if self._hdr_identifier:
-            line_style = compute_line_style(spans)
-            if line_style is not None:
-                header_level = self._hdr_identifier.classify_line_style(
-                    size=line_style.size,
-                    text=line_style.text,
-                    is_bold=line_style.is_bold,
-                    is_allcaps=line_style.is_allcaps,
-                )
-        inline_content = self._process_text_spans_to_inline(spans, links, page_num, average_line_height)
-
-        if not inline_content or not inline_has_text(inline_content):
-            return
-
-        if header_level > 0:
-            line_text = "".join(s.get("text", "") for s in spans).strip()
-            self._emit_heading(state, header_level, line_text, inline_content, page_num, _span_union_bbox(spans))
-        else:
-            # Paragraph emission orphans any buffered numbering prefix —
-            # flush it as its own heading so the marker isn't lost.
-            self._flush_pending_heading_prefix(state)
-            state.nodes.append(
-                AstParagraph(content=inline_content, source_location=SourceLocation(format="pdf", page=page_num + 1))
-            )
-
-    def _process_text_blocks_to_nodes(
-        self, blocks_to_process: list[dict], links: list[dict], page_num: int
-    ) -> list[Node]:
-        """Process text blocks into AST nodes.
-
-        Parameters
-        ----------
-        blocks_to_process : list[dict]
-            Text blocks to process
-        links : list[dict]
-            Links on the page
-        page_num : int
-            Page number for source tracking
-
-        Returns
-        -------
-        list[Node]
-            List of AST nodes
-
-        """
-        average_line_height = self._calculate_blocks_average_line_height(blocks_to_process)
-        state = _BlockProcessingState()
-
-        for block in blocks_to_process:
-            previous_y = 0.0
-
-            for line in block["lines"]:
-                # Handle rotated text — group consecutive same-direction lines
-                if line.get("dir", (0, 0))[1] != 0:
-                    if self.options.handle_rotated_text:
-                        self._accumulate_rotated_line(line, state, page_num)
-                    continue
-                # Horizontal line: flush any pending rotated run before continuing
-                self._flush_rotated_text(state, page_num)
-
-                spans = list(line["spans"])
-                if not spans:
-                    continue
-
-                this_y = line["bbox"][3]
-                same_line = abs(this_y - previous_y) <= DEFAULT_OVERLAP_THRESHOLD_PX and previous_y > 0
-                text = "".join([s["text"] for s in spans])
-
-                if not same_line:
-                    previous_y = this_y
-
-                # Handle monospace text (code blocks)
-                if self._process_blocks_line_monospace(spans, text, block, state):
-                    continue
-
-                # Finalize code block if we were in one
-                if state.in_code_block:
-                    self._finalize_code_block(state, page_num)
-
-                # Process text line (heading or paragraph)
-                self._process_blocks_line_text(spans, links, page_num, average_line_height, state)
-
-        # Finalize any remaining code block
-        if state.in_code_block:
-            self._finalize_code_block(state, page_num)
-
-        # Flush any trailing rotated-text run
-        self._flush_rotated_text(state, page_num)
-
-        # Drop any unmerged numbering prefix as a standalone heading rather
-        # than silently swallowing it.
-        self._flush_pending_heading_prefix(state)
-
-        return state.nodes
-
-    def _process_text_region_to_ast(self, page: "pymupdf.Page", clip: "pymupdf.Rect", page_num: int) -> list[Node]:
-        """Process a text region to AST nodes.
-
-        Parameters
-        ----------
-        page : pymupdf.Page
-            PDF page
-        clip : pymupdf.Rect
-            Clipping rectangle for text extraction
-        page_num : int
-            Page number for source tracking
-
-        Returns
-        -------
-        list of Node
-            List of AST nodes (paragraphs, headings, code blocks)
-
-        """
-        import pymupdf
-
-        # Extract URL type links on page
-        try:
-            links = [line for line in page.get_links() if line["kind"] == 2]
-        except (AttributeError, Exception):
-            links = []
-
-        # Extract text blocks
-        try:
-            blocks = page.get_text(
-                "dict",
-                clip=clip,
-                flags=pymupdf.TEXTFLAGS_TEXT,
-                sort=False,
-            )["blocks"]
-            if self.options.merge_hyphenated_words:
-                dehyphenate_blocks(blocks)
-        except (AttributeError, KeyError, Exception):
-            # If extraction fails (e.g., in tests), return empty
-            return []
-
-        # Filter out headers/footers if trim_headers_footers is enabled
-        if self.options.trim_headers_footers:
-            blocks = self._filter_headers_footers(blocks, page)
-
-        # Apply column detection
-        blocks_to_process = self._apply_column_detection(blocks)
-
-        # Process blocks to create AST nodes
-        return self._process_text_blocks_to_nodes(blocks_to_process, links, page_num)
 
     def _process_text_spans_to_inline(
         self, spans: list[dict], links: list[dict], page_num: int, average_line_height: float | None = None
@@ -3660,38 +3451,6 @@ class PdfToAstConverter(BaseParser):
             filtered_blocks.append(block)
 
         return filtered_blocks
-
-    def _merge_columns_for_reading_order(self, columns: list[list[dict]]) -> list[dict]:
-        """Merge multiple columns into proper reading order.
-
-        For multi-column layouts, the standard reading order is column-by-column:
-        read the entire left column top-to-bottom, then move to the right column
-        and read it top-to-bottom. This matches how PyMuPDF naturally orders blocks
-        and is the expected behavior for most multi-column documents.
-
-        Parameters
-        ----------
-        columns : list[list[dict]]
-            List of columns, where each column is a list of blocks
-
-        Returns
-        -------
-        list[dict]
-            Merged list of blocks in proper reading order
-
-        """
-        if len(columns) <= 1:
-            # Single column or empty, just return flattened
-            return [block for col in columns for block in col]
-
-        # Sort each column by y-coordinate (top to bottom)
-        # Then concatenate: all of column 0, then all of column 1, etc.
-        result = []
-        for column in columns:
-            sorted_column = sorted(column, key=lambda b: b.get("bbox", [0, 0, 0, 0])[1])
-            result.extend(sorted_column)
-
-        return result
 
     def _is_list_item_paragraph(self, paragraph: AstParagraph) -> bool:
         """Check if paragraph starts with a list marker.

--- a/tests/unit/formats/pdf/test_pdf_list_nesting_levels.py
+++ b/tests/unit/formats/pdf/test_pdf_list_nesting_levels.py
@@ -1,0 +1,208 @@
+#  Copyright (c) 2025 Tom Villani, Ph.D.
+#
+# tests/unit/formats/pdf/test_pdf_list_nesting_levels.py
+"""A PDF list item's nesting level comes from its indent, not from when it was seen.
+
+``_determine_list_level_from_x`` used to hand out levels in arrival order --
+``len(x_levels)`` -- with no comparison of the x-coordinates themselves. The first list
+item of a run became level 0 whatever its indent, and each new indent after it became one
+level deeper whether it was further right or further left.
+
+That inverts a very ordinary shape. A nested list continuing at the top of a column or a
+page starts on a *sub*-bullet, so the sub-bullet was recorded as level 0 and the genuine
+top-level bullet after it as level 1. The caller reads a larger level as deeper and calls
+``_handle_deeper_nesting``, so the parent list ended up nested inside its own child.
+
+The requirement pinned here is an ordering one -- larger indent, larger level -- and not
+any particular numbering, so these tests assert the ordering and never the numbers. The
+levels are deliberately neither 0-based nor contiguous: renumbering them to keep either
+property would strand the level numbers the caller has already recorded on its list
+stack, so a shallower indent takes a lower number instead, and one arriving between two
+known indents takes a number between theirs.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from all2md.ast.nodes import List, ListItem, SourceLocation, Text
+from all2md.ast.nodes import Paragraph as AstParagraph
+from all2md.ast.utils import extract_text
+from all2md.options.pdf import PdfOptions
+from all2md.parsers.pdf import PdfToAstConverter
+
+pytestmark = [pytest.mark.unit, pytest.mark.pdf]
+
+TOP_LEVEL_X = 72.0
+SUB_LEVEL_X = 100.0
+SUB_SUB_LEVEL_X = 128.0
+
+
+@pytest.fixture
+def converter() -> PdfToAstConverter:
+    return PdfToAstConverter(options=PdfOptions())
+
+
+def _levels(converter: PdfToAstConverter, *xs: float) -> list[int]:
+    """The level assigned to each x, in the order the items were seen."""
+    x_levels: dict[int, float] = {}
+    return [converter._determine_list_level_from_x(x, x_levels) for x in xs]
+
+
+class TestTheLevelFollowsTheIndent:
+    def test_a_plain_nested_list_still_deepens(self, converter):
+        """The ordinary case, and the only thing the numbers themselves have to satisfy."""
+        top, sub, sub_sub = _levels(converter, TOP_LEVEL_X, SUB_LEVEL_X, SUB_SUB_LEVEL_X)
+
+        assert top < sub < sub_sub
+
+    def test_a_sub_bullet_seen_first_is_still_the_deeper_one(self, converter):
+        """The whole bug: the sub-bullet arrives first, so arrival order said it was level 0."""
+        sub, top = _levels(converter, SUB_LEVEL_X, TOP_LEVEL_X)
+
+        assert sub > top, "the item further right must be the deeper level, whichever was seen first"
+
+    def test_returning_to_the_first_indent_returns_the_first_level(self, converter):
+        sub, top, sub_again = _levels(converter, SUB_LEVEL_X, TOP_LEVEL_X, SUB_LEVEL_X)
+
+        assert sub_again == sub
+        assert sub_again > top
+
+    def test_three_indents_arriving_in_the_worst_order(self, converter):
+        levels = _levels(converter, SUB_SUB_LEVEL_X, SUB_LEVEL_X, TOP_LEVEL_X)
+
+        assert levels[0] > levels[1] > levels[2]
+
+    @pytest.mark.parametrize(
+        "order",
+        [
+            pytest.param((0, 1, 2), id="outside-in"),
+            pytest.param((2, 1, 0), id="inside-out"),
+            pytest.param((1, 0, 2), id="middle-first"),
+            pytest.param((1, 2, 0), id="middle-then-deepest"),
+            pytest.param((2, 0, 1), id="deepest-then-shallowest"),
+            pytest.param((0, 2, 1), id="shallowest-then-deepest"),
+        ],
+    )
+    def test_the_level_order_matches_the_indent_order_whatever_the_arrival_order(self, converter, order):
+        """The invariant, over every arrival order of the same three indents."""
+        indents = [TOP_LEVEL_X, SUB_LEVEL_X, SUB_SUB_LEVEL_X]
+        seen = [indents[i] for i in order]
+
+        levels = dict(zip(seen, _levels(converter, *seen), strict=True))
+
+        assert levels[TOP_LEVEL_X] < levels[SUB_LEVEL_X] < levels[SUB_SUB_LEVEL_X]
+
+    def test_distinct_indents_get_distinct_levels(self, converter):
+        levels = _levels(converter, SUB_LEVEL_X, SUB_SUB_LEVEL_X, TOP_LEVEL_X)
+
+        assert len(set(levels)) == 3
+
+
+class TestIndentsCloseTogetherAreOneLevel:
+    def test_a_couple_of_points_of_jitter_is_the_same_level(self, converter):
+        assert _levels(converter, TOP_LEVEL_X, TOP_LEVEL_X + 2.0) == [0, 0]
+
+    def test_it_matches_the_nearest_indent_not_the_first_one_within_tolerance(self, converter):
+        """With several levels established, "first match wins" is arrival order again."""
+        levels = _levels(converter, TOP_LEVEL_X, TOP_LEVEL_X + 6.0, TOP_LEVEL_X + 5.5)
+
+        assert levels[2] == levels[1], "5.5 is nearer to 6.0 than to 0.0"
+
+    def test_an_indent_arriving_between_two_levels_lands_between_them(self, converter):
+        """Levels are spaced out precisely so a later, middle indent has somewhere to go."""
+        outer, inner, middle = _levels(converter, TOP_LEVEL_X, SUB_SUB_LEVEL_X, SUB_LEVEL_X)
+
+        assert outer < middle < inner
+
+
+# --- through the list builder ------------------------------------------------------
+
+
+def _bullet(text: str, x: float) -> AstParagraph:
+    return AstParagraph(
+        content=[Text(content=f"• {text}")],
+        source_location=SourceLocation(format="pdf", page=1, metadata={"bbox": (x, 100.0, 400.0, 110.0)}),
+    )
+
+
+def _item_texts(node) -> list[str]:
+    """Every list item at or under ``node``, each by its *own* text.
+
+    An item's own text excludes any nested list's, so that a parent and its child are
+    two entries rather than one concatenation.
+    """
+    found: list[str] = []
+
+    def visit(current) -> None:
+        if isinstance(current, ListItem):
+            own = " ".join(extract_text(child, joiner="") for child in current.children if not isinstance(child, List))
+            found.append(" ".join(own.split()))
+            for child in current.children:
+                if isinstance(child, List):
+                    visit(child)
+            return
+        for item in getattr(current, "items", None) or []:
+            visit(item)
+
+    visit(node)
+    return found
+
+
+class TestTheListBuilderNestsTheRightWayRound:
+    def test_a_normal_nested_list_is_unchanged(self, converter):
+        nodes = converter._convert_paragraphs_to_lists(
+            [
+                _bullet("parent", TOP_LEVEL_X),
+                _bullet("child", SUB_LEVEL_X),
+                _bullet("parent again", TOP_LEVEL_X),
+            ]
+        )
+
+        assert len(nodes) == 1
+        outer = nodes[0]
+        assert isinstance(outer, List)
+        assert _item_texts(outer.items[0]) == ["parent", "child"], "the child belongs under the parent"
+
+    def test_a_parent_is_never_nested_under_its_own_child(self, converter):
+        """A nested list continuing at the top of a column: the sub-bullet comes first."""
+        nodes = converter._convert_paragraphs_to_lists(
+            [
+                _bullet("continued sub-item", SUB_LEVEL_X),
+                _bullet("a top-level item", TOP_LEVEL_X),
+                _bullet("another top-level item", TOP_LEVEL_X),
+            ]
+        )
+
+        for node in nodes:
+            if isinstance(node, List):
+                for item in node.items:
+                    nested = _item_texts(item)
+                    if nested and nested[0] == "continued sub-item":
+                        assert "a top-level item" not in nested, "the parent was nested under its own child"
+
+    def test_no_item_is_lost_when_the_run_starts_on_a_sub_bullet(self, converter):
+        """Re-anchoring pops the stack empty, and the popped list has to go somewhere."""
+        nodes = converter._convert_paragraphs_to_lists(
+            [
+                _bullet("continued sub-item", SUB_LEVEL_X),
+                _bullet("a top-level item", TOP_LEVEL_X),
+                _bullet("another top-level item", TOP_LEVEL_X),
+            ]
+        )
+
+        emitted = [text for node in nodes for text in _item_texts(node)]
+        assert sorted(emitted) == sorted(["continued sub-item", "a top-level item", "another top-level item"])
+
+    def test_the_two_top_level_items_stay_siblings(self, converter):
+        nodes = converter._convert_paragraphs_to_lists(
+            [
+                _bullet("continued sub-item", SUB_LEVEL_X),
+                _bullet("a top-level item", TOP_LEVEL_X),
+                _bullet("another top-level item", TOP_LEVEL_X),
+            ]
+        )
+
+        top_level_lists = [node for node in nodes if isinstance(node, List) and "a top-level item" in _item_texts(node)]
+        assert len(top_level_lists) == 1
+        assert _item_texts(top_level_lists[0]) == ["a top-level item", "another top-level item"]

--- a/tests/unit/formats/pdf/test_pdf_ruling_table_guards.py
+++ b/tests/unit/formats/pdf/test_pdf_ruling_table_guards.py
@@ -1,0 +1,245 @@
+#  Copyright (c) 2025 Tom Villani, Ph.D.
+#
+# tests/unit/formats/pdf/test_pdf_ruling_table_guards.py
+"""The ruling-line fallback detector must never delete a region's text either.
+
+``test_pdf_table_guards.py`` pins this down for the ``find_tables()`` path. The
+ruling-line fallback -- the detector that reads a page's stroked lines directly -- has
+exactly the same ordering trap and had none of the same protection: text under any rect
+in ``table_info`` is removed from the ordinary text blocks *before* extraction runs, so
+every ``return None`` in ``_extract_table_from_ruling_rect`` dropped a whole framed
+region on the floor.
+
+The synthetic page below (a stroked frame with one internal rule and a sentence in the
+bottom-left cell) produced **no output at all** under
+``table_detection_mode="ruling"``: the grid was 75% empty, the sparsity guard rejected
+it, and the sentence went with it. The conversion still reported success.
+"""
+
+from __future__ import annotations
+
+import io
+
+import pytest
+
+from all2md.ast import Paragraph as AstParagraph
+from all2md.ast import Table as AstTable
+from all2md.ast.utils import extract_text
+from all2md.options.pdf import PdfOptions
+from all2md.parsers.pdf import PdfToAstConverter
+
+pytestmark = [pytest.mark.unit, pytest.mark.pdf, pytest.mark.table]
+
+pymupdf = pytest.importorskip("pymupdf")
+
+
+class _RuledRegion:
+    """A framed region with a text grid, addressable the way the ruling path asks for it.
+
+    ``_extract_table_from_ruling_rect`` reads one cell rectangle at a time and then, when
+    it rejects the grid, asks for the whole region -- so the region's text here is the
+    union of its cells', exactly as a real page's would be.
+    """
+
+    def __init__(self, cells: list[list[str]], xs: list[float], ys: list[float]) -> None:
+        self.cells = cells
+        self.xs = xs
+        self.ys = ys
+
+    @property
+    def h_lines(self) -> list[tuple]:
+        return [(self.xs[0], y, self.xs[-1], y) for y in self.ys]
+
+    @property
+    def v_lines(self) -> list[tuple]:
+        return [(x, self.ys[0], x, self.ys[-1]) for x in self.xs]
+
+    @property
+    def rect(self):
+        return pymupdf.Rect(self.xs[0], self.ys[0], self.xs[-1], self.ys[-1])
+
+    def get_textbox(self, rect) -> str:
+        for row, (y0, y1) in enumerate(zip(self.ys, self.ys[1:], strict=False)):
+            for col, (x0, x1) in enumerate(zip(self.xs, self.xs[1:], strict=False)):
+                if (rect.x0, rect.y0, rect.x1, rect.y1) == (x0, y0, x1, y1):
+                    return self.cells[row][col]
+        # Anything else is the whole-region query the rejection paths make.
+        return "\n".join(" ".join(cell for cell in row if cell) for row in self.cells)
+
+
+def _grid(cells: list[list[str]]) -> _RuledRegion:
+    """A region whose ruling lines bound exactly ``cells``."""
+    n_rows = len(cells)
+    n_cols = len(cells[0])
+    return _RuledRegion(
+        cells,
+        xs=[72.0 + 80.0 * i for i in range(n_cols + 1)],
+        ys=[100.0 + 40.0 * i for i in range(n_rows + 1)],
+    )
+
+
+def _extract(converter: PdfToAstConverter, region: _RuledRegion):
+    return converter._extract_table_from_ruling_rect(region, region.rect, region.h_lines, region.v_lines, page_num=0)
+
+
+@pytest.fixture
+def converter() -> PdfToAstConverter:
+    conv = PdfToAstConverter()
+    conv._tables_rejected = 0
+    return conv
+
+
+# Each grid fires exactly one rejection branch under the default thresholds
+# (empty > 0.70, uniform >= 5 filled, dot-leader > 0.30).
+MOSTLY_EMPTY = [["alpha beta", ""], ["", ""]]
+UNIFORM = [["X", "X", "X"], ["X", "X", "X"], ["X", "X", "X"]]
+DOT_LEADER = [["Introduction", ".........."], ["Methods", ".........."]]
+
+REAL_GRID = [["Model", "Score"], ["baseline", "0.62"]]
+
+
+@pytest.mark.parametrize(
+    ("cells", "rejection"),
+    [
+        pytest.param(MOSTLY_EMPTY, "mostly_empty", id="mostly-empty"),
+        pytest.param(UNIFORM, "uniform_cells", id="uniform"),
+        pytest.param(DOT_LEADER, "dot_leader_toc", id="dot-leader-toc"),
+    ],
+)
+def test_every_ruling_rejection_branch_demotes_to_prose(converter, cells, rejection):
+    """A rejected ruling-line region comes back as prose, not as nothing.
+
+    Its text has already been excluded from the page's text blocks by the time this
+    runs, so ``None`` here is a deletion.
+    """
+    region = _grid(cells)
+    node = _extract(converter, region)
+
+    assert not isinstance(node, AstTable), f"a {rejection} region is not a real table"
+    assert isinstance(node, AstParagraph), f"{rejection} must demote to prose, not delete (returned {node!r})"
+
+    recovered = extract_text(node).split()
+    for word in " ".join(" ".join(row) for row in cells).split():
+        assert word in recovered, f"rejecting the {rejection} region lost the word {word!r}"
+    assert converter._tables_rejected == 1, f"{rejection} demotion must be recorded for the quality card"
+
+
+def test_a_real_ruled_grid_is_still_a_table(converter):
+    """The guards must not touch a genuine ruled table."""
+    node = _extract(converter, _grid(REAL_GRID))
+
+    assert isinstance(node, AstTable)
+    assert converter._tables_rejected == 0
+    assert [c.content[0].content for c in node.header.cells] == ["Model", "Score"]
+    assert len(node.rows) == 1
+
+
+def test_too_few_ruling_lines_keeps_the_text():
+    """Fewer than 2x2 lines cannot form cells -- but the region still holds prose."""
+    converter = PdfToAstConverter()
+    region = _grid([["alpha beta", "gamma"]])
+    single_h_line = region.h_lines[:1]
+
+    node = converter._extract_table_from_ruling_rect(region, region.rect, single_h_line, region.v_lines, page_num=0)
+
+    assert isinstance(node, AstParagraph)
+    assert "alpha" in extract_text(node)
+
+
+def test_extraction_mode_none_still_returns_the_text():
+    """``"none"`` means "don't build a table here", not "throw the region away".
+
+    The region was still *detected*, so its text is already out of the text blocks.
+    """
+    converter = PdfToAstConverter(options=PdfOptions(table_fallback_extraction_mode="none"))
+    region = _grid(REAL_GRID)
+
+    node = _extract(converter, region)
+
+    assert isinstance(node, AstParagraph)
+    assert "baseline" in extract_text(node)
+
+
+def test_extraction_mode_none_is_not_counted_as_a_rejection():
+    """Nothing was rejected: the caller configured extraction off. Don't dock the score."""
+    converter = PdfToAstConverter(options=PdfOptions(table_fallback_extraction_mode="none"))
+    converter._tables_rejected = 0
+
+    _extract(converter, _grid(REAL_GRID))
+
+    assert converter._tables_rejected == 0
+
+
+def test_an_empty_region_still_yields_nothing(converter):
+    """Only genuinely empty regions may return ``None`` -- there is nothing to preserve."""
+    node = _extract(converter, _grid([["", ""], ["", ""]]))
+
+    assert node is None
+
+
+# --- end to end -------------------------------------------------------------------
+#
+# The unit tests above call the method directly. This one drives the whole converter
+# over a real PDF, because the bug is not visible from the method's own code: it lives
+# in the ordering between the text-block exclusion and the table validation.
+
+FRAMED_TEXT = ("Prohibited items include glass", "containers and open flames.")
+
+
+def _framed_pdf_bytes() -> bytes:
+    """A page with a stroked frame, one internal rule, and a sentence in one cell.
+
+    The lines have to be stroked ``"l"`` commands of page-proportional length to reach
+    the ruling-line detector at all -- ``"re"`` rectangles are not read as ruling lines.
+    The resulting 2x2 grid is 75% empty, which trips the sparsity guard.
+    """
+    xs = [72.0, 250.0, 420.0]
+    ys = [100.0, 160.0, 300.0]
+
+    doc = pymupdf.open()
+    page = doc.new_page()
+    for y in ys:
+        page.draw_line((xs[0], y), (xs[-1], y))
+    for x in xs:
+        page.draw_line((x, ys[0]), (x, ys[-1]))
+    for offset, line in enumerate(FRAMED_TEXT):
+        page.insert_text((80, 200 + offset * 14), line, fontsize=11)
+    return doc.tobytes()
+
+
+def test_a_rejected_framed_region_reaches_the_output_as_prose():
+    """The whole page's text used to vanish, and the conversion still reported success."""
+    from all2md import to_markdown
+
+    output = to_markdown(
+        io.BytesIO(_framed_pdf_bytes()),
+        source_format="pdf",
+        parser_options=PdfOptions(table_detection_mode="ruling"),
+    )
+
+    assert "Prohibited items include glass containers and open flames." in output
+
+
+def test_the_rejected_region_is_not_emitted_twice():
+    """Nested ruling regions overlap; the text must still appear once, not once per region."""
+    from all2md import to_markdown
+
+    output = to_markdown(
+        io.BytesIO(_framed_pdf_bytes()),
+        source_format="pdf",
+        parser_options=PdfOptions(table_detection_mode="ruling"),
+    )
+
+    assert output.count("Prohibited items") == 1
+
+
+def test_the_rejected_region_is_not_rendered_as_a_table():
+    from all2md import to_markdown
+
+    output = to_markdown(
+        io.BytesIO(_framed_pdf_bytes()),
+        source_format="pdf",
+        parser_options=PdfOptions(table_detection_mode="ruling"),
+    )
+
+    assert "|" not in output

--- a/tests/unit/formats/pdf/test_pdf_ruling_table_guards.py
+++ b/tests/unit/formats/pdf/test_pdf_ruling_table_guards.py
@@ -177,6 +177,70 @@ def test_an_empty_region_still_yields_nothing(converter):
     assert node is None
 
 
+# --- the caps are shared, not re-derived -------------------------------------------
+#
+# ``_pdf_tables`` says the caps "apply to both PyMuPDF's find_tables() output and our
+# ruling-line detector since both can fire on the same false-positive shapes". The
+# ruling path did not honour that: it required only two lines on each axis, which bound
+# a *single cell*, and it re-hardcoded the empty ratio and the uniformity floor as bare
+# literals next to the constants that name them.
+#
+# These are parity tests rather than ideal-outcome tests. The requirement is that the
+# two detectors agree about what a table is; asserting an ideal for either one would
+# encode a spec neither meets.
+
+
+class _FakeTable:
+    """The shape of a PyMuPDF table: an ``extract()`` grid and a ``bbox``."""
+
+    def __init__(self, grid: list[list[str]], bbox: tuple[float, float, float, float]) -> None:
+        self._grid = grid
+        self.bbox = bbox
+
+    def extract(self) -> list[list[str]]:
+        return self._grid
+
+
+SHARED_CAP_GRIDS = [
+    pytest.param([["A framed callout, not a table."]], id="1x1-framed-box"),
+    pytest.param([["What", "is", "the", "capital"]], id="1xN-single-row"),
+    pytest.param([["one"], ["two"], ["three"]], id="Nx1-single-column"),
+    pytest.param(REAL_GRID, id="2x2-real-grid"),
+    # Sparsity, either side of MAX_TABLE_EMPTY_RATIO: 7/10 empty is not *past* 0.70.
+    pytest.param([["a", "b", "c", "", ""], ["", "", "", "", ""]], id="empty-at-the-line"),
+    pytest.param([["a", "b", "", "", ""], ["", "", "", "", ""]], id="empty-past-the-line"),
+    # Uniformity, either side of MIN_FILLED_FOR_UNIFORMITY_CHECK.
+    pytest.param([["X", "X"], ["X", "X"]], id="uniform-under-the-floor"),
+    pytest.param([["X", "X", "X"], ["X", "X", "X"]], id="uniform-over-the-floor"),
+]
+
+
+@pytest.mark.parametrize("cells", SHARED_CAP_GRIDS)
+def test_both_detectors_agree_on_what_counts_as_a_table(cells):
+    """The same grid must be accepted, or rejected, by both detectors alike."""
+    region = _grid(cells)
+    by_ruling = _extract(PdfToAstConverter(), region)
+    by_find_tables = PdfToAstConverter()._process_table_to_ast(
+        _FakeTable(cells, tuple(region.rect)), region, page_num=0
+    )
+
+    assert isinstance(by_ruling, AstTable) == isinstance(by_find_tables, AstTable), (
+        f"the ruling-line detector and find_tables() disagree about {cells!r}: " f"{by_ruling!r} vs {by_find_tables!r}"
+    )
+
+
+def test_a_framed_text_box_is_prose_not_a_one_cell_table(converter):
+    """Two lines on each axis bound one cell. One cell is a frame, not a grid."""
+    region = _grid([["A framed callout, not a table."]])
+
+    node = _extract(converter, region)
+
+    assert not isinstance(node, AstTable), "a 1x1 region is a framed box, not a table"
+    assert isinstance(node, AstParagraph)
+    assert "framed callout" in extract_text(node)
+    assert converter._tables_rejected == 1
+
+
 # --- end to end -------------------------------------------------------------------
 #
 # The unit tests above call the method directly. This one drives the whole converter

--- a/tests/unit/formats/pdf/test_pdf_unreadable_page.py
+++ b/tests/unit/formats/pdf/test_pdf_unreadable_page.py
@@ -1,0 +1,150 @@
+#  Copyright (c) 2025 Tom Villani, Ph.D.
+#
+# tests/unit/formats/pdf/test_pdf_unreadable_page.py
+"""A page whose text cannot be read is dropped, but never silently.
+
+``_process_page_to_ast`` wrapped its ``page.get_text("dict", ...)`` call in
+``except (AttributeError, KeyError, Exception): return []`` -- no log line, no degraded
+event, no progress event. The catch-all began life as test support for mock pages, and a
+later commit moved the in-place ``dehyphenate_blocks()`` call inside it as well, so a bug
+in our own dehyphenation would have been laundered into "this page was blank" too.
+
+Three things go wrong when a page can disappear without a trace:
+
+* an empty page and an unreadable page are indistinguishable in the output;
+* the conversion reports success either way;
+* the document-level OCR safety net counts meaningful characters, so if every page trips
+  this it sees an empty document -- and can put a perfectly good text PDF through OCR.
+
+The tolerance itself is deliberate and stays: one broken page must not cost the other
+400. What is asserted here is that it leaves evidence.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import pytest
+
+from all2md.options.pdf import PdfOptions
+from all2md.parsers.pdf import PdfToAstConverter
+
+pytestmark = [pytest.mark.unit, pytest.mark.pdf]
+
+pymupdf = pytest.importorskip("pymupdf")
+
+
+class _UnreadablePage:
+    """A page that cannot answer ``get_text()`` -- the shape a mock page has."""
+
+    def get_text(self, *args, **kwargs):
+        raise RuntimeError("mupdf: cannot open page")
+
+
+def _sequencer(name: str, mime: str) -> tuple[str, int]:
+    return name, 0
+
+
+def _converter() -> PdfToAstConverter:
+    # table_detection_mode="none" so nothing touches the page before get_text() does.
+    converter = PdfToAstConverter(options=PdfOptions(table_detection_mode="none"))
+    converter._degraded_events = []
+    return converter
+
+
+def _process(converter: PdfToAstConverter, page, page_num: int = 0):
+    return converter._process_page_to_ast(page, page_num, "doc", _sequencer, total_pages=1)
+
+
+class TestAnUnreadablePageIsToleratedButReported:
+    def test_the_page_is_still_dropped_rather_than_raising(self):
+        """The tolerance is the point: mock pages reach here, and one bad page of 400 is not fatal."""
+        assert _process(_converter(), _UnreadablePage()) == []
+
+    def test_it_is_logged_with_the_page_number(self, caplog):
+        converter = _converter()
+
+        with caplog.at_level(logging.WARNING, logger="all2md.parsers.pdf"):
+            _process(converter, _UnreadablePage(), page_num=6)
+
+        logged = "\n".join(record.getMessage() for record in caplog.records)
+        assert "page 7" in logged.lower(), "the 0-based index must be reported 1-based, as everywhere else"
+
+    def test_the_cause_is_in_the_log(self, caplog):
+        with caplog.at_level(logging.WARNING, logger="all2md.parsers.pdf"):
+            _process(_converter(), _UnreadablePage())
+
+        logged = "\n".join(record.getMessage() for record in caplog.records)
+        assert "cannot open page" in logged
+
+    def test_a_degraded_event_is_recorded(self):
+        converter = _converter()
+
+        _process(converter, _UnreadablePage())
+
+        kinds = [event.kind for event in converter._degraded_events]
+        assert "page_text_extraction_failed" in kinds
+
+    def test_losing_a_whole_page_is_scored_as_an_error(self):
+        """Every other degradation here is a rejected table or a dropped image. A page is not."""
+        converter = _converter()
+
+        _process(converter, _UnreadablePage())
+
+        event = next(e for e in converter._degraded_events if e.kind == "page_text_extraction_failed")
+        assert event.severity == "error"
+        assert "page 1" in (event.detail or ""), "the event has to say which page went missing"
+
+
+class TestDehyphenationIsNoLongerSwallowed:
+    """``dehyphenate_blocks()`` runs on blocks already read successfully.
+
+    A failure in it is a bug in our code, not an unreadable page. Inside the ``except``
+    it became an empty page; outside, it surfaces.
+    """
+
+    @staticmethod
+    def _one_line_pdf_page():
+        doc = pymupdf.open()
+        page = doc.new_page()
+        page.insert_text((72, 100), "a line of ordinary prose", fontsize=11)
+        return pymupdf.open(stream=doc.tobytes(), filetype="pdf")[0]
+
+    def test_a_dehyphenation_failure_propagates(self, monkeypatch):
+        def explode(blocks):
+            raise ValueError("bug in dehyphenation")
+
+        monkeypatch.setattr("all2md.parsers.pdf.dehyphenate_blocks", explode)
+        converter = _converter()
+
+        with pytest.raises(ValueError, match="bug in dehyphenation"):
+            _process(converter, self._one_line_pdf_page())
+
+    def test_it_is_not_reported_as_an_unreadable_page(self, monkeypatch):
+        def explode(blocks):
+            raise ValueError("bug in dehyphenation")
+
+        monkeypatch.setattr("all2md.parsers.pdf.dehyphenate_blocks", explode)
+        converter = _converter()
+
+        with pytest.raises(ValueError):
+            _process(converter, self._one_line_pdf_page())
+
+        assert [e.kind for e in converter._degraded_events] == []
+
+    def test_a_readable_page_still_gets_dehyphenated(self, monkeypatch):
+        """Hoisting the call out of the ``try`` must not have skipped it."""
+        import all2md.parsers.pdf as pdf_module
+
+        calls: list[int] = []
+        original = pdf_module.dehyphenate_blocks
+
+        def counting(blocks):
+            calls.append(len(blocks))
+            return original(blocks)
+
+        monkeypatch.setattr(pdf_module, "dehyphenate_blocks", counting)
+
+        _process(_converter(), self._one_line_pdf_page())
+
+        assert calls, "merge_hyphenated_words is on by default; the blocks must still be dehyphenated"


### PR DESCRIPTION
Fixes five verified findings from the 2026-08-13 codebase audit (Leg 4, findings #37, #7, #20, #18, #21), all in `pdf.py`, one commit each.

## #37: delete the unreachable parallel block-processing pipeline (low, refactor)

`_process_text_region_to_ast` and its five sole-consumer helpers (~241 lines) had zero callers in src/ or tests/ (verified per symbol) and had drifted behaviorally from the live path. Deleted, along with `DEFAULT_OVERLAP_THRESHOLD_PX` which only the dead loop imported. Shared helpers with live callers stayed.

## #7: ruling-line rejections deleted the region's text (high)

Text under a `table_info` rect is excluded from body blocks before extraction is validated, and every rejection path in `_extract_table_from_ruling_rect` returned bare `None` — deleting the region's prose outright (the exact trap `_region_text_as_paragraph`'s docstring documents from the pymupdf path's history). All five paths now return the region's text as a paragraph. The `"none"`-mode question resolved by reading the call chain: `_detect_page_tables` registers fallback rects regardless of the mode, so exclusion has already happened and the text must come back; the caller appends what it receives and adds nothing on `None`, so no double-count. That path deliberately records no rejection — nothing was rejected, extraction was configured off. Before/after on a synthetic framed PDF: `table_detection_mode="ruling"` previously produced empty output plus the "almost no text" advisory; now the text appears once, as prose.

## #20: shared degenerate-grid caps bypassed (medium)

The ">= 2 lines per axis" test admitted a 1x1 "table" (n lines bound n-1 cells) — a framed text box came out as prose wrapped in pipes. `MIN_TABLE_ROWS`/`MIN_TABLE_COLS` now apply to the actual grid dimensions, and the inline `> 0.70` / `>= 5` literals are replaced with `MAX_TABLE_EMPTY_RATIO` / `MIN_FILLED_FOR_UNIFORMITY_CHECK` so tuning the named constants can't silently diverge the two detectors. Tests are parity tests: the same grid must be accepted or rejected by both detectors alike.

## #18: bare except silently dropped a whole page (medium)

`except (AttributeError, KeyError, Exception): return []` around text extraction hid page-level failures entirely — and if every page tripped, the OCR safety net could re-OCR a good text PDF. The except now logs a warning (1-based page number + exception) and records a `page_text_extraction_failed` degraded event at `error` severity (first parser use; a silently lost page is the largest loss available). Still returns `[]` — a swept check confirmed no existing mock-page test relies on the swallow, but tolerance for broken single pages stays. `dehyphenate_blocks` is hoisted out of the try: it operates on successfully-read blocks, so an exception from it is our bug, not an unreadable page.

## #21: list nesting level by arrival order, not indent (medium)

`_determine_list_level_from_x` handed out levels in encounter order, so a run starting on a sub-bullet (routine when a nested list continues atop a column/page) nested the parent under its own child. Levels are now an opaque ordering key, only compared, never counted: shallower indent → `min - stride`, deeper → `max + stride`, in-between → midpoint of its neighbours (stride 1024 leaves room; an exhausted gap joins the nearer indent). Nothing is renumbered, so levels already on the caller's list stack stay valid. Two knock-ons fixed along the way: "first match within tolerance" became "nearest indent" (the old form was arrival order again via dict insertion), and `_handle_shallower_level` can now pop the stack empty — the popped list was previously built and then dropped, deleting its items; it's now emitted as a list in its own right. Known limitation, out of scope per the audit: cross-column siblings still need column awareness.

## Verification

- Three new test files (ruling-table guards, unreadable page, list nesting levels): 28 of the new tests fail against pre-fix source, all pass after.
- `tests/unit -m pdf` (-n 3), `tests/integration tests/e2e -m pdf` (49 passed), `tests/golden` all green (PDF goldens skip on Windows as documented).
- Sphinx `-W` docs build succeeds; black / ruff / mypy clean; the pre-existing `test_random_binary_as_pdf` Hypothesis deadline flake reproduces identically on unmodified main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
