### PR TITLE
feat(pdf): emit captioned figures under the default alt_text mode

### DIFF
--- a/changelog.d/340-default-mode-captioned-figures.changed.md
+++ b/changelog.d/340-default-mode-captioned-figures.changed.md
@@ -1,0 +1,14 @@
+- **Default options no longer drop every PDF figure silently.** The default
+  `attachment_mode="alt_text"` returned before extracting anything, so a journal
+  PDF's figures left no trace — a 23-page arXiv paper with 251 embedded rasters
+  produced zero `Image` nodes ([#340](https://github.com/thomas-villani/all2md/issues/340)).
+  The mode now runs a decode-free geometry pass and emits the figures that carry
+  a detected caption, as URL-less `Image` nodes whose caption renders through
+  the caption marker device. Uncaptioned images stay suppressed under that mode:
+  with no bytes and no caption, an `![alt]()` placeholder is noise, which was
+  the sound half of the old rationale
+  ([#338](https://github.com/thomas-villani/all2md/issues/338)). No pixmap is
+  decoded on this path, so the default mode keeps its performance edge over
+  `save`/`base64`. Vector-drawn figures still yield nothing — they emit no
+  raster placement to hang a caption on, and reaching them is #338's
+  caption-bearing container, deliberately not attempted here.

--- a/src/all2md/options/pdf.py
+++ b/src/all2md/options/pdf.py
@@ -152,7 +152,11 @@ class PdfOptions(PaginatedParserOptions):
         real URL/path). In ``alt_text`` mode no markers are emitted because
         they would have no target.
     include_image_captions : bool, default True
-        Try to extract image captions.
+        Try to extract image captions. Under ``attachment_mode="alt_text"`` (the
+        default) this is also what makes figures appear at all: only figures
+        with a detected caption are emitted there, since a captioned figure
+        carrying no URL is meaningful output and an uncaptioned placeholder is
+        noise (#338). Disabling it under that mode suppresses figures entirely.
 
     include_page_numbers : bool, default False
         Include page numbers in output (automatically added to separator).
@@ -436,7 +440,7 @@ class PdfOptions(PaginatedParserOptions):
     include_image_captions: bool = field(
         default=DEFAULT_INCLUDE_IMAGE_CAPTIONS,
         metadata={
-            "help": "Try to extract image captions",
+            "help": "Try to extract image captions (under alt_text mode, only captioned figures are emitted)",
             "cli_name": "no-include-image-captions",  # default=True, use --no-*
             "importance": "core",
         },

--- a/src/all2md/parsers/_pdf_images.py
+++ b/src/all2md/parsers/_pdf_images.py
@@ -183,7 +183,11 @@ def extract_page_images(
     """Extract images from a PDF page with their positions.
 
     Extracts all images from the page and optionally saves them to disk
-    or converts to base64 data URIs for embedding in Markdown.
+    or converts to base64 data URIs for embedding in Markdown. Under
+    ``attachment_mode="alt_text"`` no pixmap is ever decoded: the pass records
+    geometry and detected captions only, and returns just the figures that carry
+    a caption -- a captioned figure with no URL is meaningful output, an
+    uncaptioned ``![alt]()`` placeholder is not (#338).
 
     Parameters
     ----------
@@ -232,11 +236,14 @@ def extract_page_images(
     if not options or options.attachment_mode == "skip":
         return [], collected_footnotes
 
-    # In alt_text mode there is no URL to point markers at, so emitting
-    # ``![alt]()`` placeholders is just noise. Skip extraction entirely —
-    # this also avoids decoding every pixmap only to throw the bytes away.
+    # In alt_text mode there are no bytes to embed, so what is worth emitting is a
+    # *captioned* figure: the caption is meaningful page content, while an uncaptioned
+    # URL-less ``![alt]()`` placeholder is just noise (#338, #340). The pass below
+    # detects geometry and captions without ever decoding a pixmap; with caption
+    # detection off there is nothing it could emit, so skip it entirely.
     # ``image_placement_markers`` remains meaningful for ``save`` / ``base64``.
-    if options.attachment_mode == "alt_text":
+    caption_only = options.attachment_mode == "alt_text"
+    if caption_only and not options.include_image_captions:
         return [], collected_footnotes
 
     import pymupdf
@@ -271,6 +278,27 @@ def extract_page_images(
             # Filter out images that sit inside layout-detected page-header /
             # page-footer regions.
             if exclusion_rects and _bbox_in_any_region(bbox, exclusion_rects):
+                continue
+
+            if caption_only:
+                # Captioned figures survive the default mode; uncaptioned ones stay
+                # suppressed as noise. No pixmap is ever decoded on this path, and
+                # ``process_attachment`` with no data reduces to the alt-text result,
+                # so footnote-style alt text keeps working.
+                caption = detect_image_caption(page, bbox, caption_regions)
+                if not caption:
+                    continue
+                result = process_attachment(
+                    attachment_data=None,
+                    attachment_name=f"{base_filename}-page{page_num + 1}-img{img_idx + 1}",
+                    alt_text=f"Image from page {page_num + 1}",
+                    attachment_mode="alt_text",
+                    is_image=True,
+                    alt_text_mode=options.alt_text_mode,
+                )
+                if result.get("footnote_label") and result.get("footnote_content"):
+                    collected_footnotes[result["footnote_label"]] = result["footnote_content"]
+                images.append({"bbox": bbox, "result": result, "caption": caption})
                 continue
 
             pix = pymupdf.Pixmap(page.parent, xref)

--- a/tests/unit/parsers/test_pdf_parser.py
+++ b/tests/unit/parsers/test_pdf_parser.py
@@ -634,6 +634,44 @@ startxref
             converter.parse(stream)
 
 
+_FIGURE_CAPTION = "Figure 1. Growth of the assay over twelve weeks."
+
+
+def _pdf_with_image(tmp_path, caption_text=None, body_text=None):
+    """A one-page PDF holding one raster image, optionally with a caption below it."""
+    pymupdf = pytest.importorskip("pymupdf")
+    source = pymupdf.open()
+    source_page = source.new_page()
+    source_page.draw_rect(pymupdf.Rect(0, 0, 100, 100), fill=(0.5, 0.5, 0.5))
+    pixmap = source_page.get_pixmap(dpi=36)
+    source.close()
+
+    document = pymupdf.open()
+    page = document.new_page()
+    # keep_proportion=False so the placement rect equals the requested rect;
+    # fitted placement would leave the caption outside the detector's band.
+    page.insert_image(pymupdf.Rect(72.0, 120.0, 400.0, 240.0), pixmap=pixmap, keep_proportion=False)
+    if caption_text:
+        page.insert_text((72, 250.0), caption_text, fontsize=9)
+    if body_text:
+        page.insert_text((72, 320.0), body_text, fontsize=9)
+    path = tmp_path / "figure.pdf"
+    document.save(path)
+    document.close()
+    return path
+
+
+def _images_in(path, attachment_mode="base64", **option_overrides):
+    from all2md.api import to_ast
+    from all2md.ast.transforms import NodeCollector
+
+    options = PdfOptions(attachment_mode=attachment_mode, **option_overrides)
+    ast_doc = to_ast(path, parser_options=options)
+    collector = NodeCollector(lambda node: isinstance(node, Image))
+    ast_doc.accept(collector)
+    return collector.collected
+
+
 @pytest.mark.unit
 @pytest.mark.pdf
 @pytest.mark.image
@@ -646,61 +684,26 @@ class TestDetectedCaptionsReachTheImageNode:
     PDF through the whole route -- extract, detect, node -- rather than mocking it.
     """
 
-    CAPTION = "Figure 1. Growth of the assay over twelve weeks."
-
-    def _pdf_with_image(self, tmp_path, caption_text=None, body_text=None):
-        """A one-page PDF holding one raster image, optionally with a caption below it."""
-        pymupdf = pytest.importorskip("pymupdf")
-        source = pymupdf.open()
-        source_page = source.new_page()
-        source_page.draw_rect(pymupdf.Rect(0, 0, 100, 100), fill=(0.5, 0.5, 0.5))
-        pixmap = source_page.get_pixmap(dpi=36)
-        source.close()
-
-        document = pymupdf.open()
-        page = document.new_page()
-        # keep_proportion=False so the placement rect equals the requested rect;
-        # fitted placement would leave the caption outside the detector's band.
-        page.insert_image(pymupdf.Rect(72.0, 120.0, 400.0, 240.0), pixmap=pixmap, keep_proportion=False)
-        if caption_text:
-            page.insert_text((72, 250.0), caption_text, fontsize=9)
-        if body_text:
-            page.insert_text((72, 320.0), body_text, fontsize=9)
-        path = tmp_path / "figure.pdf"
-        document.save(path)
-        document.close()
-        return path
-
-    def _images_in(self, path, **option_overrides):
-        from all2md.api import to_ast
-        from all2md.ast.transforms import NodeCollector
-
-        options = PdfOptions(attachment_mode="base64", **option_overrides)
-        ast_doc = to_ast(path, parser_options=options)
-        collector = NodeCollector(lambda node: isinstance(node, Image))
-        ast_doc.accept(collector)
-        return collector.collected
-
     def test_the_caption_lands_on_image_caption_and_not_on_alt_text(self, tmp_path) -> None:
-        path = self._pdf_with_image(tmp_path, caption_text=self.CAPTION)
-        images = self._images_in(path)
+        path = _pdf_with_image(tmp_path, caption_text=_FIGURE_CAPTION)
+        images = _images_in(path)
 
         assert len(images) == 1
-        assert images[0].caption == self.CAPTION
+        assert images[0].caption == _FIGURE_CAPTION
         # Alt text substitutes for the image; the caption sits beside it. The
         # placeholder stays, the caption must not leak into it.
-        assert self.CAPTION not in images[0].alt_text
+        assert _FIGURE_CAPTION not in images[0].alt_text
 
     def test_an_uncaptioned_image_carries_no_caption(self, tmp_path) -> None:
-        path = self._pdf_with_image(tmp_path)
-        images = self._images_in(path)
+        path = _pdf_with_image(tmp_path)
+        images = _images_in(path)
 
         assert len(images) == 1
         assert images[0].caption is None
 
     def test_disabling_caption_detection_leaves_the_caption_off(self, tmp_path) -> None:
-        path = self._pdf_with_image(tmp_path, caption_text=self.CAPTION)
-        images = self._images_in(path, include_image_captions=False)
+        path = _pdf_with_image(tmp_path, caption_text=_FIGURE_CAPTION)
+        images = _images_in(path, include_image_captions=False)
 
         assert len(images) == 1
         assert images[0].caption is None
@@ -715,8 +718,54 @@ class TestDetectedCaptionsReachTheImageNode:
         from all2md.api import to_markdown
 
         body = "The assay was repeated in triplicate across all cohorts."
-        path = self._pdf_with_image(tmp_path, caption_text=self.CAPTION, body_text=body)
+        path = _pdf_with_image(tmp_path, caption_text=_FIGURE_CAPTION, body_text=body)
         markdown = to_markdown(path, attachment_mode="base64")
 
-        assert markdown.count(self.CAPTION) == 1
+        assert markdown.count(_FIGURE_CAPTION) == 1
         assert body in markdown
+
+
+@pytest.mark.unit
+@pytest.mark.pdf
+@pytest.mark.image
+class TestDefaultModeEmitsCaptionedFigures:
+    """Default options must not silently drop every figure (#340).
+
+    ``attachment_mode="alt_text"`` used to return before extracting anything, so
+    a journal PDF's figures left no trace at all. The mode now runs a decode-free
+    geometry pass and emits the figures that carry a detected caption -- a
+    captioned figure with no URL is meaningful output. Uncaptioned images stay
+    suppressed: with no bytes and no caption, ``![alt]()`` is noise (#338).
+    """
+
+    def test_a_captioned_figure_survives_default_options(self, tmp_path) -> None:
+        path = _pdf_with_image(tmp_path, caption_text=_FIGURE_CAPTION)
+        images = _images_in(path, attachment_mode="alt_text")
+
+        assert len(images) == 1
+        assert images[0].caption == _FIGURE_CAPTION
+        assert images[0].url == ""
+
+    def test_an_uncaptioned_image_stays_suppressed(self, tmp_path) -> None:
+        path = _pdf_with_image(tmp_path)
+        images = _images_in(path, attachment_mode="alt_text")
+
+        assert images == []
+
+    def test_disabling_captions_suppresses_figures_entirely(self, tmp_path) -> None:
+        path = _pdf_with_image(tmp_path, caption_text=_FIGURE_CAPTION)
+        images = _images_in(path, attachment_mode="alt_text", include_image_captions=False)
+
+        assert images == []
+
+    def test_the_caption_reaches_the_markdown_output(self, tmp_path) -> None:
+        """End to end: default ``to_markdown`` now shows the figure and its caption, once."""
+        from all2md.api import to_markdown
+
+        path = _pdf_with_image(tmp_path, caption_text=_FIGURE_CAPTION)
+        markdown = to_markdown(path)
+
+        # Exactly once: the bound caption line, with its body copy suppressed.
+        assert markdown.count(_FIGURE_CAPTION) == 1
+        # The marker comment is what makes the italic caption line round-trippable.
+        assert "all2md:image-caption" in markdown


### PR DESCRIPTION
Stacked on #378 — diff shown against that branch; retarget to `main` when it merges.

## What

The default `attachment_mode="alt_text"` returned from `extract_page_images` before extracting anything, so a journal PDF's figures left no trace at all — the arXiv report in #340 was a 23-page paper with 251 embedded rasters and zero `Image` nodes, silently.

The mode now runs a **decode-free geometry pass**: image rects, the existing size and header/footer filters, and caption detection — but never a pixmap, so the default keeps its performance edge over `save`/`base64`. Figures with a detected caption are emitted as URL-less `Image` nodes whose caption renders through the marker device; with #378's suppression the caption appears exactly once.

## The design call

**Uncaptioned images stay suppressed under this mode.** #338's decision line — "a captioned figure carrying no URL is meaningful output, unlike `![alt]()`" — cuts both ways: the old early return was right that a bare URL-less placeholder is noise, and wrong to let that reasoning also swallow captioned figures. `include_image_captions` therefore gains a second meaning under this mode (with detection off there is nothing the pass could emit, so it short-circuits to the old skip); the docstring and CLI help say so.

**Not attempted:** vector-drawn figures still yield nothing — they emit no raster placement to hang a caption on; reaching them is #338's caption-bearing container.

This changes default output for every PDF user, so it's a **minor-version** change (per #338) and the fragment is filed under `changed`.

## Testing

Four new real-PDF tests: captioned figure survives default options (URL-less, caption set), uncaptioned image stays suppressed, `include_image_captions=False` restores the old silence, and end-to-end default `to_markdown` shows the caption exactly once with the round-trip marker. Full pdf-marked unit sweep (325), lint, mypy, manifest all clean.

Closes the default-mode half of #340.

🤖 Generated with [Claude Code](https://claude.com/claude-code)