### PR TITLE
build: per-PR changelog fragments compiled at release; cancel superseded PR CI runs

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -20,7 +20,9 @@
 - [ ] `ruff check` and `ruff format` pass
 - [ ] `mypy src/` passes
 - [ ] `pytest` passes locally
-- [ ] Docs/README/CHANGELOG updated if user-facing
+- [ ] Docs/README updated if user-facing
+- [ ] Changelog entry added as a `changelog.d/<slug>.<category>.md` fragment, not as an
+      edit to `CHANGELOG.md` (see `changelog.d/README.md`)
 - [ ] If a parser/renderer was added or changed, regenerated the converter manifest
       (`scripts/generate_converter_manifest.py --update`)
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,27 @@ on:
 permissions:
   contents: write  # Required for `gh release create` in the release job
 
+# Cancel a pull request's superseded runs, and nothing else. A pull request starts
+# fourteen runners here (the five-way test matrix plus nine single jobs), so pushing
+# three times to a branch under review used to leave twenty-eight obsolete runners
+# competing for the queue with the fourteen anybody will actually read.
+#
+# The group is keyed on `github.ref`, which for a `pull_request` event is
+# `refs/pull/<n>/merge` -- a namespace no push can ever enter. A push to `main` or
+# `release/**` is `refs/heads/...` and a tag is `refs/tags/v...`, so those runs are
+# alone in their own groups and have nothing to be cancelled by even if the flag were
+# on. It is not: `cancel-in-progress` is evaluated on the incoming run, and only a
+# `pull_request` event sets it true.
+#
+# Both exclusions are load-bearing rather than tidy defaults. The push-to-main run is
+# the only CI that ever executes on a squash or rebase SHA -- cancel it and the commit
+# that ships has never been tested. The tag run is what `release.yml` watches via
+# `workflow_run` to gate the PyPI publish on CI success; cancelling one does not fail
+# the release, it silently never publishes it.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   lint-and-typecheck:
     name: Lint & Type Check

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -619,6 +619,32 @@ For third-party plugins, see the detailed guide in `docs/source/plugins.rst`.
      - Test results
      - Documentation updates
 
+### Changelog Entries
+
+Do **not** edit `CHANGELOG.md` directly. Add a fragment instead:
+
+```
+changelog.d/<slug>.<category>.md
+```
+
+where `<category>` is one of `added`, `changed`, `deprecated`, `removed`, `fixed` or
+`security`, and `<slug>` is anything that keeps the filename distinct (the branch
+name, the PR or issue number, a couple of words). The file holds one or more complete
+Markdown bullets, written exactly as they should read in the changelog.
+
+Every branch used to append to the same place in `CHANGELOG.md`, which made it a
+guaranteed merge conflict whenever more than one pull request was in flight. A
+fragment is a new file, so two branches never touch the same lines.
+
+```bash
+# Validate your fragment (writes nothing)
+python scripts/compile_changelog.py --check
+```
+
+At release time a maintainer runs `python scripts/compile_changelog.py --version X.Y.Z`,
+which folds the fragments into a new released section and deletes them. See
+`changelog.d/README.md` for the full format and house style.
+
 ### Code Review
 
 - Address reviewer feedback promptly

--- a/changelog.d/README.md
+++ b/changelog.d/README.md
@@ -1,0 +1,66 @@
+# changelog.d
+
+Pending changelog entries, one file per pull request. **Add a fragment here instead
+of editing `CHANGELOG.md`.**
+
+`CHANGELOG.md` is a single file that every branch appends to at the same place, under
+`## [Unreleased]`, which made it a guaranteed merge conflict in any sweep that landed
+more than one PR. A fragment is a new file, so two branches never touch the same
+lines. `scripts/compile_changelog.py` folds the fragments into `CHANGELOG.md` when a
+release is cut, and deletes them.
+
+## Filename
+
+```
+<slug>.<category>.md
+```
+
+- **slug** — anything that identifies the change: the branch name, the PR or issue
+  number, a couple of words. It is only there to keep filenames distinct, and it does
+  not appear in the compiled changelog.
+- **category** — one of `added`, `changed`, `deprecated`, `removed`, `fixed`,
+  `security`. It selects the `###` section the entry lands in.
+
+Examples: `338-figure-captions.added.md`, `pdf-ruling-lines.fixed.md`,
+`347.changed.md`.
+
+## Contents
+
+One or more complete Markdown bullets, written exactly as they should read in
+`CHANGELOG.md` — the compiler copies them verbatim into the matching section. Match
+the house style of the existing entries: a bolded sentence naming the change, then
+prose explaining what was wrong, what it does now, and what was deliberately *not*
+done. Wrap at the width the rest of the file uses and indent continuation lines by
+two spaces. Link the issue where there is one.
+
+```markdown
+- **A PDF list no longer nests a parent item underneath its own child.**
+  `_determine_list_level_from_x` assigned each newly seen indent the level
+  `len(x_levels)` -- arrival order -- and never compared the x-coordinates to each
+  other. Levels are now assigned by comparing x.
+  ([#340](https://github.com/thomas-villani/all2md/issues/340))
+```
+
+Put several bullets in one fragment when a PR makes several distinct changes in the
+same category, and add one fragment per category when it spans categories.
+
+## Checking your fragment
+
+```bash
+python scripts/compile_changelog.py --check
+```
+
+This validates every fragment's category and shape and writes nothing. It fails on an
+unknown category, an empty file, or content that does not begin with a `- ` bullet.
+
+## At release time
+
+```bash
+python scripts/compile_changelog.py --version 1.13.0
+```
+
+Everything under `## [Unreleased]` — the fragments and any entries written into the
+section by hand — moves into a new `## [1.13.0] - <today>` section, the link
+references at the bottom of the changelog are updated, and the consumed fragments are
+deleted. Add `--dry-run` to see what it would do first, or `--date YYYY-MM-DD` to set
+the date explicitly.

