### PR TITLE
fix(rst): footnotes survive round trips with their identifiers and paragraphs (#347)

### DIFF
--- a/changelog.d/347-rst-named-footnotes.fixed.md
+++ b/changelog.d/347-rst-named-footnotes.fixed.md
@@ -1,0 +1,16 @@
+- **reST footnotes survive a round trip with their identifiers and paragraphs.**
+  Three defects stacked ([#347](https://github.com/thomas-villani/all2md/issues/347)):
+  the renderer spelled every footnote `[a1]_` / `.. [a1]`, which for an
+  alphanumeric label is reST *citation* syntax, so the footnote stopped being
+  one -- non-numeric identifiers now use the named auto-numbered form
+  (`[#a1]_` / `.. [#a1]`), with escaped whitespace (`word\ [#a1]_`) where a
+  marker rides a word, since docutils only starts inline markup after a
+  boundary. A multi-paragraph definition rendered as continuation lines and
+  read back as one paragraph -- its blocks now separate with blank lines at
+  the marker's body column, and hard breaks inside a body fall back to raw
+  newlines so `| ` line-block syntax cannot displace it. And the parser
+  preferred docutils' normalized anchors (`ids`, e.g. `footnote-1`) over the
+  label as written (`names`), mangling identifiers even for plain numbered
+  footnotes; it now takes the name on both definitions and resolved
+  references, and resolves docutils' internal `\x00` escape markers instead
+  of copying them into text.

--- a/src/all2md/parsers/rst.py
+++ b/src/all2md/parsers/rst.py
@@ -684,7 +684,17 @@ class RestructuredTextParser(BaseParser):
         from docutils import nodes as docutils_nodes
 
         if isinstance(node, docutils_nodes.Text):
-            return Text(content=str(node))
+            text = str(node)
+            if "\x00" in text:
+                # Docutils keeps backslash escapes in the doctree as internal
+                # null markers (`0\ [0]_` -> '0\x00 [0]_'); unescape resolves
+                # them, removing escaped whitespace entirely per reST semantics.
+                from docutils.utils import unescape
+
+                text = unescape(text)
+                if not text:
+                    return None
+            return Text(content=text)
         elif isinstance(node, docutils_nodes.emphasis):
             content = self._process_inline_nodes(node.children)
             return Emphasis(content=content)
@@ -744,18 +754,19 @@ class RestructuredTextParser(BaseParser):
             Footnote definition AST node
 
         """
-        # Extract footnote identifier
+        # Extract footnote identifier. The label the author wrote lives in
+        # `names`; `ids` holds docutils' normalized anchor, which mangles it
+        # (`.. [42]` gets id 'footnote-1', `.. [#42x]` gets id 'x' because id
+        # normalization strips leading digits). Preferring ids lost the label.
         identifier = None
         if hasattr(node, "get"):
-            # Try to get footnote IDs
-            ids = node.get("ids", [])
-            if ids:
-                identifier = ids[0]
-            # Also check names attribute
+            names = node.get("names", [])
+            if names:
+                identifier = names[0]
             if not identifier:
-                names = node.get("names", [])
-                if names:
-                    identifier = names[0]
+                ids = node.get("ids", [])
+                if ids:
+                    identifier = ids[0]
 
         if not identifier:
             # Fallback to auto-numbering
@@ -791,9 +802,20 @@ class RestructuredTextParser(BaseParser):
             Footnote reference AST node
 
         """
-        # Extract identifier from refid or refname
-        identifier = node.get("refid") or node.get("refname") or "footnote"
-        return FootnoteReference(identifier=identifier)
+        # `refname` is the label as written; after docutils' reference
+        # resolution it is replaced by `refid`, the target's normalized anchor
+        # ('footnote-1' for `.. [42]`). Follow the refid back to the footnote
+        # node and take its name, so the reference carries the same identifier
+        # its definition does.
+        identifier = node.get("refname")
+        if not identifier:
+            refid = node.get("refid")
+            if refid:
+                document = getattr(node, "document", None)
+                target = document.ids.get(refid) if document is not None else None
+                names = target.get("names", []) if target is not None else []
+                identifier = names[0] if names else refid
+        return FootnoteReference(identifier=identifier or "footnote")
 
     def _process_math_block(self, node: Any) -> MathBlock:
         """Process a math block (displayed equation).

--- a/src/all2md/renderers/rst.py
+++ b/src/all2md/renderers/rst.py
@@ -101,6 +101,7 @@ class RestructuredTextRenderer(NodeVisitor, InlineContentMixin, BaseRenderer):
         self._in_list: bool = False
         self._list_depth: int = 0
         self._in_blockquote: int = 0
+        self._in_footnote: int = 0
 
     def render_to_string(self, document: Document) -> str:
         """Render a document AST to RST string.
@@ -120,6 +121,7 @@ class RestructuredTextRenderer(NodeVisitor, InlineContentMixin, BaseRenderer):
         self._in_list = False
         self._list_depth = 0
         self._in_blockquote = 0
+        self._in_footnote = 0
 
         document.accept(self)
 
@@ -737,7 +739,7 @@ class RestructuredTextRenderer(NodeVisitor, InlineContentMixin, BaseRenderer):
         else:
             # Hard line break rendering depends on configured mode and context
             # Check if we should fallback to raw mode in containers
-            in_container = self._in_list or self._in_blockquote > 0
+            in_container = self._in_list or self._in_blockquote > 0 or self._in_footnote > 0
             use_raw_mode = self.options.hard_line_break_mode == "raw" or (
                 self.options.hard_line_break_fallback_in_containers and in_container
             )
@@ -894,22 +896,70 @@ class RestructuredTextRenderer(NodeVisitor, InlineContentMixin, BaseRenderer):
         """Render HTML block (preserve as-is)."""
         self._output.append(node.content)
 
+    @staticmethod
+    def _footnote_label(identifier: str) -> str:
+        """Spell a footnote identifier the way reST footnote syntax can carry it.
+
+        A bare alphanumeric label (``[a1]_``) is reST *citation* syntax, so an
+        identifier rendered that way stops being a footnote. Non-numeric
+        identifiers need the named auto-numbered form (``[#a1]_``); purely
+        numeric ones are already valid as manually numbered footnotes.
+        """
+        return identifier if identifier.isdigit() else f"#{identifier}"
+
+    def _needs_inline_markup_boundary(self) -> bool:
+        r"""Whether output ends where reST inline markup cannot start.
+
+        Docutils only recognizes an inline markup start after whitespace or an
+        opening/quoting character, so ``0[0]_`` is plain text. The reST idiom
+        for a marker glued to a word is escaped whitespace: ``0\ [0]_``.
+        """
+        for fragment in reversed(self._output):
+            if fragment:
+                last = fragment[-1]
+                return not (last.isspace() or last in "-:/'\"<([{")
+        return False
+
     def visit_footnote_reference(self, node: FootnoteReference) -> None:
         """Render footnote reference."""
-        self._output.append(f"[{node.identifier}]_")
+        if self._needs_inline_markup_boundary():
+            self._output.append("\\ ")
+        self._output.append(f"[{self._footnote_label(node.identifier)}]_")
 
     def visit_footnote_definition(self, node: FootnoteDefinition) -> None:
         """Render footnote definition."""
-        self._output.append(f".. [{node.identifier}] ")
-        for i, child in enumerate(node.content):
+        self._output.append(f".. [{self._footnote_label(node.identifier)}] ")
+        # A footnote body is a container like a list item: line-block syntax
+        # (`| line`) on the marker line becomes a line_block node instead of
+        # the definition's paragraph, so hard breaks fall back to raw newlines
+        # here, the same trade visit_line_break already makes inside lists.
+        self._in_footnote += 1
+        block_texts = []
+        try:
+            for child in node.content:
+                saved_output = self._output
+                self._output = []
+                child.accept(self)
+                block_texts.append("".join(self._output))
+                self._output = saved_output
+        finally:
+            self._in_footnote -= 1
+
+        # The first block rides the marker line; every further line -- a later
+        # block, or a continuation line within one -- indents to the marker's
+        # body column, with blank lines between blocks so they stay separate
+        # paragraphs. Joining with a bare newline made every block a
+        # continuation line of the first paragraph, collapsing a
+        # multi-paragraph definition to one paragraph on re-parse (#347).
+        for i, block_text in enumerate(block_texts):
+            lines = [line for line in block_text.split("\n") if line.strip()]
             if i > 0:
-                self._output.append("\n   ")
-            saved_output = self._output
-            self._output = []
-            child.accept(self)
-            child_content = "".join(self._output)
-            self._output = saved_output
-            self._output.append(child_content)
+                self._output.append("\n")
+            for j, line in enumerate(lines):
+                if i == 0 and j == 0:
+                    self._output.append(line)
+                else:
+                    self._output.append(f"\n   {line}")
 
     def visit_math_inline(self, node: MathInline) -> None:
         """Render inline math."""

--- a/tests/unit/parsers/test_rst_parser.py
+++ b/tests/unit/parsers/test_rst_parser.py
@@ -568,6 +568,84 @@ This has a footnote [1]_.
         assert len(refs) >= 1
         assert len(defs) >= 1
 
+    @staticmethod
+    def _refs_and_defs(doc: Document) -> tuple[list[FootnoteReference], list[FootnoteDefinition]]:
+        refs: list[FootnoteReference] = []
+        defs: list[FootnoteDefinition] = []
+
+        def walk(node) -> None:
+            if isinstance(node, FootnoteReference):
+                refs.append(node)
+            if isinstance(node, FootnoteDefinition):
+                defs.append(node)
+            for attr in ("children", "content"):
+                value = getattr(node, attr, None)
+                if isinstance(value, list):
+                    for child in value:
+                        if hasattr(child, "accept"):
+                            walk(child)
+
+        walk(doc)
+        return refs, defs
+
+    def test_numbered_footnote_keeps_its_label(self) -> None:
+        """`.. [42]` carries identifier '42', not docutils' anchor 'footnote-1'.
+
+        The label lives in the docutils `names` attribute; `ids` holds a
+        normalized anchor. Preferring ids lost the label on both the
+        definition and the resolved reference.
+        """
+        doc = RestructuredTextParser().parse("Body [42]_ end.\n\n.. [42] Note.\n")
+        refs, defs = self._refs_and_defs(doc)
+
+        assert [r.identifier for r in refs] == ["42"]
+        assert [d.identifier for d in defs] == ["42"]
+
+    def test_named_footnote_identifier_survives(self) -> None:
+        """The named auto-numbered form `[#a1]_` / `.. [#a1]` keeps its name."""
+        doc = RestructuredTextParser().parse("Body [#a1]_ end.\n\n.. [#a1] Note.\n")
+        refs, defs = self._refs_and_defs(doc)
+
+        assert [r.identifier for r in refs] == ["a1"]
+        assert [d.identifier for d in defs] == ["a1"]
+
+    def test_named_footnote_with_leading_digits(self) -> None:
+        """A name like '42x' survives -- id normalization would strip it to 'x'."""
+        doc = RestructuredTextParser().parse("Body [#42x]_ end.\n\n.. [#42x] Note.\n")
+        refs, defs = self._refs_and_defs(doc)
+
+        assert [r.identifier for r in refs] == ["42x"]
+        assert [d.identifier for d in defs] == ["42x"]
+
+    def test_multi_paragraph_definition_keeps_both_paragraphs(self) -> None:
+        """An indented blank-line-separated body parses as two paragraphs."""
+        doc = RestructuredTextParser().parse("Body [#a1]_ end.\n\n.. [#a1] First paragraph.\n\n   Second paragraph.\n")
+        _refs, defs = self._refs_and_defs(doc)
+
+        assert len(defs) == 1
+        paragraphs = [c for c in defs[0].content if isinstance(c, Paragraph)]
+        assert len(paragraphs) == 2
+
+    def test_escaped_whitespace_leaves_no_null_marker(self) -> None:
+        r"""Escaped whitespace (`0\ [0]_`) vanishes instead of leaking '\x00 ' into text."""
+        doc = RestructuredTextParser().parse("0\\ [0]_ end.\n\n.. [0] Note.\n")
+
+        texts: list[str] = []
+
+        def walk(node) -> None:
+            if isinstance(node, Text):
+                texts.append(node.content)
+            for attr in ("children", "content"):
+                value = getattr(node, attr, None)
+                if isinstance(value, list):
+                    for child in value:
+                        if hasattr(child, "accept"):
+                            walk(child)
+
+        walk(doc)
+        assert all("\x00" not in t for t in texts)
+        assert texts[0] == "0"
+
 
 @pytest.mark.unit
 class TestMath:

--- a/tests/unit/renderers/test_rst_renderer.py
+++ b/tests/unit/renderers/test_rst_renderer.py
@@ -26,6 +26,8 @@ from all2md.ast import (
     DefinitionTerm,
     Document,
     Emphasis,
+    FootnoteDefinition,
+    FootnoteReference,
     Heading,
     Image,
     LineBreak,
@@ -1508,3 +1510,100 @@ class TestEdgeCases:
         assert "``code``" in rst
         assert "* Item" in rst
         assert "----" in rst
+
+
+@pytest.mark.unit
+class TestFootnotes:
+    """Tests for footnote rendering.
+
+    A bare alphanumeric label (``[a1]_``) is reST *citation* syntax, so
+    non-numeric identifiers must render as named auto-numbered footnotes
+    (``[#a1]_``) to stay footnotes on re-parse (#347).
+    """
+
+    def test_non_numeric_identifier_uses_named_form(self) -> None:
+        """A non-numeric identifier renders as `[#name]_` / `.. [#name]`."""
+        doc = Document(
+            children=[
+                Paragraph(content=[Text(content="Body "), FootnoteReference(identifier="a1")]),
+                FootnoteDefinition(identifier="a1", content=[Paragraph(content=[Text(content="Note.")])]),
+            ]
+        )
+        rst = RestructuredTextRenderer().render_to_string(doc)
+
+        assert "[#a1]_" in rst
+        assert ".. [#a1] Note." in rst
+        assert "[a1]_" not in rst.replace("[#a1]_", "")
+
+    def test_numeric_identifier_stays_numbered(self) -> None:
+        """A purely numeric identifier keeps the manually numbered form."""
+        doc = Document(
+            children=[
+                Paragraph(content=[Text(content="Body "), FootnoteReference(identifier="42")]),
+                FootnoteDefinition(identifier="42", content=[Paragraph(content=[Text(content="Note.")])]),
+            ]
+        )
+        rst = RestructuredTextRenderer().render_to_string(doc)
+
+        assert "[42]_" in rst
+        assert ".. [42] Note." in rst
+        assert "#42" not in rst
+
+    def test_multi_paragraph_definition_keeps_blank_line(self) -> None:
+        """Definition blocks separate with a blank line at the body column, not continuation lines."""
+        doc = Document(
+            children=[
+                Paragraph(content=[Text(content="Body "), FootnoteReference(identifier="a1")]),
+                FootnoteDefinition(
+                    identifier="a1",
+                    content=[
+                        Paragraph(content=[Text(content="First paragraph.")]),
+                        Paragraph(content=[Text(content="Second paragraph.")]),
+                    ],
+                ),
+            ]
+        )
+        rst = RestructuredTextRenderer().render_to_string(doc)
+
+        assert ".. [#a1] First paragraph.\n\n   Second paragraph." in rst
+
+    def test_reference_glued_to_word_gets_escaped_boundary(self) -> None:
+        """A marker directly after a word needs `\\ ` -- docutils only starts inline markup after a boundary."""
+        doc = Document(
+            children=[
+                Paragraph(content=[Text(content="word"), FootnoteReference(identifier="a1")]),
+                FootnoteDefinition(identifier="a1", content=[Paragraph(content=[Text(content="Note.")])]),
+            ]
+        )
+        rst = RestructuredTextRenderer().render_to_string(doc)
+
+        assert "word\\ [#a1]_" in rst
+
+    def test_reference_after_space_needs_no_escape(self) -> None:
+        """No escaped whitespace is inserted where a boundary already exists."""
+        doc = Document(
+            children=[
+                Paragraph(content=[Text(content="word "), FootnoteReference(identifier="a1")]),
+                FootnoteDefinition(identifier="a1", content=[Paragraph(content=[Text(content="Note.")])]),
+            ]
+        )
+        rst = RestructuredTextRenderer().render_to_string(doc)
+
+        assert "word [#a1]_" in rst
+        assert "\\ " not in rst
+
+    def test_hard_break_in_definition_falls_back_to_raw(self) -> None:
+        """Hard breaks inside a footnote body use raw newlines -- `| ` on the marker line becomes a line_block."""
+        doc = Document(
+            children=[
+                Paragraph(content=[Text(content="Body "), FootnoteReference(identifier="a1")]),
+                FootnoteDefinition(
+                    identifier="a1",
+                    content=[Paragraph(content=[Text(content="one"), LineBreak(soft=False), Text(content="two")])],
+                ),
+            ]
+        )
+        rst = RestructuredTextRenderer().render_to_string(doc)
+
+        assert "| " not in rst
+        assert ".. [#a1] one\n   two" in rst

--- a/tests/unit/test_roundtrip_fuzzing.py
+++ b/tests/unit/test_roundtrip_fuzzing.py
@@ -671,14 +671,19 @@ KNOWN_FOOTNOTE_GAPS: dict[tuple[str, str], str] = {
         "html",
         "definition_paragraphs",
     ): "Follows from the markers gap: there is no definition left to count paragraphs in.",
-    ("rst", "markers"): (
-        "The reST renderer emits `body[a1]_` and `.. [a1] text`. With an alphanumeric label that is "
-        "reST *citation* syntax, not footnote syntax (which wants `[#name]_` or a number), so the "
-        "identifiers the generator draws do not survive as footnotes."
-    ),
+    # ("rst", "markers") is gone: the renderer now spells non-numeric identifiers
+    # as named auto-numbered footnotes (`[#a1]_` / `.. [#a1]`) instead of citation
+    # syntax, escapes the whitespace boundary a marker glued to a word needs
+    # (`0\ [0]_`), and the parser prefers docutils `names` (the label as written)
+    # over `ids` (normalized anchors like 'footnote-1') on both definitions and
+    # resolved references.
     ("rst", "definition_paragraphs"): (
-        "A multi-paragraph definition renders as indented continuation lines under `.. [a1]`, which "
-        "reads back as one paragraph rather than two. #347"
+        "Multi-paragraph text bodies now survive (blocks separate with blank lines at the "
+        "marker's body column, and hard breaks fall back to raw newlines so `| ` line-block "
+        "syntax cannot eat the body). What remains is images: reST has no inline image markup, "
+        "so a paragraph holding an Image renders as an `.. image::` directive and stops being "
+        "a paragraph. A general trait of the reST renderer, not footnote-specific; faithful "
+        "spelling would need substitution machinery (`|name|` + `.. |name| image::`)."
     ),
     # ("markdown", "definition_paragraphs") is gone: what looked like #347's collapse was
     # three defects wearing one reason -- consecutive hard breaks splitting the definition's


### PR DESCRIPTION
## Summary

Closes the reST slice of #347 and deletes the `(rst, markers)` round-trip gate entry. Three stacked defects, each read off the rendered output:

**Renderer**
- Every footnote was spelled `[a1]_` / `.. [a1]`. With an alphanumeric label that is reST *citation* syntax, so the footnote stopped being one on re-parse. Non-numeric identifiers now use the named auto-numbered form (`[#a1]_` / `.. [#a1]`); purely numeric ones keep the manually numbered form.
- A marker glued to a word (`word[#a1]_`) never parsed — docutils only starts inline markup after a boundary. The renderer now emits the reST idiom for that: escaped whitespace (`word\ [#a1]_`).
- A multi-paragraph definition rendered its blocks as continuation lines, which read back as one paragraph. Blocks now separate with blank lines at the marker's body column. Hard breaks inside a footnote body fall back to raw newlines (the same trade `visit_line_break` already makes inside lists) — otherwise `| ` line-block syntax on the marker line becomes a `line_block` node and displaces the body entirely.

**Parser**
- Identifier extraction preferred docutils `ids` (normalized anchors) over `names` (the label as written), mangling identifiers even for plain numbered footnotes: `.. [42]` came back as `footnote-1`, and `.. [#42x]` as `x` (id normalization strips leading digits). Both definitions and resolved references now take the name — references follow their `refid` back to the target footnote's name.
- Docutils leaves internal `\x00` escape markers in doctree text (`0\ [0]_` → `'0\x00 [0]_'`); the parser now resolves them with `docutils.utils.unescape` instead of copying them into `Text` nodes.

**Gate**
- `(rst, markers)`: deleted.
- `(rst, definition_paragraphs)`: rewritten to its true residual cause — reST has no inline image markup, so a paragraph holding an `Image` renders as an `.. image::` directive and stops being a paragraph. A general trait of the reST renderer, not footnote-specific; a faithful spelling would need substitution machinery (`|name|` + `.. |name| image::`).

Found along the way, not fixed here (separate defect class): the rst parser drops `line_block` nodes entirely — any `| ` line block loses its content. Fix branch coming next... after the org slice.

## Testing

- Full round-trip fuzzing gate: 80 passed, 11 xfailed, 0 xpassed/failed (~5 min).
- New unit tests: 6 renderer (named/numbered spelling, blank-line body, boundary escape both ways, raw-mode hard break), 5 parser (label fidelity for `42`/`a1`/`42x`, multi-paragraph body, no `\x00` leak).
- Full unit suite green; ruff, mypy, changelog check clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
