### PR TITLE
fix(dokuwiki): stop fusing footnote definition paragraphs

### DIFF
--- a/changelog.d/347-dokuwiki-footnote-fusion.fixed.md
+++ b/changelog.d/347-dokuwiki-footnote-fusion.fixed.md
@@ -1,0 +1,8 @@
+- **DokuWiki footnote definitions no longer fuse their paragraphs into one token.**
+  A multi-paragraph definition was rendered through the inline path with nothing
+  between the blocks, so `first para` and `second para` came out `first parasecond
+  para` -- a destroyed word boundary, the same corruption class fixed for reST and
+  Org definition lists ([#347](https://github.com/thomas-villani/all2md/issues/347)).
+  Blocks now render separately and join with a space. The paragraph boundary itself
+  is still lost -- DokuWiki's inline footnotes have nowhere to carry it -- and the
+  round-trip fuzzing gate continues to document that; the words survive.

--- a/src/all2md/renderers/dokuwiki.py
+++ b/src/all2md/renderers/dokuwiki.py
@@ -641,7 +641,19 @@ class DokuWikiRenderer(NodeVisitor, InlineContentMixin, BaseRenderer):
         # DokuWiki doesn't support separate footnote definitions
         # Skip or render as HTML comment if use_html_for_unsupported
         if self.options.use_html_for_unsupported:
-            content = self._render_inline_content(node.content)
+            # The definition holds BLOCKS. Feeding them through the inline path
+            # joined the blocks with nothing at all, fusing the last word of one
+            # paragraph to the first word of the next ('first para' + 'second
+            # para' -> 'first parasecond para') -- destroyed word boundaries,
+            # not lost formatting (#347). Each block renders separately and the
+            # pieces join with a space; the paragraph boundary is still lost
+            # (documented in the fuzzing gate), the words are not.
+            parts = []
+            for child in node.content:
+                inline = getattr(child, "content", None)
+                if isinstance(inline, list):
+                    parts.append(self._render_inline_content(inline))
+            content = " ".join(part for part in parts if part)
             self._output.append(f"<!-- Footnote {node.identifier}: {content} -->")
 
     def visit_definition_list(self, node: DefinitionList) -> None:

--- a/tests/unit/renderers/test_dokuwiki_renderer.py
+++ b/tests/unit/renderers/test_dokuwiki_renderer.py
@@ -930,6 +930,33 @@ class TestDokuWikiFootnotes:
         # Should be skipped when use_html_for_unsupported is False
         assert "<!--" not in output
 
+    def test_multi_paragraph_definition_keeps_its_word_boundary(self) -> None:
+        """A definition's paragraphs must not fuse into one token (#347).
+
+        They were rendered through the inline path with nothing between the
+        blocks, so 'first para' + 'second para' came out 'first parasecond
+        para' -- a destroyed word boundary, the same corruption class #352
+        fixed for reST and Org definition lists. The paragraph boundary itself
+        is still lost (DokuWiki's inline footnotes have nowhere to carry it;
+        the fuzzing gate documents that), but the words survive.
+        """
+        doc = Document(
+            children=[
+                FootnoteDefinition(
+                    identifier="a1",
+                    content=[
+                        Paragraph(content=[Text(content="first para")]),
+                        Paragraph(content=[Text(content="second para")]),
+                    ],
+                )
+            ]
+        )
+        output = DokuWikiRenderer().render_to_string(doc)
+
+        assert "parasecond" not in output
+        assert "first para" in output
+        assert "second para" in output
+
 
 @pytest.mark.unit
 class TestDokuWikiHTML:


### PR DESCRIPTION
Partial #347 — the word-corruption slice, deliberately scoped small.

## The defect

A multi-paragraph footnote definition rendered its blocks through the inline path with nothing between them, so `first para` + `second para` came out as `first parasecond para` inside the renderer's `<!-- Footnote id: ... -->` comment — a destroyed word boundary, the same corruption class #352 fixed for reST/Org definition lists. Blocks now render separately and join with a space.

## What is deliberately NOT here

The rest of #347 decomposes per format and each piece is its own logical change on files the three open PRs (#393/#394/#395) already touch:

- **rst**: `defs=0` on reparse — the paragraph question is unreachable until the `(rst, markers)` gap is fixed (alphanumeric `.. [a1]` is *citation* syntax; the renderer needs the named-footnote spelling `[#a1]_` / `.. [#a1]`). One future branch closes both rst entries.
- **org**: org proper allows blank lines inside a `[fn:id]` definition (two blanks end it), but the org parser's block splitter discards blank-line counts, so multi-paragraph support needs a splitter change — the same file #394 touches.
- **dokuwiki paragraph count**: still collapses (inline `((...))` footnotes have nowhere to carry a paragraph boundary); the fuzzing-gate entry stands and stays accurate.

## Verification

New unit test red before the fix; dokuwiki renderer suite, full fuzzing gate (the dokuwiki entry keeps failing on the collapse, no XPASS), ruff, mypy, changelog check all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
