### PR TITLE
test: make assert_markdown_valid a real oracle that can fail

### DIFF
--- a/tests/unit/test_test_utils.py
+++ b/tests/unit/test_test_utils.py
@@ -1,0 +1,168 @@
+"""Tests for the test suite's own helpers in ``tests/utils.py``.
+
+``assert_markdown_valid`` is called at ~300 sites across the docx/html/pptx/eml/pdf
+unit, integration and e2e suites, always positioned as *the* validity check right
+after a conversion. It previously asserted nothing at all -- every branch ended in
+``pass`` -- so it accepted empty output, garbage, and structurally broken Markdown.
+
+These tests exist to prove the oracle can actually fail. An oracle that has never
+been re-run against known-bad input is not evidence of anything.
+"""
+
+import pytest
+from utils import assert_markdown_valid
+
+pytestmark = pytest.mark.unit
+
+
+class TestAssertMarkdownValidRejectsGarbage:
+    """The oracle must raise AssertionError on malformed input."""
+
+    def test_rejects_none(self) -> None:
+        with pytest.raises(AssertionError, match="expected Markdown as str"):
+            assert_markdown_valid(None)  # type: ignore[arg-type]
+
+    def test_rejects_bytes(self) -> None:
+        with pytest.raises(AssertionError, match="expected Markdown as str"):
+            assert_markdown_valid(b"# Heading")  # type: ignore[arg-type]
+
+    def test_rejects_nul_byte(self) -> None:
+        with pytest.raises(AssertionError, match="NUL byte"):
+            assert_markdown_valid("Some text\x00more text")
+
+    def test_rejects_leaked_python_repr(self) -> None:
+        leaked = "Paragraph: <all2md.ast.nodes.Paragraph object at 0x000001F2A3B4C5D6>\n"
+        with pytest.raises(AssertionError, match="leaked Python object repr"):
+            assert_markdown_valid(leaked)
+
+    def test_rejects_unclosed_backtick_fence(self) -> None:
+        with pytest.raises(AssertionError, match="unclosed code fence"):
+            assert_markdown_valid("# Title\n\n```python\nprint('hi')\n")
+
+    def test_rejects_unclosed_tilde_fence(self) -> None:
+        with pytest.raises(AssertionError, match="unclosed code fence"):
+            assert_markdown_valid("~~~\nsome code\n")
+
+    def test_rejects_stray_closing_fence(self) -> None:
+        """A lone closing fence is itself read as an opener, so it must fail too."""
+        with pytest.raises(AssertionError, match="unclosed code fence"):
+            assert_markdown_valid("Some prose.\n\n```\n")
+
+    def test_rejects_three_fences(self) -> None:
+        markdown = "```\na\n```\n\n```python\nb\n"
+        with pytest.raises(AssertionError, match="unclosed code fence"):
+            assert_markdown_valid(markdown)
+
+    def test_rejects_closing_fence_that_is_too_short(self) -> None:
+        """A 4-backtick block is not closed by a 3-backtick fence."""
+        with pytest.raises(AssertionError, match="unclosed code fence"):
+            assert_markdown_valid("````\ncode with ``` inside\n```\n")
+
+    def test_rejects_table_delimiter_without_header(self) -> None:
+        markdown = "Some prose.\n\n|---|---|\n| a | b |\n"
+        with pytest.raises(AssertionError, match="not preceded by a header row"):
+            assert_markdown_valid(markdown)
+
+    def test_rejects_table_delimiter_after_blank_line(self) -> None:
+        markdown = "| a | b |\n\n| --- | --- |\n| 1 | 2 |\n"
+        with pytest.raises(AssertionError, match="not preceded by a header row"):
+            assert_markdown_valid(markdown)
+
+    def test_rejects_table_delimiter_as_first_line(self) -> None:
+        with pytest.raises(AssertionError, match="not preceded by a header row"):
+            assert_markdown_valid("| --- | --- |\n| 1 | 2 |\n")
+
+    def test_error_message_names_the_offending_line(self) -> None:
+        with pytest.raises(AssertionError) as excinfo:
+            assert_markdown_valid("para\n\n```js\nvar x = 1;\n")
+        assert "line 3" in str(excinfo.value)
+
+
+class TestAssertMarkdownValidAcceptsRealOutput:
+    """Representative real conversion output must pass unchanged."""
+
+    def test_accepts_empty_string(self) -> None:
+        """Empty documents legitimately convert to empty output."""
+        assert_markdown_valid("")
+
+    def test_accepts_whitespace_only(self) -> None:
+        assert_markdown_valid("\n\n")
+
+    def test_accepts_plain_prose(self) -> None:
+        assert_markdown_valid("# Main Heading\n\nA paragraph with **bold** and *italic* text.\n")
+
+    def test_accepts_balanced_fence_with_info_string(self) -> None:
+        markdown = "## Code Example\n\nInline `code` example.\n\n```python\ndef f():\n    return 1\n```\n"
+        assert_markdown_valid(markdown)
+
+    def test_accepts_fence_indented_inside_list_item(self) -> None:
+        markdown = "- item\n\n  ```python\n  x = 1\n  ```\n\n- next item\n"
+        assert_markdown_valid(markdown)
+
+    def test_accepts_closing_fence_with_trailing_whitespace(self) -> None:
+        assert_markdown_valid("```\ncode\n```   \n")
+
+    def test_accepts_longer_closing_fence(self) -> None:
+        assert_markdown_valid("```\ncode\n`````\n")
+
+    def test_accepts_nested_fence_inside_longer_fence(self) -> None:
+        """A markdown sample containing ``` inside a 4-backtick block is balanced."""
+        assert_markdown_valid("````markdown\n```python\nx = 1\n```\n````\n")
+
+    def test_accepts_tilde_fence(self) -> None:
+        assert_markdown_valid("~~~python\nx = 1\n~~~\n")
+
+    def test_accepts_well_formed_table(self) -> None:
+        markdown = "| Name | Value |\n| --- | --- |\n| a | 1 |\n| b | 2 |\n"
+        assert_markdown_valid(markdown)
+
+    def test_accepts_table_with_alignment_row(self) -> None:
+        markdown = "| L | C | R |\n|:---|:---:|---:|\n| a | b | c |\n"
+        assert_markdown_valid(markdown)
+
+    def test_accepts_table_delimiter_inside_code_block(self) -> None:
+        """Delimiter-looking lines inside a fence are code, not tables."""
+        markdown = "```\n|---|---|\n| a | b |\n```\n"
+        assert_markdown_valid(markdown)
+
+    def test_accepts_horizontal_rule(self) -> None:
+        assert_markdown_valid("Above\n\n---\n\nBelow\n")
+
+    def test_accepts_yaml_frontmatter(self) -> None:
+        assert_markdown_valid("---\ntitle: Doc\n---\n\n# Doc\n")
+
+    def test_accepts_setext_heading(self) -> None:
+        assert_markdown_valid("Title\n-----\n\nBody.\n")
+
+    def test_accepts_html_and_links(self) -> None:
+        markdown = "A [link](https://example.com) and an ![img](data:image/png;base64,iVBOR)\n\n<br />\n"
+        assert_markdown_valid(markdown)
+
+    def test_accepts_merged_cell_table(self) -> None:
+        """Merged cells produce ragged rows; that is measured, expected output.
+
+        Markdown cannot express colspan/rowspan, so a DOCX/HTML table with merged
+        cells renders rows whose cell counts differ from the delimiter row. 20 of 327
+        real conversion outputs look like this. A column-count-consistency rule was
+        measured, found to fail all of them, and dropped rather than special-cased.
+        """
+        markdown = "| Header 1 | Header Group |\n|---|---|---|\n| Sub Header 1 | Sub Header 2 |\n| Row 1 Cell 1 | Row 1 Cell 2 | Row 1 Cell 3 |\n"
+        assert_markdown_valid(markdown)
+
+    def test_accepts_non_nul_control_character(self) -> None:
+        """An HTML entity test legitimately round-trips ``&#4;`` to a literal U+0004."""
+        assert_markdown_valid("Incomplete: \\{ \x04 ©\n")
+
+    @pytest.mark.parametrize(
+        "markdown",
+        [
+            "# H1\n\n## H2\n\n- a\n- b\n\n1. one\n2. two\n",
+            "> quoted\n> more\n\nAfter.\n",
+            "Text with ~~strike~~ and ==highlight== and ^sup^ and ~sub~.\n",
+            "| a |\n| --- |\n| 1 |\n",
+            "Footnote ref[^1]\n\n[^1]: The note.\n",
+            "Term\n\n: Definition\n",
+        ],
+    )
+    def test_accepts_assorted_renderer_output(self, markdown: str) -> None:
+        assert_markdown_valid(markdown)

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -7,6 +7,7 @@ Markdown output, and other common testing functions.
 import base64
 import datetime
 import email
