### PR TITLE
fix(webarchive): UTF-8 subresource writes and Windows-safe filenames; drop dead metadata enricher

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   it — same responsibilities, different rotated-text, code-block and heading handling — so
   reading them gave a misleading picture of what the parser actually does, and any fix
   applied to one copy silently missed the other. No behaviour changes: nothing called them.
+- **Removed `enrich_metadata_with_conversion_info`** (`utils/metadata.py`). A repo-wide
+  search found no reference to it outside its own definition — not imported, not exported,
+  not called from any parser, test, or script. ~85 unmaintained lines, including a
+  stream-position trap for file-like input. No behaviour changes: nothing called it.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -452,6 +452,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   real behaviour change for header detection: a font size that previously qualified on
   character count alone but occurs only a couple of times (and is not the page's largest)
   will no longer be treated as a heading size.
+- **WebArchive subresource extraction no longer silently drops files on Windows.**
+  `_extract_subresources` had two defects, both masked by the method's blanket
+  `except Exception: logger.warning(...)`. A text subresource (a plist `<string>`, not
+  `<data>`) was written with `Path.write_text()` and no explicit encoding, so on Windows —
+  where the platform default is cp1252 — any non-Latin content raised `UnicodeEncodeError`
+  and the resource was dropped; it's now written as UTF-8. Separately, the filename was
+  taken as `Path(resource_url).name`, which keeps a URL's query string (`img.png?v=1`); `?`
+  is illegal in a Windows filename, so the write raised `OSError` and the resource was
+  dropped. The filename is now taken from the URL's path only (query string and fragment
+  stripped) and run through the existing attachment-filename sanitizer.
 
 ### Changed
 

--- a/src/all2md/parsers/webarchive.py
+++ b/src/all2md/parsers/webarchive.py
@@ -23,6 +23,7 @@ from all2md.options.webarchive import WebArchiveOptions
 from all2md.parsers.base import BaseParser
 from all2md.parsers.html import HtmlToAstConverter
 from all2md.progress import ProgressCallback
+from all2md.utils.attachments import sanitize_attachment_filename
 from all2md.utils.decorators import requires_dependencies
 from all2md.utils.inputs import validate_and_convert_input
 from all2md.utils.metadata import DocumentMetadata
@@ -214,10 +215,15 @@ class WebArchiveToAstConverter(BaseParser):
                 if not resource_data:
                     continue
 
-                # Extract filename from URL
+                # Extract filename from URL, stripping any query string/fragment
+                # (e.g. "img.png?v=1") and sanitizing characters illegal on Windows
+                filename = ""
                 if resource_url:
-                    filename = Path(resource_url).name
-                else:
+                    raw_name = Path(urlparse(resource_url).path).name
+                    if raw_name:
+                        filename = sanitize_attachment_filename(raw_name, preserve_case=True, allow_unicode=False)
+
+                if not filename:
                     # Generate filename from MIME type
                     ext = self._mime_to_extension(mime_type)
                     filename = f"resource_{id(resource)}{ext}"
@@ -227,7 +233,7 @@ class WebArchiveToAstConverter(BaseParser):
                 if isinstance(resource_data, bytes):
                     output_file.write_bytes(resource_data)
                 else:
-                    output_file.write_text(str(resource_data))
+                    output_file.write_text(str(resource_data), encoding="utf-8")
 
                 logger.debug(f"Extracted resource: {filename} ({mime_type})")
 

