### PR TITLE
ci(benchmarks): give the PMC lane the defusedxml its fetcher imports

### DIFF
--- a/.github/workflows/pmc-borndigital.yml
+++ b/.github/workflows/pmc-borndigital.yml
@@ -71,8 +71,10 @@ jobs:
           sudo apt-get update
           sudo apt-get install --yes tesseract-ocr tesseract-ocr-eng
 
+      # `benchmarks` carries what the lane's own modules import beyond the library --
+      # without it the run dies at `import defusedxml` before scoring anything.
       - name: Install all2md from the lockfile
-        run: uv sync --frozen --extra pdf_layout --extra ocr
+        run: uv sync --frozen --extra pdf_layout --extra ocr --extra benchmarks
 
       - name: Score the corpus
         run: |
@@ -85,7 +87,7 @@ jobs:
           if [ -n "${LIMIT}" ]; then
             ARGS+=(--limit "${LIMIT}")
           fi
-          uv run --frozen --extra pdf_layout --extra ocr python -m benchmarks.pmc score "${ARGS[@]}" \
+          uv run --frozen --extra pdf_layout --extra ocr --extra benchmarks python -m benchmarks.pmc score "${ARGS[@]}" \
             | tee "${RUNNER_TEMP}/pmc-summary.txt"
         env:
           LIMIT: ${{ inputs.limit }}

--- a/changelog.d/pmc-lane-defusedxml.fixed.md
+++ b/changelog.d/pmc-lane-defusedxml.fixed.md
@@ -1,0 +1,9 @@
+- **The PMC born-digital lane runs again.** Moving the corpus fetchers' XML parsing to
+  `defusedxml` left the scheduled `PMC Born-Digital Fidelity` workflow crashing at import:
+  it syncs a deliberately lean environment (`--extra pdf_layout --extra ocr`), and
+  `defusedxml` lived only in format extras the lane does not install, so the 2026-08-15
+  scheduled run died in 29 seconds before scoring a page. A run that cannot execute also
+  cannot count toward the lane's exit criterion (two consecutive clean scheduled runs
+  before a fidelity baseline is recorded), so this was holding the gate open. What the
+  benchmark lanes import beyond the library now has its own named home — a `benchmarks`
+  extra — instead of borrowing from a format extra that happened to carry it.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -146,6 +146,14 @@ chunk = [
 chm = [
     "pychm>=0.8.6"
 ]
+# What the external benchmark lanes import beyond the library itself. The scheduled
+# workflows sync a deliberately lean environment (--extra pdf_layout --extra ocr), so a
+# dependency a benchmark module imports at top level must be named here rather than
+# borrowed from a format extra that happens to carry it -- the PMC lane's scheduled run
+# crashed at import exactly that way when its JATS parsing moved to defusedxml.
+benchmarks = [
+    "defusedxml>=0.7.1",
+]
 dev = [
     "all2md[all]",
     "mypy>=2.1.0",

--- a/uv.lock
+++ b/uv.lock
@@ -111,6 +111,9 @@ archive = [
     { name = "py7zr" },
     { name = "rarfile" },
 ]
+benchmarks = [
+    { name = "defusedxml" },
+]
 chm = [
     { name = "pychm" },
 ]
@@ -307,6 +310,7 @@ requires-dist = [
     { name = "chardet", marker = "extra == 'wiki'", specifier = ">=5.2.0" },
     { name = "chardet", marker = "extra == 'xlsx'", specifier = ">=5.2.0" },
     { name = "defusedxml", marker = "extra == 'all'", specifier = ">=0.7.1" },
+    { name = "defusedxml", marker = "extra == 'benchmarks'", specifier = ">=0.7.1" },
     { name = "defusedxml", marker = "extra == 'enex'", specifier = ">=0.7.1" },
     { name = "defusedxml", marker = "extra == 'fb2'", specifier = ">=0.7.1" },
     { name = "defusedxml", marker = "extra == 'pptx'", specifier = ">=0.7.1" },
@@ -408,7 +412,7 @@ requires-dist = [
     { name = "watchdog", marker = "extra == 'all'", specifier = ">=4.0.0" },
     { name = "watchdog", marker = "extra == 'cli-extras'", specifier = ">=4.0.0" },
 ]
-provides-extras = ["odf", "pdf", "pdf-layout", "docx", "fb2", "enex", "pptx", "rtf", "html", "http", "html-readability", "sanitizer", "latex", "search", "chunk", "chm", "dev", "epub", "cli-extras", "xlsx", "markdown", "pdf-render", "docx-render", "mcp", "templates", "rst", "org", "archive", "ocr", "ocr-easyocr", "outlook", "textile", "openapi", "all", "wiki", "langdetect", "window"]
+provides-extras = ["odf", "pdf", "pdf-layout", "docx", "fb2", "enex", "pptx", "rtf", "html", "http", "html-readability", "sanitizer", "latex", "search", "chunk", "chm", "benchmarks", "dev", "epub", "cli-extras", "xlsx", "markdown", "pdf-render", "docx-render", "mcp", "templates", "rst", "org", "archive", "ocr", "ocr-easyocr", "outlook", "textile", "openapi", "all", "wiki", "langdetect", "window"]
 
 [[package]]
 name = "annotated-doc"


### PR DESCRIPTION
## What

The scheduled **PMC Born-Digital Fidelity** run of 2026-08-15 failed in 29 seconds with `ModuleNotFoundError: No module named 'defusedxml'` ([run 31868996468](https://github.com/thomas-villani/all2md/actions/runs/31868996468)) — before scoring a single page.

## Why

978c989 moved the corpus fetchers' XML parsing to `defusedxml` (the #328-motivated hardening). The lane deliberately syncs a lean environment — `uv sync --frozen --extra pdf_layout --extra ocr` — and `defusedxml` lived only in format extras (`fb2`/`enex`/`pptx`) and `all`, none of which the lane installs. The weekly corpus gate was unaffected (it installs `.[all,dev]`), and the OmniDocBench lane's modules don't import it.

This matters beyond one red run: the lane's exit criterion is **two consecutive scheduled runs that open no new defect issue** before its fidelity baseline is recorded and gated. A run that cannot execute can't count toward that, so a broken import quietly holds the gate open.

## How

A `benchmarks` extra now names what the benchmark lanes' own modules import beyond the library, instead of borrowing a module from a format extra that happens to carry it today. Both workflow steps sync it. `uv.lock` re-resolved with no version movement.

## Verification

- `uv sync --frozen --extra pdf_layout --extra ocr --extra benchmarks` dry-run keeps `defusedxml` in the lean environment.
- A `workflow_dispatch` of the lane on this branch is the end-to-end proof — being kicked off next; it doubles as the first corpus-wide measurement of the #387 word-gutter table strategy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)