### PR TITLE
fix(markdown): keep nested ordered lists with start != 1 through a round trip

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,10 +64,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   fixed point, so the reparsed (now loose) document renders byte-identically. Renumbering
   the sublist from 1 was rejected: ordinal markers are real data — a PDF bibliography
   continues its numbering across list fragments, and rewriting it would silently falsify
-  the citation numbers. **Formatting note:** a list whose item holds such a sublist now
-  renders loose, so blank lines appear between its items where there were none before.
-  Lists with no offset-numbered sublist are untouched — tight stays tight, and the golden
-  snapshot suite is unchanged.
+  the citation numbers. **Formatting note:** a list gains blank lines between its items
+  when one of them holds an offset-numbered sublist *after* some other block — that is
+  the shape that was broken. A sublist that is an item's very first block sits against
+  the marker, already reads as a nested list, and keeps its tight rendering. Lists with
+  no offset-numbered sublist are untouched — tight stays tight, and the golden snapshot
+  suite is unchanged.
 - **A PDF's ruling-line table fallback no longer deletes the text of any region it
   rejects.** Text that falls inside a detected table's bounding box is removed from the
   page's ordinary text blocks *before* the table is validated, so that it is not emitted

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **A nested ordered list numbered from anything but 1 no longer collapses into the
+  paragraph above it.** CommonMark lets only a `1.` ordered item interrupt a paragraph.
+  The Markdown renderer put a nested list on the line straight after its item's text, so
+  a sublist starting at `10.` — or at `0.` — was read back as more paragraph text and the
+  entire sublist vanished: two `List` nodes went in, one came out, and the numbers ended
+  up inside a sentence. This hit tight *and* loose parents alike, since loose rendering
+  only put blank lines *between* items and never between a paragraph and the sublist
+  *inside* one. The renderer now emits a blank line before such a sublist and renders the
+  list containing it loose, which is what makes that blank line legal; the output is a
+  fixed point, so the reparsed (now loose) document renders byte-identically. Renumbering
+  the sublist from 1 was rejected: ordinal markers are real data — a PDF bibliography
+  continues its numbering across list fragments, and rewriting it would silently falsify
+  the citation numbers. **Formatting note:** a list whose item holds such a sublist now
+  renders loose, so blank lines appear between its items where there were none before.
+  Lists with no offset-numbered sublist are untouched — tight stays tight, and the golden
+  snapshot suite is unchanged.
 - **A PDF's ruling-line table fallback no longer deletes the text of any region it
   rejects.** Text that falls inside a detected table's bounding box is removed from the
   page's ordinary text blocks *before* the table is validated, so that it is not emitted

--- a/src/all2md/renderers/markdown.py
+++ b/src/all2md/renderers/markdown.py
@@ -1075,12 +1075,15 @@ class MarkdownRenderer(NodeVisitor, InlineContentMixin, BaseRenderer):
             self._indent_level += 1
 
         self._in_list = True
-        # An item holding an ordered sublist that does not start at 1 needs a
-        # blank line in front of that sublist (see ``_interrupts_paragraph``),
-        # and a list with a blank line inside an item is loose. Derive the
-        # tightness we render with rather than mutating the node.
+        # An ordered sublist that does not start at 1 needs a blank line in
+        # front of it (see ``_interrupts_paragraph``), and a list with a blank
+        # line inside an item is loose. Only a sublist that *follows* another
+        # block has a paragraph to be swallowed by, so an item whose very first
+        # block is such a sublist needs nothing: it sits directly against the
+        # marker, where it already reads as a nested list. Derive the tightness
+        # we render with rather than mutating the node.
         effective_tight = node.tight and not any(
-            any(_interrupts_paragraph(child) for child in item.children) for item in node.items
+            any(_interrupts_paragraph(child) for child in item.children[1:]) for item in node.items
         )
         self._list_tight = effective_tight
 

