### PR TITLE
fix(org): footnote definitions keep their paragraphs across round trips (#347)

### DIFF
--- a/changelog.d/347-org-multiparagraph-footnotes.fixed.md
+++ b/changelog.d/347-org-multiparagraph-footnotes.fixed.md
@@ -1,0 +1,15 @@
+- **Org footnote definitions keep their paragraphs across a round trip.**
+  Org continues a footnote definition across a single blank line and ends it at
+  two, but neither side spoke that dialect
+  ([#347](https://github.com/thomas-villani/all2md/issues/347)): the renderer
+  joined a definition's paragraphs with a bare newline (one continuation line on
+  re-parse) and followed a definition with a single blank line (which would
+  swallow the next block), while the parser's block splitter discarded the blank
+  counts entirely. The renderer now separates a definition's paragraphs with one
+  blank line and follows a definition with two; the splitter counts the blank
+  lines between blocks, and single-gap paragraph blocks after a `[fn:id]` join
+  its definition. Also ported the boundary-break hoisting cure
+  ([#391](https://github.com/thomas-villani/all2md/issues/391)) to the Org
+  span delimiters (`/`, `*`, `+`, `_`): a hard break at a span's edge stranded
+  the delimiter at a line start, where `* ` opens a headline and `+ ` a list
+  item.

--- a/src/all2md/parsers/org.py
+++ b/src/all2md/parsers/org.py
@@ -646,7 +646,7 @@ class OrgParser(BaseParser):
         return Heading(level=level, content=content, metadata=heading_metadata)
 
     @staticmethod
-    def _split_body_blocks(body_text: str) -> list[str]:
+    def _split_body_blocks(body_text: str) -> list[tuple[int, str]]:
         """Split body text into blocks, keeping each greater block in one piece.
 
         Blank lines separate Org elements, but not inside a greater block: a
@@ -661,15 +661,28 @@ class OrgParser(BaseParser):
         follows or precedes ordinary text without a blank line between them still marks
         a boundary. The one exception is an affiliated keyword such as ``#+CAPTION:``,
         which belongs to the block written underneath it and therefore stays attached.
+
+        Each block is returned with the number of blank lines that preceded it,
+        because Org gives that count meaning: one blank line after a footnote
+        definition continues the definition, two end it.
         """
-        blocks: list[str] = []
+        blocks: list[tuple[int, str]] = []
         current: list[str] = []
         open_kind: str | None = None
+        gap = 0
+        gap_before_current = 0
 
         def flush() -> None:
             if current:
-                blocks.append("\n".join(current))
+                blocks.append((gap_before_current, "\n".join(current)))
                 current.clear()
+
+        def append_line(text: str) -> None:
+            nonlocal gap, gap_before_current
+            if not current:
+                gap_before_current = gap
+            gap = 0
+            current.append(text)
 
         for line in body_text.split("\n"):
             stripped = line.strip()
@@ -688,17 +701,39 @@ class OrgParser(BaseParser):
                 if not all(re.match(r"^#\+[\w-]+:", pending.strip()) for pending in current):
                     flush()
                 open_kind = begin.group(1)
-                current.append(line)
+                append_line(line)
                 continue
 
             if not stripped:
                 flush()
+                gap += 1
                 continue
 
-            current.append(line)
+            append_line(line)
 
         flush()
         return blocks
+
+    @staticmethod
+    def _is_paragraph_content_block(block: str) -> bool:
+        """Whether *block* would parse as a plain paragraph.
+
+        Used to decide if a block continues a footnote definition. Anything
+        that would parse as a structural element -- another definition, a
+        thematic break, a table, a list, a greater block, a block quote --
+        ends the definition instead of joining it.
+        """
+        if not block or re.match(r"^-{5,}$", block) or re.match(r"^\[fn:[^\]]+\]", block):
+            return False
+        if block.startswith(("#+", "|", "\\[")):
+            return False
+        if re.search(r"^-\s+.+?\s+::\s+", block, re.MULTILINE):
+            return False
+        if re.match(r"^([\-\+\*]\s+|\d+[\.\)]\s*)", block):
+            return False
+        if all(line.strip().startswith(":") for line in block.split("\n") if line.strip()):
+            return False
+        return True
 
     def _process_body(self, body_text: str) -> list[Node]:
         """Process body text into AST nodes.
@@ -727,8 +762,10 @@ class OrgParser(BaseParser):
         # Track footnote definitions for later
         footnote_defs: list[FootnoteDefinition] = []
 
-        for block in blocks:
-            block = block.strip()
+        index = 0
+        while index < len(blocks):
+            block = blocks[index][1].strip()
+            index += 1
             if not block:
                 continue
 
@@ -755,6 +792,21 @@ class OrgParser(BaseParser):
                 footnote_content_text = footnote_match.group(2)
                 # Parse footnote content as inline
                 footnote_content = [Paragraph(content=self._parse_inline(footnote_content_text))]
+                # Org continues a definition across a single blank line; two
+                # consecutive blank lines (or the next definition) end it. Each
+                # single-gap paragraph block that follows is another paragraph
+                # of this definition, not document content. Structural blocks
+                # (lists, tables, greater blocks...) end the definition here --
+                # a conservative reading of the spec, which would keep them too.
+                while index < len(blocks):
+                    next_gap, next_block = blocks[index]
+                    next_block = next_block.strip()
+                    if next_gap != 1 or not self._is_paragraph_content_block(next_block):
+                        break
+                    continuation = self._parse_paragraph(next_block)
+                    if continuation:
+                        footnote_content.append(continuation)
+                    index += 1
                 footnote_def = FootnoteDefinition(identifier=footnote_id, content=cast(list[Node], footnote_content))
                 footnote_defs.append(footnote_def)
                 continue

--- a/src/all2md/renderers/org.py
+++ b/src/all2md/renderers/org.py
@@ -216,7 +216,13 @@ class OrgRenderer(NodeVisitor, InlineContentMixin, BaseRenderer):
         for i, child in enumerate(node.children):
             child.accept(self)
             if i < len(node.children) - 1:
-                self._output.append("\n\n")
+                # A footnote definition continues across a single blank line
+                # (that is how its own paragraphs separate), so it needs two
+                # blank lines to hand the document back its next block.
+                if isinstance(child, FootnoteDefinition):
+                    self._output.append("\n\n\n")
+                else:
+                    self._output.append("\n\n")
 
     def _render_file_properties(self, metadata: dict) -> None:
         """Render metadata as Org file-level properties.
@@ -732,7 +738,11 @@ class OrgRenderer(NodeVisitor, InlineContentMixin, BaseRenderer):
 
         """
         content = self._render_inline_content(node.content)
-        self._output.append(f"/{content}/")
+        lead, core, trail = self._split_boundary_breaks(content)
+        if not core.strip():
+            self._output.append(content)
+            return
+        self._output.append(f"{lead}/{core}/{trail}")
 
     def visit_strong(self, node: Strong) -> None:
         """Render a Strong node.
@@ -744,7 +754,44 @@ class OrgRenderer(NodeVisitor, InlineContentMixin, BaseRenderer):
 
         """
         content = self._render_inline_content(node.content)
-        self._output.append(f"*{content}*")
+        lead, core, trail = self._split_boundary_breaks(content)
+        if not core.strip():
+            self._output.append(content)
+            return
+        self._output.append(f"{lead}*{core}*{trail}")
+
+    @staticmethod
+    def _split_boundary_breaks(content: str) -> tuple[str, str, str]:
+        """Split rendered inline content into leading breaks, core, trailing breaks.
+
+        A break at the edge of a span strands the delimiter alone at a line
+        start, where Org stops reading it as inline syntax: ``* `` opens a
+        headline or list item and ``+ `` a list item, so the span silently
+        becomes structure (the same class as markdown's #391 and AsciiDoc's
+        #353). Breaks hoist outside the delimiters instead: a span over a line
+        break marks nothing visible, so nothing is lost, and a span left with
+        no visible core emits no delimiters at all.
+        """
+        spellings = (" \\\\\n", "\n")
+        lead = ""
+        stripped = True
+        while stripped:
+            stripped = False
+            for spelling in spellings:
+                if content.startswith(spelling):
+                    lead += spelling
+                    content = content[len(spelling) :]
+                    stripped = True
+        trail = ""
+        stripped = True
+        while stripped:
+            stripped = False
+            for spelling in spellings:
+                if content.endswith(spelling):
+                    trail = spelling + trail
+                    content = content[: -len(spelling)]
+                    stripped = True
+        return lead, content, trail
 
     def visit_code(self, node: Code) -> None:
         """Render a Code node.
@@ -820,7 +867,11 @@ class OrgRenderer(NodeVisitor, InlineContentMixin, BaseRenderer):
 
         """
         content = self._render_inline_content(node.content)
-        self._output.append(f"+{content}+")
+        lead, core, trail = self._split_boundary_breaks(content)
+        if not core.strip():
+            self._output.append(content)
+            return
+        self._output.append(f"{lead}+{core}+{trail}")
 
     def visit_underline(self, node: Underline) -> None:
         """Render an Underline node.
@@ -832,7 +883,11 @@ class OrgRenderer(NodeVisitor, InlineContentMixin, BaseRenderer):
 
         """
         content = self._render_inline_content(node.content)
-        self._output.append(f"_{content}_")
+        lead, core, trail = self._split_boundary_breaks(content)
+        if not core.strip():
+            self._output.append(content)
+            return
+        self._output.append(f"{lead}_{core}_{trail}")
 
     def visit_superscript(self, node: Superscript) -> None:
         """Render a Superscript node.
@@ -877,17 +932,28 @@ class OrgRenderer(NodeVisitor, InlineContentMixin, BaseRenderer):
         self._output.append(f"[fn:{node.identifier}]")
 
     def visit_footnote_definition(self, node: FootnoteDefinition) -> None:
-        """Render footnote definition."""
+        """Render footnote definition.
+
+        Org continues a footnote definition across single blank lines (it ends
+        at two consecutive blank lines, the next definition, or a heading), so
+        a blank line is the correct spelling of a paragraph boundary inside the
+        body. The single newline this used to emit made the second paragraph a
+        continuation line of the first (#347).
+        """
         self._output.append(f"[fn:{node.identifier}] ")
-        for i, child in enumerate(node.content):
-            if i > 0:
-                self._output.append("\n")
+        rendered_blocks = []
+        for child in node.content:
             saved_output = self._output
             self._output = []
             child.accept(self)
-            child_content = "".join(self._output)
+            # Newlines at a block's edge (a hard break renders ' \\' plus a
+            # newline) would stack with the blank-line separator into two blank
+            # lines, which is the spelling for "the definition ends here".
+            child_content = "".join(self._output).strip("\n")
             self._output = saved_output
-            self._output.append(child_content)
+            if child_content:
+                rendered_blocks.append(child_content)
+        self._output.append("\n\n".join(rendered_blocks))
 
     def visit_math_inline(self, node: MathInline) -> None:
         """Render inline math."""

--- a/tests/unit/parsers/test_org_parser.py
+++ b/tests/unit/parsers/test_org_parser.py
@@ -682,6 +682,49 @@ This has a footnote [fn:test].
         assert refs[0].identifier == "test"
         assert defs[0].identifier == "test"
 
+    def test_single_blank_line_continues_definition(self) -> None:
+        """One blank line inside a definition separates its paragraphs, not the definition from the document."""
+        org = "Body [fn:a1] end.\n\n[fn:a1] First paragraph.\n\nSecond paragraph.\n"
+        doc = OrgParser().parse(org)
+
+        defs = [n for n in doc.children if isinstance(n, FootnoteDefinition)]
+        assert len(defs) == 1
+        paragraphs = [c for c in defs[0].content if isinstance(c, Paragraph)]
+        assert len(paragraphs) == 2
+        # The continuation belongs to the footnote, not the document.
+        top_paragraphs = [n for n in doc.children if isinstance(n, Paragraph)]
+        assert len(top_paragraphs) == 1
+
+    def test_two_blank_lines_end_definition(self) -> None:
+        """Two consecutive blank lines end the definition; what follows is document content."""
+        org = "Body [fn:a1] end.\n\n[fn:a1] Only paragraph.\n\n\nDocument continues.\n"
+        doc = OrgParser().parse(org)
+
+        defs = [n for n in doc.children if isinstance(n, FootnoteDefinition)]
+        assert len(defs) == 1
+        assert len([c for c in defs[0].content if isinstance(c, Paragraph)]) == 1
+        top_paragraphs = [n for n in doc.children if isinstance(n, Paragraph)]
+        assert len(top_paragraphs) == 2
+
+    def test_next_definition_ends_definition(self) -> None:
+        """A following `[fn:]` block starts a new definition even across a single blank line."""
+        org = "Body [fn:a1][fn:b2] end.\n\n[fn:a1] First note.\n\n[fn:b2] Second note.\n"
+        doc = OrgParser().parse(org)
+
+        defs = [n for n in doc.children if isinstance(n, FootnoteDefinition)]
+        assert sorted(d.identifier for d in defs) == ["a1", "b2"]
+        assert all(len([c for c in d.content if isinstance(c, Paragraph)]) == 1 for d in defs)
+
+    def test_structural_block_ends_definition(self) -> None:
+        """A list after one blank line ends the definition instead of joining it."""
+        org = "Body [fn:a1] end.\n\n[fn:a1] Only paragraph.\n\n- item one\n- item two\n"
+        doc = OrgParser().parse(org)
+
+        defs = [n for n in doc.children if isinstance(n, FootnoteDefinition)]
+        assert len(defs) == 1
+        assert len([c for c in defs[0].content if isinstance(c, Paragraph)]) == 1
+        assert any(isinstance(n, List) for n in doc.children)
+
 
 @pytest.mark.unit
 class TestMath:

--- a/tests/unit/renderers/test_org_renderer.py
+++ b/tests/unit/renderers/test_org_renderer.py
@@ -25,8 +25,11 @@ from all2md.ast import (
     CommentInline,
     Document,
     Emphasis,
+    FootnoteDefinition,
+    FootnoteReference,
     Heading,
     Image,
+    LineBreak,
     Link,
     List,
     ListItem,
@@ -986,3 +989,89 @@ class TestEdgeCases:
         assert "- Item 1" in org
         assert "#+BEGIN_SRC python" in org
         assert "| Header" in org
+
+
+@pytest.mark.unit
+class TestFootnoteDefinitions:
+    """Tests for footnote definition rendering.
+
+    Org continues a definition across a single blank line and ends it at two,
+    so the blank-line budget carries meaning (#347).
+    """
+
+    @staticmethod
+    def _doc_with_definition(*, blocks: list, after: list | None = None) -> Document:
+        children = [
+            Paragraph(content=[Text(content="Body "), FootnoteReference(identifier="a1"), Text(content=" end.")]),
+            FootnoteDefinition(identifier="a1", content=blocks),
+        ]
+        children.extend(after or [])
+        return Document(children=children)
+
+    def test_paragraphs_separate_with_one_blank_line(self) -> None:
+        """A definition's paragraphs separate with a single blank line -- Org's continuation spelling."""
+        doc = self._doc_with_definition(
+            blocks=[
+                Paragraph(content=[Text(content="First paragraph.")]),
+                Paragraph(content=[Text(content="Second paragraph.")]),
+            ]
+        )
+        org = OrgRenderer().render_to_string(doc)
+
+        assert "[fn:a1] First paragraph.\n\nSecond paragraph." in org
+
+    def test_two_blank_lines_before_following_content(self) -> None:
+        """A definition followed by ordinary content emits two blank lines so it does not swallow it."""
+        doc = self._doc_with_definition(
+            blocks=[Paragraph(content=[Text(content="Only paragraph.")])],
+            after=[Paragraph(content=[Text(content="Document continues.")])],
+        )
+        org = OrgRenderer().render_to_string(doc)
+
+        assert "Only paragraph.\n\n\nDocument continues." in org
+
+    def test_break_only_paragraph_does_not_end_definition(self) -> None:
+        """A hard break's own newline must not stack with the separator into a definition-ending double blank."""
+        doc = self._doc_with_definition(
+            blocks=[
+                Paragraph(content=[LineBreak(soft=False)]),
+                Paragraph(content=[Text(content="Second paragraph.")]),
+            ]
+        )
+        org = OrgRenderer().render_to_string(doc)
+
+        assert "\n\n\nSecond" not in org
+
+
+@pytest.mark.unit
+class TestBoundaryBreakHoisting:
+    """Breaks at a span's edge hoist outside the delimiters.
+
+    A delimiter stranded at a line start stops being inline syntax: ``* ``
+    opens a headline or list item, ``+ `` a list item -- the same class as
+    markdown's #391 and AsciiDoc's #353.
+    """
+
+    def test_trailing_break_hoists_out_of_strong(self) -> None:
+        """The break renders after the closing delimiter, not inside it."""
+        doc = Document(
+            children=[
+                Paragraph(
+                    content=[
+                        Strong(content=[Text(content="bold"), LineBreak(soft=False)]),
+                        Text(content="after"),
+                    ]
+                )
+            ]
+        )
+        org = OrgRenderer().render_to_string(doc)
+
+        assert "*bold*" in org
+        assert "\n*" not in org
+
+    def test_break_only_strong_emits_no_delimiters(self) -> None:
+        """A span over nothing visible marks nothing: it renders bare."""
+        doc = Document(children=[Paragraph(content=[Strong(content=[LineBreak(soft=False)])])])
+        org = OrgRenderer().render_to_string(doc)
+
+        assert "*" not in org

--- a/tests/unit/test_roundtrip_fuzzing.py
+++ b/tests/unit/test_roundtrip_fuzzing.py
@@ -685,7 +685,11 @@ KNOWN_FOOTNOTE_GAPS: dict[tuple[str, str], str] = {
     # paragraph (#384), and nested/empty strikethrough opening a tilde fence that ate the
     # definition (#391). With both fixed, the canonical two-paragraph markdown footnote
     # round-trips whole.
-    ("org", "definition_paragraphs"): "Multi-paragraph definitions collapse toward a single paragraph. #347",
+    # ("org", "definition_paragraphs") is gone: Org continues a footnote definition
+    # across a single blank line and ends it at two, so the renderer now separates a
+    # definition's paragraphs with a blank line (and follows a definition with two
+    # before ordinary content), and the parser's block splitter counts the blank
+    # lines between blocks instead of discarding them.
     ("dokuwiki", "definition_paragraphs"): "Multi-paragraph definitions collapse toward a single paragraph. #347",
 }
 


### PR DESCRIPTION
## Summary

Closes the Org slice of #347 and deletes the `(org, definition_paragraphs)` round-trip gate entry.

Org's own semantics give the blank-line budget meaning: a footnote definition **continues** across a single blank line and **ends** at two consecutive blank lines, the next `[fn:]` definition, or a heading. Neither side spoke that dialect:

**Renderer**
- A definition's paragraphs were joined with a bare newline, so the second paragraph came back as a continuation line of the first. They now separate with one blank line — Org's continuation spelling.
- A definition followed by ordinary content emitted a single blank line, which (under correct Org semantics) would swallow the next block into the footnote. `visit_document` now follows a footnote definition with two blank lines.
- A hard break renders as ` \` plus a newline; at a block's edge that newline stacked with the separator into a definition-ending double blank. Rendered child blocks are now stripped of edge newlines before joining (a break-only paragraph survives as a ` \` line the parser reads back as a hard break).
- Ports the boundary-break hoisting cure (#391 markdown / #353 asciidoc) to the Org span delimiters `/`, `*`, `+`, `_`: a break at a span's edge stranded the delimiter at a line start, where `* ` opens a headline and `+ ` a list item. Breaks hoist outside the span; a span with no visible core emits no delimiters.

**Parser**
- `_split_body_blocks` now returns each block with the count of blank lines that preceded it, instead of discarding the counts (measured correct across affiliated keywords, greater blocks with interior blanks, and multi-blank runs).
- After a `[fn:id]` block, single-gap paragraph-shaped blocks join the definition as additional paragraphs. Structural blocks (lists, tables, greater blocks, block quotes, the next definition) end it — a conservative reading of the spec, which would keep those too.

## Testing

- Full round-trip fuzzing gate: 80 passed, 11 xfailed, 0 xpassed/failed. Hypothesis found and this PR fixed two follow-on falsifiers along the way (span-over-break via `Strong([LineBreak])`, and the break-only first paragraph).
- New unit tests: 5 renderer (paragraph separation, double-blank handoff, break-only paragraph, hoisting both ways), 4 parser (continue on one blank, end on two, end on next definition, end on structural block).
- Full unit suite green; ruff, mypy, changelog check clean.

Note: this PR and #397 both edit adjacent allowlist lines in `tests/unit/test_roundtrip_fuzzing.py` — whichever merges second may need a trivial rebase; tell me and I'll handle it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
