### PR TITLE
fix(rst): stop dropping line blocks in the parser

### DIFF
--- a/changelog.d/rst-line-blocks.fixed.md
+++ b/changelog.d/rst-line-blocks.fixed.md
@@ -1,0 +1,5 @@
+- **reST line blocks are no longer silently dropped.** A `| ` line block fell
+  through the parser's unknown-node branch, so every line of it vanished from
+  the output -- text loss, not formatting loss. A line block now parses as a
+  paragraph whose lines join with hard breaks; nested (indented) lines flatten
+  into the same paragraph, since the AST does not model their indentation.

--- a/src/all2md/parsers/rst.py
+++ b/src/all2md/parsers/rst.py
@@ -232,6 +232,8 @@ class RestructuredTextParser(BaseParser):
         elif isinstance(node, docutils_nodes.math_block):
             # Math block (displayed equation)
             return self._process_math_block(node)
+        elif isinstance(node, docutils_nodes.line_block):
+            return self._process_line_block(node)
         elif isinstance(node, docutils_nodes.raw):
             # Raw content (could be HTML or other formats)
             return self._process_raw_block(node)
@@ -239,6 +241,33 @@ class RestructuredTextParser(BaseParser):
             # Unknown node type - log and skip
             logger.debug(f"Skipping unknown docutils node type: {node_type}")
             return None
+
+    def _process_line_block(self, node: Any) -> Paragraph | None:
+        """Process a line block (``| `` verse lines) into a hard-broken paragraph.
+
+        The node used to fall through the unknown-block branch and be dropped,
+        so every ``| `` line in a document silently lost its text. Lines join
+        with hard breaks -- the closest shape this AST has for "these lines
+        break exactly here". Nested line blocks flatten into the same
+        paragraph; their indentation is presentation the AST does not model.
+        """
+        from docutils import nodes as docutils_nodes
+
+        content: list[Node] = []
+
+        def add_lines(block: Any) -> None:
+            for child in block.children:
+                if isinstance(child, docutils_nodes.line_block):
+                    add_lines(child)
+                elif isinstance(child, docutils_nodes.line):
+                    if content:
+                        content.append(LineBreak(soft=False))
+                    content.extend(self._process_inline_nodes(child.children))
+
+        add_lines(node)
+        if not content:
+            return None
+        return Paragraph(content=content)
 
     def _process_section(self, node: Any) -> list[Node]:
         """Process a section node (heading + content).

--- a/tests/unit/parsers/test_rst_parser.py
+++ b/tests/unit/parsers/test_rst_parser.py
@@ -28,6 +28,7 @@ from all2md.ast import (
     FootnoteReference,
     Heading,
     HTMLBlock,
+    LineBreak,
     Link,
     List,
     MathBlock,
@@ -567,6 +568,46 @@ This has a footnote [1]_.
 
         assert len(refs) >= 1
         assert len(defs) >= 1
+
+
+@pytest.mark.unit
+class TestLineBlocks:
+    """Tests for line block (`| ` verse lines) parsing.
+
+    Line blocks used to fall through the unknown-node branch and be dropped
+    entirely -- silent text loss for any document using them.
+    """
+
+    def test_line_block_text_survives(self) -> None:
+        """A line block parses as a paragraph with hard breaks between lines."""
+        rst = "Intro.\n\n| line one\n| line two\n\nOutro.\n"
+        doc = RestructuredTextParser().parse(rst)
+
+        paragraphs = [n for n in doc.children if isinstance(n, Paragraph)]
+        assert len(paragraphs) == 3
+        verse = paragraphs[1]
+        texts = [n.content for n in verse.content if isinstance(n, Text)]
+        assert texts == ["line one", "line two"]
+        assert sum(1 for n in verse.content if isinstance(n, LineBreak)) == 1
+
+    def test_line_block_keeps_inline_markup(self) -> None:
+        """Inline markup inside a line block line survives."""
+        rst = "| plain *emphasized* end\n"
+        doc = RestructuredTextParser().parse(rst)
+
+        verse = doc.children[0]
+        assert isinstance(verse, Paragraph)
+        assert any(isinstance(n, Emphasis) for n in verse.content)
+
+    def test_nested_line_block_flattens(self) -> None:
+        """Indented (nested) lines flatten into the same paragraph."""
+        rst = "| outer line\n|   indented line\n| back out\n"
+        doc = RestructuredTextParser().parse(rst)
+
+        verse = doc.children[0]
+        assert isinstance(verse, Paragraph)
+        texts = [n.content for n in verse.content if isinstance(n, Text)]
+        assert texts == ["outer line", "indented line", "back out"]
 
 
 @pytest.mark.unit


### PR DESCRIPTION
## Summary

Found while working #397: the rst parser's `_process_node` has no branch for docutils `line_block` nodes, so a `| ` line block fell through to the unknown-node debug-log-and-skip path — **every line of it silently vanished** from the output. That's text loss for any hand-written reST using verse/address blocks.

A line block now parses as a paragraph whose lines join with hard `LineBreak`s — the closest shape the AST has for "these lines break exactly here". Nested (indented) line blocks flatten into the same paragraph; their indentation is presentation the AST doesn't model. Inline markup inside lines survives (it goes through the normal inline pipeline).

Kept deliberately parser-side and small: the renderer's own `hard_line_break_mode="line_block"` output mid-paragraph doesn't actually produce docutils line_blocks (a `| ` line directly under a paragraph line stays literal text), so there's no renderer half to this fix.

## Testing

- 3 new parser tests: text survival with break count, inline markup inside a line, nested-block flattening.
- rst round-trip fuzz tests unchanged (no new failures, no unexpected XPASS).
- All rst-named unit tests green; ruff, mypy, changelog check clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
