### PR TITLE
feat(pdf): recover borderless tables from word-box gutters (#386)

### DIFF
--- a/changelog.d/386-word-gutter-tables.added.md
+++ b/changelog.d/386-word-gutter-tables.added.md
@@ -1,0 +1,18 @@
+- **The PDF parser recovers borderless tables from word-box gutters.** Layout-predicted
+  table regions that PyMuPDF's strategies could not grid — 56 of the 63 tables missing
+  from the born-digital corpus, every one shredded by the text strategy and then
+  correctly refused by the split-word guard — now get a third pass that builds the grid
+  from the page's own word boxes: columns from vertical bands no word crosses, whole
+  words assigned to the column holding their center, wrapped cell lines folded into
+  their logical row with hyphenation repair across the join
+  ([#386](https://github.com/thomas-villani/all2md/issues/386)). Cut and space-joined
+  words are impossible by construction. Three measured guards keep prose out: a grid
+  needs three-plus columns (one gutter is what any two-column layout has), a
+  sequential-integer column beside sentence-length cells reads as a numbered
+  bibliography and demotes to prose (gridding one scrambles every citation), and a
+  region of predominantly rotated words is declined in favor of the rotation-aware
+  prose path. Measured on the 12-article PMC sample: tables emitted rose 12 → 30 of 32
+  expected, `table_content_similarity` median 0.000 → 0.88, `table_structure_similarity`
+  median 0.000 → 0.73, with whole-article attainable recall at 0.941 (baseline 0.951 —
+  a table's cell stream breaks a few truth blocks' n-grams that its prose form kept)
+  and both wrong-article controls at zero.

--- a/src/all2md/parsers/_pdf_tables.py
+++ b/src/all2md/parsers/_pdf_tables.py
@@ -18,6 +18,7 @@ if TYPE_CHECKING:
 
 __all__ = [
     "MAX_DOT_LEADER_CELL_RATIO",
+    "MAX_GUTTER_INTRUSION_SHARE",
     "MAX_TABLE_COLS",
     "MIN_TABLE_COLS",
     "MIN_TABLE_ROWS",
@@ -25,12 +26,19 @@ __all__ = [
     "MAX_TABLE_ROWS",
     "MAX_SPLIT_WORD_RATIO",
     "MIN_FILLED_FOR_UNIFORMITY_CHECK",
+    "MIN_GUTTER_LINES",
+    "MIN_GUTTER_WIDTH_PT",
+    "MAX_ROTATED_WORD_SHARE",
+    "MIN_WORD_GUTTER_COLS",
     "TABLE_REGION_STRATEGIES",
     "TABLE_SIGNAL_RULING_THRESHOLD",
     "detect_tables_by_ruling_lines",
+    "group_words_into_lines",
     "is_dot_leader_cell",
+    "looks_like_numbered_bibliography",
     "page_has_table_signals",
     "split_word_ratio",
+    "word_gutter_grid",
 ]
 
 # Hard caps and guards applied to detected tables. Real prose tables rarely
@@ -104,6 +112,37 @@ _DOT_LEADER_TAIL = re.compile(r"\n\s*[.…](?:\s*[.…]){2,}\s*$")
 # Letters only. Digits are never "split words" -- a column boundary falling inside a number
 # yields two numbers, both plausible, and counting those would flag real numeric tables.
 _WORD_TOKEN = re.compile(r"[^\W\d_]+", re.UNICODE)
+
+# Word-gutter grid recovery (the third region strategy; see #386). The first two
+# strategies delegate the grid to find_tables(), whose text mode both invents column
+# boundaries through words and reassembles cell text with lost spaces -- on the PMC
+# born-digital corpus that combination cost 56 of the 63 missing tables, every one
+# killed by the split-word guard telling the truth about a damaged grid. Building the
+# grid from the page's own word boxes makes both damage classes impossible: a column
+# boundary can only fall in a gutter no word crosses, and cell text is the words
+# themselves.
+#
+# A gutter must be corroborated by enough printed lines to mean anything: with fewer
+# than MIN_GUTTER_LINES lines, the space between any two words "spans" the region.
+MIN_GUTTER_LINES = 3
+# Share of a region's lines that may intrude into an x-band before it stops counting
+# as a gutter. Nonzero because spanning headers and footnote lines legitimately cross
+# column boundaries -- measured on the PMC corpus, requiring 90% clearance recovered
+# the truth column count almost exactly (35 of 37 guard-killed tables, counts matching
+# JATS: 4->4, 5->5, 9->9) while one intruding line per ten still blocks prose.
+MAX_GUTTER_INTRUSION_SHARE = 0.1
+# Narrower bands than this are ordinary word spacing, not column separation.
+MIN_GUTTER_WIDTH_PT = 4.0
+# A gutter grid needs at least this many columns. One gutter is what ANY two-column
+# layout has -- a reference list, a chart legend beside its axis, a title page -- so a
+# single band is not evidence of a table, it is evidence of columns. Measured on the
+# PMC corpus: 8 of the 13 genuinely non-tabular regions this pass would otherwise emit
+# were two-column (bibliographies split at the page's own column gutter), against 1 of
+# the 34 real tables it recovers.
+MIN_WORD_GUTTER_COLS = 3
+# Share of a region's multi-character words that may stand taller than wide before the
+# region reads as rotated and the gutter pass declines it.
+MAX_ROTATED_WORD_SHARE = 0.5
 
 
 def split_word_ratio(page: "pymupdf.Page", table_data: list[list[str | None]]) -> float:
@@ -435,3 +474,201 @@ def detect_tables_by_ruling_lines(
         filtered_lines.append((th, tv))
 
     return filtered_rects, filtered_lines
+
+
+def group_words_into_lines(words: list[tuple]) -> list[list[tuple]]:
+    """Group word boxes into printed lines by vertical overlap.
+
+    Two words share a line when their boxes overlap vertically by more than half the
+    shorter box's height. Superscripts and subscripts overlap their base line well past
+    that bar; consecutive printed lines do not.
+
+    Parameters
+    ----------
+    words : list of tuple
+        Word entries as returned by ``page.get_text("words")``:
+        ``(x0, y0, x1, y1, text, ...)``.
+
+    Returns
+    -------
+    list of list of tuple
+        Lines in reading order, each line's words sorted by ``x0``.
+
+    """
+    lines: list[dict] = []
+    for word in sorted(words, key=lambda entry: (entry[3], entry[0])):
+        x0, y0, x1, y1 = word[:4]
+        for line in lines:
+            overlap = min(y1, line["y1"]) - max(y0, line["y0"])
+            if overlap > 0.5 * min(y1 - y0, line["y1"] - line["y0"]):
+                line["words"].append(word)
+                line["y0"] = min(y0, line["y0"])
+                line["y1"] = max(y1, line["y1"])
+                break
+        else:
+            lines.append({"y0": y0, "y1": y1, "words": [word]})
+    lines.sort(key=lambda line: line["y0"])
+    return [sorted(line["words"], key=lambda entry: entry[0]) for line in lines]
+
+
+def word_gutter_grid(words: list[tuple]) -> list[list[str]] | None:
+    """Recover a table grid from word boxes alone: columns from gutters, one row per line.
+
+    A gutter is a vertical band of x that at most :data:`MAX_GUTTER_INTRUSION_SHARE` of
+    the region's printed lines intrude into, at least :data:`MIN_GUTTER_WIDTH_PT` wide.
+    Column boundaries sit at gutter midpoints, so a word box can never be cut: every word
+    lands whole in the column holding its center, and cell text is those words joined in
+    x order. Running prose has no such bands -- justified text aligns its outer edges but
+    scatters its inner gaps -- so a region yielding fewer than two columns is not a table
+    to this detector.
+
+    Parameters
+    ----------
+    words : list of tuple
+        Word entries as returned by ``page.get_text("words")`` clipped to the region.
+
+    Returns
+    -------
+    list of list of str or None
+        Cell text per row, or ``None`` when no gutter-corroborated grid exists here.
+
+    """
+    # Rotated regions are not this detector's to grid. A landscape table read in page
+    # coordinates groups perpendicular text into fake lines, and the grid that falls out
+    # scrambles the reading order rather than merely mis-shaping it -- measured, a 28x4
+    # truth table came back 8x12 with its containment destroyed, where the rotation-aware
+    # prose path reads it fine. A multi-character word taller than it is wide is almost
+    # surely rotated; single characters are excluded because an upright "I" is too.
+    sized = [word for word in words if len(str(word[4])) >= 3]
+    if sized:
+        rotated = sum(1 for word in sized if (word[3] - word[1]) > (word[2] - word[0]))
+        if rotated > MAX_ROTATED_WORD_SHARE * len(sized):
+            return None
+
+    lines = group_words_into_lines(words)
+    if len(lines) < MIN_GUTTER_LINES:
+        return None
+
+    # Sweep the x axis: between consecutive interval endpoints the set of intruding
+    # lines is constant, so intrusion counts only change at word-box edges.
+    intervals = []  # (x0, x1, line_index) -- per line, the union is what matters
+    for index, line in enumerate(lines):
+        for word in line:
+            intervals.append((word[0], word[2], index))
+    edges = sorted({x for x0, x1, _ in intervals for x in (x0, x1)})
+    if len(edges) < 2:
+        return None
+
+    max_intruding = MAX_GUTTER_INTRUSION_SHARE * len(lines)
+    gutters: list[tuple[float, float]] = []  # merged maximal clear bands
+    band_start: float | None = None
+    for left, right in zip(edges, edges[1:], strict=False):
+        mid = (left + right) / 2
+        intruding = len({index for x0, x1, index in intervals if x0 < mid < x1})
+        if intruding <= max_intruding:
+            if band_start is None:
+                band_start = left
+        else:
+            if band_start is not None and left - band_start >= MIN_GUTTER_WIDTH_PT:
+                gutters.append((band_start, left))
+            band_start = None
+    # A trailing clear band ends at the region's edge: that is the right margin, not a
+    # column separator, and the leading band is the left margin for the same reason --
+    # margins separate the table from the page, not cell from cell. Bands starting at
+    # edges[0] are excluded by construction only when a word starts there, so drop any
+    # band touching the outer edges explicitly.
+    boundaries = [(start + end) / 2 for start, end in gutters if start > edges[0] and end < edges[-1]]
+    if len(boundaries) < MIN_WORD_GUTTER_COLS - 1:
+        return None
+
+    line_rows: list[list[str]] = []
+    for line in lines:
+        cells: list[list[str]] = [[] for _ in range(len(boundaries) + 1)]
+        for word in line:
+            center = (word[0] + word[2]) / 2
+            column = sum(1 for boundary in boundaries if boundary < center)
+            cells[column].append(str(word[4]))
+        line_rows.append([" ".join(parts) for parts in cells])
+    return _merge_continuation_lines(line_rows)
+
+
+def _merge_continuation_lines(line_rows: list[list[str]]) -> list[list[str]]:
+    """Fold wrapped cell lines into their logical row.
+
+    One printed line is not one table row: a cell holding more than a line of text wraps,
+    and emitting each printed line as a row splits every wrapped cell -- including through
+    hyphenated words, which the whole-word guarantee is supposed to make impossible. The
+    anchor is the leftmost column filled on at least 60% of lines: a line with the anchor
+    cell empty is a continuation of the row above it, because a new logical row announces
+    itself in the column that names rows. Leftmost-qualifying rather than most-filled on
+    purpose -- a heavily wrapped description column is *more* filled than the key column
+    beside it, and choosing it would read every real row as a continuation of the first.
+    Fully-dense numeric tables have every anchor cell filled, so nothing merges and the
+    per-line rows stand.
+
+    Cell fragments join with a newline rather than a space so the caller can run its
+    hyphenation repair across the join, exactly as the paragraph path does.
+    """
+    column_count = max(len(row) for row in line_rows)
+    fill = [sum(1 for row in line_rows if column < len(row) and row[column]) for column in range(column_count)]
+    anchor = next(
+        (column for column in range(column_count) if fill[column] >= 0.6 * len(line_rows)),
+        max(range(column_count), key=lambda column: (fill[column], -column)),
+    )
+
+    merged: list[list[str]] = []
+    for row in line_rows:
+        is_continuation = merged and not (anchor < len(row) and row[anchor])
+        if not is_continuation:
+            merged.append(list(row))
+            continue
+        target = merged[-1]
+        for column, fragment in enumerate(row):
+            if not fragment:
+                continue
+            target[column] = f"{target[column]}\n{fragment}" if target[column] else fragment
+    return merged
+
+
+# The integer forms a bibliography numbers its entries with: ``42.``, ``42``, ``[42]``.
+_BIB_INTEGER = re.compile(r"^\[?(\d{1,3})[.\]]?$")
+# A run of consecutive integers needs this many members before it reads as numbering
+# rather than coincidence.
+MIN_BIB_SEQUENTIAL_CELLS = 5
+# Bibliographies are sentences chopped into cells; tables are values placed in them.
+# Measured on the PMC corpus over the grids the sequential-integer test flags: the four
+# reference-page grids had a 90th-percentile filled-cell length of 10-15 words, the three
+# real tables with a sequential "No." column 1-8. The bar sits in the gap.
+MIN_BIB_CELL_WORDS_P90 = 9
+
+
+def looks_like_numbered_bibliography(grid: list[list[str]]) -> bool:
+    """Decide whether this grid is a numbered reference list rather than a table.
+
+    A bibliography that reaches a grid detector is the worst false positive available:
+    row-major cell order interleaves the page's columns, so every citation is scrambled
+    rather than merely re-wrapped. Two signals must agree before a grid is condemned:
+    a column that counts (five-plus consecutive integers -- ``42.``, ``43.``, ``44.``),
+    and prose-length cells beside it. Either alone describes plenty of real tables; a
+    numbered column of sentences is how a reference list is typeset.
+    """
+    word_counts = sorted(len(cell.split()) for row in grid for cell in row if cell.strip())
+    if not word_counts:
+        return False
+    if word_counts[int(0.9 * len(word_counts))] < MIN_BIB_CELL_WORDS_P90:
+        return False
+
+    column_count = max(len(row) for row in grid)
+    for column in range(column_count):
+        values: list[int | None] = []
+        for row in grid:
+            if column < len(row) and row[column].strip():
+                match = _BIB_INTEGER.match(row[column].strip())
+                values.append(int(match.group(1)) if match else None)
+        integers = [value for value in values if value is not None]
+        if len(integers) < MIN_BIB_SEQUENTIAL_CELLS or len(integers) < 0.8 * len(values):
+            continue
+        consecutive = sum(1 for a, b in zip(integers, integers[1:], strict=False) if b == a + 1)
+        if consecutive >= 0.8 * (len(integers) - 1):
+            return True
+    return False

--- a/src/all2md/parsers/pdf.py
+++ b/src/all2md/parsers/pdf.py
@@ -102,8 +102,10 @@ from all2md.parsers._pdf_tables import (
     TABLE_REGION_STRATEGIES,
     detect_tables_by_ruling_lines,
     is_dot_leader_cell,
+    looks_like_numbered_bibliography,
     page_has_table_signals,
     split_word_ratio,
+    word_gutter_grid,
 )
 from all2md.parsers._pdf_text import (
     classify_line_rotation,
@@ -3440,6 +3442,21 @@ class PdfToAstConverter(BaseParser):
             if isinstance(table, AstTable):
                 return table
 
+        # Third pass: build the grid from the page's own word boxes (#386). The two
+        # find_tables() strategies above delegate both geometry and cell text to
+        # PyMuPDF, and on borderless journal tables its text mode invents column
+        # boundaries through words and reassembles cells with lost spaces -- so the
+        # split-word guard kills the grid, correctly, and the table is lost. Word
+        # boxes cannot be cut by construction (boundaries sit at gutter midpoints and
+        # every word lands whole in the column holding its center), so this pass needs
+        # no word-integrity guard; the gutters themselves are the evidence, and the
+        # shape guards below still apply. Runs last so every grid the established
+        # strategies already accept keeps its exact path.
+        gutter_found, table = self._extract_table_from_word_gutters(page, table_rect, page_num)
+        if isinstance(table, AstTable):
+            return table
+        found_grid = found_grid or gutter_found
+
         # No table here -- the layout model was wrong. Keep the text, drop the pipes.
         paragraph = self._region_text_as_paragraph(page, table_rect, page_num)
         if paragraph is not None and not found_grid:
@@ -3449,6 +3466,100 @@ class PdfToAstConverter(BaseParser):
             # second bite out of the confidence score.
             self._record_table_rejection("layout_region_not_tabular")
         return paragraph
+
+    def _extract_table_from_word_gutters(
+        self, page: "pymupdf.Page", table_rect: "pymupdf.Rect", page_num: int
+    ) -> tuple[bool, AstTable | None]:
+        """Recover a borderless table from word-box gutters inside a layout region.
+
+        Parameters
+        ----------
+        page : pymupdf.Page
+            PDF page containing the region.
+        table_rect : pymupdf.Rect
+            Bounding box predicted by the layout model.
+        page_num : int
+            Page number for source tracking.
+
+        Returns
+        -------
+        tuple of (bool, AstTable or None)
+            Whether anything tabular was found (a grid that a guard then rejected
+            still counts, so the caller does not also record the vaguer
+            ``layout_region_not_tabular`` on top of the guard's reason), and the
+            table when one survives the guards.
+
+        """
+        import pymupdf
+
+        try:
+            words = [word for word in page.get_text("words") if pymupdf.Rect(word[:4]).intersects(table_rect)]
+        except Exception:
+            return False, None
+        grid = word_gutter_grid(words)
+        if grid is None:
+            return False, None
+
+        n_rows = len(grid)
+        n_cols = max((len(row) for row in grid), default=0)
+        if n_rows < MIN_TABLE_ROWS or n_cols < MIN_TABLE_COLS:
+            self._record_table_rejection("degenerate_grid")
+            return True, None
+        if n_rows > MAX_TABLE_ROWS or n_cols > MAX_TABLE_COLS:
+            self._record_table_rejection("oversized_grid")
+            return True, None
+
+        n_cells = n_rows * n_cols
+        n_empty = 0
+        n_dot_leader = 0
+        unique_texts: set[str] = set()
+        for row in grid:
+            for cell_text in row:
+                if cell_text:
+                    unique_texts.add(cell_text)
+                    if is_dot_leader_cell(cell_text):
+                        n_dot_leader += 1
+                else:
+                    n_empty += 1
+
+        if n_empty / n_cells > MAX_TABLE_EMPTY_RATIO:
+            logger.debug(
+                f"Rejecting word-gutter table on page {page_num + 1}: "
+                f"{n_empty}/{n_cells} ({n_empty / n_cells:.0%}) cells empty"
+            )
+            self._record_table_rejection("mostly_empty")
+            return True, None
+        n_filled = n_cells - n_empty
+        if len(unique_texts) == 1 and n_filled >= MIN_FILLED_FOR_UNIFORMITY_CHECK:
+            self._record_table_rejection("uniform_cells")
+            return True, None
+        if n_filled and n_dot_leader / n_filled > MAX_DOT_LEADER_CELL_RATIO:
+            self._record_table_rejection("dot_leader_toc")
+            return True, None
+        # A numbered reference list is the worst grid to emit: row-major cell order
+        # interleaves the page's two columns, scrambling every citation -- measured on
+        # the PMC corpus, one gridded bibliography cost 15 of an article's 21 citation
+        # titles their recall. Demoted to prose it reads exactly as it did before.
+        if looks_like_numbered_bibliography(grid):
+            self._record_table_rejection("numbered_bibliography")
+            return True, None
+
+        def cell_node(cell_text: str) -> TableCell:
+            # Merged continuation lines join with a newline so hyphenation repair can
+            # run across the wrap, the same as the paragraph path does.
+            if self.options.merge_hyphenated_words:
+                cell_text = dehyphenate_text(cell_text)
+            return TableCell(content=[Text(content=" ".join(cell_text.split()))])
+
+        rows = [
+            TableRow(cells=[cell_node(cell_text) for cell_text in row], is_header=index == 0)
+            for index, row in enumerate(grid)
+        ]
+        return True, AstTable(
+            header=rows[0],
+            rows=rows[1:],
+            source_location=SourceLocation(format="pdf", page=page_num + 1),
+        )
 
     def _region_text_as_paragraph(
         self, page: "pymupdf.Page", region: "pymupdf.Rect", page_num: int

--- a/tests/unit/formats/pdf/test_pdf_layout_region_tables.py
+++ b/tests/unit/formats/pdf/test_pdf_layout_region_tables.py
@@ -215,3 +215,274 @@ class TestLayoutRegionExtraction:
             "text_grid_splits_words"
         ], "the specific guard reports; the vaguer layout_region_not_tabular must not pile on"
         assert converter._tables_rejected == 1, "one region, one rejection, one hit to confidence"
+
+
+class _PositionedPage(_FakePage):
+    """A page whose words carry real geometry, for the word-gutter pass."""
+
+    def __init__(self, words: list[tuple], by_strategy: dict[str, list[_FakeTable]] | None = None) -> None:
+        super().__init__(" ".join(word[4] for word in words), by_strategy)
+        self._words = words
+
+    def get_text(self, kind: str, **kwargs):
+        assert kind == "words"
+        return list(self._words)
+
+
+def _word(x0: float, y: float, text: str, width: float = 8.0) -> tuple:
+    return (x0, y, x0 + width * max(1, len(text)) / 2, y + 10.0, text, 0, 0, 0)
+
+
+def _booktabs_words() -> list[tuple]:
+    """Three lines, three columns, 40pt gutters -- a borderless journal table's geometry."""
+    columns = (10.0, 100.0, 180.0)
+    rows = (
+        ("Variables", "AUC", "Sensitivity"),
+        ("Magnesium", "0.774", "0.71"),
+        ("Vitamin", "0.901", "0.88"),
+    )
+    return [_word(columns[i], 10.0 + 20.0 * r, text) for r, row in enumerate(rows) for i, text in enumerate(row)]
+
+
+def _prose_words() -> list[tuple]:
+    """Justified prose: word gaps land at different x on every line, so no shared band is clear."""
+    words = []
+    for line_index in range(6):
+        x = 10.0
+        for word_index in range(12):
+            text = f"w{line_index}{word_index}"
+            entry = _word(x, 10.0 + 15.0 * line_index, text, width=6.0)
+            words.append(entry)
+            x = entry[2] + 2.0 + (line_index * 7 + word_index * 3) % 3
+    return words
+
+
+class TestWordGutterGrid:
+    """The pure geometry: columns from gutters, whole words by construction."""
+
+    def test_a_borderless_table_yields_its_grid(self):
+        from all2md.parsers._pdf_tables import word_gutter_grid
+
+        grid = word_gutter_grid(_booktabs_words())
+
+        assert grid == [
+            ["Variables", "AUC", "Sensitivity"],
+            ["Magnesium", "0.774", "0.71"],
+            ["Vitamin", "0.901", "0.88"],
+        ]
+
+    def test_prose_has_no_gutters(self):
+        """Justified text aligns its outer edges but scatters its inner gaps."""
+        from all2md.parsers._pdf_tables import word_gutter_grid
+
+        assert word_gutter_grid(_prose_words()) is None
+
+    def test_too_few_lines_cannot_corroborate_a_gutter(self):
+        """With two lines, the space between any two words 'spans' the region."""
+        from all2md.parsers._pdf_tables import word_gutter_grid
+
+        two_lines = [entry for entry in _booktabs_words() if entry[1] < 45.0]
+        assert word_gutter_grid(two_lines) is None
+
+    def test_a_spanning_header_does_not_destroy_the_gutter(self):
+        """One line in ten may cross a boundary: titles and footnotes span; columns survive.
+
+        The spanning word itself lands whole in the column holding its center -- cut
+        words are impossible here, which is the entire point of the pass.
+        """
+        from all2md.parsers._pdf_tables import word_gutter_grid
+
+        columns = (10.0, 100.0, 180.0)
+        words = [_word(10.0, 0.0, "SpanningTitleAcrossEverything", width=15.0)]
+        for line in range(9):
+            for column in columns:
+                words.append(_word(column, 20.0 + 20.0 * line, f"c{line}", width=6.0))
+
+        grid = word_gutter_grid(words)
+
+        assert grid is not None
+        assert len(grid) == 10
+        assert all(len(row) == 3 for row in grid)
+        assert (
+            grid[0].count("SpanningTitleAcrossEverything") == 1
+        ), "the spanning word stays whole in exactly one cell -- the column holding its center"
+
+    def test_multiword_cells_join_in_reading_order(self):
+        """Real multi-word cells put their word gaps at different x per line, unlike a gutter."""
+        from all2md.parsers._pdf_tables import word_gutter_grid
+
+        words = []
+        for line in range(3):
+            y = 10.0 + 20.0 * line
+            first = _word(10.0, y, "left")
+            words.extend(
+                [
+                    first,
+                    _word(first[2] + 2.0 + 3.0 * line, y, "part"),
+                    _word(120.0, y, "mid"),
+                    _word(200.0, y, "right"),
+                ]
+            )
+
+        grid = word_gutter_grid(words)
+
+        assert grid == [["left part", "mid", "right"]] * 3
+
+    def test_a_single_gutter_is_columns_not_a_table(self):
+        """One clear band is what any two-column layout has.
+
+        A bibliography split at the page's own column gutter was the dominant junk shape
+        on the PMC corpus. Two aligned internal boundaries is where the evidence starts.
+        """
+        from all2md.parsers._pdf_tables import word_gutter_grid
+
+        words = []
+        for line in range(6):
+            y = 10.0 + 15.0 * line
+            words.extend([_word(10.0, y, f"leftref{line}"), _word(200.0, y, f"rightref{line}")])
+
+        assert word_gutter_grid(words) is None
+
+
+class TestWordGutterRegionExtraction:
+    """The third pass in _extract_table_from_layout_region, behind the find_tables strategies."""
+
+    def test_a_table_both_strategies_miss_is_recovered_from_word_boxes(self, converter):
+        """The #386 headline: 56 of 63 missing corpus tables died after this point."""
+        page = _PositionedPage(_booktabs_words())
+        node = converter._extract_table_from_layout_region(page, _rect(0, 0, 300, 100), page_num=0)
+
+        assert isinstance(node, AstTable)
+        assert [cell.content[0].content for cell in node.header.cells] == ["Variables", "AUC", "Sensitivity"]
+        assert len(node.rows) == 2
+        assert converter._tables_rejected == 0, "recovering a table is not a rejection"
+
+    def test_word_gutters_run_only_after_the_established_strategies(self, converter):
+        """Additive by design: every grid the strategies already accept keeps its exact path."""
+        page = _PositionedPage(_booktabs_words(), {"lines_strict": [_FakeTable(BORDERLESS_TABLE, (0, 0, 100, 50))]})
+        node = converter._extract_table_from_layout_region(page, _rect(0, 0, 300, 100), page_num=0)
+
+        assert isinstance(node, AstTable)
+        assert [cell.content[0].content for cell in node.header.cells] == BORDERLESS_TABLE[0]
+
+    def test_prose_still_falls_through_to_a_paragraph(self, converter):
+        page = _PositionedPage(_prose_words())
+        node = converter._extract_table_from_layout_region(page, _rect(0, 0, 300, 100), page_num=0)
+
+        assert isinstance(node, AstParagraph)
+        assert _rejection_reasons(converter) == ["layout_region_not_tabular"]
+
+    def test_a_gutter_grid_killed_by_a_guard_is_counted_once(self, converter):
+        """Same accounting rule as the other strategies: the specific reason, recorded once."""
+        words = []
+        for line in range(3):
+            y = 10.0 + 20.0 * line
+            words.extend([_word(10.0, y, "na"), _word(120.0, y, "na"), _word(200.0, y, "na")])
+        page = _PositionedPage(words)
+        node = converter._extract_table_from_layout_region(page, _rect(0, 0, 300, 100), page_num=0)
+
+        assert isinstance(node, AstParagraph)
+        assert _rejection_reasons(converter) == ["uniform_cells"]
+        assert converter._tables_rejected == 1
+
+
+class TestContinuationLineMerging:
+    """A wrapped cell folds into its logical row instead of splitting into fake rows."""
+
+    def test_a_line_with_an_empty_anchor_cell_merges_up(self):
+        from all2md.parsers._pdf_tables import word_gutter_grid
+
+        columns = (10.0, 100.0, 180.0)
+        words = []
+        for line in range(4):
+            y = 10.0 + 20.0 * line
+            words.extend(_word(column, y, f"r{line}") for column in columns)
+        # a wrap line under row 1: only the middle column continues
+        words.append(_word(100.0, 35.0, "wrapped"))
+
+        grid = word_gutter_grid(words)
+
+        assert grid is not None
+        assert len(grid) == 4, "the wrap line is a continuation, not a row"
+        assert grid[1][1] == "r1\nwrapped", "fragments join with a newline for hyphenation repair"
+
+    def test_a_dense_numeric_table_keeps_its_per_line_rows(self):
+        from all2md.parsers._pdf_tables import word_gutter_grid
+
+        grid = word_gutter_grid(_booktabs_words())
+
+        assert grid is not None and len(grid) == 3
+
+
+class TestNumberedBibliography:
+    def test_a_numbered_reference_grid_is_condemned(self):
+        from all2md.parsers._pdf_tables import looks_like_numbered_bibliography
+
+        citation = "Smith AB Jones CD Telehealth for global emergencies implications for disease study"
+        grid = [[f"{n}.", citation] for n in range(41, 50)]
+
+        assert looks_like_numbered_bibliography(grid)
+
+    def test_a_real_table_with_a_sequential_number_column_is_not(self):
+        """Sequential numbering alone describes plenty of real tables; the cells decide."""
+        from all2md.parsers._pdf_tables import looks_like_numbered_bibliography
+
+        grid = [[f"{n}", "TP53", "0.901", "significant"] for n in range(1, 12)]
+
+        assert not looks_like_numbered_bibliography(grid)
+
+    def test_prose_cells_without_numbering_are_not(self):
+        from all2md.parsers._pdf_tables import looks_like_numbered_bibliography
+
+        long_cell = "a description column can hold a full sentence of explanatory text per row easily"
+        grid = [["ACE2", long_cell, "yes"] for _ in range(8)]
+
+        assert not looks_like_numbered_bibliography(grid)
+
+    def test_the_region_extractor_demotes_a_bibliography_to_prose(self, converter):
+        """The worst false positive is a gridded bibliography.
+
+        Row-major cells interleave the page's columns and scramble every citation --
+        measured, one gridded bibliography cost an article 15 of its 21 citation titles.
+
+        Geometry: two page columns, each a numbered citation whose intra-citation word
+        gaps are narrow and jittered per line (real justified text), so the only shared
+        gutters are the number-text gaps and the page column separator.
+        """
+        words = []
+        for line in range(9):
+            y = 10.0 + 15.0 * line
+            for half, number in ((10.0, 41 + line), (300.0, 50 + line)):
+                words.append(_word(half, y, f"{number}.", width=8.0))
+                x = half + 30.0
+                for index in range(10):
+                    entry = _word(x, y, f"w{line}{index}", width=8.0)
+                    words.append(entry)
+                    x = entry[2] + 2.0 + (line * 5 + index * 3) % 2
+        page = _PositionedPage(words)
+
+        node = converter._extract_table_from_layout_region(page, _rect(0, 0, 600, 200), page_num=0)
+
+        assert not isinstance(node, AstTable)
+        assert _rejection_reasons(converter) == ["numbered_bibliography"]
+
+
+class TestRotatedRegions:
+    def test_a_rotated_table_is_not_gridded_in_page_coordinates(self):
+        """Perpendicular text groups into fake lines and the grid scrambles reading order.
+
+        Measured: a rotated 28x4 truth table came back 8x12 with its containment
+        destroyed. The rotation-aware prose path reads those regions fine; this
+        detector must decline them.
+        """
+        from all2md.parsers._pdf_tables import word_gutter_grid
+
+        words = []
+        for column in range(4):
+            x = 10.0 + 30.0 * column
+            for row in range(8):
+                y = 10.0 + 40.0 * row
+                # tall narrow boxes: a rotated word's bbox
+                words.append((x, y, x + 8.0, y + 34.0, f"word{column}{row}", 0, 0, 0))
+
+        assert word_gutter_grid(words) is None


### PR DESCRIPTION
Closes #386.

## The gap this closes

The PMC born-digital lane reported **94 tables emitted against 121 expected**, carried on the roadmap as "detection is the bottleneck." The characterization in #386 showed otherwise: the layout model predicts a region for nearly every missing table, `find_tables(strategy="text")` builds a grid there, and the split-word guard kills it — **correctly**, because the grid is genuinely damaged. The text strategy both invents column boundaries through words (`moderat`/`ely`) and reassembles cell text with dropped spaces (`Samplecontents`). 56 of the 63 attributable missing tables died exactly there; join-aware fragment counting and `find_tables` parameter tuning were both measured and refuted as fixes before this approach was chosen.

## The fix

A third region pass, strictly additive (every grid the existing strategies accept keeps its exact path): build the grid from the page's own word boxes.

- **Columns from gutters** — vertical bands that at most 10% of printed lines intrude into (spanning headers legitimately cross), at least 4pt wide. On the 37 single-truth-table specimen pages, the gutter column count matched the JATS truth almost exactly (4→4, 5→5, 9→9, 11→12).
- **Whole words by construction** — boundaries sit at gutter midpoints and each word lands in the column holding its center, so the two damage classes that killed the text strategy's grids cannot occur.
- **Logical rows** — wrapped cell lines fold into their row (anchor column: leftmost filled on ≥60% of lines), and cell text runs through the same hyphenation repair as the paragraph path.

## Three guards, each measured against the corpus

| guard | evidence |
|---|---|
| ≥3 columns (`MIN_WORD_GUTTER_COLS`) | one gutter is what any two-column layout has: 8 of 13 genuinely non-tabular emissions were two-column (bibliographies split at the page's own gutter, a chart legend), vs 1 of 34 real recoveries |
| numbered bibliography → prose (`numbered_bibliography` rejection) | a sequential-integer column beside sentence-length cells (p90 ≥ 9 words; bibliographies measured 10–15, sequential-numbered real tables 1–8). Gridding one interleaves the page's columns: one such grid cost an article **15 of its 21 citation titles** |
| rotated regions declined (`MAX_ROTATED_WORD_SHARE`) | a landscape table gridded in page coordinates scrambles reading order (28×4 truth → 8×12 emitted, containment destroyed); the rotation-aware prose path reads those regions fine |

## Measured (12-article PMC A/B, baseline = main)

| | baseline | this PR |
|---|---|---|
| tables emitted (32 expected) | 12 | **30** |
| `table_content_similarity` (mean/median) | 0.241 / 0.000 | **0.621 / 0.883** |
| `table_structure_similarity` (mean/median) | 0.235 / 0.000 | **0.601 / 0.733** |
| whole-article attainable recall | 0.9513 | 0.9413 |
| precision novel share | 0.0134 | 0.0142 |
| `figure_binding` (rate / controls) | 0.5588 / 0.0 | 0.5588 / 0.0 |

The one-point recall trade is understood and concentrated: a table's cell stream breaks a few truth blocks' n-grams that its prose form kept (3 tables, 5 titles — the title losses are mostly one front-matter page the layout model mislabels a table). The first iteration of this PR cost 5.65 points; the bibliography and rotation guards above are what clawed it back, each added in response to a named, diagnosed regression.

Beyond the oracle's view, the pass also recovers real tables the JATS ground truth doesn't record — multi-page continuations ("Table 1", pages 3–8 of PMC7000152.1) and supplementary tables — which is why "junk" emissions against truth-0 pages are dominated by verified-real tables on visual inspection.

## Known residue (documented, not hidden)

- 4 of 37 specimen tables stay dead: two are one-column truth tables `MIN_TABLE_COLS = 2` excludes by policy, one is the single two-column real table the ≥3-column floor costs, one has no recoverable grid.
- One front-matter page (article title/authors) still grids as 17×3; it is 1 page in 66 articles and carries most of the remaining title-recall dip. A follow-up guard needs a signature measured on more than one specimen.
- The committed `benchmarks/pmc/reference.json` still predates the figures batch; one CI re-record after this merges captures both changes.

## Tests

9 new unit tests in `tests/unit/formats/pdf/test_pdf_layout_region_tables.py` (pure geometry: gutters, continuation merging, single-gutter refusal, rotation; guard accounting: bibliography demotion, one-rejection-per-region). Full PDF-marked suite green (351 tests; the one pre-existing failure in `test_random_binary_as_pdf` fails identically on unmodified main).

🤖 Generated with [Claude Code](https://claude.com/claude-code)