+import re
 import tempfile
 from email.mime.image import MIMEImage
 from email.mime.multipart import MIMEMultipart
@@ -586,27 +587,93 @@ Café résumé naïve
 """
 
 
+# A fenced code block opener/closer: up to 3 leading spaces, then 3+ backticks or
+# tildes. Group "info" is the info string (only legal on an opening fence).
+_CODE_FENCE_RE = re.compile(r"^ {0,3}(?P<fence>`{3,}|~{3,})(?P<info>.*)$")
+
+# A GFM table delimiter row, e.g. "|---|:--:|" or "| --- | ---: |". Deliberately
+# strict: every pipe-separated segment must be a bare alignment spec.
+_TABLE_DELIMITER_RE = re.compile(r"^ {0,3}\|?(?:\s*:?-+:?\s*\|)+\s*:?-*:?\s*$")
+
+# A Python object repr that leaked into the output instead of being rendered,
+# e.g. "<all2md.ast.nodes.Paragraph object at 0x000001F2>".
+_REPR_LEAK_RE = re.compile(r"<[A-Za-z_][\w.]* object at 0x[0-9A-Fa-f]+>")
+
+
 def assert_markdown_valid(markdown: str) -> None:
-    """Assert that the generated Markdown is valid and well-formed."""
+    """Assert that generated Markdown is structurally well-formed.
+
+    This is a conservative structural oracle, not a Markdown spec validator. Every
+    rule below was measured against ~450 real conversion outputs (the outputs of
+    every test that calls this helper, plus the golden snapshots) and produces zero
+    false positives on them, so a failure here means the output genuinely changed
+    shape.
+
+    Checks performed:
+
+    1. The value is a ``str`` (catches ``None``/``bytes`` leaking out of a converter).
+    2. No NUL bytes.
+    3. No leaked Python object ``repr``\\ s (a node that was ``str()``-ed instead of
+       rendered).
+    4. Every fenced code block is closed. Tracked with a CommonMark-style state
+       machine: an opening fence may carry an info string, a closing fence must be
+       bare, use the same fence character, and be at least as long as the opener.
+    5. Every GFM table delimiter row is preceded by a non-blank header row that
+       contains a pipe (a delimiter row without a header does not render as a table).
+       Delimiter rows inside fenced code blocks are ignored.
+
+    Deliberately NOT checked (each was measured and rejected):
+
+    * **Table column-count consistency.** 20 of 327 real outputs have rows whose cell
+      count differs from the delimiter row, in every case because the source table
+      used merged cells (colspan/rowspan), which Markdown cannot express. Enforcing
+      this rule would fail legitimate, intentionally-tested output. See the note in
+      ``tests/unit/test_test_utils.py``.
+    * **Control characters.** A real HTML-entity test legitimately round-trips
+      ``&#4;`` into a literal U+0004, so only NUL is rejected.
+    * **Non-empty output.** Empty documents legitimately convert to ``""``.
+    * Style rules (blank line before headings/lists, link syntax): not structural.
+    """
+    assert isinstance(markdown, str), f"expected Markdown as str, got {type(markdown).__name__}"
+    assert "\x00" not in markdown, "Markdown output contains a NUL byte"
+
+    leak = _REPR_LEAK_RE.search(markdown)
+    assert leak is None, f"Markdown output contains a leaked Python object repr: {leak.group(0)!r}"
+
     lines = markdown.split("\n")
 
-    # Check for common Markdown issues
-    for i, line in enumerate(lines):
-        # Check for unescaped special characters at start of line
-        if line.startswith(("#", "*", "-", "+")) and i > 0:
-            if not lines[i - 1].strip() == "":  # Should have empty line before headers/lists
-                pass  # Could add warnings for style issues
+    open_fence_char: str | None = None
+    open_fence_len = 0
+    open_fence_lineno = 0
 
-        # Check for proper link formatting
-        if "[" in line and "]" in line:
-            # Basic link structure validation
-            pass
+    for lineno, line in enumerate(lines, start=1):
+        fence_match = _CODE_FENCE_RE.match(line)
+        if fence_match is not None:
+            fence = fence_match.group("fence")
+            char, length = fence[0], len(fence)
+            info = fence_match.group("info")
+            if open_fence_char is None:
+                # A backtick opening fence may not contain a backtick in its info string.
+                if char == "`" and "`" in info:
+                    continue
+                open_fence_char, open_fence_len, open_fence_lineno = char, length, lineno
+            elif char == open_fence_char and length >= open_fence_len and not info.strip():
+                open_fence_char, open_fence_len, open_fence_lineno = None, 0, 0
+            continue
 
-    # Check for proper table formatting
-    table_lines = [line for line in lines if "|" in line]
-    if table_lines:
-        # Validate table structure consistency
-        pass
+        if open_fence_char is not None:
+            continue  # inside a code block; nothing below applies
+
+        if line.count("|") >= 2 and "-" in line and _TABLE_DELIMITER_RE.match(line):
+            previous = lines[lineno - 2] if lineno >= 2 else ""
+            assert previous.strip() and "|" in previous, (
+                f"line {lineno}: table delimiter row {line!r} is not preceded by a header row "
+                f"(previous line: {previous!r}); this will not render as a table"
+            )
+
+    assert (
+        open_fence_char is None
+    ), f"unclosed code fence opened on line {open_fence_lineno} ({open_fence_char * open_fence_len!r})"
 
 
 def create_test_temp_dir() -> Path:


### PR DESCRIPTION
Audit finding #32 (review leg 5). Test-only.

`assert_markdown_valid` was called 304 times across 24 files as "the validity check" yet contained no assert — every branch ended in `pass`. It now performs real structural checks, each measured against 453 real conversion outputs (every string the calling suites hand it, plus the golden snapshots) with zero false positives:

1. value is `str` (catches None/bytes), 2. no NUL bytes, 3. no leaked Python object reprs, 4. every code fence closed (CommonMark-style state machine: indented fences, info strings, tilde fences, closer-length rule — not naive even-counting), 5. every GFM table delimiter row preceded by a pipe-bearing header row (delimiter rows inside fences ignored).

Measured-and-rejected rules are documented in the docstring, most notably table column-count consistency: 20/327 real outputs violate it, all from merged-cell source tables — see the product-bug note below.

New `tests/unit/test_test_utils.py` (37 tests): 13 prove the oracle *raises* on garbage, 24 prove it accepts representative real output — per the repo's verify-the-judge-can-fail rule.

Fallout: all 23 calling files re-run in batches (unit 132, integration formats 151, integration parsers 157, e2e 54, golden at clean baseline) — zero new failures, no rule weakened after the measurement pass.

**Side-discovery (not fixed here, src/ out of scope):** the Markdown renderer emits ragged rows for merged-cell tables — `_render_minimal_table` uses `num_cols` only for the alignment row and joins data rows verbatim, so a leading colspan shifts data under the wrong headers on GFM rendering. The AST carries colspan/rowspan and the AsciiDoc renderer honors them; only Markdown drops them. Filed for follow-up in the review doc; fixing it would make the column-count rule safe to add to this oracle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)