--- a/src/all2md/utils/metadata.py
+++ b/src/all2md/utils/metadata.py
@@ -12,12 +12,10 @@ The metadata extraction supports various document properties like title, author,
 creation date, keywords, and format-specific metadata fields.
 """
 
-import hashlib
 import json
 import re
 from dataclasses import dataclass, field
 from datetime import datetime
-from pathlib import Path
 from typing import Any, Dict, List, Literal, Mapping, Optional, Tuple, Union
 
 import tomli_w
@@ -747,91 +745,3 @@ def prepend_metadata_if_enabled(
         if frontmatter:
             return frontmatter + content
     return content
-
-
-def enrich_metadata_with_conversion_info(
-    metadata: DocumentMetadata, input_data: Any, content: str = "", page_count: Optional[int] = None
-) -> DocumentMetadata:
-    """Enrich metadata with conversion-specific information.
-
-    Adds fields like extraction_date, source_path, sha256, word_count, and page_count
-    to the metadata based on the input and content.
-
-    Parameters
-    ----------
-    metadata : DocumentMetadata
-        The metadata object to enrich
-    input_data : Any
-        The input data (file path, bytes, or file object)
-    content : str, default ""
-        The extracted text content for word count calculation
-    page_count : int | None, default None
-        Number of pages (for paginated formats)
-
-    Returns
-    -------
-    DocumentMetadata
-        The enriched metadata object
-
-    """
-    metadata.extraction_date = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
-
-    # Try to extract source_path from input
-    if isinstance(input_data, (str, Path)):
-        metadata.source_path = str(input_data)
-
-    # Calculate SHA256 hash using chunked reading to avoid memory issues with large files
-    # Use 1MB chunks for efficient memory usage
-    chunk_size = 1024 * 1024  # 1MB
-    try:
-        if isinstance(input_data, bytes):
-            metadata.sha256 = hashlib.sha256(input_data).hexdigest()
-        elif isinstance(input_data, (str, Path)):
-            # Hash file content if it's a path using chunked reading
-            try:
-                hash_obj = hashlib.sha256()
-                with open(str(input_data), "rb") as f:
-                    while True:
-                        chunk = f.read(chunk_size)
-                        if not chunk:
-                            break
-                        hash_obj.update(chunk)
-                metadata.sha256 = hash_obj.hexdigest()
-            except Exception:
-                pass  # Skip if file can't be read
-        elif hasattr(input_data, "read"):
-            # For file-like objects, use chunked reading
-            try:
-                # Save position if seekable
-                current_pos = input_data.tell() if hasattr(input_data, "tell") else None
-
-                # Hash in chunks
-                hash_obj = hashlib.sha256()
-                while True:
-                    chunk = input_data.read(chunk_size)
-                    if not chunk:
-                        break
-                    hash_obj.update(chunk)
-                metadata.sha256 = hash_obj.hexdigest()
-
-                # Try to restore position if seekable
-                if current_pos is not None and hasattr(input_data, "seek"):
-                    try:
-                        input_data.seek(current_pos)
-                    except Exception:
-                        pass  # If seek fails, continue without restoring position
-            except Exception:
-                pass  # Skip if reading fails
-    except Exception:
-        pass  # Skip hash calculation on any error
-
-    # Calculate word count from content
-    if content:
-        # Simple word count: split on whitespace
-        metadata.word_count = len(content.split())
-
-    # Set page count if provided
-    if page_count is not None:
-        metadata.page_count = page_count
-
-    return metadata

--- a/tests/fixtures/generators/webarchive_fixtures.py
+++ b/tests/fixtures/generators/webarchive_fixtures.py
@@ -248,6 +248,104 @@ body {
     return plistlib.dumps(archive_data, fmt=plistlib.FMT_BINARY)
 
 
+def create_webarchive_with_query_string_asset() -> bytes:
+    """Create WebArchive file with a subresource URL containing a query string.
+
+    The query string ("?v=1") is illegal in Windows filenames and must be
+    stripped from the extracted filename.
+
+    Returns
+    -------
+    bytes
+        WebArchive file content as bytes (binary plist).
+
+    """
+    html_content = """<!DOCTYPE html>
+<html>
+<head>
+    <title>WebArchive with Query String Asset</title>
+</head>
+<body>
+    <h1>WebArchive with Query String Asset</h1>
+    <img src="img.png?v=1" alt="Versioned image">
+</body>
+</html>"""
+
+    test_image_data = (
+        b"\x89PNG\r\n\x1a\n\x00\x00\x00\rIHDR\x00\x00\x00\x01\x00\x00\x00\x01"
+        b"\x08\x06\x00\x00\x00\x1f\x15\xc4\x89\x00\x00\x00\nIDATx\x9cc\x00\x01"
+        b"\x00\x00\x05\x00\x01\r\n-\xdb\x00\x00\x00\x00IEND\xaeB`\x82"
+    )
+
+    archive_data = {
+        "WebMainResource": {
+            "WebResourceData": html_content.encode("utf-8"),
+            "WebResourceMIMEType": "text/html",
+            "WebResourceTextEncodingName": "UTF-8",
+            "WebResourceURL": "http://example.com/query_string.html",
+        },
+        "WebSubresources": [
+            {
+                "WebResourceData": test_image_data,
+                "WebResourceMIMEType": "image/png",
+                "WebResourceURL": "http://example.com/img.png?v=1&cache=abc",
+            }
+        ],
+    }
+
+    return plistlib.dumps(archive_data, fmt=plistlib.FMT_BINARY)
+
+
+def create_webarchive_with_non_latin_text_asset() -> bytes:
+    """Create WebArchive file with a text subresource stored as a plist string.
+
+    plistlib decodes plist ``<string>`` values into native Python ``str``
+    objects (not ``bytes``), which exercises the ``write_text`` branch of
+    subresource extraction. The content uses non-Latin (CJK) characters to
+    ensure the file is written as UTF-8 rather than a platform-default
+    encoding such as cp1252.
+
+    Returns
+    -------
+    bytes
+        WebArchive file content as bytes (binary plist).
+
+    """
+    html_content = """<!DOCTYPE html>
+<html>
+<head>
+    <title>WebArchive with Non-Latin Text Asset</title>
+</head>
+<body>
+    <h1>WebArchive with Non-Latin Text Asset</h1>
+    <link rel="stylesheet" href="cjk_notes.txt">
+</body>
+</html>"""
+
+    # A plain Python str (not bytes) so it decodes from the plist as <string>,
+    # exercising the write_text() branch in _extract_subresources.
+    non_latin_text = "你好世界"  # "Hello World" in Chinese
+
+    archive_data = {
+        "WebMainResource": {
+            "WebResourceData": html_content.encode("utf-8"),
+            "WebResourceMIMEType": "text/html",
+            "WebResourceTextEncodingName": "UTF-8",
+            "WebResourceURL": "http://example.com/non_latin.html",
+        },
+        "WebSubresources": [
+            {
+                "WebResourceData": non_latin_text,
+                "WebResourceMIMEType": "text/plain",
+                "WebResourceTextEncodingName": "UTF-8",
+                "WebResourceURL": "http://example.com/cjk_notes.txt",
+            }
+        ],
+    }
+
+    return plistlib.dumps(archive_data, fmt=plistlib.FMT_BINARY)
+
+
 def create_webarchive_with_complex_html() -> bytes:
     """Create WebArchive file with complex HTML structure for testing.
 

