### PR TITLE
fix(pdf): stop fusing a subsection heading into the section heading above it (#400)

### DIFF
--- a/changelog.d/400-pdf-fused-heading-wrap.fixed.md
+++ b/changelog.d/400-pdf-fused-heading-wrap.fixed.md
@@ -1,0 +1,12 @@
+- **PDF: a subsection heading printed directly under its section heading is no
+  longer fused into it.** The wrap-merge that reassembles a long title set on
+  two printed lines had no width test, so `Methods` over `Study design` became
+  one heading — and both section titles went missing, the largest single class
+  (~30%) of the heading residual on the PMC born-digital corpus
+  ([#400](https://github.com/thomas-villani/all2md/issues/400)). A line only
+  wraps because it filled its measure, so the merge now requires the first line
+  to fill at least `HEADING_WRAP_MIN_FILL` (0.8) of the two lines' shared
+  width — a threshold read off 307 labeled merges: true wraps fill 0.852–1.0,
+  the separable fused band 0.22–0.84. Pairs whose first line is the wider one
+  (`Methods and Design` over `Study design`) remain geometrically inseparable
+  and still merge; that residual is documented on the issue.

--- a/src/all2md/parsers/pdf.py
+++ b/src/all2md/parsers/pdf.py
@@ -156,6 +156,17 @@ _RUNNING_DIGITS = re.compile(r"\d+")
 #: section, which is what puts them beyond this.
 HEADING_WRAP_GAP_RATIO = 1.6
 
+#: How much of the two lines' shared measure the *first* line must fill for the second to
+#: be its wrap. A line only wraps because it ran out of room, so a "continuation" that
+#: extends past the line above it is a different heading -- a section title with its
+#: subsection printed directly beneath was fusing into one heading this way, losing both
+#: titles (#400). Measured on the PMC born-digital corpus (307 merges, labeled against
+#: JATS): true wraps fill 0.852-1.0 (plausible unlabeled ones 0.822+), while fused pairs
+#: separable by width sit at 0.222-0.835. 0.8 keeps every measured wrap and cuts the
+#: fused band; pairs whose first line is the wider one (`Methods` + `Animals`) stay
+#: geometrically inseparable and still merge.
+HEADING_WRAP_MIN_FILL = 0.8
+
 
 def _span_union_bbox(spans: list) -> tuple[float, float, float, float] | None:
     """Bounding box covering every span on a line, or None if none carry one.
@@ -594,6 +605,10 @@ class _BlockProcessingState:
     last_heading_slot: int = -1
     last_heading_bottom: float = 0.0
     last_heading_height: float = 0.0
+    # Full bbox of that line, kept for the wrap-width test: a line only wraps
+    # because it filled its measure, so a "continuation" wider than the line
+    # above it is a different heading, not the rest of this one.
+    last_heading_bbox: tuple[float, float, float, float] | None = None
 
     def reset_paragraph(self) -> None:
         """Reset paragraph accumulation state."""
@@ -2510,6 +2525,7 @@ class PdfToAstConverter(BaseParser):
             heading.content.extend([Text(content=" "), *inline_content])
             state.last_heading_bottom = line_bbox[3]
             state.last_heading_height = max(line_bbox[3] - line_bbox[1], state.last_heading_height)
+            state.last_heading_bbox = line_bbox
             return
 
         if parse_numbering_prefix(line_text) is not None:
@@ -2559,10 +2575,12 @@ class PdfToAstConverter(BaseParser):
         """Record where the heading just appended to ``state.nodes`` was printed."""
         if line_bbox is None:
             state.last_heading_slot = -1
+            state.last_heading_bbox = None
             return
         state.last_heading_slot = len(state.nodes) - 1
         state.last_heading_bottom = line_bbox[3]
         state.last_heading_height = line_bbox[3] - line_bbox[1]
+        state.last_heading_bbox = line_bbox
 
     @staticmethod
     def _continues_wrapped_heading(
@@ -2573,13 +2591,16 @@ class PdfToAstConverter(BaseParser):
     ) -> bool:
         """Report whether this line is the rest of the heading emitted immediately above it.
 
-        Four things have to hold, and each rules out a way two heading lines can be
+        Five things have to hold, and each rules out a way two heading lines can be
         adjacent without being one heading: the previous node is a heading and nothing
         came between them; it is at this line's level, since a subheading under a
         heading is two headings; the line sits within a line's height of it, which is
-        what a wrap looks like and what the space above a new section does not; and it
+        what a wrap looks like and what the space above a new section does not; it
         does not open with its own numbering, which announces a new section however
-        tightly it is set.
+        tightly it is set; and the line above it filled the measure the two lines
+        share, because a line only wraps when it ran out of room -- a section title
+        with its subsection printed directly beneath fused into one heading before
+        this test, losing both titles (#400).
         """
         if not state.nodes or state.last_heading_slot != len(state.nodes) - 1:
             return False
@@ -2588,6 +2609,14 @@ class PdfToAstConverter(BaseParser):
             return False
         if parse_numbering_prefix(line_text.split(" ", 1)[0]) is not None:
             return False
+
+        prev_bbox = state.last_heading_bbox
+        if prev_bbox is not None:
+            left = min(prev_bbox[0], line_bbox[0])
+            right = max(prev_bbox[2], line_bbox[2])
+            width = right - left
+            if width > 0 and (prev_bbox[2] - left) / width < HEADING_WRAP_MIN_FILL:
+                return False
 
         height = max(line_bbox[3] - line_bbox[1], state.last_heading_height)
         if height <= 0:

--- a/tests/unit/formats/pdf/test_pdf_wrapped_headings.py
+++ b/tests/unit/formats/pdf/test_pdf_wrapped_headings.py
@@ -141,6 +141,67 @@ class TestAdjacentHeadingsStayApart:
         assert _headings(second) == ["Results"]
 
 
+class TestASubsectionUnderItsSectionStaysItsOwnHeading:
+    """The wrap-width test (#400).
+
+    A line only wraps because it filled its measure, so a "continuation" that
+    extends past the line above it is a different heading. Before this test a
+    section title with its subsection printed directly beneath -- `Methods` /
+    `Study design` -- fused into one heading, and both JATS titles went
+    missing; measured at ~30% of the heading residual on the PMC corpus.
+    """
+
+    def test_a_wider_second_line_is_a_new_heading(self, converter):
+        state = _BlockProcessingState()
+
+        _emit(converter, state, "Methods", bottom=100, bbox=_bbox(100, x1=95.0))
+        _emit(converter, state, "Study design", bottom=100 + LINE_HEIGHT, bbox=_bbox(100 + LINE_HEIGHT, x1=140.0))
+
+        assert _headings(state) == ["Methods", "Study design"]
+
+    def test_a_first_line_nearly_at_the_measure_still_wraps(self, converter):
+        # Ragged-right wraps rarely end exactly at the measure; 0.96 fill is a wrap.
+        state = _BlockProcessingState()
+
+        _emit(converter, state, "Effects of long-term exposure on", bottom=100, bbox=_bbox(100, x1=290.0))
+        _emit(
+            converter,
+            state,
+            "cardiovascular outcomes",
+            bottom=100 + LINE_HEIGHT,
+            bbox=_bbox(100 + LINE_HEIGHT, x1=300.0),
+        )
+
+        assert _headings(state) == ["Effects of long-term exposure on cardiovascular outcomes"]
+
+    def test_the_fill_boundary_separates(self, converter):
+        # Just under HEADING_WRAP_MIN_FILL: (247 - 50) / (300 - 50) = 0.788.
+        state = _BlockProcessingState()
+
+        _emit(converter, state, "Results", bottom=100, bbox=_bbox(100, x1=247.0))
+        _emit(
+            converter,
+            state,
+            "Dynamic regulation of miRNAs",
+            bottom=100 + LINE_HEIGHT,
+            bbox=_bbox(100 + LINE_HEIGHT, x1=300.0),
+        )
+
+        assert _headings(state) == ["Results", "Dynamic regulation of miRNAs"]
+
+    def test_a_wider_first_line_still_merges(self, converter):
+        # The known residual: when the section title is the wider line
+        # (`Methods and Design` over `Study design`), width cannot separate the
+        # pair and the merge stands. Pinned so a future fix has to change this
+        # test deliberately rather than by side effect.
+        state = _BlockProcessingState()
+
+        _emit(converter, state, "Methods and Design", bottom=100, bbox=_bbox(100, x1=200.0))
+        _emit(converter, state, "Study design", bottom=100 + LINE_HEIGHT, bbox=_bbox(100 + LINE_HEIGHT, x1=150.0))
+
+        assert _headings(state) == ["Methods and Design Study design"]
+
+
 class TestTheJoinNeedsGeometry:
     def test_without_a_bbox_nothing_joins(self, converter):
         # Callers that cannot supply a line box keep the old behaviour rather than


### PR DESCRIPTION
## Summary

Closes #400. The wrap-merge that reassembles a long title set on two printed lines (`_continues_wrapped_heading`) had no width test, so a section heading with its subsection printed directly beneath — `Methods` / `Study design` — fused into one heading, and **both** JATS section titles went missing. Measured at ~83 of the 277 missing titles (30%) on the PMC born-digital corpus: the largest single class of the heading residual, bigger than #296's run-in class (8%).

## The fix, measured before it was written

A line only wraps because it filled its measure, so the merge now additionally requires the first line to fill **`HEADING_WRAP_MIN_FILL` (0.8)** of the two lines' shared width (pair-union, so centered headings are handled without needing the block box).

The threshold comes from instrumenting all 307 merges the parser performs on the corpus, labeled against JATS:
- **true wraps** (concatenation is one section title): fill 0.852–1.0, overwhelmingly 1.0; plausible unlabeled wraps sit at 0.822+.
- **fused pairs** (both halves are section titles): the width-separable band sits at 0.222–0.835.
- At 0.8 the cut kills 13/33 labeled fusions plus ~18 unlabeled ones (which on inspection include headings merged with **author bylines** and `RESULTS` + first-subsection pairs), and loses **zero** labeled wraps.

## A/B on the corpus (the same probe that found the defect)

- Missing section titles: **277 → 252**.
- Per-article: **36 titles fixed, 1 regressed** — the regression is the known boundary case (`4 Hematopoietic homeostasis` / `dysregulation: …`, a genuine three-line wrap whose middle line fills 0.781) and is accepted as the cost of the band the fused pairs occupy.
- The residual this cannot reach: pairs whose *first* line is the wider one (`Methods and Design` over `Study design`) are geometrically inseparable by width; ~19 cases, pinned by a dedicated test and documented on #400.

## Testing

- 4 new unit tests in `test_pdf_wrapped_headings.py` (wider-second-line splits, near-measure wrap still joins, boundary value, and the inseparable residual pinned so a future fix must change it deliberately). All 18 in the file pass.
- Full `-m pdf` suite: 364 passed.
- Ruff, mypy, changelog check clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
