### PR TITLE
test: patch pymupdf.open directly and assert exact docx escaping forms

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -67,23 +67,6 @@ def pytest_report_header() -> list[str]:
     return lines
 
 
-def _setup_test_imports():
-    """Setup imports needed for testing while maintaining lazy loading in production."""
-    # Make pymupdf available for PDF tests that need to mock it
-    try:
-        import pymupdf
-
-        import all2md.parsers.pdf
-
-        all2md.parsers.pdf.pymupdf = pymupdf
-    except ImportError:
-        # If pymupdf isn't available, that's ok - tests that need it will skip
-        pass
-
-    # Make Hyperlink available for DOCX tests (already handled in the module)
-    # No additional setup needed since we fixed the module-level approach
-
-
 def pytest_configure(config):
     """Configure pytest with custom markers."""
     config.addinivalue_line("markers", "unit: Unit tests - fast, isolated component tests")
@@ -91,9 +74,6 @@ def pytest_configure(config):
     config.addinivalue_line("markers", "e2e: End-to-end tests - full pipeline tests")
     config.addinivalue_line("markers", "slow: Slow tests that may take several seconds")
     config.addinivalue_line("markers", "cli: Tests related to command-line interface")
-
-    # Make lazy imports available for testing
-    _setup_test_imports()
 
 
 @pytest.fixture

--- a/tests/integration/formats/pdf/test_pdf_layout_advanced.py
+++ b/tests/integration/formats/pdf/test_pdf_layout_advanced.py
@@ -100,7 +100,7 @@ class TestPdfLayoutAdvanced:
         assert len(columns) == 1
         assert len(columns[0]) == len(blocks)
 
-    @patch("all2md.parsers.pdf.pymupdf.open")
+    @patch("pymupdf.open")
     def test_rotated_text_handling(self, mock_fitz_open):
         """Test handling of rotated text blocks."""
         # Mock PDF with rotated text
@@ -216,7 +216,7 @@ class TestPdfLayoutAdvanced:
         columns_large = detect_columns(blocks, column_gap_threshold=50)
         assert len(columns_large) <= 3
 
-    @patch("all2md.parsers.pdf.pymupdf.open")
+    @patch("pymupdf.open")
     def test_header_detection_with_rotation(self, mock_fitz_open):
         """Test header detection considering rotated text."""
         mock_doc = Mock()

--- a/tests/unit/formats/docx/test_docx_escaping.py
+++ b/tests/unit/formats/docx/test_docx_escaping.py
@@ -30,14 +30,23 @@ class TestDocxEscaping:
         temp_file = self.temp_dir / "special_chars.docx"
         doc.save(str(temp_file))
 
-        # Test with escaping enabled (default)
+        # Test with escaping enabled (default). Mid-paragraph *, _, [, ], {, },
+        # backslash and backtick are escaped so they can't be misread as
+        # Markdown syntax. '#' is left bare here: it only needs escaping when
+        # it starts a line (ATX heading marker), and mid-paragraph it is
+        # unambiguous, so escaping it would be over-escaping.
         markdown = docx_to_markdown(str(temp_file))
         assert_markdown_valid(markdown)
 
-        # Common characters that should be escaped in certain contexts
-        assert "\\*" in markdown or "*" in markdown  # Depends on context
-        assert "\\_" in markdown or "_" in markdown
-        assert "\\#" in markdown or "#" in markdown
+        assert "Special characters: \\* \\_ # \\[ \\] ( ) \\{ \\} \\\\ \\` + - . ! ~ ^ | < >" in markdown
+        assert "\\#" not in markdown
+
+        # Test with escaping disabled: every character comes through raw.
+        renderer_options_no_escape = MarkdownRendererOptions(escape_special=False)
+        markdown_no_escape = docx_to_markdown(str(temp_file), renderer_options=renderer_options_no_escape)
+        assert_markdown_valid(markdown_no_escape)
+
+        assert "Special characters: * _ # [ ] ( ) { } \\ ` + - . ! ~ ^ | < >" in markdown_no_escape
 
     def test_escaping_in_different_contexts(self):
         """Test escaping behavior in different document contexts."""
@@ -91,25 +100,31 @@ class TestDocxEscaping:
         temp_file = self.temp_dir / "formatted_special_chars.docx"
         doc.save(str(temp_file))
 
