### PR TITLE
feat(pdf): admit two-column word-gutter grids behind measured guards

### DIFF
--- a/changelog.d/391-two-column-gutter-tables.added.md
+++ b/changelog.d/391-two-column-gutter-tables.added.md
@@ -1,0 +1,14 @@
+- **The word-gutter table pass admits two-column grids.** A single gutter is what any
+  two-column layout has, so the pass shipped refusing it outright -- and that refusal
+  cost the 4 real two-column tables still missing on the PMC born-digital corpus
+  (`Questions | Answers`, `Male patients | 226 (69.8%)`) to save junk the downstream
+  guards were already catching ([#389](https://github.com/thomas-villani/all2md/issues/389)).
+  Measured, the corpus's whole two-column population is 12 regions: the 4 real tables,
+  7 numbered reference lists, and 1 chart whose axis ticks and legend grid perfectly.
+  Six reference lists were already condemned by the bibliography guard; the seventh
+  numbered its entries `2)`, a spelling the guard's integer pattern now counts. The
+  chart is caught by a new drawing-density gate that runs only at the two-column tier:
+  a chart's labels float over its plot's vector paths (541 in the measured region)
+  while a borderless table has at most its own rules (0-4 in all four real ones).
+  Wider grids carry two aligned boundaries, which chart labels do not produce, so no
+  established path changes.

--- a/src/all2md/parsers/_pdf_tables.py
+++ b/src/all2md/parsers/_pdf_tables.py
@@ -29,6 +29,7 @@ __all__ = [
     "MIN_GUTTER_LINES",
     "MIN_GUTTER_WIDTH_PT",
     "MAX_ROTATED_WORD_SHARE",
+    "MAX_TWO_COLUMN_REGION_DRAWINGS",
     "MIN_WORD_GUTTER_COLS",
     "TABLE_REGION_STRATEGIES",
     "TABLE_SIGNAL_RULING_THRESHOLD",
@@ -134,12 +135,23 @@ MAX_GUTTER_INTRUSION_SHARE = 0.1
 # Narrower bands than this are ordinary word spacing, not column separation.
 MIN_GUTTER_WIDTH_PT = 4.0
 # A gutter grid needs at least this many columns. One gutter is what ANY two-column
-# layout has -- a reference list, a chart legend beside its axis, a title page -- so a
-# single band is not evidence of a table, it is evidence of columns. Measured on the
-# PMC corpus: 8 of the 13 genuinely non-tabular regions this pass would otherwise emit
-# were two-column (bibliographies split at the page's own column gutter), against 1 of
-# the 34 real tables it recovers.
-MIN_WORD_GUTTER_COLS = 3
+# layout has -- a reference list, a chart legend beside its axis -- so a single band is
+# the weakest geometry this pass accepts, and two-column admission leans on the
+# downstream guards rather than the sweep. Measured on the PMC corpus (#389), the
+# whole two-column population is 12 regions: 4 real tables, 7 numbered reference
+# lists (6 already condemned by looks_like_numbered_bibliography, the 7th once its
+# ``42)`` spelling counted), and 1 chart whose axis ticks and legend gridded --
+# the shape MAX_TWO_COLUMN_REGION_DRAWINGS exists for. Refusing the single gutter
+# outright, as this pass first shipped, cost the 4 real tables to save nothing the
+# guards were not already saving. Three-plus columns need no such corroboration:
+# two aligned internal boundaries do not happen to prose.
+MIN_WORD_GUTTER_COLS = 2
+# A two-column grid whose region holds more vector drawing paths than this is a chart,
+# not a table: plot lines sit under a chart's tick labels and legend, while a
+# borderless table has at most its own ruling lines. Measured on the PMC corpus, the
+# one chart region in the two-column population held 541 intersecting paths; the four
+# real two-column tables held 0-4.
+MAX_TWO_COLUMN_REGION_DRAWINGS = 25
 # Share of a region's multi-character words that may stand taller than wide before the
 # region reads as rotated and the gutter pass switches to the transposed frame.
 MAX_ROTATED_WORD_SHARE = 0.5
@@ -721,8 +733,10 @@ def _merge_continuation_lines(line_rows: list[list[str]]) -> list[list[str]]:
     return merged
 
 
-# The integer forms a bibliography numbers its entries with: ``42.``, ``42``, ``[42]``.
-_BIB_INTEGER = re.compile(r"^\[?(\d{1,3})[.\]]?$")
+# The integer forms a bibliography numbers its entries with: ``42.``, ``42``, ``[42]``,
+# ``42)`` -- the paren form measured on the PMC corpus as the one spelling the guard
+# missed.
+_BIB_INTEGER = re.compile(r"^\[?(\d{1,3})[.)\]]?$")
 # A run of consecutive integers needs this many members before it reads as numbering
 # rather than coincidence.
 MIN_BIB_SEQUENTIAL_CELLS = 5

--- a/src/all2md/parsers/pdf.py
+++ b/src/all2md/parsers/pdf.py
@@ -96,6 +96,7 @@ from all2md.parsers._pdf_tables import (
     MAX_TABLE_COLS,
     MAX_TABLE_EMPTY_RATIO,
     MAX_TABLE_ROWS,
+    MAX_TWO_COLUMN_REGION_DRAWINGS,
     MIN_FILLED_FOR_UNIFORMITY_CHECK,
     MIN_TABLE_COLS,
     MIN_TABLE_ROWS,
@@ -3543,6 +3544,17 @@ class PdfToAstConverter(BaseParser):
         if looks_like_numbered_bibliography(grid):
             self._record_table_rejection("numbered_bibliography")
             return True, None
+        # A two-column grid rides on a single gutter -- the weakest geometry the sweep
+        # accepts, and the one shape it shares with a chart, whose axis ticks and
+        # legend labels grid perfectly across the plot area. What separates them is
+        # under the text: a chart's words float over its plot's vector paths, while a
+        # borderless table has at most its own ruling lines -- measured on the PMC
+        # corpus (#389), 541 intersecting paths against 0-4. get_drawings() is costly,
+        # so this runs last and only at the two-column tier; wider grids carry two
+        # aligned boundaries, which stray chart labels do not produce.
+        if n_cols == 2 and self._region_drawing_count(page, table_rect) > MAX_TWO_COLUMN_REGION_DRAWINGS:
+            self._record_table_rejection("two_column_chart_region")
+            return True, None
 
         def cell_node(cell_text: str) -> TableCell:
             # Merged continuation lines join with a newline so hyphenation repair can
@@ -3560,6 +3572,34 @@ class PdfToAstConverter(BaseParser):
             rows=rows[1:],
             source_location=SourceLocation(format="pdf", page=page_num + 1),
         )
+
+    @staticmethod
+    def _region_drawing_count(page: "pymupdf.Page", region: "pymupdf.Rect") -> int:
+        """Count the vector drawing paths intersecting *region*.
+
+        Returns ``0`` on any error, so an unreadable page falls back to the other
+        guards rather than dropping a table nothing has shown to be bad -- the same
+        fail-open posture as :func:`split_word_ratio`.
+
+        Parameters
+        ----------
+        page : pymupdf.Page
+            Page holding the region.
+        region : pymupdf.Rect
+            Region whose drawing density is being measured.
+
+        Returns
+        -------
+        int
+            Number of drawing paths whose bounding box intersects the region.
+
+        """
+        import pymupdf
+
+        try:
+            return sum(1 for drawing in page.get_drawings() if pymupdf.Rect(drawing["rect"]).intersects(region))
+        except Exception:
+            return 0
 
     def _region_text_as_paragraph(
         self, page: "pymupdf.Page", region: "pymupdf.Rect", page_num: int

--- a/tests/unit/formats/pdf/test_pdf_layout_region_tables.py
+++ b/tests/unit/formats/pdf/test_pdf_layout_region_tables.py
@@ -220,13 +220,22 @@ class TestLayoutRegionExtraction:
 class _PositionedPage(_FakePage):
     """A page whose words carry real geometry, for the word-gutter pass."""
 
-    def __init__(self, words: list[tuple], by_strategy: dict[str, list[_FakeTable]] | None = None) -> None:
+    def __init__(
+        self,
+        words: list[tuple],
+        by_strategy: dict[str, list[_FakeTable]] | None = None,
+        drawings: list[dict] | None = None,
+    ) -> None:
         super().__init__(" ".join(word[4] for word in words), by_strategy)
         self._words = words
+        self._drawings = drawings or []
 
     def get_text(self, kind: str, **kwargs):
         assert kind == "words"
         return list(self._words)
+
+    def get_drawings(self):
+        return list(self._drawings)
 
 
 def _word(x0: float, y: float, text: str, width: float = 8.0) -> tuple:
@@ -328,20 +337,27 @@ class TestWordGutterGrid:
 
         assert grid == [["left part", "mid", "right"]] * 3
 
-    def test_a_single_gutter_is_columns_not_a_table(self):
-        """One clear band is what any two-column layout has.
+    def test_a_single_gutter_yields_a_two_column_grid(self):
+        """One clear band is weak evidence, but the geometry no longer refuses it.
 
-        A bibliography split at the page's own column gutter was the dominant junk shape
-        on the PMC corpus. Two aligned internal boundaries is where the evidence starts.
+        Two-column admission moved from the sweep to the guards: measured on the PMC
+        corpus (#389), the two-column population was 4 real tables against 8 junk
+        regions, and every junk region is caught downstream -- 7 numbered reference
+        lists by the bibliography guard, 1 chart by the drawing-density gate. Refusing
+        the geometry outright cost the 4 real tables to save nothing the guards were
+        not already saving.
         """
         from all2md.parsers._pdf_tables import word_gutter_grid
 
+        rows = (("Male", "226"), ("Mean", "41"), ("Median", "38"), ("Deaths", "7"), ("Cured", "219"), ("Open", "0"))
         words = []
-        for line in range(6):
+        for line, (label, value) in enumerate(rows):
             y = 10.0 + 15.0 * line
-            words.extend([_word(10.0, y, f"leftref{line}"), _word(200.0, y, f"rightref{line}")])
+            words.extend([_word(10.0, y, label), _word(200.0, y, value)])
 
-        assert word_gutter_grid(words) is None
+        grid = word_gutter_grid(words)
+
+        assert grid == [list(row) for row in rows]
 
 
 class TestWordGutterRegionExtraction:
@@ -423,6 +439,19 @@ class TestNumberedBibliography:
 
         assert looks_like_numbered_bibliography(grid)
 
+    def test_a_paren_numbered_reference_grid_is_condemned(self):
+        """``42)`` numbers its entries as surely as ``42.`` does.
+
+        Measured: the one reference list the guard missed on the PMC corpus
+        numbered its entries with exactly this paren form.
+        """
+        from all2md.parsers._pdf_tables import looks_like_numbered_bibliography
+
+        citation = "Ng F Pushing back the retirement age by department of statistics labour force report"
+        grid = [[f"{n})", citation] for n in range(2, 11)]
+
+        assert looks_like_numbered_bibliography(grid)
+
     def test_a_real_table_with_a_sequential_number_column_is_not(self):
         """Sequential numbering alone describes plenty of real tables; the cells decide."""
         from all2md.parsers._pdf_tables import looks_like_numbered_bibliography
@@ -462,6 +491,84 @@ class TestNumberedBibliography:
         page = _PositionedPage(words)
 
         node = converter._extract_table_from_layout_region(page, _rect(0, 0, 600, 200), page_num=0)
+
+        assert not isinstance(node, AstTable)
+        assert _rejection_reasons(converter) == ["numbered_bibliography"]
+
+
+def _two_column_words() -> list[tuple]:
+    """A label/value table: six lines, one 100pt gutter, varied cell text."""
+    rows = (
+        ("Male", "226"),
+        ("Mean", "41"),
+        ("Median", "38"),
+        ("Deaths", "7"),
+        ("Cured", "219"),
+        ("Open", "0"),
+    )
+    words = []
+    for line, (label, value) in enumerate(rows):
+        y = 10.0 + 15.0 * line
+        words.extend([_word(10.0, y, label), _word(200.0, y, value)])
+    return words
+
+
+def _dense_drawings(count: int = 100) -> list[dict]:
+    """Vector paths inside the region, the way a chart's plot lines sit under its labels."""
+    return [{"rect": (20.0 + i, 20.0, 22.0 + i, 80.0), "items": []} for i in range(count)]
+
+
+class TestTwoColumnAdmission:
+    """One gutter admits a grid only when the region cannot be a chart or a reference list.
+
+    Measured on the PMC corpus (#389): the two-column population is 4 real tables,
+    7 numbered reference lists, and 1 chart whose axis ticks and legend gridded.
+    The reference lists fall to the bibliography guard; the chart is the shape this
+    drawing-density gate exists for -- its region held 541 vector paths where the
+    real two-column tables held 0-4 (their own ruling lines).
+    """
+
+    def test_a_two_column_table_is_recovered(self, converter):
+        page = _PositionedPage(_two_column_words())
+        node = converter._extract_table_from_layout_region(page, _rect(0, 0, 300, 120), page_num=0)
+
+        assert isinstance(node, AstTable)
+        assert [cell.content[0].content for cell in node.header.cells] == ["Male", "226"]
+        assert len(node.rows) == 5
+        assert converter._tables_rejected == 0
+
+    def test_a_two_column_grid_over_dense_drawings_is_demoted(self, converter):
+        page = _PositionedPage(_two_column_words(), drawings=_dense_drawings())
+        node = converter._extract_table_from_layout_region(page, _rect(0, 0, 300, 120), page_num=0)
+
+        assert not isinstance(node, AstTable)
+        assert _rejection_reasons(converter) == ["two_column_chart_region"]
+
+    def test_dense_drawings_do_not_touch_wider_grids(self, converter):
+        """The gate is scoped to the single-gutter tier.
+
+        Two aligned internal boundaries do not happen to a chart's stray labels,
+        so no established multi-column path changes behavior.
+        """
+        page = _PositionedPage(_booktabs_words(), drawings=_dense_drawings())
+        node = converter._extract_table_from_layout_region(page, _rect(0, 0, 300, 100), page_num=0)
+
+        assert isinstance(node, AstTable)
+
+    def test_a_two_column_paren_numbered_reference_list_is_demoted(self, converter):
+        """The junk shape the old column threshold existed for, on its worst spelling."""
+        words = []
+        for line in range(9):
+            y = 10.0 + 15.0 * line
+            words.append(_word(10.0, y, f"{2 + line})", width=8.0))
+            x = 60.0
+            for index in range(10):
+                entry = _word(x, y, f"w{line}{index}", width=8.0)
+                words.append(entry)
+                x = entry[2] + 2.0 + (line * 5 + index * 3) % 2
+        page = _PositionedPage(words)
+
+        node = converter._extract_table_from_layout_region(page, _rect(0, 0, 400, 200), page_num=0)
 
         assert not isinstance(node, AstTable)
         assert _rejection_reasons(converter) == ["numbered_bibliography"]


### PR DESCRIPTION
Part of #389 (the two-column slice of the remaining table deficit).

## What

The word-gutter pass (#387) refused any grid riding on a single gutter, because one clear band is what *any* two-column layout has. That refusal was costing the 4 real two-column tables still missing on the PMC born-digital corpus (`Questions | Answers`, `Male patients | 226 (69.8%)`, ...). This PR admits two-column grids and moves the burden of proof to the guards -- which, measured, were already carrying almost all of it.

## The measurement (before any code changed)

A corpus-wide probe enumerated every region the sweep rejects *solely* for having two columns: **12 regions across 66 articles**, labeled by token containment against JATS truth tables:

| class | count | what catches it |
|---|---|---|
| real tables (containment 0.99-1.00) | 4 | admitted -- these are the target |
| numbered reference lists (containment 0.00) | 7 | `looks_like_numbered_bibliography` already condemned 6; the 7th numbers entries `2)`, a spelling the guard's integer pattern now counts |
| chart (axis ticks + legend gridded) | 1 | new drawing-density gate |

The cell-level signals originally proposed for a discriminator (numeric share, short cells) were **refuted by the first real sample**: the `Questions | Answers` table has prose-length cells and looks exactly like a bibliography at the cell level. The signals that actually separate the classes are structural, and mostly already encoded in the existing guards.

## The changes

- `MIN_WORD_GUTTER_COLS` 3 -> 2, with the measured story in its comment.
- `_BIB_INTEGER` accepts the `42)` paren form.
- New `MAX_TWO_COLUMN_REGION_DRAWINGS = 25` gate, applied only at the two-column tier and only after every cheaper guard: a chart's labels float over its plot's vector paths (**541** intersecting paths in the measured chart region) while borderless tables hold at most their own rules (**0-4** in all four real ones). Wider grids carry two aligned internal boundaries, which stray chart labels do not produce, so no established multi-column path changes behavior. Fail-open on error, same posture as `split_word_ratio`.

## Corpus re-measurement (after)

- Table deficit **10 -> 6**; 173 tables emitted against 121 JATS-placed truth tables.
- Surplus unchanged at 58: every recovered table landed on a former deficit page -- **zero junk added**.
- Spot-checks: the chart page (PMC9000011.1 p22) and reference-list pages of both numbering spellings emit 0 tables; the three multi-table pages holding recovered tables now match truth exactly (4/4, 2/2, 2/2).
- Remaining deficit is the known non-two-column classes: 2 layout-model misses, 4 regions whose only grid splits words (boxed panels, line-grouping edge, ambiguous rotation).

## Tests

5 new unit tests, each red before its change: the single-gutter geometry now yields a grid, the paren-numbered grid is condemned, a two-column region over dense drawings demotes to prose with its own rejection reason, dense drawings leave wider grids untouched, and a two-column paren-numbered reference list demotes at the region level. Full pdf-marked suite green; ruff, mypy, changelog check green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