--- a/src/all2md/renderers/markdown.py
+++ b/src/all2md/renderers/markdown.py
@@ -46,6 +46,7 @@ from all2md.ast.nodes import (
     Mark,
     MathBlock,
     MathInline,
+    Node,
     Paragraph,
     Strikethrough,
     Strong,
@@ -93,6 +94,29 @@ _BLOCK_START_WORD = re.compile(r"^(?:[-+*>|=~#]|\d+[.)]|:)")
 # code spans, link/image destinations, reference-link labels, autolinks and raw
 # HTML, and math delimiters. A paragraph containing any of them is left alone.
 _UNWRAPPABLE_MARKERS = ("`", "](", "][", "<", "$")
+
+
+def _interrupts_paragraph(node: Node) -> bool:
+    """Report whether an ordered list may not follow a paragraph line directly.
+
+    CommonMark lets only a ``1.`` ordered item interrupt a paragraph. A nested
+    ordered list numbered from anything else -- ``10.``, ``0.`` -- placed on the
+    line after its item's paragraph is read as more paragraph text, so the whole
+    sublist is swallowed and lost on reparse. Such a list needs a blank line in
+    front of it, which in turn makes its containing list loose.
+
+    Parameters
+    ----------
+    node : Node
+        Candidate child of a list item.
+
+    Returns
+    -------
+    bool
+        True for an ordered List whose numbering does not start at 1.
+
+    """
+    return isinstance(node, List) and node.ordered and node.start != 1
 
 
 class MarkdownRenderer(NodeVisitor, InlineContentMixin, BaseRenderer):
@@ -1051,7 +1075,14 @@ class MarkdownRenderer(NodeVisitor, InlineContentMixin, BaseRenderer):
             self._indent_level += 1
 
         self._in_list = True
-        self._list_tight = node.tight
+        # An item holding an ordered sublist that does not start at 1 needs a
+        # blank line in front of that sublist (see ``_interrupts_paragraph``),
+        # and a list with a blank line inside an item is loose. Derive the
+        # tightness we render with rather than mutating the node.
+        effective_tight = node.tight and not any(
+            any(_interrupts_paragraph(child) for child in item.children) for item in node.items
+        )
+        self._list_tight = effective_tight
 
         for i, item in enumerate(node.items):
             if node.ordered:
@@ -1066,7 +1097,7 @@ class MarkdownRenderer(NodeVisitor, InlineContentMixin, BaseRenderer):
             self._list_marker_stack.pop()
 
             if i < len(node.items) - 1:
-                if node.tight:
+                if effective_tight:
                     self._output.append("\n")
                 else:
                     self._output.append("\n\n")
@@ -1153,8 +1184,15 @@ class MarkdownRenderer(NodeVisitor, InlineContentMixin, BaseRenderer):
                 # Both nested lists and other blocks (paragraphs, code blocks, etc.)
                 # will use _current_indent() which now includes the marker width.
                 # In a loose list, block-level siblings (paragraphs, code) are
-                # separated by a blank line; a nested list attaches directly.
-                if not self._list_tight and not isinstance(child, List):
+                # separated by a blank line; a nested list attaches directly --
+                # unless it is an ordered list numbered from something other than
+                # 1, which may not interrupt the preceding paragraph and would be
+                # swallowed by it. That one always takes a blank line, whether or
+                # not the containing list was already loose, so that the promoted
+                # output is a fixed point of the round trip.
+                if _interrupts_paragraph(child):
+                    self._output.append("\n\n")
+                elif not self._list_tight and not isinstance(child, List):
                     self._output.append("\n\n")
                 else:
                     self._output.append("\n")

--- a/tests/unit/renderers/test_markdown_renderer.py
+++ b/tests/unit/renderers/test_markdown_renderer.py
@@ -896,6 +896,158 @@ class TestLists:
 
 
 @pytest.mark.unit
+class TestNestedOrderedListStartOffset:
+    """A nested ordered list numbered from anything but 1 must survive a reparse.
+
+    CommonMark lets only a ``1.`` ordered item interrupt a paragraph. Rendering
+    ``10. alpha`` on the line straight after its item's paragraph made the whole
+    sublist read as more paragraph text, so it was silently swallowed: two List
+    nodes went in, one came out. The renderer now puts a blank line in front of
+    such a sublist and renders the containing list loose.
+    """
+
+    @staticmethod
+    def _sublist_doc(*, parent_ordered=True, parent_tight=True, start=10, first_child=False):
+        """Build a two-item list whose first item carries an ordered sublist."""
+        sublist = List(
+            ordered=True,
+            start=start,
+            items=[
+                ListItem(children=[Paragraph(content=[Text(content="alpha")])]),
+                ListItem(children=[Paragraph(content=[Text(content="beta")])]),
+            ],
+        )
+        first_children = [sublist] if first_child else [Paragraph(content=[Text(content="outer one")]), sublist]
+        return Document(
+            children=[
+                List(
+                    ordered=parent_ordered,
+                    tight=parent_tight,
+                    items=[
+                        ListItem(children=first_children),
+                        ListItem(children=[Paragraph(content=[Text(content="outer two")])]),
+                    ],
+                )
+            ]
+        )
+
+    @staticmethod
+    def _lists(node):
+        """Collect every List reachable from ``node``, outermost first."""
+        found = []
+        for child in getattr(node, "children", []) or []:
+            if isinstance(child, List):
+                found.append(child)
+                for item in child.items:
+                    found.extend(TestNestedOrderedListStartOffset._lists(item))
+            else:
+                found.extend(TestNestedOrderedListStartOffset._lists(child))
+        return found
+
+    def test_render_separates_offset_sublist_and_loosens_parent(self):
+        """The target layout: blank line before the sublist, loose parent."""
+        result = MarkdownRenderer().render_to_string(self._sublist_doc())
+        assert result == "1. outer one\n\n   10. alpha\n   11. beta\n\n2. outer two"
+
+    def test_offset_sublist_survives_the_round_trip(self):
+        """Both lists come back, with the sublist's numbering intact."""
+        from all2md import to_ast
+
+        rendered = MarkdownRenderer().render_to_string(self._sublist_doc())
+        lists = self._lists(to_ast(rendered, source_format="markdown"))
+        assert len(lists) == 2, f"nested list was swallowed: {rendered!r}"
+        assert lists[1].start == 10
+        assert [item.children[0].content[0].content for item in lists[1].items] == ["alpha", "beta"]
+
+    @pytest.mark.parametrize(
+        ("parent_ordered", "parent_tight", "start", "first_child"),
+        [
+            (True, True, 10, False),  # the reported shape
+            (True, False, 10, False),  # parent already loose
+            (False, True, 10, False),  # unordered parent, ordered sublist
+            (True, True, 0, False),  # 0. may not interrupt a paragraph either
+            (True, True, 10, True),  # sublist is the item's first block
+        ],
+    )
+    def test_offset_sublist_is_byte_idempotent_from_cycle_one(self, parent_ordered, parent_tight, start, first_child):
+        """Promotion must be a fixed point: the reparsed loose parent renders the same."""
+        from all2md import to_ast
+
+        doc = self._sublist_doc(
+            parent_ordered=parent_ordered, parent_tight=parent_tight, start=start, first_child=first_child
+        )
+        renderer = MarkdownRenderer()
+        md1 = renderer.render_to_string(doc)
+        md2 = MarkdownRenderer().render_to_string(to_ast(md1, source_format="markdown"))
+        assert md1 == md2, f"not idempotent:\n{md1!r}\n{md2!r}"
+
+        lists = self._lists(to_ast(md1, source_format="markdown"))
+        assert len(lists) == 2, f"nested list was swallowed: {md1!r}"
+        assert lists[1].start == start
+
+    def test_sublist_starting_at_one_is_left_tight(self):
+        """A ``1.`` sublist may interrupt a paragraph, so nothing changes for it."""
+        result = MarkdownRenderer().render_to_string(self._sublist_doc(start=1))
+        assert result == "1. outer one\n   1. alpha\n   2. beta\n2. outer two"
+
+    def test_unordered_sublist_is_left_tight(self):
+        """A bullet sublist was never at risk and must keep its tight layout."""
+        doc = Document(
+            children=[
+                List(
+                    ordered=True,
+                    items=[
+                        ListItem(
+                            children=[
+                                Paragraph(content=[Text(content="outer one")]),
+                                List(
+                                    ordered=False,
+                                    items=[ListItem(children=[Paragraph(content=[Text(content="alpha")])])],
+                                ),
+                            ]
+                        ),
+                        ListItem(children=[Paragraph(content=[Text(content="outer two")])]),
+                    ],
+                )
+            ]
+        )
+        assert MarkdownRenderer().render_to_string(doc) == "1. outer one\n   - alpha\n2. outer two"
+
+    def test_promotion_applies_per_level(self):
+        """Only the level that holds the offset sublist loosens, not its ancestors."""
+        from all2md import to_ast
+
+        level3 = List(ordered=True, start=7, items=[ListItem(children=[Paragraph(content=[Text(content="L3")])])])
+        level2 = List(
+            ordered=True,
+            items=[
+                ListItem(children=[Paragraph(content=[Text(content="L2")]), level3]),
+                ListItem(children=[Paragraph(content=[Text(content="L2b")])]),
+            ],
+        )
+        doc = Document(
+            children=[
+                List(
+                    ordered=True,
+                    items=[
+                        ListItem(children=[Paragraph(content=[Text(content="L1")]), level2]),
+                        ListItem(children=[Paragraph(content=[Text(content="L1b")])]),
+                    ],
+                )
+            ]
+        )
+        md1 = MarkdownRenderer().render_to_string(doc)
+        # The outer list keeps its tight layout; only the middle one loosens.
+        assert md1 == "1. L1\n   1. L2\n\n      7. L3\n\n   2. L2b\n2. L1b"
+
+        md2 = MarkdownRenderer().render_to_string(to_ast(md1, source_format="markdown"))
+        assert md1 == md2
+        lists = self._lists(to_ast(md1, source_format="markdown"))
+        assert [lst.start for lst in lists] == [1, 1, 7]
+        assert [lst.tight for lst in lists] == [True, False, True]
+
+
+@pytest.mark.unit
 class TestTables:
     """Tests for table rendering."""
 

--- a/tests/unit/renderers/test_markdown_renderer.py
+++ b/tests/unit/renderers/test_markdown_renderer.py
@@ -985,6 +985,26 @@ class TestNestedOrderedListStartOffset:
         assert len(lists) == 2, f"nested list was swallowed: {md1!r}"
         assert lists[1].start == start
 
+    def test_offset_sublist_as_an_items_first_block_is_left_tight(self):
+        """With no block in front of it there is no paragraph to be swallowed by.
+
+        The sublist sits directly against the parent's marker, where it already
+        reads as a nested list, so neither the blank line nor the loose parent is
+        needed. This shape round-tripped before the fix and must keep its layout:
+        the promotion looks only at blocks after an item's first.
+        """
+        from all2md import to_ast
+
+        md1 = MarkdownRenderer().render_to_string(self._sublist_doc(first_child=True))
+        assert md1 == "1. 10. alpha\n   11. beta\n2. outer two"
+
+        # Still correct, and still a fixed point.
+        md2 = MarkdownRenderer().render_to_string(to_ast(md1, source_format="markdown"))
+        assert md1 == md2
+        lists = self._lists(to_ast(md1, source_format="markdown"))
+        assert [lst.start for lst in lists] == [1, 10]
+        assert [lst.tight for lst in lists] == [True, True]
+
     def test_sublist_starting_at_one_is_left_tight(self):
         """A ``1.`` sublist may interrupt a paragraph, so nothing changes for it."""
         result = MarkdownRenderer().render_to_string(self._sublist_doc(start=1))


### PR DESCRIPTION
Audit finding #41 (post-audit addition; flavor decision made 2026-08-14).

A nested ordered list with `start != 1` rendered as e.g. `10. alpha` directly after its item's paragraph line. CommonMark lets only `1.` interrupt a paragraph, so on reparse the sublist was read as paragraph text and the list structure was silently lost — for any parent, tight or loose (loose rendering only separated items, never the blocks inside an item).

Chosen flavor (renumbering was rejected — ordinal markers are real data, e.g. PDF bibliography fragments that continue numbering):

- **Blank line** before an ordered sublist whose numbering doesn't start at 1, whenever it follows another block inside its item. Unconditional, so the output is a fixed point of the round trip.
- **Promote the containing list to loose** (computed as effective tightness at render time; the AST is not mutated) when such a sublist follows another block in any item. A sublist that is an item's *first* block sits directly against the marker, was never at risk, and keeps its tight rendering.

Verified over an 8-shape matrix (tight/loose/unordered parents, `start=0`, first-block sublist, deep nesting with per-level promotion, `start=1` and unordered-sublist controls): every affected shape now round-trips to the original structure with `start` preserved, and every shape is byte-idempotent from the first render (`render(doc) == render(parse(render(doc)))`). 11 new tests; 7 of the original 10 fail on the unfixed code (the passes are the deliberate no-change controls).

Blast radius: full `tests/golden` is byte-identical to a control run on the unfixed tree — no snapshot changes. Derandomized fuzz gates: exit 0, no XPASS, no known-gap changes. Full unit + integration + e2e: green. mypy clean; converter manifest unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)