-        # Test with escaping enabled
+        # Test with escaping enabled: formatting markers (** / *) come from the
+        # renderer, not the source text, so they appear either way; the
+        # literal *, _, {, and } characters from the source must be
+        # backslash-escaped so they aren't misread as emphasis/code syntax.
         parser_options = DocxOptions()
         renderer_options = MarkdownRendererOptions(escape_special=True)
         markdown = docx_to_markdown(str(temp_file), parser_options=parser_options, renderer_options=renderer_options)
         assert_markdown_valid(markdown)
 
-        # Should preserve formatting while handling special characters
-        assert "**" in markdown  # Bold formatting
-        assert "*" in markdown  # Italic formatting
-        assert "\\*" in markdown  # escaped
-        assert "\\`function() \\{" in markdown
+        assert "**Bold text with \\* asterisks \\***" in markdown
+        assert "*Italic text with \\_ underscores \\_*" in markdown
+        assert "Code: \\`function() \\{ return 'hello'; \\}\\`" in markdown
 
-        # Test with escaping disabled
+        # Test with escaping disabled: the same literal characters come
+        # through raw.
         parser_options_no_escape = DocxOptions()
         renderer_options_no_escape = MarkdownRendererOptions(escape_special=False)
         markdown_no_escape = docx_to_markdown(
             str(temp_file), parser_options=parser_options_no_escape, renderer_options=renderer_options_no_escape
         )
         assert_markdown_valid(markdown_no_escape)
+
+        assert "**Bold text with * asterisks ***" in markdown_no_escape
+        assert "*Italic text with _ underscores _*" in markdown_no_escape
+        assert "Code: `function() { return 'hello'; }`" in markdown_no_escape
 
     def test_code_blocks_and_inline_code(self):
         """Test special characters in code-like contexts."""

--- a/tests/unit/formats/pdf/test_pdf_formatting.py
+++ b/tests/unit/formats/pdf/test_pdf_formatting.py
@@ -72,7 +72,7 @@ class TestPdfFormatting:
         assert bold_italic_span["flags"] & 16  # Bold flag set
         assert bold_italic_span["flags"] & 2  # Italic flag set
 
-    @patch("all2md.parsers.pdf.pymupdf.open")
+    @patch("pymupdf.open")
     def test_emphasis_mapping_to_markdown(self, mock_fitz_open):
         """Test mapping of PDF font flags to Markdown emphasis."""
         mock_doc = Mock()
@@ -263,7 +263,7 @@ class TestPdfFormatting:
         # The proportional_span is defined for documentation purposes
         assert "Courier" in monospace_span.get("font", "")
 
-    @patch("all2md.parsers.pdf.pymupdf.open")
+    @patch("pymupdf.open")
     def test_mixed_formatting_in_paragraph(self, mock_fitz_open):
         """Test paragraphs with mixed formatting within same line."""
         mock_doc = Mock()


### PR DESCRIPTION
Audit findings #38 and #39 (review leg 5), one commit each. Test-only.

**#38 — conftest injected pymupdf as a module attribute production code never reads.** The four tests that patched `@patch("all2md.parsers.pdf.pymupdf.open")` (test_pdf_formatting.py ×2, test_pdf_layout_advanced.py ×2) now patch `pymupdf.open` directly — semantically identical, since pdf.py only ever does function-local `import pymupdf`, so the alias patch already mutated the global module. The `_setup_test_imports()` function in tests/conftest.py existed solely for that injection (plus a no-op comment) and is removed along with its `pytest_configure` call site. Precedent for direct patching already existed in `test_pdf_ocr.py`.

**#39 — docx escaping tests asserted tautologies.** `assert "\*" in markdown or "*" in markdown` is satisfied by escaped and unescaped output alike. Replaced with exact-form assertions measured from the real renderer output for both `escape_special=True` and `False` (the False branch previously had zero content assertions), plus a `"\#" not in markdown` guard against over-escaping — `#` is deliberately left bare mid-paragraph (only ambiguous at line start), which is correct behavior, not a hidden bug. Also tightened the weak `"**" in markdown` checks in `test_formatted_text_with_special_chars` the same way.

Judge-can-fail proof: against simulated no-op-escaping output the old assertions still pass (blind) while the new exact-form assertions fail; simulated `#` over-escaping is caught by the new guard.

Runs: full `tests/unit/formats/pdf` 322 passed (no mock leakage), docx escaping file 10 passed, combined sweep 350 passed, full `tests/golden` matches the clean-state baseline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)