--- a/changelog.d/changelog-fragments.changed.md
+++ b/changelog.d/changelog-fragments.changed.md
@@ -1,0 +1,19 @@
+- **Changelog entries are now written as `changelog.d/` fragments, not as edits to
+  `CHANGELOG.md`.** Every branch appended its entry to the same place in the same
+  file — under `## [Unreleased]`, at the end of the same `###` section — so any sweep
+  landing more than one PR hit a conflict in `CHANGELOG.md` on every merge after the
+  first, and resolving it by hand next to two thousand lines of prose is exactly the
+  situation in which an entry gets dropped. A PR now adds
+  `changelog.d/<slug>.<category>.md` holding the bullets it wants published; two
+  branches never write the same lines because they never write the same file.
+  `scripts/compile_changelog.py --version X.Y.Z` folds the fragments into a new
+  released section at release time, updates the link references at the bottom of the
+  changelog, and deletes what it consumed; `--check` validates fragments without
+  writing. Entries already sitting under `## [Unreleased]` were deliberately left
+  there rather than migrated: the compiler merges hand-written content and fragments
+  into the same sections by design, so the two styles coexist and nothing had to be
+  rewritten to adopt this. towncrier and scriv were both rejected — they rewrite the
+  whole changelog with their own newline and formatting conventions, which would turn
+  a two-line release edit into a whole-file diff and flatten the long-form entries
+  this project writes. Nothing enforces the fragment yet; adding a CI check that a PR
+  touching `src/` carries one is a separate decision.

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -29,6 +29,36 @@ powershell -ExecutionPolicy Bypass -c "irm https://raw.githubusercontent.com/tho
 needed). Both are documented for users in `docs/source/installation.rst` and the
 project README.
 
+## compile_changelog.py
+
+Compiles the pending changelog fragments in `changelog.d/` into `CHANGELOG.md`.
+
+Pull requests add a `changelog.d/<slug>.<category>.md` fragment rather than editing
+`CHANGELOG.md`, so that two branches in flight never conflict over the same lines.
+This script is what turns those fragments into a released section.
+
+### Usage
+
+**Validate the pending fragments** (writes nothing; run this on any branch that adds
+one):
+```bash
+python scripts/compile_changelog.py --check
+```
+
+**Cut a release section** — moves everything under `## [Unreleased]`, fragments and
+hand-written entries alike, into a new `## [X.Y.Z] - DATE` section, updates the link
+references at the bottom of the file, and deletes the consumed fragments:
+```bash
+python scripts/compile_changelog.py --version 1.13.0
+```
+
+`--date YYYY-MM-DD` overrides today's date, and `--dry-run` reports what would happen
+without writing or deleting anything.
+
+It preserves the changelog's existing line endings byte for byte and touches only the
+lines it logically changes, which is why this is a small local script rather than
+towncrier or scriv. See `changelog.d/README.md` for the fragment format.
+
 ## update_document_formats.py
 
 Manages the synchronization between the `DocumentFormat` Literal type hint in `constants.py` and the dynamically discovered formats in the converter registry.

