### PR TITLE
fix(asciidoc): close the AsciiDoc round-trip cluster

### DIFF
--- a/changelog.d/asciidoc-roundtrip-cluster.fixed.md
+++ b/changelog.d/asciidoc-roundtrip-cluster.fixed.md
@@ -1,0 +1,20 @@
+- **The AsciiDoc renderer/parser pair stops rejecting, corrupting, or leaking its own
+  output.** Four defects, one format. A bold or italic span wrapping only a hard break
+  stranded its delimiters at a line start, where `* ` is a level-1 list marker and
+  `** ` a level-2 one -- the first silently turned emphasis into a list item, the
+  second crashed the parser outright, the round-trip matrix's only open crash
+  ([#353](https://github.com/thomas-villani/all2md/issues/353)); boundary breaks now
+  hoist outside the delimiters, the same cure as markdown's #391. A definition-list
+  description on the line directly below its `term::` -- the standard placement, and
+  what this renderer itself emits -- parsed to nothing: the term came back empty, the
+  text as a sibling paragraph, and the list split at every term
+  ([#351](https://github.com/thomas-villani/all2md/issues/351)); unindented lines
+  adjacent to the term now bind to it as one wrapped paragraph. The renderer also
+  fused a description's paragraphs into one token (`only`+`extra` -> `onlyextra`,
+  #352's class); blocks now join as continuation lines. And the parser did not
+  recognise the named inline footnote form `footnote:a1[text]` -- valid Asciidoctor
+  and the renderer's own spelling -- so the raw markup leaked into the prose as
+  literal text ([#346](https://github.com/thomas-villani/all2md/issues/346)); it now
+  parses, a hard break inside the macro's brackets degrades to a space instead of an
+  unparseable embedded newline, and an id referenced but never defined gets an empty
+  definition rather than an unbalanced round trip.

--- a/src/all2md/parsers/asciidoc.py
+++ b/src/all2md/parsers/asciidoc.py
@@ -426,6 +426,7 @@ class AsciiDocParser(BaseParser):
 
         # Footnote collection for tracking footnote definitions
         self._footnote_definitions: dict[str, str] = {}  # identifier -> footnote content
+        self._footnote_referenced: set[str] = set()  # every named identifier seen at all
         self._footnote_counter = 0  # Counter for auto-generated footnote IDs
 
         # Inline patterns
@@ -476,9 +477,14 @@ class AsciiDocParser(BaseParser):
 
         # Footnotes
         # footnote:[text] - inline footnote with content
+        # footnote:id[text] - NAMED inline footnote: first occurrence defines, later
+        #   ones (usually footnote:id[]) reference it. Valid Asciidoctor, and the
+        #   form this project's own renderer emits -- unmatched, the raw markup
+        #   leaked into the prose as literal text (#346).
         # footnoteref:[id,text] - footnote reference with optional text (first occurrence defines, rest reference)
         # footnoteref:[id] - footnote reference without text (must be defined elsewhere)
         self.footnote_pattern = re.compile(r"footnote:\[([^\]]+)\]")
+        self.footnote_named_pattern = re.compile(r"footnote:([A-Za-z0-9_-]+)\[([^\]]*)\]")
         self.footnoteref_pattern = re.compile(r"footnoteref:\[([^\],]+)(?:,([^\]]+))?\]")
 
         # Math
@@ -524,6 +530,7 @@ class AsciiDocParser(BaseParser):
                 r"\{([^\}]+)\}",  # Attribute reference
                 r"(?:\+\+([^\+]+)\+\+|\+([^\+]+)\+|pass:\[([^\]]+)\])",  # Passthrough
                 r"footnote:\[([^\]]+)\]",  # Footnote with inline content
+                r"footnote:([A-Za-z0-9_-]+)\[([^\]]*)\]",  # Named inline footnote
                 r"footnoteref:\[([^\],]+)(?:,([^\]]+))?\]",  # Footnote reference
                 r"latexmath:\[(?:\$([^\$]+)\$|([^\]]+))\]",  # LaTeX math inline
                 r"stem:\[(?:\$([^\$]+)\$|([^\]]+))\]",  # STEM math inline
@@ -567,6 +574,7 @@ class AsciiDocParser(BaseParser):
         self.current_token_index = 0
         self.pending_block_attrs = {}
         self._footnote_definitions = {}
+        self._footnote_referenced = set()
         self._footnote_counter = 0
 
         # Emit progress event
@@ -1382,6 +1390,18 @@ class AsciiDocParser(BaseParser):
             self._footnote_definitions[identifier] = footnote_text
             return [FootnoteReference(identifier=identifier)], match.end()
 
+        match = self.footnote_named_pattern.match(text)
+        if match:
+            identifier = match.group(1)
+            named_text = self._postprocess_escapes(match.group(2), escape_map) if match.group(2) else ""
+            # First occurrence defines; footnote:id[] (or a repeat) references. A
+            # repeat with different text does not overwrite -- Asciidoctor keeps
+            # the first definition too.
+            if named_text and identifier not in self._footnote_definitions:
+                self._footnote_definitions[identifier] = named_text
+            self._footnote_referenced.add(identifier)
+            return [FootnoteReference(identifier=identifier)], match.end()
+
         match = self.footnoteref_pattern.match(text)
         if match:
             identifier = match.group(1).strip()
@@ -1390,6 +1410,7 @@ class AsciiDocParser(BaseParser):
                 processed_text = self._postprocess_escapes(footnote_ref_text, escape_map)
                 if identifier not in self._footnote_definitions:
                     self._footnote_definitions[identifier] = processed_text
+            self._footnote_referenced.add(identifier)
             return [FootnoteReference(identifier=identifier)], match.end()
 
         return None
@@ -1529,7 +1550,7 @@ class AsciiDocParser(BaseParser):
         representation. Footnote content is parsed as inline text.
 
         """
-        if not self._footnote_definitions:
+        if not self._footnote_definitions and not self._footnote_referenced:
             return
 
         # Append each footnote definition
@@ -1540,6 +1561,18 @@ class AsciiDocParser(BaseParser):
             content_nodes = [Paragraph(content=footnote_content)]
             # Create and append the footnote definition
             children.append(FootnoteDefinition(identifier=identifier, content=cast(list[Node], content_nodes)))
+
+        # An identifier referenced (footnote:id[] / footnoteref:[id]) but never
+        # defined gets an EMPTY definition rather than none at all. AsciiDoc has
+        # no other spelling for a footnote whose text is invisible -- this
+        # project's own renderer emits `footnote:id[]` when a definition's
+        # content flattens to nothing (a lone line break) -- so dropping the
+        # definition here silently unbalanced every such round trip: the
+        # reference survived, its definition did not (#346).
+        for identifier in self._footnote_referenced:
+            if identifier not in self._footnote_definitions:
+                empty: list[Node] = [Paragraph(content=[])]
+                children.append(FootnoteDefinition(identifier=identifier, content=empty))
 
     def _is_list_continuation(self) -> bool:
         """Report whether the cursor sits on a list continuation ("+") line.

--- a/src/all2md/parsers/asciidoc.py
+++ b/src/all2md/parsers/asciidoc.py
@@ -1705,13 +1705,28 @@ class AsciiDocParser(BaseParser):
                 desc_content = self._parse_inline(description_text)
                 desc_nodes.append(Paragraph(content=desc_content))
 
-            # Check for continuation lines (indented text or explicit blocks)
-            # Continue while we have text lines that are indented or continuation markers
+            # Check for continuation lines. Two spellings bind text to the term:
+            # lines directly below it with no blank between (any indent -- the
+            # standard AsciiDoc description placement, and what this project's
+            # own renderer emits: `t0::` newline `d0`), and indented lines after
+            # a blank. Demanding indent on the adjacent lines too dropped every
+            # description written the standard way -- the term parsed empty and
+            # its text reappeared as a sibling paragraph outside the list, with
+            # the list splitting at every term for the same reason (#351).
+            # Adjacent lines accumulate into ONE wrapped paragraph, because
+            # consecutive lines are one paragraph in AsciiDoc.
+            adjacent = True
+            adjacent_lines: list[str] = []
+
             while self._current_token().type in (TokenType.TEXT_LINE, TokenType.BLANK_LINE):
                 next_token = self._current_token()
 
                 # If it's a blank line, check if the next non-blank is still part of description
                 if next_token.type == TokenType.BLANK_LINE:
+                    if adjacent_lines:
+                        desc_nodes.append(Paragraph(content=self._parse_inline(" ".join(adjacent_lines))))
+                        adjacent_lines = []
+                    adjacent = False
                     # Peek ahead to see if there's more indented content
                     saved_index = self.current_token_index
                     self._advance()  # Skip blank line
@@ -1726,15 +1741,22 @@ class AsciiDocParser(BaseParser):
                         self.current_token_index = saved_index
                         break
 
-                # Check if this line is indented (continuation)
                 if next_token.type == TokenType.TEXT_LINE and next_token.indent > 0:
+                    if adjacent_lines:
+                        desc_nodes.append(Paragraph(content=self._parse_inline(" ".join(adjacent_lines))))
+                        adjacent_lines = []
                     self._advance()
                     # Add continuation line to description
                     line_content = self._parse_inline(next_token.content)
                     desc_nodes.append(Paragraph(content=line_content))
+                elif next_token.type == TokenType.TEXT_LINE and adjacent:
+                    self._advance()
+                    adjacent_lines.append(next_token.content)
                 else:
-                    # Not indented, end of description
+                    # Unindented and past a blank line: the list has ended.
                     break
+            if adjacent_lines:
+                desc_nodes.append(Paragraph(content=self._parse_inline(" ".join(adjacent_lines))))
 
             # Create description from collected nodes
             if desc_nodes:

--- a/src/all2md/renderers/asciidoc.py
+++ b/src/all2md/renderers/asciidoc.py
@@ -1009,11 +1009,22 @@ class AsciiDocRenderer(NodeVisitor, InlineContentMixin, BaseRenderer):
             term_content = self._render_inline_content(term.content)
             self._output.append(f"{term_content}::")
 
-            # Render descriptions
+            # Render descriptions. Each block renders separately and the pieces
+            # join as continuation lines under the term -- they used to be
+            # concatenated with nothing between them, fusing the last word of one
+            # paragraph to the first word of the next ('only' + 'extra' ->
+            # 'onlyextra'): destroyed word boundaries, the same class #352 fixed
+            # for reST and Org. The paragraph boundary degrades to a line wrap
+            # (documented in the fuzzing gate); the words survive.
             for desc in descriptions:
-                self._output.append("\n")
                 for child in desc.content:
+                    self._output.append("\n")
+                    saved_output = self._output
+                    self._output = []
                     child.accept(self)
+                    block_text = "".join(self._output)
+                    self._output = saved_output
+                    self._output.append(block_text)
 
     def visit_definition_term(self, node: DefinitionTerm) -> None:
         """Render a DefinitionTerm node (handled by visit_definition_list).

--- a/src/all2md/renderers/asciidoc.py
+++ b/src/all2md/renderers/asciidoc.py
@@ -748,7 +748,11 @@ class AsciiDocRenderer(NodeVisitor, InlineContentMixin, BaseRenderer):
 
         """
         content = self._render_inline_content(node.content)
-        self._output.append(f"_{content}_")
+        lead, core, trail = self._split_boundary_breaks(content)
+        if not core.strip():
+            self._output.append(content)
+            return
+        self._output.append(f"{lead}_{core}_{trail}")
 
     def visit_strong(self, node: Strong) -> None:
         """Render a Strong node.
@@ -760,7 +764,45 @@ class AsciiDocRenderer(NodeVisitor, InlineContentMixin, BaseRenderer):
 
         """
         content = self._render_inline_content(node.content)
-        self._output.append(f"*{content}*")
+        lead, core, trail = self._split_boundary_breaks(content)
+        if not core.strip():
+            self._output.append(content)
+            return
+        self._output.append(f"{lead}*{core}*{trail}")
+
+    @staticmethod
+    def _split_boundary_breaks(content: str) -> tuple[str, str, str]:
+        """Split rendered inline content into leading breaks, core, trailing breaks.
+
+        A hard break at the edge of a bold or italic span puts a delimiter run
+        alone at a line start, where it stops being inline syntax: AsciiDoc reads
+        ``* `` at a line start as a level-1 list marker and ``** `` as a level-2
+        one -- the first silently turns emphasis into a list item, the second
+        crashes the parser outright, since no level-1 item is open to nest under
+        (#353). Breaks are hoisted outside the delimiters instead: a span over a
+        line break marks nothing visible, so nothing is lost, and a span left
+        with no visible core emits no delimiters at all.
+        """
+        spellings = (" +\n", "\n")
+        lead = ""
+        stripped = True
+        while stripped:
+            stripped = False
+            for spelling in spellings:
+                if content.startswith(spelling):
+                    lead += spelling
+                    content = content[len(spelling) :]
+                    stripped = True
+        trail = ""
+        stripped = True
+        while stripped:
+            stripped = False
+            for spelling in spellings:
+                if content.endswith(spelling):
+                    trail = spelling + trail
+                    content = content[: -len(spelling)]
+                    stripped = True
+        return lead, content, trail
 
     def visit_code(self, node: Code) -> None:
         """Render a Code node.
@@ -1005,8 +1047,14 @@ class AsciiDocRenderer(NodeVisitor, InlineContentMixin, BaseRenderer):
 
         """
         content = self._render_inline_content(node.content)
-        # AsciiDoc uses [line-through] for strikethrough
-        self._output.append(f"[line-through]#{content}#")
+        # AsciiDoc uses [line-through] for strikethrough. Boundary breaks hoist
+        # outside the span for the same reason as bold/italic (#353): a `#` or
+        # `[line-through]#` stranded on its own line is not inline syntax.
+        lead, core, trail = self._split_boundary_breaks(content)
+        if not core.strip():
+            self._output.append(content)
+            return
+        self._output.append(f"{lead}[line-through]#{core}#{trail}")
 
     def visit_footnote_reference(self, node: FootnoteReference) -> None:
         """Render a FootnoteReference node.

--- a/src/all2md/renderers/asciidoc.py
+++ b/src/all2md/renderers/asciidoc.py
@@ -99,7 +99,7 @@ class AsciiDocRenderer(NodeVisitor, InlineContentMixin, BaseRenderer):
         self._list_ordered_stack: list[bool] = []  # Track ordered/unordered at each level
         self._footnote_collector: FootnoteCollector = FootnoteCollector()
         self._footnotes_emitted: set[str] = set()  # Track which footnotes have been emitted inline
-        self._in_table_cell: bool = False
+        self._in_inline_only: bool = False
 
     def render_to_string(self, document: Document) -> str:
         """Render a document AST to AsciiDoc string.
@@ -121,7 +121,7 @@ class AsciiDocRenderer(NodeVisitor, InlineContentMixin, BaseRenderer):
         self._list_ordered_stack = []
         self._footnote_collector = FootnoteCollector()
         self._footnotes_emitted = set()
-        self._in_table_cell = False
+        self._in_inline_only = False
 
         document.accept(self)
 
@@ -433,8 +433,20 @@ class AsciiDocRenderer(NodeVisitor, InlineContentMixin, BaseRenderer):
         This is an inherent limitation of AsciiDoc's footnote syntax.
 
         """
-        result_parts = []
+        result_parts: list[str] = []
 
+        # Everything rendered here lands between a macro's brackets, which hold
+        # exactly one line -- so hard breaks must degrade to spaces here just as
+        # they do in table cells.
+        was_in_inline_only = self._in_inline_only
+        self._in_inline_only = True
+        try:
+            return self._flatten_blocks_to_inline_parts(nodes, result_parts)
+        finally:
+            self._in_inline_only = was_in_inline_only
+
+    def _flatten_blocks_to_inline_parts(self, nodes: list[Node], result_parts: list[str]) -> str:
+        """Flatten each node in *nodes* into ``result_parts`` and join them."""
         for node in nodes:
             if isinstance(node, Paragraph):
                 # Extract inline content from paragraph
@@ -582,8 +594,8 @@ class AsciiDocRenderer(NodeVisitor, InlineContentMixin, BaseRenderer):
             # splits on '|' within a single source line, so any node that would
             # normally emit a literal '\n' (a hard LineBreak's ' +\n') has to fall
             # back to something line-safe while we're inside a cell.
-            was_in_table_cell = self._in_table_cell
-            self._in_table_cell = True
+            was_in_inline_only = self._in_inline_only
+            self._in_inline_only = True
             try:
                 for index, cell in enumerate(cells):
                     content = self._render_inline_content(cell.content)
@@ -591,7 +603,7 @@ class AsciiDocRenderer(NodeVisitor, InlineContentMixin, BaseRenderer):
                     separator = "" if index == 0 else " "
                     self._output.append(f"{separator}{delimiter}{content}")
             finally:
-                self._in_table_cell = was_in_table_cell
+                self._in_inline_only = was_in_inline_only
             self._output.append("\n")
 
         # Render header
@@ -870,12 +882,15 @@ class AsciiDocRenderer(NodeVisitor, InlineContentMixin, BaseRenderer):
             Line break to render
 
         """
-        if node.soft or self._in_table_cell:
-            # Soft breaks render as space in AsciiDoc. Inside a table cell the
-            # hard-break marker ' +\n' would embed a newline in a psv row and
-            # the project's own parser reads it back as a row split (the ' +'
-            # marker leaking into the first cell's text) rather than a break,
-            # so fall back to the same space used for soft breaks.
+        if node.soft or self._in_inline_only:
+            # Soft breaks render as space in AsciiDoc. In an inline-only context
+            # the hard-break marker ' +\n' embeds a newline where none can be: in
+            # a psv table cell the project's own parser reads it back as a row
+            # split (the ' +' marker leaking into the first cell's text), and
+            # inside a footnote macro's brackets the newline leaves
+            # `footnote:id[...` unclosed on its line, so the whole footnote leaks
+            # into the prose as literal text (#346). Fall back to the same space
+            # used for soft breaks.
             self._output.append(" ")
         else:
             # Hard break with explicit line break

--- a/tests/unit/parsers/test_asciidoc_parser_improvements.py
+++ b/tests/unit/parsers/test_asciidoc_parser_improvements.py
@@ -389,6 +389,90 @@ NewTerm:: New def"""
         # Should have two separate terms
         assert len(deflist.items) == 2
 
+    def test_a_description_on_the_next_line_binds_to_its_term(self) -> None:
+        """``t0::`` with the description on the following unindented line (#351).
+
+        The standard AsciiDoc spelling -- and this project's own renderer's
+        output -- puts the description on the line below the term with no
+        indent. It parsed to a term with NO description, the text reappearing
+        as a sibling paragraph outside the list.
+        """
+        asciidoc = "t0::\nd0\nt1::\nd1\n"
+        parser = AsciiDocParser()
+        doc = parser.parse(asciidoc)
+
+        deflists = [node for node in doc.children if isinstance(node, DefinitionList)]
+        assert len(deflists) == 1, "an N-term list must not split into N lists"
+        assert len(deflists[0].items) == 2
+
+        for expected_term, expected_desc, (term, descs) in [
+            ("t0", "d0", deflists[0].items[0]),
+            ("t1", "d1", deflists[0].items[1]),
+        ]:
+            assert term.content[0].content == expected_term
+            assert len(descs) == 1, f"{expected_term}'s description was dropped"
+            paragraph = descs[0].content[0]
+            assert paragraph.content[0].content == expected_desc
+
+    def test_adjacent_unindented_lines_wrap_into_one_description_paragraph(self) -> None:
+        """Consecutive lines are one paragraph in AsciiDoc, wrapped or not."""
+        asciidoc = "t0::\nfirst line\nsecond line\n\nafter\n"
+        parser = AsciiDocParser()
+        doc = parser.parse(asciidoc)
+
+        deflist = doc.children[0]
+        assert isinstance(deflist, DefinitionList)
+        _, descs = deflist.items[0]
+        assert len(descs) == 1
+        assert len(descs[0].content) == 1, "wrapped lines are one paragraph, not one each"
+        text = "".join(getattr(c, "content", "") for c in descs[0].content[0].content)
+        assert "first line second line" in text
+
+        paragraphs = [node for node in doc.children if isinstance(node, Paragraph)]
+        assert any(
+            "after" in "".join(getattr(c, "content", "") for c in p.content) for p in paragraphs
+        ), "the paragraph after the blank line stays outside the list"
+
+    def test_a_multi_paragraph_description_round_trips_with_its_words(self) -> None:
+        """The renderer fused a description's paragraphs into one token (#352's class).
+
+        'only' + 'extra' rendered as 'onlyextra'. They now join as continuation
+        lines: the paragraph boundary degrades to a wrap, the words survive.
+        """
+        import io
+
+        from all2md import from_ast, to_ast
+        from all2md.ast import DefinitionDescription, DefinitionTerm, Document
+        from all2md.ast.utils import extract_text
+
+        doc = Document(
+            children=[
+                DefinitionList(
+                    items=[
+                        (
+                            DefinitionTerm(content=[Text(content="t0")]),
+                            [
+                                DefinitionDescription(
+                                    content=[
+                                        Paragraph(content=[Text(content="only")]),
+                                        Paragraph(content=[Text(content="extra")]),
+                                    ]
+                                )
+                            ],
+                        )
+                    ]
+                )
+            ]
+        )
+        out = from_ast(doc, "asciidoc")
+        assert "onlyextra" not in out
+
+        back = to_ast(io.BytesIO(out.encode()), source_format="asciidoc")
+        (deflist,) = [n for n in back.children if isinstance(n, DefinitionList)]
+        text = extract_text(deflist)
+        assert "only" in text and "extra" in text
+        assert "onlyextra" not in text
+
 
 class TestAsciiDocAdmonitions:
     """Tests for admonition block support."""

--- a/tests/unit/parsers/test_asciidoc_parser_improvements.py
+++ b/tests/unit/parsers/test_asciidoc_parser_improvements.py
@@ -474,6 +474,59 @@ NewTerm:: New def"""
         assert "onlyextra" not in text
 
 
+class TestAsciiDocNamedInlineFootnotes:
+    """The named inline form ``footnote:id[text]`` must parse, not leak as prose (#346).
+
+    It is valid Asciidoctor and it is what this project's own renderer emits, but
+    the parser matched only ``footnote:[text]`` and ``footnoteref:[id,text]`` -- the
+    identifier between ``footnote:`` and ``[`` defeated both, so the raw markup
+    passed through as literal text.
+    """
+
+    def test_named_inline_footnote_becomes_a_reference_and_definition(self) -> None:
+        from all2md.ast import FootnoteDefinition, FootnoteReference
+
+        parser = AsciiDocParser()
+        doc = parser.parse("body footnote:a1[note one]\n")
+
+        paragraph = doc.children[0]
+        refs = [n for n in paragraph.content if isinstance(n, FootnoteReference)]
+        assert len(refs) == 1
+        assert refs[0].identifier == "a1"
+        assert "footnote:a1" not in "".join(getattr(n, "content", "") for n in paragraph.content if isinstance(n, Text))
+
+        defs = [n for n in doc.children if isinstance(n, FootnoteDefinition)]
+        assert len(defs) == 1
+        assert defs[0].identifier == "a1"
+        text = "".join(getattr(c, "content", "") for p in defs[0].content for c in p.content)
+        assert "note one" in text
+
+    def test_a_repeat_reference_with_empty_brackets_does_not_redefine(self) -> None:
+        from all2md.ast import FootnoteDefinition, FootnoteReference
+
+        parser = AsciiDocParser()
+        doc = parser.parse("one footnote:a1[the note] and footnote:a1[] again\n")
+
+        paragraph = doc.children[0]
+        refs = [n for n in paragraph.content if isinstance(n, FootnoteReference)]
+        assert [r.identifier for r in refs] == ["a1", "a1"]
+
+        defs = [n for n in doc.children if isinstance(n, FootnoteDefinition)]
+        assert len(defs) == 1
+        text = "".join(getattr(c, "content", "") for p in defs[0].content for c in p.content)
+        assert "the note" in text
+
+    def test_the_unnamed_form_still_parses(self) -> None:
+        from all2md.ast import FootnoteDefinition, FootnoteReference
+
+        parser = AsciiDocParser()
+        doc = parser.parse("body footnote:[anonymous note]\n")
+
+        paragraph = doc.children[0]
+        assert any(isinstance(n, FootnoteReference) for n in paragraph.content)
+        assert any(isinstance(n, FootnoteDefinition) for n in doc.children)
+
+
 class TestAsciiDocAdmonitions:
     """Tests for admonition block support."""
 

--- a/tests/unit/renderers/test_asciidoc_renderer.py
+++ b/tests/unit/renderers/test_asciidoc_renderer.py
@@ -641,6 +641,89 @@ class TestLineBreak:
 
 
 @pytest.mark.unit
+class TestInvisibleInlineSpans:
+    """Spans over nothing visible must not strand their delimiters at line starts (#353).
+
+    A hard break inside a bold span puts the delimiters on their own lines, where
+    AsciiDoc reads ``* `` as a level-1 list marker and ``** `` as a level-2 one --
+    the first silently turns emphasis into a list, the second CRASHES the parser
+    (no level-1 item is open for the level-2 marker to nest under).
+    """
+
+    def _reparse(self, text: str):
+        import io
+
+        from all2md import to_ast
+
+        return to_ast(io.BytesIO(text.encode()), source_format="asciidoc")
+
+    def test_nested_bold_over_a_break_does_not_crash_the_parser(self):
+        from all2md.ast import LineBreak
+
+        doc = Document(
+            children=[
+                Paragraph(
+                    content=[
+                        Text(content="before"),
+                        LineBreak(),
+                        Strong(content=[Strong(content=[LineBreak()])]),
+                        Text(content="after"),
+                    ]
+                )
+            ]
+        )
+        result = AsciiDocRenderer().render_to_string(doc)
+        assert not any(line.startswith(("* ", "** ")) for line in result.split("\n"))
+
+        back = self._reparse(result)
+        assert [type(n).__name__ for n in back.children] == ["Paragraph"]
+
+    def test_bold_over_a_break_does_not_become_a_list_item(self):
+        from all2md.ast import LineBreak, List
+
+        doc = Document(
+            children=[
+                Paragraph(
+                    content=[
+                        Text(content="before"),
+                        LineBreak(),
+                        Strong(content=[LineBreak()]),
+                        Text(content="after"),
+                    ]
+                )
+            ]
+        )
+        result = AsciiDocRenderer().render_to_string(doc)
+        assert not any(line.startswith("* ") for line in result.split("\n"))
+
+        back = self._reparse(result)
+        assert not any(isinstance(n, List) for n in back.children)
+        assert [type(n).__name__ for n in back.children] == ["Paragraph"]
+
+    def test_trailing_break_inside_nested_spans_is_hoisted_out(self):
+        from all2md.ast import LineBreak
+
+        doc = Document(
+            children=[
+                Paragraph(
+                    content=[
+                        Strong(content=[Emphasis(content=[Text(content="lead"), LineBreak()])]),
+                        Text(content="after"),
+                    ]
+                )
+            ]
+        )
+        result = AsciiDocRenderer().render_to_string(doc)
+
+        back = self._reparse(result)
+        assert [type(n).__name__ for n in back.children] == ["Paragraph"]
+        from all2md.ast.utils import extract_text
+
+        text = extract_text(back.children[0])
+        assert "lead" in text and "after" in text
+
+
+@pytest.mark.unit
 class TestSubscriptSuperscript:
     """Tests for subscript and superscript rendering."""
 

--- a/tests/unit/test_roundtrip_fuzzing.py
+++ b/tests/unit/test_roundtrip_fuzzing.py
@@ -767,15 +767,17 @@ DEFINITION_FORMATS = ("ast", "markdown", "html", "rst", "org", "asciidoc")
 #: right and three do not.
 KNOWN_DEFINITION_GAPS: dict[tuple[str, str], str] = {
     ("asciidoc", "shape"): (
-        "The AsciiDoc parser drops every description and splits one list into one list per "
-        "term. `t::\\ndesc` comes back as a DefinitionTerm with no DefinitionDescription, the "
-        "description text becoming a sibling paragraph, and an N-term list comes back as N "
-        "single-term lists. The text survives; the binding between term and description does "
-        "not. See #351."
+        "AsciiDoc attaches one description to each `term::`, so a term's several "
+        "descriptions flatten into it -- as continuation lines since #351's fix bound "
+        "descriptions to their terms at all, so the words survive; the description count "
+        "cannot. The same inherent expressibility gap as reST and Org."
     ),
     ("asciidoc", "description_paragraphs"): (
-        "Follows from the same defect as ('asciidoc', 'shape'): with no DefinitionDescription "
-        "surviving the trip there is nothing left to count paragraphs inside. See #351."
+        "A description's paragraph boundary degrades to a continuation line, so two "
+        "paragraphs come back as one -- words intact since the renderer stopped fusing "
+        "them ('only'+'extra' -> 'onlyextra'). Asciidoctor proper spells the boundary "
+        "with a `+` continuation line, which this parser does not read yet; teaching it "
+        "`+` would close this."
     ),
     ("rst", "shape"): (
         "The reStructuredText renderer emits a term's several descriptions as consecutive "

--- a/tests/unit/test_roundtrip_fuzzing.py
+++ b/tests/unit/test_roundtrip_fuzzing.py
@@ -651,12 +651,11 @@ FOOTNOTE_FORMATS = ("ast", "markdown", "html", "rst", "org", "asciidoc", "dokuwi
 #: here: "asciidoc loses every footnote" reads like a renderer that drops them,
 #: and the renderer is in fact correct.
 KNOWN_FOOTNOTE_GAPS: dict[tuple[str, str], str] = {
-    ("asciidoc", "markers"): (
-        "The AsciiDoc parser does not recognise the named inline form. The renderer emits "
-        "`footnote:a1[text]`, which is valid Asciidoctor, but the parser's patterns match only "
-        "`footnote:[text]` and `footnoteref:[id,text]` -- so its own output comes back as literal "
-        "text and the raw markup leaks into the prose."
-    ),
+    # ("asciidoc", "markers") is gone: the parser reads the named inline form
+    # `footnote:a1[text]` (#346), degrades a hard break inside the macro's brackets to a
+    # space instead of an unparseable embedded newline, and synthesizes an empty
+    # definition for an id referenced but never defined -- the spelling the renderer
+    # itself emits when a definition's content flattens to nothing.
     ("asciidoc", "definition_paragraphs"): (
         "The AsciiDoc renderer flattens a multi-paragraph definition into one inline argument: "
         "two paragraphs render as `footnote:a1[note one note two]`. Lost at render time, before "


### PR DESCRIPTION
Fixes #353. Fixes #351. Fixes #346. Three commits, one per defect, all in the AsciiDoc renderer/parser pair.

## #353 — bold over a hard break crashed the parser (the matrix's only open crash)

A span wrapping only a hard break stranded its delimiters at line starts, where AsciiDoc reads `* ` as a level-1 list marker and `** ` as level-2: `Strong(LineBreak)` silently became a list item, `Strong(Strong(LineBreak))` raised (`Cannot nest to level 2 without a parent item at level 1`). Boundary breaks now hoist outside emphasis/strong/strikethrough delimiters and spans with no visible core emit none — the same cure as the markdown renderer's #391, which this shape turned out to share.

## #351 — definition descriptions dropped, lists split per term

The parser required indentation on every description line, but the standard AsciiDoc placement — and this renderer's own output — is the line directly below `term::` with no indent. Those descriptions parsed to nothing (term empty, text as a sibling paragraph, list split at every term). Unindented lines adjacent to the term now bind to it, accumulated into one wrapped paragraph; indented-after-blank continuation and list termination on blank+unindented are unchanged. The renderer half also stopped fusing a description's paragraphs into one token (`only`+`extra` → `onlyextra`, #352's class) — blocks join as continuation lines.

The two definition-gate entries survive (multi-description flattening is inherent — one description per `term::` — and paragraph boundaries degrade to wraps until the parser reads `+` continuation) with honest rewritten reasons.

## #346 — the named inline footnote form leaked as literal text

`footnote:a1[text]` is valid Asciidoctor and the renderer's own spelling, but the parser matched only `footnote:[text]`/`footnoteref:[...]`. Now: the named form parses (first use defines, `footnote:id[]` references, repeats don't overwrite); a hard break inside the macro's brackets degrades to a space via the inline-only flag (generalized from `_in_table_cell` — same constraint, second site) instead of embedding an unparseable newline; and an id referenced but never defined synthesizes an empty definition, since `footnote:id[]` is also what the renderer emits when a definition's content flattens to nothing. The `(asciidoc, markers)` allowlist entry is deleted.

## Verification

- 9 new unit tests across renderer and parser files, each red before its fix.
- Property hunts: 400 random footnote documents clean on the markers property; three fresh-corpus discovery runs (`ALL2MD_FUZZ_DISCOVERY=1`) of the full fuzzing file, all green — deleted entry stays green, surviving entries fail durably.
- Full unit suite, ruff, mypy, changelog check green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