--- a/tests/unit/parsers/test_webarchive_parser.py
+++ b/tests/unit/parsers/test_webarchive_parser.py
@@ -25,6 +25,8 @@ from fixtures.generators.webarchive_fixtures import (
     create_webarchive_with_different_encoding,
     create_webarchive_with_image,
     create_webarchive_with_multiple_assets,
+    create_webarchive_with_non_latin_text_asset,
+    create_webarchive_with_query_string_asset,
     create_webarchive_with_subframes,
 )
 
@@ -189,6 +191,47 @@ class TestSubresourceExtraction:
             assert (Path(temp_dir) / "image1.png").exists()
             assert (Path(temp_dir) / "image2.png").exists()
             assert (Path(temp_dir) / "styles.css").exists()
+
+    def test_extract_subresource_strips_query_string_from_filename(self) -> None:
+        """Test that a URL query string is stripped from the extracted filename.
+
+        A subresource URL like ``img.png?v=1&cache=abc`` must not produce a
+        filename containing ``?``, which is illegal on Windows and would
+        otherwise cause the write to silently fail.
+        """
+        webarchive_bytes = create_webarchive_with_query_string_asset()
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            options = WebArchiveOptions(extract_subresources=True, attachment_output_dir=temp_dir)
+            converter = WebArchiveToAstConverter(options)
+            _ = converter.parse(webarchive_bytes)
+
+            extracted_files = list(Path(temp_dir).glob("*"))
+            assert len(extracted_files) == 1
+            assert extracted_files[0].name == "img.png"
+            assert "?" not in extracted_files[0].name
+
+    def test_extract_subresource_writes_non_latin_text_as_utf8(self) -> None:
+        """Test that a text (non-bytes) subresource is written as UTF-8.
+
+        The resource data decodes from the plist as a native ``str`` rather
+        than ``bytes``, which exercises the ``write_text`` path. The content
+        uses non-Latin characters to guard against a platform default
+        encoding (e.g. cp1252 on Windows) causing a silent UnicodeEncodeError.
+        """
+        webarchive_bytes = create_webarchive_with_non_latin_text_asset()
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            options = WebArchiveOptions(extract_subresources=True, attachment_output_dir=temp_dir)
+            converter = WebArchiveToAstConverter(options)
+            _ = converter.parse(webarchive_bytes)
+
+            extracted_files = list(Path(temp_dir).glob("*"))
+            assert len(extracted_files) == 1
+            assert extracted_files[0].name == "cjk_notes.txt"
+
+            content = extracted_files[0].read_text(encoding="utf-8")
+            assert content == "你好世界"
 
 
 @pytest.mark.unit


### PR DESCRIPTION
Audit findings #35 and #36 (review leg 5), one commit each.

**#35 — WebArchive subresource extraction silently dropped files on Windows.** Two defects in `_extract_subresources`, both masked by the blanket `except Exception: logger.warning(...)`:
- The text-subresource branch used `write_text()` with no encoding; on Windows (cp1252 default) any non-Latin content raised `UnicodeEncodeError` and the resource was skipped. Now written as UTF-8.
- The filename was `Path(resource_url).name`, which keeps a URL query string (`img.png?v=1`), and `?` is illegal in Windows filenames, so `open()` raised `OSError` and the resource was dropped. The name is now taken from the URL path only and run through the existing `sanitize_attachment_filename` helper (same pattern as `static_site.py`); an empty result falls back to the pre-existing `resource_{id}{ext}` naming.

Both new tests (query-string asset, CJK text asset) were verified to fail on the unfixed code with exactly the predicted `OSError` / `UnicodeEncodeError`.

**#36 — deleted `enrich_metadata_with_conversion_info`** (`utils/metadata.py`): zero callers repo-wide, ~85 unmaintained lines carrying a stream-position trap for file-like input. Orphaned `hashlib`/`Path` imports removed with it.

Converter manifest checked (`--update`: no changes). CHANGELOG entries under `[Unreleased]`. mypy clean (273 files); webarchive unit+integration, metadata-utils suites green; full `tests/golden` matches the clean-state baseline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)