--- a/scripts/compile_changelog.py
+++ b/scripts/compile_changelog.py
@@ -1,0 +1,422 @@
+"""Compile ``changelog.d/`` fragments into ``CHANGELOG.md`` at release time.
+
+Every pull request used to edit ``CHANGELOG.md`` under ``## [Unreleased]``, which
+made that one file a guaranteed merge conflict in any sweep landing more than one
+branch. Instead a PR now drops a small file into ``changelog.d/`` named
+``<slug>.<category>.md``, and this script folds those fragments into the changelog
+when a release is cut.
+
+Two modes:
+
+``--check``
+    Validate every fragment and write nothing. Non-zero exit on a bad category, an
+    empty fragment, or content that does not start with a Markdown bullet.
+
+``--version X.Y.Z [--date YYYY-MM-DD]``
+    Roll ``## [Unreleased]`` -- both the fragments and anything written into the
+    section by hand -- into a new ``## [X.Y.Z] - DATE`` section, refresh the link
+    reference block at the bottom of the file, and delete the consumed fragments.
+
+This is a hand-rolled compiler rather than towncrier or scriv on purpose. The
+changelog's entries are long Keep a Changelog prose bullets, and the third-party
+tools rewrite the whole file with their own wrapping, ordering and newline opinions
+-- which would turn a two-line release edit into a several-thousand-line diff and
+flatten the entries. Every line this script does not logically change is passed
+through byte for byte, *including its original line ending*: the repository normalises
+to LF through ``.gitattributes``, but a Windows checkout, an editor or a future
+attribute change can put CRLF in front of this script, and rewriting all of them
+would bury the release in a whole-file diff. Nothing here goes through text-mode I/O
+or ``str.splitlines`` for that reason.
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import re
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+DEFAULT_CHANGELOG = REPO_ROOT / "CHANGELOG.md"
+DEFAULT_FRAGMENTS_DIR = REPO_ROOT / "changelog.d"
+
+#: Fragment categories, in the order Keep a Changelog gives their sections. A new
+#: ``### Section`` is created at the position this order implies.
+CATEGORIES: tuple[str, ...] = (
+    "added",
+    "changed",
+    "deprecated",
+    "removed",
+    "fixed",
+    "security",
+)
+SECTION_TITLES: dict[str, str] = {category: category.capitalize() for category in CATEGORIES}
+CANONICAL_ORDER: tuple[str, ...] = tuple(SECTION_TITLES[category] for category in CATEGORIES)
+
+_UNRELEASED_HEADING = re.compile(r"^## \[Unreleased\]\s*$")
+_ANY_HEADING = re.compile(r"^## ")
+_SECTION_HEADING = re.compile(r"^### (.+?)\s*$")
+_LINK_REFERENCE = re.compile(r"^\[[^\]]+\]:\s")
+_UNRELEASED_LINK = re.compile(r"^\[Unreleased\]:\s*(?P<prefix>\S*/compare/)v(?P<previous>\S+?)\.\.\.HEAD\s*$")
+_VERSION = re.compile(r"\d+\.\d+\.\d+(?:[-+][0-9A-Za-z.]+)?")
+_DATE = re.compile(r"\d{4}-\d{2}-\d{2}")
+
+# Splits on CRLF, LF or CR and keeps each line's own ending attached to it, so that
+# "".join(lines) reproduces the input exactly. str.splitlines() is not usable here:
+# it also breaks on form feeds, vertical tabs and U+2028, and would silently rewrite
+# any of those into the file's dominant newline on the way out.
+_LINE = re.compile(r"[^\r\n]*(?:\r\n|\n|\r|$)")
+
+
+class CompileError(Exception):
+    """A condition the caller has to fix before a release can be compiled."""
+
+
+def split_lines(text: str) -> list[str]:
+    """Split ``text`` into lines that each keep their own trailing newline."""
+    lines = _LINE.findall(text)
+    if lines and lines[-1] == "":
+        lines.pop()
+    return lines
+
+
+def detect_newline(text: str) -> str:
+    """Return the newline the file is written with, LF when it has none."""
+    if "\r\n" in text:
+        return "\r\n"
+    if "\r" in text:
+        return "\r"
+    return "\n"
+
+
+def read_text(path: Path) -> str:
+    """Read ``path`` without letting the platform translate its line endings."""
+    return path.read_bytes().decode("utf-8")
+
+
+def write_text(path: Path, text: str) -> None:
+    """Write ``path`` without letting the platform translate its line endings."""
+    path.write_bytes(text.encode("utf-8"))
+
+
+class Fragment:
+    """One ``changelog.d/<slug>.<category>.md`` file."""
+
+    def __init__(self, path: Path, category: str, bullets: list[str]) -> None:
+        """Record a validated fragment's path, category and bullet lines."""
+        self.path = path
+        self.category = category
+        self.bullets = bullets
+
+    @property
+    def section(self) -> str:
+        """The ``###`` heading this fragment's bullets belong under."""
+        return SECTION_TITLES[self.category]
+
+
+def parse_fragment(path: Path) -> Fragment:
+    """Load and validate one fragment file.
+
+    Raises
+    ------
+    CompileError
+        If the filename carries no known category, or the body is empty or does
+        not start with a Markdown bullet.
+
+    """
+    parts = path.name.split(".")
+    if len(parts) < 3 or parts[-1] != "md":
+        raise CompileError(
+            f"{path.name}: expected a name of the form '<slug>.<category>.md' "
+            f"(category one of: {', '.join(CATEGORIES)})"
+        )
+    category = parts[-2].lower()
+    if category not in CATEGORIES:
+        raise CompileError(f"{path.name}: unknown category {parts[-2]!r} (expected one of: {', '.join(CATEGORIES)})")
+
+    try:
+        text = read_text(path)
+    except UnicodeDecodeError as exc:  # pragma: no cover - defensive
+        raise CompileError(f"{path.name}: not valid UTF-8 ({exc})") from exc
+
+    bullets = [line.rstrip("\r\n") for line in split_lines(text)]
+    while bullets and not bullets[-1].strip():
+        bullets.pop()
+    while bullets and not bullets[0].strip():
+        bullets.pop(0)
+    if not bullets:
+        raise CompileError(f"{path.name}: fragment is empty")
+    if not bullets[0].startswith("- "):
+        raise CompileError(
+            f"{path.name}: fragment must start with a Markdown bullet ('- '), "
+            f"got {bullets[0][:40]!r}. Write the entry exactly as it should read "
+            f"in CHANGELOG.md."
+        )
+    return Fragment(path, category, bullets)
+
+
+def load_fragments(fragments_dir: Path) -> tuple[list[Fragment], list[str]]:
+    """Load every fragment in ``fragments_dir``, sorted by filename.
+
+    Returns the fragments that parsed and the error messages for those that did
+    not, so ``--check`` can report all of a branch's problems in one run.
+    """
+    if not fragments_dir.is_dir():
+        return [], []
+    fragments: list[Fragment] = []
+    errors: list[str] = []
+    for path in sorted(fragments_dir.glob("*.md")):
+        if path.name.lower() == "readme.md":
+            continue
+        try:
+            fragments.append(parse_fragment(path))
+        except CompileError as exc:
+            errors.append(str(exc))
+    return fragments, errors
+
+
+def _section_rank(title: str) -> int:
+    """Sort key placing known sections in canonical order and unknown ones last."""
+    try:
+        return CANONICAL_ORDER.index(title)
+    except ValueError:
+        return len(CANONICAL_ORDER)
+
+
+def _split_unreleased(body: list[str]) -> tuple[list[str], list[list[str]]]:
+    """Split the Unreleased body into its leading lines and its ``###`` sections."""
+    first = len(body)
+    for index, line in enumerate(body):
+        if _SECTION_HEADING.match(line):
+            first = index
+            break
+    preamble = body[:first]
+    sections: list[list[str]] = []
+    for line in body[first:]:
+        if _SECTION_HEADING.match(line):
+            sections.append([line])
+        else:
+            sections[-1].append(line)
+    return preamble, sections
+
+
+def _append_bullets(section: list[str], bullets: list[str], newline: str) -> list[str]:
+    """Append ``bullets`` to an existing section, keeping its trailing blank lines."""
+    heading, rest = section[0], section[1:]
+    end = len(rest)
+    while end > 0 and not rest[end - 1].strip():
+        end -= 1
+    trailing = rest[end:] or [newline]
+    return [heading, *rest[:end], *(bullet + newline for bullet in bullets), *trailing]
+
+
+def _new_section(title: str, bullets: list[str], newline: str) -> list[str]:
+    """Build a section that does not exist in the Unreleased body yet."""
+    return [
+        f"### {title}{newline}",
+        newline,
+        *(bullet + newline for bullet in bullets),
+        newline,
+    ]
+
+
+def merge_fragments(sections: list[list[str]], fragments: list[Fragment], newline: str) -> list[list[str]]:
+    """Fold every fragment into the section its category names.
+
+    An existing section gains the bullets at its end; a missing one is created at
+    the position :data:`CANONICAL_ORDER` gives it, before the first section that
+    sorts after it.
+    """
+    merged = [list(section) for section in sections]
+    by_section: dict[str, list[str]] = {}
+    for fragment in fragments:
+        by_section.setdefault(fragment.section, []).extend(fragment.bullets)
+
+    for title in CANONICAL_ORDER:
+        bullets = by_section.get(title)
+        if not bullets:
+            continue
+        existing = next(
+            (i for i, section in enumerate(merged) if _heading_title(section[0]) == title),
+            None,
+        )
+        if existing is not None:
+            merged[existing] = _append_bullets(merged[existing], bullets, newline)
+            continue
+        rank = _section_rank(title)
+        insert_at = next(
+            (i for i, section in enumerate(merged) if _section_rank(_heading_title(section[0])) > rank),
+            len(merged),
+        )
+        merged.insert(insert_at, _new_section(title, bullets, newline))
+    return merged
+
+
+def _heading_title(line: str) -> str:
+    match = _SECTION_HEADING.match(line)
+    return match.group(1) if match else ""
+
+
+def _update_link_references(lines: list[str], version: str, newline: str) -> list[str]:
+    """Point ``[Unreleased]`` at the new tag and add the released version's link."""
+    for index in range(len(lines) - 1, -1, -1):
+        match = _UNRELEASED_LINK.match(lines[index])
+        if not match:
+            continue
+        prefix = match.group("prefix")
+        base = prefix[: -len("/compare/")]
+        updated = list(lines)
+        updated[index] = f"[Unreleased]: {prefix}v{version}...HEAD{newline}"
+        updated.insert(index + 1, f"[{version}]: {base}/releases/tag/v{version}{newline}")
+        return updated
+    raise CompileError(
+        "no '[Unreleased]: .../compare/vX.Y.Z...HEAD' link reference found; "
+        "the link block at the bottom of the changelog is how released versions "
+        "are addressed and cannot be regenerated from the headings alone"
+    )
+
+
+def compile_release(
+    changelog: Path,
+    fragments: list[Fragment],
+    version: str,
+    date: str,
+) -> str:
+    """Return the changelog text with Unreleased plus ``fragments`` rolled into ``version``."""
+    if not _VERSION.fullmatch(version):
+        raise CompileError(f"{version!r} is not a version of the form X.Y.Z")
+    if not _DATE.fullmatch(date):
+        raise CompileError(f"{date!r} is not a date of the form YYYY-MM-DD")
+
+    text = read_text(changelog)
+    newline = detect_newline(text)
+    lines = split_lines(text)
+
+    heading = next((i for i, line in enumerate(lines) if _UNRELEASED_HEADING.match(line)), None)
+    if heading is None:
+        raise CompileError(f"{changelog.name}: no '## [Unreleased]' heading found")
+    if any(line.startswith(f"## [{version}]") for line in lines):
+        raise CompileError(f"{changelog.name}: a '## [{version}]' section already exists")
+
+    end = next(
+        (i for i in range(heading + 1, len(lines)) if _ANY_HEADING.match(lines[i]) or _LINK_REFERENCE.match(lines[i])),
+        len(lines),
+    )
+    preamble, sections = _split_unreleased(lines[heading + 1 : end])
+    if not sections and not fragments:
+        raise CompileError(
+            "nothing to release: '## [Unreleased]' has no '###' sections and " "changelog.d/ holds no fragments"
+        )
+    if not preamble:
+        preamble = [newline]
+
+    merged = merge_fragments(sections, fragments, newline)
+    rolled = [
+        *lines[: heading + 1],
+        newline,
+        f"## [{version}] - {date}{newline}",
+        *preamble,
+        *(line for section in merged for line in section),
+        *lines[end:],
+    ]
+    return "".join(_update_link_references(rolled, version, newline))
+
+
+def run_check(fragments_dir: Path) -> int:
+    """Validate every fragment without writing anything."""
+    fragments, errors = load_fragments(fragments_dir)
+    for error in errors:
+        print(f"error: {error}", file=sys.stderr)
+    if errors:
+        print(
+            f"\n{len(errors)} malformed fragment(s) in {fragments_dir}. "
+            f"See {fragments_dir / 'README.md'} for the format.",
+            file=sys.stderr,
+        )
+        return 1
+    print(f"{len(fragments)} fragment(s) in {fragments_dir}: all well-formed")
+    return 0
+
+
+def run_compile(changelog: Path, fragments_dir: Path, version: str, date: str, dry_run: bool) -> int:
+    """Roll Unreleased and the fragments into a released section."""
+    fragments, errors = load_fragments(fragments_dir)
+    if errors:
+        for error in errors:
+            print(f"error: {error}", file=sys.stderr)
+        print("\nrefusing to compile a release with malformed fragments", file=sys.stderr)
+        return 1
+
+    compiled = compile_release(changelog, fragments, version, date)
+    if dry_run:
+        print(f"would write {changelog} and delete {len(fragments)} fragment(s):")
+        for fragment in fragments:
+            print(f"  {fragment.path.name} -> ### {fragment.section}")
+        return 0
+
+    write_text(changelog, compiled)
+    for fragment in fragments:
+        fragment.path.unlink()
+    print(f"wrote {changelog}: [{version}] - {date}, {len(fragments)} fragment(s) consumed and deleted")
+    return 0
+
+
+def build_parser() -> argparse.ArgumentParser:
+    """Build the command-line parser."""
+    parser = argparse.ArgumentParser(
+        prog="compile_changelog.py",
+        description="Compile changelog.d/ fragments into CHANGELOG.md.",
+    )
+    mode = parser.add_mutually_exclusive_group(required=True)
+    mode.add_argument(
+        "--check",
+        action="store_true",
+        help="validate the fragments and write nothing",
+    )
+    mode.add_argument(
+        "--version",
+        metavar="X.Y.Z",
+        help="roll Unreleased and the fragments into this released version",
+    )
+    parser.add_argument(
+        "--date",
+        metavar="YYYY-MM-DD",
+        default=None,
+        help="release date for the new section (default: today)",
+    )
+    parser.add_argument(
+        "--changelog",
+        type=Path,
+        default=DEFAULT_CHANGELOG,
+        help=f"path to the changelog (default: {DEFAULT_CHANGELOG})",
+    )
+    parser.add_argument(
+        "--fragments-dir",
+        type=Path,
+        default=DEFAULT_FRAGMENTS_DIR,
+        help=f"directory holding the fragments (default: {DEFAULT_FRAGMENTS_DIR})",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="with --version, report what would happen without writing or deleting",
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Run the requested mode and return the process exit status."""
+    args = build_parser().parse_args(argv)
+    try:
+        if args.check:
+            return run_check(args.fragments_dir)
+        date = args.date or dt.date.today().isoformat()
+        return run_compile(args.changelog, args.fragments_dir, args.version, date, args.dry_run)
+    except CompileError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/unit/test_compile_changelog.py
+++ b/tests/unit/test_compile_changelog.py
@@ -1,0 +1,434 @@
+"""Tests for the changelog fragment compiler (``scripts/compile_changelog.py``).
+
+The compiler's job is to rewrite one file that nobody reviews line by line at
+release time, so most of these tests are about what it must *not* disturb: the line
+endings of the file it edits, entries someone wrote into ``## [Unreleased]`` by hand,
+the sections it did not touch, and the link-reference block at the bottom. The last
+test runs it over the real ``CHANGELOG.md`` in a copy, because everything above it
+uses a small synthetic changelog and would pass just as happily if the compiler
+tripped over the real file's two thousand lines of prose.
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+_SCRIPT = Path(__file__).resolve().parents[2] / "scripts" / "compile_changelog.py"
+_REAL_CHANGELOG = Path(__file__).resolve().parents[2] / "CHANGELOG.md"
+
+
+def _load():
+    """Import the script by path -- ``scripts/`` is not a package."""
+    spec = importlib.util.spec_from_file_location("compile_changelog", _SCRIPT)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+cc = _load()
+
+
+CHANGELOG_BODY = [
+    "# Changelog",
+    "",
+    "All notable changes to this project will be documented in this file.",
+    "",
+    "## [Unreleased]",
+    "",
+    "### Added",
+    "",
+    "- **A hand-written addition.** Someone edited the changelog directly.",
+    "",
+    "### Fixed",
+    "",
+    "- **A hand-written fix.** Also written directly into the file.",
+    "",
+    "## [1.0.0] - 2026-01-01",
+    "",
+    "### Added",
+    "",
+    "- **The first release.**",
+    "",
+    "[Unreleased]: https://github.com/thomas-villani/all2md/compare/v1.0.0...HEAD",
+    "[1.0.0]: https://github.com/thomas-villani/all2md/releases/tag/v1.0.0",
+]
+
+
+def _write(path: Path, lines: list[str], newline: str = "\n") -> None:
+    """Write ``lines`` with an explicit newline, bypassing platform translation."""
+    path.write_bytes((newline.join(lines) + newline).encode("utf-8"))
+
+
+@pytest.fixture
+def repo(tmp_path: Path) -> Path:
+    """A miniature repository: a changelog and an empty ``changelog.d/``."""
+    _write(tmp_path / "CHANGELOG.md", CHANGELOG_BODY)
+    (tmp_path / "changelog.d").mkdir()
+    return tmp_path
+
+
+def _fragment(repo: Path, name: str, body: str, newline: str = "\n") -> Path:
+    path = repo / "changelog.d" / name
+    path.write_bytes(body.replace("\n", newline).encode("utf-8"))
+    return path
+
+
+def _run(repo: Path, *args: str) -> int:
+    return cc.main(
+        [
+            *args,
+            "--changelog",
+            str(repo / "CHANGELOG.md"),
+            "--fragments-dir",
+            str(repo / "changelog.d"),
+        ]
+    )
+
+
+def _text(repo: Path) -> str:
+    return (repo / "CHANGELOG.md").read_bytes().decode("utf-8")
+
+
+class TestMerging:
+    """Fragments land in the right ``###`` section, beside what is already there."""
+
+    def test_fragment_appends_to_an_existing_section(self, repo: Path) -> None:
+        _fragment(repo, "thing.added.md", "- **A fragment addition.** From a PR.\n")
+
+        assert _run(repo, "--version", "1.1.0", "--date", "2026-02-02") == 0
+
+        text = _text(repo)
+        added = text.split("### Added")[1].split("###")[0]
+        assert "- **A hand-written addition.**" in added
+        assert "- **A fragment addition.**" in added
+        # Appended after the hand-written entry, not before it.
+        assert added.index("hand-written") < added.index("fragment addition")
+
+    def test_hand_written_entries_survive_untouched(self, repo: Path) -> None:
+        _fragment(repo, "thing.added.md", "- **A fragment addition.** From a PR.\n")
+
+        _run(repo, "--version", "1.1.0", "--date", "2026-02-02")
+
+        text = _text(repo)
+        assert "- **A hand-written addition.** Someone edited the changelog directly." in text
+        assert "- **A hand-written fix.** Also written directly into the file." in text
+
+    def test_missing_section_is_created_in_canonical_order(self, repo: Path) -> None:
+        """``Security`` does not exist yet; Keep a Changelog puts it after ``Fixed``."""
+        _fragment(repo, "hole.security.md", "- **A security fix.**\n")
+        _fragment(repo, "gone.removed.md", "- **A removal.**\n")
+
+        assert _run(repo, "--version", "1.1.0", "--date", "2026-02-02") == 0
+
+        released = _text(repo).split("## [1.1.0]")[1].split("## [1.0.0]")[0]
+        headings = [line for line in released.splitlines() if line.startswith("### ")]
+        assert headings == ["### Added", "### Removed", "### Fixed", "### Security"]
+
+    def test_several_fragments_in_one_category_are_ordered_by_filename(self, repo: Path) -> None:
+        _fragment(repo, "b-second.added.md", "- **Second.**\n")
+        _fragment(repo, "a-first.added.md", "- **First.**\n")
+
+        _run(repo, "--version", "1.1.0", "--date", "2026-02-02")
+
+        text = _text(repo)
+        assert text.index("**First.**") < text.index("**Second.**")
+
+    def test_a_fragment_may_hold_several_bullets(self, repo: Path) -> None:
+        _fragment(
+            repo,
+            "multi.fixed.md",
+            "- **One.** With a\n  continuation line.\n- **Two.**\n",
+        )
+
+        _run(repo, "--version", "1.1.0", "--date", "2026-02-02")
+
+        fixed = _text(repo).split("### Fixed")[1].split("###")[0]
+        assert "- **One.** With a\n  continuation line.\n- **Two.**" in fixed
+
+
+class TestReleaseShape:
+    """The compiled file has to look like the ones a human produced before it."""
+
+    def test_no_fragments_only_moves_the_unreleased_heading(self, repo: Path) -> None:
+        """The historical release commit added exactly two lines to the body."""
+        before = _text(repo)
+
+        assert _run(repo, "--version", "1.1.0", "--date", "2026-02-02") == 0
+
+        after = _text(repo)
+        added = [line for line in after.splitlines() if line not in before.splitlines()]
+        assert added == [
+            "## [1.1.0] - 2026-02-02",
+            "[Unreleased]: https://github.com/thomas-villani/all2md/compare/v1.1.0...HEAD",
+            "[1.1.0]: https://github.com/thomas-villani/all2md/releases/tag/v1.1.0",
+        ]
+
+    def test_empty_unreleased_skeleton_is_left_on_top(self, repo: Path) -> None:
+        _run(repo, "--version", "1.1.0", "--date", "2026-02-02")
+
+        text = _text(repo)
+        assert "## [Unreleased]\n\n## [1.1.0] - 2026-02-02\n\n### Added\n" in text
+
+    def test_link_references_are_updated_and_extended(self, repo: Path) -> None:
+        _run(repo, "--version", "1.1.0", "--date", "2026-02-02")
+
+        text = _text(repo)
+        assert "[Unreleased]: https://github.com/thomas-villani/all2md/compare/v1.1.0...HEAD" in text
+        assert "[1.1.0]: https://github.com/thomas-villani/all2md/releases/tag/v1.1.0" in text
+        assert "[1.0.0]: https://github.com/thomas-villani/all2md/releases/tag/v1.0.0" in text
+        # The old compare link is gone rather than duplicated.
+        assert "compare/v1.0.0...HEAD" not in text
+        # The new tag link sits directly under the Unreleased one, as in the file.
+        assert (
+            "[Unreleased]: https://github.com/thomas-villani/all2md/compare/v1.1.0...HEAD\n"
+            "[1.1.0]: https://github.com/thomas-villani/all2md/releases/tag/v1.1.0\n"
+            "[1.0.0]: https://github.com/thomas-villani/all2md/releases/tag/v1.0.0\n"
+        ) in text
+
+    def test_the_date_defaults_to_today(self, repo: Path) -> None:
+        assert _run(repo, "--version", "1.1.0") == 0
+        assert f"## [1.1.0] - {dt.date.today().isoformat()}" in _text(repo)
+
+    def test_a_second_run_at_the_same_version_refuses(self, repo: Path) -> None:
+        assert _run(repo, "--version", "1.1.0", "--date", "2026-02-02") == 0
+        assert _run(repo, "--version", "1.1.0", "--date", "2026-02-02") == 1
+
+
+class TestNewlinePreservation:
+    """The compiler edits a file it does not own the formatting of."""
+
+    @pytest.mark.parametrize("newline", ["\r\n", "\n"])
+    def test_line_endings_are_preserved_byte_for_byte(self, tmp_path: Path, newline: str) -> None:
+        changelog = tmp_path / "CHANGELOG.md"
+        _write(changelog, CHANGELOG_BODY, newline)
+        (tmp_path / "changelog.d").mkdir()
+        # The fragment is written with the *other* newline on purpose: its content is
+        # normalised to the changelog's, not copied in as it was found.
+        other = "\n" if newline == "\r\n" else "\r\n"
+        _fragment(tmp_path, "thing.added.md", "- **A fragment addition.**\n", other)
+        before = changelog.read_bytes()
+
+        assert _run(tmp_path, "--version", "1.1.0", "--date", "2026-02-02") == 0
+
+        after = changelog.read_bytes()
+        foreign = b"\n" if newline == "\r\n" else b"\r"
+        if newline == "\r\n":
+            assert after.count(b"\r\n") == after.count(b"\n")
+        else:
+            assert foreign not in after
+        # Every pre-existing line is still present with its original ending, and only
+        # the lines the release logically adds are new.
+        old_lines = before.split(newline.encode())
+        new_lines = after.split(newline.encode())
+        assert [line for line in old_lines if line not in new_lines] == [
+            b"[Unreleased]: https://github.com/thomas-villani/all2md/compare/v1.0.0...HEAD"
+        ]
+
+    def test_the_diff_touches_only_the_lines_it_changes(self, tmp_path: Path) -> None:
+        """A CRLF file gains exactly the release's lines -- not a rewritten file."""
+        changelog = tmp_path / "CHANGELOG.md"
+        _write(changelog, CHANGELOG_BODY, "\r\n")
+        (tmp_path / "changelog.d").mkdir()
+        before = changelog.read_bytes()
+
+        _run(tmp_path, "--version", "1.1.0", "--date", "2026-02-02")
+
+        after = changelog.read_bytes()
+        assert len(after.split(b"\r\n")) == len(before.split(b"\r\n")) + 3
+        # Byte-level: the untouched prefix is identical up to the insertion point.
+        prefix = before.split(b"## [Unreleased]\r\n")[0] + b"## [Unreleased]\r\n"
+        assert after.startswith(prefix)
+        assert after[len(prefix) :].startswith(b"\r\n## [1.1.0] - 2026-02-02\r\n\r\n### Added\r\n")
+
+
+class TestFragmentLifecycle:
+    """Consumed fragments are deleted; the README beside them is not."""
+
+    def test_fragments_are_deleted_after_a_release(self, repo: Path) -> None:
+        first = _fragment(repo, "one.added.md", "- **One.**\n")
+        second = _fragment(repo, "two.fixed.md", "- **Two.**\n")
+
+        _run(repo, "--version", "1.1.0", "--date", "2026-02-02")
+
+        assert not first.exists()
+        assert not second.exists()
+
+    def test_the_readme_is_not_a_fragment(self, repo: Path) -> None:
+        readme = repo / "changelog.d" / "README.md"
+        readme.write_bytes(b"# changelog.d\n\nNot a fragment.\n")
+
+        assert _run(repo, "--check") == 0
+        assert _run(repo, "--version", "1.1.0", "--date", "2026-02-02") == 0
+        assert readme.exists()
+        assert "Not a fragment." not in _text(repo)
+
+    def test_dry_run_writes_nothing_and_deletes_nothing(self, repo: Path) -> None:
+        fragment = _fragment(repo, "one.added.md", "- **One.**\n")
+        before = _text(repo)
+
+        assert _run(repo, "--version", "1.1.0", "--dry-run") == 0
+
+        assert fragment.exists()
+        assert _text(repo) == before
+
+    def test_a_missing_fragments_directory_is_not_an_error(self, repo: Path) -> None:
+        (repo / "changelog.d").rmdir()
+
+        assert _run(repo, "--check") == 0
+        assert _run(repo, "--version", "1.1.0", "--date", "2026-02-02") == 0
+
+
+class TestCheck:
+    """``--check`` is the gate a contributor runs; it has to be able to fail."""
+
+    def test_a_clean_directory_passes(self, repo: Path) -> None:
+        _fragment(repo, "fine.added.md", "- **Fine.**\n")
+        assert _run(repo, "--check") == 0
+
+    def test_an_empty_directory_passes(self, repo: Path) -> None:
+        assert _run(repo, "--check") == 0
+
+    def test_an_unknown_category_fails(self, repo: Path) -> None:
+        _fragment(repo, "oops.improved.md", "- **Improved something.**\n")
+        assert _run(repo, "--check") == 1
+
+    def test_a_name_without_a_category_fails(self, repo: Path) -> None:
+        _fragment(repo, "oops.md", "- **No category at all.**\n")
+        assert _run(repo, "--check") == 1
+
+    def test_an_empty_fragment_fails(self, repo: Path) -> None:
+        _fragment(repo, "empty.fixed.md", "\n   \n")
+        assert _run(repo, "--check") == 1
+
+    def test_content_that_is_not_a_bullet_fails(self, repo: Path) -> None:
+        _fragment(repo, "prose.fixed.md", "Fixed the thing.\n")
+        assert _run(repo, "--check") == 1
+
+    def test_an_indented_bullet_is_not_a_bullet(self, repo: Path) -> None:
+        _fragment(repo, "indented.fixed.md", "  - **Nested.**\n")
+        assert _run(repo, "--check") == 1
+
+    def test_a_leading_blank_line_is_tolerated(self, repo: Path) -> None:
+        _fragment(repo, "blank.fixed.md", "\n- **Fine after a blank line.**\n")
+        assert _run(repo, "--check") == 0
+
+    def test_check_reports_every_bad_fragment_not_just_the_first(
+        self, repo: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        _fragment(repo, "one.improved.md", "- **One.**\n")
+        _fragment(repo, "two.fixed.md", "Not a bullet.\n")
+
+        assert _run(repo, "--check") == 1
+
+        stderr = capsys.readouterr().err
+        assert "one.improved.md" in stderr
+        assert "two.fixed.md" in stderr
+
+    def test_a_release_refuses_to_compile_malformed_fragments(self, repo: Path) -> None:
+        _fragment(repo, "bad.improved.md", "- **Bad category.**\n")
+        before = _text(repo)
+
+        assert _run(repo, "--version", "1.1.0", "--date", "2026-02-02") == 1
+        assert _text(repo) == before
+
+
+class TestGuards:
+    """Refusals that keep a bad release out of the file rather than reporting one."""
+
+    def test_nothing_to_release_is_an_error(self, tmp_path: Path) -> None:
+        _write(
+            tmp_path / "CHANGELOG.md",
+            [
+                "# Changelog",
+                "",
+                "## [Unreleased]",
+                "",
+                "## [1.0.0] - 2026-01-01",
+                "",
+                "- **The first release.**",
+                "",
+                "[Unreleased]: https://github.com/thomas-villani/all2md/compare/v1.0.0...HEAD",
+            ],
+        )
+        (tmp_path / "changelog.d").mkdir()
+
+        assert _run(tmp_path, "--version", "1.1.0", "--date", "2026-02-02") == 1
+
+    def test_a_missing_link_reference_block_is_an_error(self, tmp_path: Path) -> None:
+        _write(
+            tmp_path / "CHANGELOG.md",
+            ["# Changelog", "", "## [Unreleased]", "", "### Added", "", "- **Something.**", ""],
+        )
+        (tmp_path / "changelog.d").mkdir()
+
+        assert _run(tmp_path, "--version", "1.1.0", "--date", "2026-02-02") == 1
+
+    def test_a_missing_unreleased_heading_is_an_error(self, tmp_path: Path) -> None:
+        _write(tmp_path / "CHANGELOG.md", ["# Changelog", "", "## [1.0.0] - 2026-01-01", ""])
+        (tmp_path / "changelog.d").mkdir()
+
+        assert _run(tmp_path, "--version", "1.1.0", "--date", "2026-02-02") == 1
+
+    @pytest.mark.parametrize("version", ["1.1", "v1.1.0", "next", "1.1.0.0"])
+    def test_a_malformed_version_is_an_error(self, repo: Path, version: str) -> None:
+        assert _run(repo, "--version", version, "--date", "2026-02-02") == 1
+
+    def test_a_malformed_date_is_an_error(self, repo: Path) -> None:
+        assert _run(repo, "--version", "1.1.0", "--date", "02/02/2026") == 1
+
+    def test_a_mode_is_required(self) -> None:
+        with pytest.raises(SystemExit):
+            cc.main([])
+
+
+class TestLineSplitting:
+    """``split_lines`` is the reason the whole file survives a rewrite."""
+
+    @pytest.mark.parametrize(
+        "text",
+        ["a\r\nb\r\n", "a\nb", "", "\r\n", "a\rb\r", "a\r\nb\nc\r", "no newline at all"],
+    )
+    def test_splitting_round_trips(self, text: str) -> None:
+        assert "".join(cc.split_lines(text)) == text
+
+    def test_a_form_feed_is_not_a_line_break(self) -> None:
+        """``str.splitlines`` breaks here and would rewrite the character away."""
+        assert cc.split_lines("a\x0cb\n") == ["a\x0cb\n"]
+
+
+class TestTheRealChangelog:
+    """Everything above uses a synthetic file a dozen lines long."""
+
+    def test_the_repository_changelog_compiles(self, tmp_path: Path) -> None:
+        original = _REAL_CHANGELOG.read_bytes()
+        changelog = tmp_path / "CHANGELOG.md"
+        changelog.write_bytes(original)
+        fragments = tmp_path / "changelog.d"
+        fragments.mkdir()
+        _fragment(tmp_path, "seed.changed.md", "- **A seeded entry.** For the test.\n")
+
+        assert _run(tmp_path, "--version", "99.0.0", "--date", "2026-02-02") == 0
+
+        after = changelog.read_bytes()
+        # Nothing below the Unreleased section moved: the tail of the file, up to the
+        # link block, is byte-identical.
+        tail = original.split(b"## [1.12.0]", 1)[1].split(b"[Unreleased]:", 1)[0]
+        assert tail in after
+        assert b"## [99.0.0] - 2026-02-02" in after
+        assert b"- **A seeded entry.** For the test." in after
+        assert b"[99.0.0]: https://github.com/thomas-villani/all2md/releases/tag/v99.0.0" in after
+        # The compiler is additive: it grows the file, it does not rewrite it.
+        assert original.count(b"\n") < after.count(b"\n")
+
+    def test_the_repositorys_own_fragments_are_well_formed(self) -> None:
+        """The seeded fragment this change ships must pass its own gate."""
+        assert cc.main(["--check"]) == 0


### PR DESCRIPTION
The process coda agreed during the audit sweep: CHANGELOG.md was a guaranteed merge conflict in every multi-PR batch, and stacked pushes to a PR branch left obsolete CI runners competing with live ones.

**Part 1 — `changelog.d/` fragments.** PRs now add a fragment file (`<slug>.<category>.md`, Keep-a-Changelog categories) instead of editing CHANGELOG.md; `scripts/compile_changelog.py --version X.Y.Z` rolls `[Unreleased]` plus all fragments into the new release section at release time (then `--check` validates fragments without writing). Custom script rather than towncrier/scriv so the file's exact conventions survive: the post-release shape is replicated from the real v1.12.0 release commit (including the link-reference block, with the repo URL derived from the existing compare line, not hardcoded), hand-written entries already in `[Unreleased]` pass through untouched, unrecognized legacy sections are preserved, and the file's own newline style is preserved byte-for-byte (proven on CRLF and LF copies of the real 241 KB changelog). 46 unit tests, including a class that runs the compiler over the real CHANGELOG.md.

This PR ships its own entry as the seed fragment — CHANGELOG.md itself is untouched. Existing `[Unreleased]` content is deliberately not migrated; the compiler merges both kinds. Docs updated additively (changelog.d/README, scripts/README, CONTRIBUTING, PR template). Possible follow-up, deliberately out of scope: a CI check that a PR carries a fragment.

**Part 2 — CI concurrency.** Workflow-level `concurrency` keyed on `${{ github.workflow }}-${{ github.ref }}` with `cancel-in-progress: ${{ github.event_name == 'pull_request' }}`. Two independent guarantees that main/tag runs can never be cancelled (group isolation — `refs/pull/<n>/merge` is a namespace no push enters — plus event-gated flag), both load-bearing: the main-push run is the only CI on a squash/rebase SHA, and release.yml watches the tag run via workflow_run — a cancelled tag run doesn't fail a release, it silently never publishes it.

Release-prep change: run `python scripts/compile_changelog.py --version X.Y.Z` before `bump-my-version`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)