### PR TITLE
fix(pdf): route the detected caption to Image.caption instead of discarding it

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -266,6 +266,51 @@ People star us because "it just converted my gnarly PDF perfectly." Protect and 
   The round-trip scorer that surfaced these now also scores code/math/HTML block content,
   so a regression in any of them shows up in `all2md roundtrip <file> --via docx` (or
   `--via html`).
+- 🌱 **`docx-plus` integration** — *evaluated 2026-08-04, no code written yet* (full writeup
+  in gitignored `design/docx-plus-evaluation.md`, [[docx_plus_evaluation]]). Verdict: adopt
+  selectively, parser read-side first, behind an optional extra pinned
+  `docx-plus>=0.6,<0.7`. It composes with `python-docx` rather than replacing it and needs
+  only `python-docx>=1.0.0` + `lxml>=4.9` — both already required, so adoption adds no
+  transitive dependency weight. Measured against a probe DOCX plus the two real DOCX files
+  already tracked in the repo (v2/v3 white papers), not read off the README.
+  - **Tier 1 — take these.** Tracked changes: `w:ins`/`w:del` currently vanish silently
+    (neither accepted nor rejected, so any default is an improvement) behind a
+    `tracked_changes: accept|reject|mark` option — biggest win, smallest diff, proposed as
+    the first spike. Effective formatting: replaces the `run.bold or False` read in
+    `_get_run_formatting_key` (`src/all2md/parsers/docx.py:1219`), which affects every
+    corporate-template document where weight lives on styles rather than runs — **benchmark
+    before committing**, it is the one change here with a plausible corpus-gate regression
+    path. Fields: one integration fixes both dropped hyperlink URLs and the `Figure :`
+    caption bug.
+  - **Tier 2 — real, narrower.** Table merges close the colspan/rowspan round-trip
+    asymmetry the renderer already half-supports (`_layout_table_grid`). Bookmarks let
+    internal anchor links survive instead of flattening to plain text. Footnote/endnote
+    reads could delete ~150 lines of hand-rolled XML (`_process_notes` and friends) — pure
+    simplification, no behaviour change.
+  - **Tier 3 — renderer, more speculative.** Real footnotes on render (today's
+    `visit_footnote_reference` writes a literal `[1]`, so DOCX→MD→DOCX degrades genuine
+    footnotes into fake ones); `add_toc`/`mark_fields_dirty` for the existing generate-toc
+    transform; redlined DOCX output via `mark_insertion`/`mark_deletion` — a real product
+    feature, scope creep unless deliberately chosen rather than a bug fix.
+  - **What it will not fix, and is our own job regardless:** block-level rich-text SDTs
+    (`w:sdt`) are structural containers, not typed form fields, so `read_controls` correctly
+    has nothing to return for them. `_iter_block_items`
+    (`src/all2md/parsers/docx.py:1951`) matches only `tbl`/`p` and skips SDTs — and where
+    they appear on real documents they are not marginal: one white paper drops 95 of 1,645
+    paragraphs (a stale TOC gallery, arguably fine to lose), the other drops the author's
+    name, twice. The rule is precise — descend into `w:sdtContent`, skip anything with
+    `w:sdtPr/w:showingPlcHdr` set — and is a same-shaped fix regardless of whether
+    `docx-plus` is adopted.
+  - **Correction surfaced during evaluation:** `read_controls` throws `DuplicateTagError` on
+    real Word output, because Word writes empty/absent `w:tag` on most controls and the
+    library keys its result dict by tag. Filed upstream; does not change the Tier 1 call —
+    revisions, styles, and fields all worked cleanly on the same real file.
+  - **Risk:** pre-1.0 and moving fast (seven releases in ~2.5 months), so pin the version
+    range and keep the parser degrading to today's behaviour when the extra is absent. Every
+    Tier 1 change also shifts default parser output, so golden snapshots move — scope each
+    item's snapshot/integration updates separately rather than batching all three.
+  - **Next step:** spike Tier 1 item 1 (tracked changes) alone; its fidelity-score delta
+    tells us whether the rest of the tier earns the dependency.
 - 🚀 **Layout-aware PDF reconstruction** — *moved to **Theme 8**.* Correct reading order
   across columns, footnote/endnote linking, running header/footer stripping, caption↔figure
   association. Every one of those is a *geometry* problem, which is why it now sits with the
@@ -864,6 +909,9 @@ more than planned:
     form. The arXiv source↔PDF pairs are the instrument that would actually measure it.
 
 **Smaller open items**, none blocking:
