### PR TITLE
test(fuzz): derandomize the five generative gates that drew a fresh corpus per run

### DIFF
--- a/tests/unit/test_roundtrip_fuzzing.py
+++ b/tests/unit/test_roundtrip_fuzzing.py
@@ -225,7 +225,7 @@ class TestLosslessFormatsAreLossless:
     """The formats that claim exactness are the harness's control."""
 
     @pytest.mark.parametrize("fmt", LOSSLESS_FORMATS)
-    @settings(deadline=None, suppress_health_check=[HealthCheck.too_slow])
+    @settings(deadline=None, derandomize=not DISCOVERY, suppress_health_check=[HealthCheck.too_slow])
     @given(doc=documents())
     def test_round_trip_scores_exactly_100(self, fmt: str, doc: Document) -> None:
         """Property: a lossless format round trip loses nothing, ever.
@@ -578,7 +578,12 @@ class TestStructuralInvariants:
 class TestGeneratedTablesAndLists:
     """Aim the generator at the two node classes that break most often."""
 
-    @settings(deadline=None, max_examples=25, suppress_health_check=[HealthCheck.too_slow])
+    @settings(
+        deadline=None,
+        max_examples=25,
+        derandomize=not DISCOVERY,
+        suppress_health_check=[HealthCheck.too_slow],
+    )
     @given(documents_of(tables()))
     def test_table_documents_round_trip_through_html(self, doc: Document) -> None:
         """Property: HTML preserves every table's declared dimensions.
@@ -590,7 +595,12 @@ class TestGeneratedTablesAndLists:
         source_widths = _header_widths(doc)
         assert _header_widths(_round_trip(doc, "html")) == source_widths
 
-    @settings(deadline=None, max_examples=25, suppress_health_check=[HealthCheck.too_slow])
+    @settings(
+        deadline=None,
+        max_examples=25,
+        derandomize=not DISCOVERY,
+        suppress_health_check=[HealthCheck.too_slow],
+    )
     @given(documents_of(lists()))
     def test_list_documents_keep_their_item_count_in_html(self, doc: Document) -> None:
         """Property: HTML keeps every list item, including the empty ones.
@@ -713,7 +723,12 @@ class TestGeneratedFootnotes:
         """
         measure = FOOTNOTE_PROPERTIES[prop]
 
-        @settings(deadline=None, max_examples=25, suppress_health_check=[HealthCheck.too_slow])
+        @settings(
+            deadline=None,
+            max_examples=25,
+            derandomize=not DISCOVERY,
+            suppress_health_check=[HealthCheck.too_slow],
+        )
         @given(documents_with_footnotes())
         def property_holds(doc: Document) -> None:
             assert measure(_round_trip(doc, fmt)) == measure(doc)
@@ -808,7 +823,12 @@ class TestGeneratedDefinitionLists:
         """Property: a document's definition lists come back with the same shape."""
         measure = DEFINITION_PROPERTIES[prop]
 
-        @settings(deadline=None, max_examples=25, suppress_health_check=[HealthCheck.too_slow])
+        @settings(
+            deadline=None,
+            max_examples=25,
+            derandomize=not DISCOVERY,
+            suppress_health_check=[HealthCheck.too_slow],
+        )
         @given(documents_with_definition_lists())
         def property_holds(doc: Document) -> None:
             assert measure(_round_trip(doc, fmt)) == measure(doc)


### PR DESCRIPTION
Audit finding #29 (review leg 5, high). Test-only, one file.

The module contract ("They are derandomize=True, so a PR replays a fixed corpus") and the pytest.ini `generative` marker text were only true for the two `TestNoUnrecognisedCrash` gates. Auditing every `@settings` in the file found **five** decorators missing `derandomize` — the audit said three; `TestGeneratedDefinitionLists` (added after the audit was written) had drifted the same way:

- `TestLosslessFormatsAreLossless.test_round_trip_scores_exactly_100`
- `TestGeneratedTablesAndLists.test_table_documents_round_trip_through_html`
- `TestGeneratedTablesAndLists.test_list_documents_keep_their_item_count_in_html`
- `TestGeneratedFootnotes.test_footnotes_survive` (inner `@settings`)
- `TestGeneratedDefinitionLists.test_definition_lists_survive` (inner `@settings`)

All five now carry `derandomize=not DISCOVERY`, matching the crash gates verbatim. `tests/conftest.py` deliberately untouched (its 'ci' profile re-registration is the #341 fix).

Verification:
- Determinism double-run (`CI=true`, full file, twice): 70 passed / 1 skipped / 15 xfailed both times, per-test outcome sequences character-identical. No XPASS, no FAIL — all 15 strict-xfail known-gap entries (9 footnote, 6 definition-list) still fail deterministically against the fixed corpus, so no allowlist changes were needed: the lists were already honest.
- `ALL2MD_FUZZ_DISCOVERY=1` now actually reaches these gates (introspection shows `derandomize` tracking the env var; short live discovery runs pass); previously the env var had no effect on them.
- Module docstring / report header / marker text needed no edits — they were aspirational before and are literally true now.
- Full `tests/golden` at the documented clean baseline; black/ruff clean.

Candidate follow-up (deliberately not added here): a guard test enforcing "every generative gate sets derandomize", precedent `test_hypothesis_profiles.py` — but the natural `ast`-walking implementation is fragile because `tests/unit/ast/` shadows stdlib `ast` for modules under `tests/unit/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)