### PR TITLE
fix(benchmarks): flush pending short blocks when a phrase placement lands

### DIFF
--- a/benchmarks/pmc/pages.py
+++ b/benchmarks/pmc/pages.py
@@ -252,6 +252,7 @@ def assign_pages(blocks: Sequence[JatsBlock], pages: Sequence[PageText]) -> Page
             if page is None:
                 pending.append((order, block))
                 continue
+            flush(page)
             buckets[page].append(PlacedBlock(block, order, "phrase"))
             counts["phrase"] += 1
             continue

--- a/tests/unit/test_pmc_oracle.py
+++ b/tests/unit/test_pmc_oracle.py
@@ -260,6 +260,35 @@ def test_a_short_block_on_no_unique_page_takes_the_page_of_what_it_introduces() 
     assert assigned.pages[0] == ()
 
 
+def test_a_pending_short_block_takes_the_phrase_placed_blocks_page_not_a_later_one() -> None:
+    """A phrase placement must flush pending short blocks too, or they inherit the wrong page.
+
+    "Results" is ambiguous (both pages print it), so it goes to `pending`. "Statistical
+    Analysis" then places by unique phrase on page 1. A later paragraph places cleanly on
+    page 2. The heading belongs with the phrase-placed block that follows it, on page 1 --
+    not with whatever happens to place after that.
+    """
+    heading = oracles.JatsBlock(kind="title", text="Results")
+    subheading = oracles.JatsBlock(kind="title", text="Statistical Analysis")
+    body = oracles.JatsBlock(
+        kind="text_block",
+        text="participants completed the protocol without any reported adverse events at all",
+    )
+    assigned = pages.assign_pages(
+        [heading, subheading, body],
+        [
+            # "Results" appears on both pages, so no phrase uniquely identifies one.
+            _page("results were mixed across every measured outcome results"),
+            _page("results statistical analysis was performed today"),
+            _page("participants completed the protocol without any reported adverse events at all"),
+        ],
+    )
+    assert [placed.assignment for placed in assigned.pages[1]] == ["inherited", "phrase"]
+    assert [placed.block.text for placed in assigned.pages[1]] == ["Results", "Statistical Analysis"]
+    assert assigned.pages[0] == ()
+    assert [placed.assignment for placed in assigned.pages[2]] == ["clean"]
+
+
 def test_a_short_block_with_nothing_after_it_is_excluded_rather_than_guessed() -> None:
     trailing = oracles.JatsBlock(kind="title", text="Results")
     assigned = pages.assign_pages([trailing], [_page("results here"), _page("results there")])


### PR DESCRIPTION
Audit finding #33 (review leg 5).

`assign_pages` documents that a block too short to place "takes the page of the next block that *was* placed". The tokens, spans, and clean placement branches all honor this by calling `flush(page)` before appending — the phrase branch was the one exception, so a pending short block skipped past a phrase-placed successor and inherited whichever *later* block placed instead (or was dropped as `too_short` if none did), skewing the per-page ground truth this module exists to account for.

Fix is one line: `flush(page)` in the phrase branch, matching the other three branches.

Regression test added (`test_a_pending_short_block_takes_the_phrase_placed_blocks_page_not_a_later_one`): an ambiguous heading in `pending`, a phrase-placed successor on one page, a clean placement on a later page — asserts the heading inherits the phrase-placed block's page. Verified to fail on the unfixed code (heading landed on the later page as `inherited`).

Test runs: `tests/unit/test_pmc_oracle.py` 53/53; plus the other files importing the pmc modules, 129/129.

🤖 Generated with [Claude Code](https://claude.com/claude-code)