+**the `docx-plus` Tier 1 spike** (Theme 2, tracked changes first — see the roadmap entry
+above and `design/docx-plus-evaluation.md` for the full measurement) is evaluated but
+unscheduled; a natural opportunistic slot whenever DOCX fidelity is the batch's focus;
 [#257](https://github.com/thomas-villani/all2md/issues/257) (stratify the raster lane's
 score — demoted from the numbered list 2026-08-13; two of its three parts already resolved,
 and what remains costs an ~80-minute re-baseline, so batch it with the next oracle change

--- a/changelog.d/340-pdf-caption-to-image-node.fixed.md
+++ b/changelog.d/340-pdf-caption-to-image-node.fixed.md
@@ -1,0 +1,10 @@
+- **A detected PDF figure caption now reaches `Image.caption` instead of being
+  discarded.** The caption was routed through `fallback_alt_text`, a dead path:
+  extraction writes a non-empty placeholder alt text (`Image from page N`), so
+  the fallback never fired and `include_image_captions=True` could not affect
+  output in any attachment mode. The caption now rides on the node's `caption`
+  field — visible page content set beside the figure, not a substitute for it —
+  and the Markdown renderer already round-trips it as an italic line plus a
+  marker comment. The default `alt_text` mode still extracts nothing; that is
+  the remaining half of the defect and is tracked separately.
+  ([#340](https://github.com/thomas-villani/all2md/issues/340))

--- a/src/all2md/constants.py
+++ b/src/all2md/constants.py
@@ -813,6 +813,10 @@ PDF_CAPTION_BAND_OVERHANG = 20.0
 # A caption is long-form prose, but not unbounded. Bounds the text handed to the cue
 # pattern so a runaway region cannot turn matching into a ReDoS surface.
 PDF_CAPTION_MAX_LENGTH = 500
+# A body text block whose whole text sits inside a bound caption is that caption's
+# duplicate and is suppressed -- unless it is shorter than this, which keeps a bare
+# cross-reference ("Figure 1.") from being mistaken for a caption fragment.
+PDF_CAPTION_DEDUP_MIN_CHARS = 10
 # When the layout model is available, also drop images that fall inside a
 # page-header / page-footer region (recurring logos, signature blocks).
 DEFAULT_FILTER_HEADER_FOOTER_IMAGES = True

--- a/src/all2md/parsers/pdf.py
+++ b/src/all2md/parsers/pdf.py
@@ -58,6 +58,7 @@ from all2md.ast.transforms import InlineFormattingConsolidator, extract_nodes
 from all2md.constants import (
     DEPS_PDF,
     DEPS_PDF_LAYOUT,
+    PDF_CAPTION_DEDUP_MIN_CHARS,
     PDF_MIN_PYMUPDF_VERSION,
     PDF_READING_ORDER_MIN_ROW_TOLERANCE,
     PDF_READING_ORDER_ROW_TOLERANCE_RATIO,
@@ -2086,9 +2087,18 @@ class PdfToAstConverter(BaseParser):
                     )
                     logger.debug("Layout analysis detected additional table at %s on page %d", pred_rect, page_num + 1)
 
+        # A caption bound to a figure renders beside that figure, so the body copy of
+        # the same text must not also survive as a paragraph -- every caption would
+        # appear twice. Matching is textual rather than geometric: the whole block,
+        # whitespace-normalized, must sit inside a caption actually bound on this
+        # page, so nothing that is not literally the caption can be dropped.
+        bound_captions = [" ".join(img["caption"].split()) for img in page_images if img.get("caption")]
+
         # Filter out blocks inside table regions
         text_blocks = []
         for block in all_blocks:
+            if bound_captions and self._is_bound_caption_block(block, bound_captions):
+                continue
             if "bbox" not in block:
                 text_blocks.append(block)
                 continue
@@ -3412,6 +3422,40 @@ class PdfToAstConverter(BaseParser):
             for pred in layout.get_predictions_by_label(label):
                 regions.append(pymupdf.Rect(pred.x0, pred.y0, pred.x1, pred.y1))
         return regions
+
+    @staticmethod
+    def _is_bound_caption_block(block: dict, bound_captions: list[str]) -> bool:
+        """Return True if this text block is the body copy of a bound figure caption.
+
+        The caption's text is real page text, so after binding it to an ``Image`` it
+        would otherwise also be emitted as an ordinary paragraph, and every caption
+        would appear twice in the output. A block is the body copy only when its
+        entire whitespace-normalized text sits inside a bound caption -- a block
+        holding the caption *plus* other prose keeps its place, because dropping it
+        would take that prose with it.
+
+        Parameters
+        ----------
+        block : dict
+            PyMuPDF text block
+        bound_captions : list of str
+            Whitespace-normalized captions bound to this page's images
+
+        Returns
+        -------
+        bool
+            True when the block should be suppressed as a duplicate
+
+        """
+        if block.get("type") != 0:
+            return False
+        text = " ".join(span.get("text", "") for line in block.get("lines", []) for span in line.get("spans", []))
+        text = " ".join(text.split())
+        # The floor keeps a short cross-reference ("Figure 1.") standing alone in the
+        # body from being mistaken for the caption fragment it is contained in.
+        if len(text) < PDF_CAPTION_DEDUP_MIN_CHARS:
+            return False
+        return any(text in caption for caption in bound_captions)
 
     def _create_image_node(self, img_info: dict, page_num: int) -> AstParagraph | None:
         """Create an image node from image info.

--- a/src/all2md/parsers/pdf.py
+++ b/src/all2md/parsers/pdf.py
@@ -3432,12 +3432,19 @@ class PdfToAstConverter(BaseParser):
         try:
             # Get the process_attachment result
             result = img_info.get("result", {})
-            caption = img_info.get("caption") or "Image"
+            caption = img_info.get("caption")
 
             # Convert result to Image node using helper
-            img_node = attachment_result_to_image_node(result, fallback_alt_text=caption)
+            img_node = attachment_result_to_image_node(result, fallback_alt_text="Image")
 
             if img_node:
+                # The detected caption is visible page content set beside the figure,
+                # not a substitute for it, so it rides on ``Image.caption`` rather
+                # than alt text (#338). Routing it through ``fallback_alt_text`` was
+                # a dead path: the placeholder alt text written at extraction time
+                # meant the fallback never fired, and the caption was discarded (#340).
+                if caption:
+                    img_node.caption = caption
                 # Add source location
                 img_node.source_location = SourceLocation(format="pdf", page=page_num + 1)
 

--- a/tests/unit/parsers/test_pdf_parser.py
+++ b/tests/unit/parsers/test_pdf_parser.py
@@ -648,7 +648,7 @@ class TestDetectedCaptionsReachTheImageNode:
 
     CAPTION = "Figure 1. Growth of the assay over twelve weeks."
 
-    def _pdf_with_image(self, tmp_path, caption_text=None):
+    def _pdf_with_image(self, tmp_path, caption_text=None, body_text=None):
         """A one-page PDF holding one raster image, optionally with a caption below it."""
         pymupdf = pytest.importorskip("pymupdf")
         source = pymupdf.open()
@@ -664,6 +664,8 @@ class TestDetectedCaptionsReachTheImageNode:
         page.insert_image(pymupdf.Rect(72.0, 120.0, 400.0, 240.0), pixmap=pixmap, keep_proportion=False)
         if caption_text:
             page.insert_text((72, 250.0), caption_text, fontsize=9)
+        if body_text:
+            page.insert_text((72, 320.0), body_text, fontsize=9)
         path = tmp_path / "figure.pdf"
         document.save(path)
         document.close()
@@ -702,3 +704,19 @@ class TestDetectedCaptionsReachTheImageNode:
 
         assert len(images) == 1
         assert images[0].caption is None
+
+    def test_the_bound_caption_appears_once_and_body_prose_survives(self, tmp_path) -> None:
+        """Binding must not double the caption: its body copy is suppressed.
+
+        The caption is real page text, so without suppression it would render
+        twice -- once as an ordinary paragraph and once as the caption line under
+        the image. Ordinary prose on the same page must be untouched.
+        """
+        from all2md.api import to_markdown
+
+        body = "The assay was repeated in triplicate across all cohorts."
+        path = self._pdf_with_image(tmp_path, caption_text=self.CAPTION, body_text=body)
+        markdown = to_markdown(path, attachment_mode="base64")
+
+        assert markdown.count(self.CAPTION) == 1
+        assert body in markdown

--- a/tests/unit/parsers/test_pdf_parser.py
+++ b/tests/unit/parsers/test_pdf_parser.py
@@ -632,3 +632,73 @@ startxref
         # This should raise an error during conversion
         with pytest.raises(Exception):  # Could be MalformedFileError or TypeError
             converter.parse(stream)
+
+
+@pytest.mark.unit
+@pytest.mark.pdf
+@pytest.mark.image
+class TestDetectedCaptionsReachTheImageNode:
+    """The detected caption must ride on ``Image.caption``, not vanish into alt text.
+
+    The caption used to be passed as ``fallback_alt_text``, a dead path: extraction
+    writes a non-empty placeholder alt text, so the fallback never fired and the
+    caption was discarded in every attachment mode (#340). These tests drive a real
+    PDF through the whole route -- extract, detect, node -- rather than mocking it.
+    """
+
+    CAPTION = "Figure 1. Growth of the assay over twelve weeks."
+
+    def _pdf_with_image(self, tmp_path, caption_text=None):
+        """A one-page PDF holding one raster image, optionally with a caption below it."""
+        pymupdf = pytest.importorskip("pymupdf")
+        source = pymupdf.open()
+        source_page = source.new_page()
+        source_page.draw_rect(pymupdf.Rect(0, 0, 100, 100), fill=(0.5, 0.5, 0.5))
+        pixmap = source_page.get_pixmap(dpi=36)
+        source.close()
+
+        document = pymupdf.open()
+        page = document.new_page()
+        # keep_proportion=False so the placement rect equals the requested rect;
+        # fitted placement would leave the caption outside the detector's band.
+        page.insert_image(pymupdf.Rect(72.0, 120.0, 400.0, 240.0), pixmap=pixmap, keep_proportion=False)
+        if caption_text:
+            page.insert_text((72, 250.0), caption_text, fontsize=9)
+        path = tmp_path / "figure.pdf"
+        document.save(path)
+        document.close()
+        return path
+
+    def _images_in(self, path, **option_overrides):
+        from all2md.api import to_ast
+        from all2md.ast.transforms import NodeCollector
+
+        options = PdfOptions(attachment_mode="base64", **option_overrides)
+        ast_doc = to_ast(path, parser_options=options)
+        collector = NodeCollector(lambda node: isinstance(node, Image))
+        ast_doc.accept(collector)
+        return collector.collected
+
+    def test_the_caption_lands_on_image_caption_and_not_on_alt_text(self, tmp_path) -> None:
+        path = self._pdf_with_image(tmp_path, caption_text=self.CAPTION)
+        images = self._images_in(path)
+
+        assert len(images) == 1
+        assert images[0].caption == self.CAPTION
+        # Alt text substitutes for the image; the caption sits beside it. The
+        # placeholder stays, the caption must not leak into it.
+        assert self.CAPTION not in images[0].alt_text
+
+    def test_an_uncaptioned_image_carries_no_caption(self, tmp_path) -> None:
+        path = self._pdf_with_image(tmp_path)
+        images = self._images_in(path)
+
+        assert len(images) == 1
+        assert images[0].caption is None
+
+    def test_disabling_caption_detection_leaves_the_caption_off(self, tmp_path) -> None:
+        path = self._pdf_with_image(tmp_path, caption_text=self.CAPTION)
+        images = self._images_in(path, include_image_captions=False)
+
+        assert len(images) == 1
+        assert images[0].caption is None


### PR DESCRIPTION
## What

The PDF parser detected figure captions and then threw them away, in every attachment mode. The caption was passed as `fallback_alt_text` — a dead path, because extraction unconditionally writes a non-empty placeholder alt text (`Image from page N`), so the fallback never fired. Consequence (measured in #340): `include_image_captions=True` could not affect PDF output in any configuration.

The detected caption now rides on `Image.caption` — the field #338 added for exactly this, which the HTML parser already populates and the Markdown renderer already round-trips through the caption marker comment (#237's device).

## What deliberately didn't change

- **Alt text keeps the placeholder.** A caption is visible page content set *beside* the figure; alt text substitutes *for* it. Writing the caption into alt text is the conflation `Image.caption` exists to end.
- **The default `alt_text` mode still extracts nothing** (`_pdf_images.py:239` early return). That is #340's remaining half — emitting captioned figures under the default mode — and lands as its own PR, since it changes default output for every PDF user.

## Testing

New tests drive a real PDF (built with pymupdf, as the caption-detector tests do) through the whole route — extract → detect → node — rather than mocking it, and the headline test was demonstrated red against the unfixed parser. One fixture subtlety worth recording: `insert_image` keeps aspect ratio by default, so the placement rect differs from the requested rect and the caption fell outside the detector's band; `keep_proportion=False` pins them equal.

Locally: 317 pdf-marked unit tests, pdf integration tests, and golden all pass (PDF goldens skip on Windows; the Linux CI leg is the real check there). Lint, mypy, manifest all clean.

Refs #340

🤖 Generated with [Claude Code](https://claude.com/claude-code)