### PR TITLE
feat(pdf): recover rotated tables by running the gutter sweep in the table's frame

### DIFF
--- a/changelog.d/389-rotated-gutter-tables.added.md
+++ b/changelog.d/389-rotated-gutter-tables.added.md
@@ -1,0 +1,20 @@
+- **The PDF parser recovers rotated (landscape) tables in their own frame.** The
+  word-gutter pass declined any region whose words were predominantly taller than
+  wide, because gridding a rotated table in page coordinates scrambles its reading
+  order — measured, a 28x4 truth table came back 8x12 with its containment destroyed.
+  Declining was the right call and the wrong ending: on the PMC born-digital corpus,
+  3 of the 13 still-missing tables were genuine landscape tables behind exactly this
+  guard ([#389](https://github.com/thomas-villani/all2md/issues/389)). Such regions
+  now go through the same gutter sweep with their boxes transposed into the table's
+  own frame. Transposing is a reflection, so one axis always runs backwards for one
+  of the two rotation directions — undecidable from the boxes alone, so both axes are
+  checked against PyMuPDF's own stream order, which holds the words as they read, and
+  mirrored where they disagree; getting that wrong would not mis-shape the grid but
+  reverse its rows or columns, putting every cell in the wrong place. Dispatch demands
+  stronger evidence than the old decline did: a word counts as rotated only when its
+  box is taller than wide by a measured margin (real rotated table words sit at median
+  aspect 2.5–2.7, a mixed-orientation region that must not be transposed at 1.05),
+  because transposing upright text manufactures perfect fake "gutters" out of its line
+  spacing. Ambiguous regions are still declined to the prose path, exactly as before —
+  including the fourth rotated table in the deficit, whose orientation evidence is
+  genuinely mixed.

--- a/src/all2md/parsers/_pdf_tables.py
+++ b/src/all2md/parsers/_pdf_tables.py
@@ -141,8 +141,14 @@ MIN_GUTTER_WIDTH_PT = 4.0
 # the 34 real tables it recovers.
 MIN_WORD_GUTTER_COLS = 3
 # Share of a region's multi-character words that may stand taller than wide before the
-# region reads as rotated and the gutter pass declines it.
+# region reads as rotated and the gutter pass switches to the transposed frame.
 MAX_ROTATED_WORD_SHARE = 0.5
+# How much taller than wide a word's box must be to count as *unambiguously* rotated.
+# Declining a region is safe on weak evidence -- the prose path picks it up -- but
+# transposing it is a positive claim, and near-square boxes cut both ways: measured on
+# the PMC corpus, genuinely rotated table regions hold words at median aspect 2.5-2.7,
+# while a mixed-orientation region that must NOT be transposed sits at median 1.05.
+MIN_ROTATED_WORD_ASPECT = 1.2
 
 
 def split_word_ratio(page: "pymupdf.Page", table_data: list[list[str | None]]) -> float:
@@ -533,18 +539,103 @@ def word_gutter_grid(words: list[tuple]) -> list[list[str]] | None:
         Cell text per row, or ``None`` when no gutter-corroborated grid exists here.
 
     """
-    # Rotated regions are not this detector's to grid. A landscape table read in page
-    # coordinates groups perpendicular text into fake lines, and the grid that falls out
+    # A rotated region must not be gridded in page coordinates. A landscape table read
+    # this way groups perpendicular text into fake lines, and the grid that falls out
     # scrambles the reading order rather than merely mis-shaping it -- measured, a 28x4
-    # truth table came back 8x12 with its containment destroyed, where the rotation-aware
-    # prose path reads it fine. A multi-character word taller than it is wide is almost
-    # surely rotated; single characters are excluded because an upright "I" is too.
+    # truth table came back 8x12 with its containment destroyed. Unambiguously rotated
+    # regions go to the transposed pass, which runs this same sweep in the table's own
+    # frame; a region whose tall boxes are only marginally tall is *declined* instead,
+    # exactly as before -- transposing upright text manufactures perfect "gutters" out
+    # of its line spacing, so the dispatch needs stronger evidence than the decline.
+    # Multi-character words only: an upright "I" is taller than wide too.
     sized = [word for word in words if len(str(word[4])) >= 3]
     if sized:
-        rotated = sum(1 for word in sized if (word[3] - word[1]) > (word[2] - word[0]))
-        if rotated > MAX_ROTATED_WORD_SHARE * len(sized):
+        tall = sum(1 for word in sized if (word[3] - word[1]) > (word[2] - word[0]))
+        if tall > MAX_ROTATED_WORD_SHARE * len(sized):
+            strongly_rotated = sum(
+                1 for word in sized if (word[3] - word[1]) > MIN_ROTATED_WORD_ASPECT * (word[2] - word[0])
+            )
+            if strongly_rotated > MAX_ROTATED_WORD_SHARE * len(sized):
+                return _transposed_gutter_grid(words)
             return None
 
+    return _gutter_grid_core(words)
+
+
+def _stream_order_mirrors(words: list[tuple]) -> tuple[bool, bool]:
+    """Decide whether either transposed axis runs against reading order.
+
+    Transposing a box swaps its axes, but a swap is a reflection, not a rotation: one
+    axis of the transposed frame always runs backwards for one of the two rotation
+    directions, and which one depends on whether the text was rotated clockwise or
+    counter-clockwise -- which the boxes alone cannot say. PyMuPDF can: each word tuple
+    carries its ``(block, line, word)`` position in the document stream, and the stream
+    holds the text in the order it reads. Words later in their line sitting at smaller
+    ``x`` means the reading axis is mirrored; later lines sitting at smaller ``y`` means
+    the stacking axis is. Majority vote over every adjacent pair, so one out-of-band
+    word (a superscript, a stray footnote marker) cannot flip an axis.
+
+    Parameters
+    ----------
+    words : list of tuple
+        Word entries **already transposed**, retaining their trailing
+        ``(block, line, word)`` stream coordinates.
+
+    Returns
+    -------
+    tuple of (bool, bool)
+        Whether to mirror the reading (x) axis and the stacking (y) axis. Tuples
+        without stream coordinates, or streams with no adjacent pairs to compare,
+        vote for no mirror -- the unmirrored frame is then as good as any.
+
+    """
+    by_line: dict[tuple, list[tuple]] = {}
+    for word in words:
+        if len(word) < 8:
+            return False, False
+        by_line.setdefault((word[5], word[6]), []).append(word)
+
+    read_pairs = read_reversed = 0
+    for group in by_line.values():
+        group.sort(key=lambda word: word[7])
+        for left, right in zip(group, group[1:], strict=False):
+            read_pairs += 1
+            if right[0] + right[2] < left[0] + left[2]:
+                read_reversed += 1
+
+    ordered_lines = sorted(by_line.items(), key=lambda item: item[0])
+    centers = [sum((word[1] + word[3]) / 2 for word in group) / len(group) for _, group in ordered_lines]
+    stack_pairs = stack_reversed = 0
+    for above, below in zip(centers, centers[1:], strict=False):
+        stack_pairs += 1
+        if below < above:
+            stack_reversed += 1
+
+    return (2 * read_reversed > read_pairs, 2 * stack_reversed > stack_pairs)
+
+
+def _transposed_gutter_grid(words: list[tuple]) -> list[list[str]] | None:
+    """Run the gutter sweep in a rotated region's own frame.
+
+    Swapping each box's axes turns the region's vertical printed lines into horizontal
+    ones, so the ordinary sweep applies unchanged -- gutters, guards and all. The swap
+    leaves one axis running backwards depending on the rotation's direction, so both
+    axes are checked against PyMuPDF's stream order and mirrored where they disagree;
+    without that, one rotation direction would come back with its columns (or rows) in
+    reverse and every cell in the wrong place, which is worse than the prose fallback
+    this pass replaces.
+    """
+    transposed = [(word[1], word[0], word[3], word[2], word[4], *word[5:]) for word in words]
+    mirror_x, mirror_y = _stream_order_mirrors(transposed)
+    if mirror_x:
+        transposed = [(-w[2], w[1], -w[0], w[3], w[4], *w[5:]) for w in transposed]
+    if mirror_y:
+        transposed = [(w[0], -w[3], w[2], -w[1], w[4], *w[5:]) for w in transposed]
+    return _gutter_grid_core(transposed)
+
+
+def _gutter_grid_core(words: list[tuple]) -> list[list[str]] | None:
+    """Run the gutter sweep proper, over words whose frame is already reading-oriented."""
     lines = group_words_into_lines(words)
     if len(lines) < MIN_GUTTER_LINES:
         return None

--- a/tests/unit/formats/pdf/test_pdf_layout_region_tables.py
+++ b/tests/unit/formats/pdf/test_pdf_layout_region_tables.py
@@ -467,13 +467,75 @@ class TestNumberedBibliography:
         assert _rejection_reasons(converter) == ["numbered_bibliography"]
 
 
-class TestRotatedRegions:
-    def test_a_rotated_table_is_not_gridded_in_page_coordinates(self):
-        """Perpendicular text groups into fake lines and the grid scrambles reading order.
+def _rotated_words(clockwise: bool) -> list[tuple]:
+    """The booktabs table's words, laid out as a landscape table on a portrait page.
 
-        Measured: a rotated 28x4 truth table came back 8x12 with its containment
-        destroyed. The rotation-aware prose path reads those regions fine; this
-        detector must decline them.
+    Rotating the 3x3 upright table maps each printed line to a vertical run of tall
+    boxes. Clockwise text reads top-to-bottom and stacks its lines right-to-left;
+    counter-clockwise reads bottom-to-top and stacks left-to-right. Stream coordinates
+    ``(block, line, word)`` follow reading order in both, exactly as PyMuPDF's do.
+    """
+    rows = (
+        ("Variables", "AUC", "Sensitivity"),
+        ("Magnesium", "0.774", "0.71"),
+        ("Vitamin", "0.901", "0.88"),
+    )
+    words = []
+    for line_index, row in enumerate(rows):
+        # Lines stack along x: later lines further left when clockwise.
+        x = (100.0 - 20.0 * line_index) if clockwise else (10.0 + 20.0 * line_index)
+        position = 10.0
+        for word_index, text in enumerate(row):
+            height = 4.0 * len(text)
+            if clockwise:
+                box = (x, position, x + 10.0, position + height)
+            else:
+                box = (x, 300.0 - position - height, x + 10.0, 300.0 - position)
+            words.append((*box, text, 0, line_index, word_index))
+            position += height + 24.0
+        # Words within a line advance +y when clockwise, -y when counter-clockwise.
+    return words
+
+
+class TestRotatedRegions:
+    def test_a_clockwise_rotated_table_is_recovered_in_its_own_frame(self):
+        """The transposed sweep grids a landscape table the page frame would scramble.
+
+        Measured before the transposed pass existed: a rotated 28x4 truth table came
+        back 8x12 with its containment destroyed. Now the same sweep runs against the
+        transposed boxes, so the grid comes out in the table's own reading order.
+        """
+        from all2md.parsers._pdf_tables import word_gutter_grid
+
+        grid = word_gutter_grid(_rotated_words(clockwise=True))
+        assert grid is not None
+        assert grid[0] == ["Variables", "AUC", "Sensitivity"]
+        assert grid[1][0] == "Magnesium"
+        assert grid[2][2] == "0.88"
+
+    def test_both_rotation_directions_yield_the_same_grid(self):
+        """Transposing is a reflection, so one direction needs a mirrored axis.
+
+        Which axis depends on clockwise versus counter-clockwise -- undecidable from
+        the boxes alone, decided here by the words' stream order. Getting it wrong
+        does not merely mis-shape the grid: it reverses the rows or the columns, and
+        every cell lands in the wrong place.
+        """
+        from all2md.parsers._pdf_tables import word_gutter_grid
+
+        clockwise = word_gutter_grid(_rotated_words(clockwise=True))
+        counter = word_gutter_grid(_rotated_words(clockwise=False))
+        assert clockwise is not None
+        assert clockwise == counter
+
+    def test_marginally_tall_boxes_are_declined_not_transposed(self):
+        """Near-square boxes are weak evidence, and weak evidence declines.
+
+        Transposing on weak evidence is worse than declining: upright text's line
+        spacing becomes perfect fake "gutters" in the transposed frame. Measured on
+        the PMC corpus: real rotated table words sit at median aspect 2.5-2.7, a
+        mixed-orientation region that must not be transposed at 1.05. This region
+        stays with the prose path, exactly as before the transposed pass existed.
         """
         from all2md.parsers._pdf_tables import word_gutter_grid
 
@@ -482,7 +544,7 @@ class TestRotatedRegions:
             x = 10.0 + 30.0 * column
             for row in range(8):
                 y = 10.0 + 40.0 * row
-                # tall narrow boxes: a rotated word's bbox
-                words.append((x, y, x + 8.0, y + 34.0, f"word{column}{row}", 0, 0, 0))
+                # taller than wide, but only just: ambiguous orientation
+                words.append((x, y, x + 30.0, y + 34.0, f"word{column}{row}", 0, 0, 0))
 
         assert word_gutter_grid(words) is None


### PR DESCRIPTION
## What

Closes the largest bucket of #389's remaining table deficit: genuine landscape tables that the word-gutter pass declined because their words stand taller than wide. Such regions now run the **same gutter sweep with their boxes transposed into the table's own frame** — no new grid logic, no change to the upright path.

## Design

Two decisions carry the correctness:

- **Axis mirroring from stream order.** Transposing is a reflection, so one axis always runs backwards for one of the two rotation directions — undecidable from the boxes alone. Both axes are checked against PyMuPDF's own `(block, line, word)` stream coordinates, which hold the words as they read, and mirrored where they disagree (majority vote over adjacent pairs, so a stray superscript cannot flip an axis). Getting this wrong would not mis-shape the grid but reverse its rows or columns wholesale — worse than the prose fallback this replaces.
- **Dispatch demands stronger evidence than the decline did.** Transposed upright text manufactures perfect fake "gutters" out of its line spacing, so a positive dispatch cannot ride the old decline threshold. Measured on the corpus: real rotated table words sit at median aspect 2.5–2.7, and a mixed-orientation region that must *not* be transposed at 1.05 — hence `MIN_ROTATED_WORD_ASPECT = 1.2`, counted per word. Regions with predominantly tall-but-near-square boxes still decline to the prose path exactly as before (including the fourth rotated table in #389's deficit, whose orientation evidence is genuinely mixed — left on the table deliberately).

## Measured

Full 66-article characterization re-run with the change ([#389](https://github.com/thomas-villani/all2md/issues/389) has the baseline):

- Deficit **13 → 10**: exactly the 3 strongly-rotated tables (PMC9000000.1 pages 15/16/27), each now emitting with a coherent header row in reading order (`Feature category | Feature Name | Description | …`).
- Two further recoveries on non-truth pages are literally titled **"Table 6 (continued)"** — landscape continuation pages of a truth table. No prose-gridding appeared anywhere; every guard still applies to the transposed grid.
- The remaining 10: 4 two-column exclusions, 2 no-gutter boxed panels, 2 layout-model misses, 1 line-grouping edge, 1 ambiguous rotation.

## Tests

- Rewrote the rotated-decline test into recovery tests: clockwise recovery with cell-level assertions, CW/CCW direction equivalence (the mirrored-axis case), and the ambiguous-aspect decline.
- `tests/unit/formats/pdf` green (341 passed; the one failure, `test_format_detection_with_random_headers`, fails identically on clean `main` and passes in isolation — pre-existing order-dependent flake, unrelated).
- ruff, black, mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)