### PR TITLE
fix(rst,org): give definition descriptions their separators back

### DIFF
--- a/changelog.d/352-definition-description-separators.fixed.md
+++ b/changelog.d/352-definition-description-separators.fixed.md
@@ -1,0 +1,13 @@
+- **reST and Org definition descriptions no longer fuse or lose words.** Both
+  renderers concatenated a description's paragraphs with nothing at all between them,
+  so `alpha` and `beta` came back as the single token `alphabeta` -- a destroyed word
+  boundary, not a lost break ([#352](https://github.com/thomas-villani/all2md/issues/352)).
+  The reST renderer now separates blocks with a blank line at the same indent, which
+  round-trips the paragraph count exactly; the Org renderer joins blocks as indented
+  continuation lines, so the boundary degrades to a line rather than a fused word.
+  Worse than the reported fusion, the Org *parser* silently deleted every definition
+  line that did not start a new `- term ::` item -- a wrapped definition lost all but
+  its first line; continuation lines now join the open definition. A term's several
+  descriptions still flatten into the one definition each syntax can hold (docutils:
+  one definition per term; Org: one `::` per item) -- words intact, count inherently
+  lost -- and the fuzzing-gate entries now say exactly that.

--- a/src/all2md/parsers/org.py
+++ b/src/all2md/parsers/org.py
@@ -1184,7 +1184,7 @@ class OrgParser(BaseParser):
 
         """
         lines = block.split("\n")
-        items: list[tuple[DefinitionTerm, list[DefinitionDescription]]] = []
+        entries: list[tuple[str, list[str]]] = []  # (term text, definition lines)
 
         for line in lines:
             line_stripped = line.strip()
@@ -1194,17 +1194,23 @@ class OrgParser(BaseParser):
             # Match definition list item: - term :: definition
             match = re.match(r"^-\s+(.+?)\s+::\s+(.+)$", line_stripped)
             if match:
-                term_text = match.group(1)
-                definition_text = match.group(2)
+                entries.append((match.group(1), [match.group(2)]))
+            elif entries:
+                # A line that does not open a new item continues the previous item's
+                # definition -- an indented wrap, which is how Org (and this module's
+                # own renderer) spells a definition longer than one line. These lines
+                # used to be skipped outright, silently DELETING every line of a
+                # definition after its first (#352). Within one block there are no
+                # blank lines, so a continuation is the same paragraph by Org's rules
+                # and joins with a space.
+                entries[-1][1].append(line_stripped)
 
-                # Parse term and definition content
-                term_content = self._parse_inline(term_text)
-                term = DefinitionTerm(content=term_content)
-
-                def_content = self._parse_inline(definition_text)
-                definition = DefinitionDescription(content=[Paragraph(content=def_content)])
-
-                items.append((term, [definition]))
+        items: list[tuple[DefinitionTerm, list[DefinitionDescription]]] = []
+        for term_text, definition_lines in entries:
+            term = DefinitionTerm(content=self._parse_inline(term_text))
+            def_content = self._parse_inline(" ".join(definition_lines))
+            definition = DefinitionDescription(content=[Paragraph(content=def_content)])
+            items.append((term, [definition]))
 
         if not items:
             return None

--- a/src/all2md/renderers/org.py
+++ b/src/all2md/renderers/org.py
@@ -324,9 +324,7 @@ class OrgRenderer(NodeVisitor, InlineContentMixin, BaseRenderer):
         entry_type = entry.get("type")
 
         if entry_type == "state_change":
-            self._output.append(
-                f"- State \"{entry['new_state']}\" " f"from \"{entry['old_state']}\" " f"[{entry['timestamp']}]\n"
-            )
+            self._output.append(f'- State "{entry["new_state"]}" from "{entry["old_state"]}" [{entry["timestamp"]}]\n')
         elif entry_type == "clock":
             if entry.get("end"):
                 clock_line = f"CLOCK: [{entry['start']}]--[{entry['end']}]"
@@ -923,19 +921,26 @@ class OrgRenderer(NodeVisitor, InlineContentMixin, BaseRenderer):
             term_content = self._render_inline_content(term.content)
             self._output.append(f"- {term_content} :: ")
 
-            # Render descriptions
-            for j, desc in enumerate(descriptions):
-                if j > 0:
-                    self._output.append("\n  ")
-                saved_output = self._output
-                self._output = []
-
+            # Render descriptions. Each block renders separately and the pieces join
+            # as indented continuation lines -- they used to be concatenated with
+            # nothing at all, fusing the last word of one paragraph to the first word
+            # of the next ('alpha' + 'beta' -> 'alphabeta'): destroyed word
+            # boundaries, not lost formatting (#352). Org proper spells a paragraph
+            # boundary inside an item as a blank line plus indent, but the parser's
+            # block splitter cannot see across blank lines yet, so the boundary
+            # deliberately degrades to a continuation line: the paragraph count is
+            # lost (documented in the fuzzing gate), the words are not.
+            block_texts = []
+            for desc in descriptions:
                 for child in desc.content:
+                    saved_output = self._output
+                    self._output = []
                     child.accept(self)
+                    block_texts.append("".join(self._output))
+                    self._output = saved_output
 
-                desc_content = "".join(self._output)
-                self._output = saved_output
-                self._output.append(desc_content)
+            desc_content = "\n".join(block_texts).replace("\n", "\n  ")
+            self._output.append(desc_content)
 
             if i < len(node.items) - 1:
                 self._output.append("\n")

--- a/src/all2md/renderers/rst.py
+++ b/src/all2md/renderers/rst.py
@@ -763,20 +763,27 @@ class RestructuredTextRenderer(NodeVisitor, InlineContentMixin, BaseRenderer):
             term_content = self._render_inline_content(term.content)
             self._output.append(term_content + "\n")
 
-            # Render descriptions
+            # Every block of every description, rendered separately so blocks can be
+            # joined with a blank line at the same indent -- the reST spelling of "the
+            # definition continues". They used to be concatenated with nothing at all,
+            # which fused the last word of one paragraph to the first word of the next
+            # ('alpha' + 'beta' -> 'alphabeta'): destroyed word boundaries, not lost
+            # formatting (#352). Several descriptions flatten into the one definition
+            # reST gives each term (its syntax has no second one); their paragraphs
+            # stay separate, so the merge loses the description count and nothing else.
+            block_texts = []
             for desc in descriptions:
-                saved_output = self._output
-                self._output = []
-
                 for child in desc.content:
+                    saved_output = self._output
+                    self._output = []
                     child.accept(self)
+                    block_texts.append("".join(self._output))
+                    self._output = saved_output
 
-                desc_content = "".join(self._output)
-                self._output = saved_output
-
-                # Indent description
-                lines = desc_content.split("\n")
-                for line in lines:
+            for j, block_text in enumerate(block_texts):
+                if j > 0:
+                    self._output.append("\n")
+                for line in block_text.split("\n"):
                     if line.strip():
                         self._output.append(f"   {line}\n")
 

--- a/tests/unit/parsers/test_org_parser.py
+++ b/tests/unit/parsers/test_org_parser.py
@@ -838,6 +838,31 @@ class TestDefinitionList:
         # Term should have Strong node
         assert any(isinstance(node, Strong) for node in term.content)
 
+    def test_a_continuation_line_joins_its_definition(self) -> None:
+        """An indented line under an item continues that item's definition (#352).
+
+        Lines that did not start a new ``- term ::`` item were silently skipped,
+        so a wrapped definition lost every line after its first -- deletion, not
+        degradation.
+        """
+        org = """
+- term1 :: starts here
+  and continues here
+- term2 :: short
+"""
+        parser = OrgParser()
+        doc = parser.parse(org)
+
+        def_lists = [node for node in doc.children if isinstance(node, DefinitionList)]
+        assert len(def_lists) == 1
+        assert len(def_lists[0].items) == 2
+
+        from all2md.ast.utils import extract_text
+
+        _, definitions = def_lists[0].items[0]
+        text = extract_text(definitions[0])
+        assert "starts here and continues here" in text
+
 
 @pytest.mark.unit
 class TestLineBreak:

--- a/tests/unit/renderers/test_org_renderer.py
+++ b/tests/unit/renderers/test_org_renderer.py
@@ -658,6 +658,84 @@ class TestDefinitionLists:
         assert "Term 2" in org
         assert "Description 2" in org
 
+    def test_multi_paragraph_description_keeps_its_word_boundary(self) -> None:
+        """Two paragraphs must not fuse into one token (#352).
+
+        They were joined with nothing at all, so 'alpha' and 'beta' rendered as
+        'alphabeta' -- a destroyed word boundary. Org continues an item on an
+        indented line, which keeps the words apart and reads back into the item.
+        """
+        import io
+
+        from all2md import to_ast
+        from all2md.ast import DefinitionDescription, DefinitionList, DefinitionTerm
+        from all2md.ast.utils import extract_text
+
+        doc = Document(
+            children=[
+                DefinitionList(
+                    items=[
+                        (
+                            DefinitionTerm(content=[Text(content="t0")]),
+                            [
+                                DefinitionDescription(
+                                    content=[
+                                        Paragraph(content=[Text(content="alpha")]),
+                                        Paragraph(content=[Text(content="beta")]),
+                                    ]
+                                )
+                            ],
+                        )
+                    ]
+                )
+            ]
+        )
+        org = OrgRenderer().render_to_string(doc)
+        assert "alphabeta" not in org
+
+        back = to_ast(io.BytesIO(org.encode()), source_format="org")
+        (definition_list,) = [n for n in back.children if isinstance(n, DefinitionList)]
+        text = extract_text(definition_list)
+        assert "alpha" in text and "beta" in text
+        assert "alphabeta" not in text
+
+    def test_several_descriptions_survive_the_round_trip_with_their_words(self) -> None:
+        """The second description used to be silently DELETED on reparse.
+
+        The org parser skipped every line that did not start a new `- term ::`
+        item, so `- t0 :: first` followed by an indented `second` came back as
+        just 'first'. Continuation lines now append to the open description.
+        """
+        import io
+
+        from all2md import to_ast
+        from all2md.ast import DefinitionDescription, DefinitionList, DefinitionTerm
+        from all2md.ast.utils import extract_text
+
+        doc = Document(
+            children=[
+                DefinitionList(
+                    items=[
+                        (
+                            DefinitionTerm(content=[Text(content="t0")]),
+                            [
+                                DefinitionDescription(content=[Paragraph(content=[Text(content="first")])]),
+                                DefinitionDescription(content=[Paragraph(content=[Text(content="second")])]),
+                            ],
+                        )
+                    ]
+                )
+            ]
+        )
+        org = OrgRenderer().render_to_string(doc)
+        assert "firstsecond" not in org
+
+        back = to_ast(io.BytesIO(org.encode()), source_format="org")
+        (definition_list,) = [n for n in back.children if isinstance(n, DefinitionList)]
+        text = extract_text(definition_list)
+        assert "first" in text and "second" in text
+        assert "firstsecond" not in text
+
 
 @pytest.mark.unit
 class TestSubscriptSuperscript:

--- a/tests/unit/renderers/test_rst_renderer.py
+++ b/tests/unit/renderers/test_rst_renderer.py
@@ -402,6 +402,84 @@ class TestDefinitionLists:
         assert "Definition 1" in rst
         assert "Definition 2" in rst
 
+    def test_multi_paragraph_description_keeps_its_word_boundary(self) -> None:
+        """Two paragraphs must not fuse into one token (#352).
+
+        The paragraphs were joined with nothing at all between them, so 'alpha'
+        and 'beta' came back as 'alphabeta' -- a destroyed word boundary, not
+        merely a lost break. reST spells a multi-paragraph definition as
+        same-indent paragraphs separated by a blank line, which our parser reads
+        back as one description holding two paragraphs.
+        """
+        import io
+
+        from all2md import to_ast
+        from all2md.ast import DefinitionList as AstDefinitionList
+
+        doc = Document(
+            children=[
+                DefinitionList(
+                    items=[
+                        (
+                            DefinitionTerm(content=[Text(content="t0")]),
+                            [
+                                DefinitionDescription(
+                                    content=[
+                                        Paragraph(content=[Text(content="alpha")]),
+                                        Paragraph(content=[Text(content="beta")]),
+                                    ]
+                                )
+                            ],
+                        )
+                    ]
+                )
+            ]
+        )
+        rst = RestructuredTextRenderer().render_to_string(doc)
+        assert "alphabeta" not in rst
+
+        back = to_ast(io.BytesIO(rst.encode()), source_format="rst")
+        (definition_list,) = [n for n in back.children if isinstance(n, AstDefinitionList)]
+        ((_, descriptions),) = definition_list.items
+        assert len(descriptions) == 1
+        assert [type(c).__name__ for c in descriptions[0].content] == ["Paragraph", "Paragraph"]
+
+    def test_several_descriptions_keep_their_word_boundaries(self) -> None:
+        """Two descriptions merge into reST's one definition, never into fused words.
+
+        Docutils gives each term exactly one definition body, so the description
+        count is inherently lost -- the words must not be.
+        """
+        import io
+
+        from all2md import to_ast
+        from all2md.ast import DefinitionList as AstDefinitionList
+        from all2md.ast.utils import extract_text
+
+        doc = Document(
+            children=[
+                DefinitionList(
+                    items=[
+                        (
+                            DefinitionTerm(content=[Text(content="t0")]),
+                            [
+                                DefinitionDescription(content=[Paragraph(content=[Text(content="first")])]),
+                                DefinitionDescription(content=[Paragraph(content=[Text(content="second")])]),
+                            ],
+                        )
+                    ]
+                )
+            ]
+        )
+        rst = RestructuredTextRenderer().render_to_string(doc)
+        assert "firstsecond" not in rst
+
+        back = to_ast(io.BytesIO(rst.encode()), source_format="rst")
+        (definition_list,) = [n for n in back.children if isinstance(n, AstDefinitionList)]
+        text = extract_text(definition_list)
+        assert "first" in text and "second" in text
+        assert "firstsecond" not in text
+
 
 @pytest.mark.unit
 class TestBlockQuote:

--- a/tests/unit/test_roundtrip_fuzzing.py
+++ b/tests/unit/test_roundtrip_fuzzing.py
@@ -777,23 +777,26 @@ KNOWN_DEFINITION_GAPS: dict[tuple[str, str], str] = {
         "Follows from the same defect as ('asciidoc', 'shape'): with no DefinitionDescription "
         "surviving the trip there is nothing left to count paragraphs inside. See #351."
     ),
+    # ("rst", "description_paragraphs") is gone: the word-fusing concatenation (#352) is
+    # fixed -- blocks now render as same-indent paragraphs separated by blank lines, and
+    # the parser reads the paragraph count back exactly.
     ("rst", "shape"): (
-        "The reStructuredText renderer emits a term's several descriptions as consecutive "
-        "indented lines with nothing between them, so they parse back as one description. "
-        "See #352."
-    ),
-    ("rst", "description_paragraphs"): (
-        "The reStructuredText renderer concatenates a description's paragraphs with no "
-        "separator at all -- two paragraphs 'alpha' and 'beta' render as 'alphabeta', which "
-        "fuses a word boundary rather than merely losing a break. See #352."
+        "reST's own syntax holds ONE definition per term (docutils: (term, classifier*, "
+        "definition)), so a term's several descriptions flatten into that one definition -- "
+        "as separate paragraphs since #352's fix, so the words survive; the description "
+        "count cannot. An inherent expressibility gap, not a renderer defect."
     ),
     ("org", "shape"): (
-        "Same defect as ('rst', 'shape') in the Org renderer: a term's several descriptions "
-        "are emitted as continuation lines and parse back as one. See #352."
+        "Org has one `::` definition per item, so a term's several descriptions flatten "
+        "into it -- as continuation lines since #352's fix, words intact, count lost. "
+        "Inherent to the syntax, like ('rst', 'shape')."
     ),
     ("org", "description_paragraphs"): (
-        "Same defect as ('rst', 'description_paragraphs') in the Org renderer: a description's "
-        "paragraphs are concatenated with no separator, fusing the words either side. See #352."
+        "A description's paragraph boundary degrades to a continuation line, so two "
+        "paragraphs come back as one -- with their words intact since #352's fix (they "
+        "used to fuse: 'alpha'+'beta' -> 'alphabeta'). Org proper spells the boundary as "
+        "a blank line plus indent, which the org parser's block splitter cannot see "
+        "across yet; parser-side continuation support would close this."
     ),
 }
 


### PR DESCRIPTION
Addresses #352 (fixes the word fusion everywhere; the inexpressible shapes are now documented as such).

## The defects

Both the reST and Org renderers concatenated a definition description's blocks with **nothing at all** between them, so paragraphs `alpha` and `beta` came back as the single token `alphabeta` -- a destroyed word boundary, silent content corruption.

Investigating the fix surfaced something worse than the issue reported: the **Org parser silently deleted** every definition line that did not start a new `- term ::` item. A wrapped or multi-line definition lost all but its first line on reparse -- deletion, not degradation (`- t0 :: first\n  second` round-tripped as just `first`).

## The fixes

- **reST renderer:** each block renders separately and blocks join as same-indent paragraphs with a blank line between -- the docutils spelling of "the definition continues." Our rst parser reads this back as one description holding the right paragraph count, so `(rst, description_paragraphs)` is fixed and its gate entry deleted.
- **Org renderer:** blocks join as indented continuation lines. The paragraph boundary degrades to a line rather than fusing words; Org proper spells the boundary as blank line + indent, which the org parser's block splitter cannot see across yet (noted in the gate entry as the future parser work that would close it).
- **Org parser:** continuation lines now join the open definition instead of being dropped.

## What inherently cannot round-trip

A term's several descriptions: docutils gives each term exactly one definition body (`(term, classifier*, definition)`), and Org one `::` per item. Since this fix they flatten into that one definition as separate paragraphs/lines -- words intact, count lost. The surviving gate entries (`rst-shape`, `org-shape`, `org-description_paragraphs`) are rewritten to say exactly that, and were verified to keep failing across three discovery-mode (random seed) runs, so the strict xfails hold in CI and under discovery alike.

## Tests

5 new unit tests (rst renderer x2, org renderer x2, org parser x1), red before the fixes -- including one pinning the org deletion. Full unit suite, fuzzing gates (CI + 3x discovery mode), related integration tests, ruff, mypy, changelog check all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
