### PR TITLE
docs: tell the measured PDF story in the README and pdf guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -469,13 +469,23 @@ It also refuses to pass quietly: no matching files, no threshold set, or a docum
 
 Built on an **AST-based pipeline** (parse → transform → render), all2md offers capabilities that direct format-to-format converters can't:
 
-- **Advanced PDF parsing** — intelligent table detection, multi-column layout analysis, optional GNN-based semantic layout classification (`pdf_layout` extra), header/footer removal, and OCR for scanned documents (Tesseract or binary-free EasyOCR), powered by PyMuPDF.
+- **Advanced PDF parsing** — table recovery that goes beyond ruling lines (booktabs-style and fully borderless tables via word-gutter analysis, rotated tables read in their own frame), figure/caption binding, multi-column layout analysis, heading reconstruction (wrapped titles rejoined, adjacent headings kept apart), optional ML layout classification (`pdf_layout` extra), header/footer removal, and OCR for scanned pages (Tesseract or binary-free EasyOCR) — powered by PyMuPDF, measured against external ground truth (see below).
 - **Conversion quality tooling** — `all2md report` gives a reference-free confidence "quality card" for any document (usable as a CI gate); `all2md roundtrip` scores how much structure survives a `convert → parse-back` round trip; `all2md optimize` auto-tunes converter settings for a difficult document.
 - **Document diff** — a `diff` command that works like Unix `diff` but across any document formats, with text-based symmetric comparison.
 - **Custom output via templates** — render the AST to any text format (DocBook XML, YAML, ANSI, custom markup) using Jinja2 templates, no Python required.
 - **Static site generation** — turn document collections into ready-to-deploy Hugo, Jekyll, MkDocs, Zola, or Eleventy sites.
 - **Extensible plugin system** — add custom converters (`all2md.converters` entry point) and transforms (`all2md.transforms` entry point). See [examples/plugins/](examples/plugins/).
 - **Security-conscious** — SSRF protection when fetching remote resources, archive validation (ZIP bombs, path traversal), and sandboxed HTML rendering.
+
+## How good is the conversion, measured?
+
+all2md's conversion quality is measured, not asserted — against three independent ground truths, each published beside a control that shows what the measurement looks like when it *should* fail:
+
+- **Born-digital PDFs** (`benchmarks/pmc/`): 66 publisher PDFs from PubMed Central scored against the JATS XML deposited beside them. Text recall, structural recovery of headings and tables, and an invented-text rate — with the corpus pinned by committed SHA-256 digests.
+- **Scanned pages** (`benchmarks/omnidocbench/`): 981 raster pages against human annotation, exercising the OCR path the born-digital corpus never touches.
+- **Round-trip fidelity** (`benchmarks/roundtrip/`): Markdown → format → Markdown must survive at fidelity 100 for the repository's own docs, gated on every pull request.
+
+Current figures, their controls, and — just as important — what each lane structurally *cannot* see are documented in [Conversion Fidelity](https://all2md.readthedocs.io/en/latest/benchmarks.html).
 
 ## Frequently asked questions
 
@@ -510,7 +520,7 @@ Use parallel processing: `all2md ./docs -r --output-dir ./output -p 8`, or `--wa
 
 Contributions are welcome — bug reports, feature requests, documentation improvements, and code. Ways to help: report bugs, improve docs, add support for new formats via the plugin system, create new AST transforms, or fix bugs in existing converters.
 
-For contributors evaluating parser changes, all2md ships benchmark harnesses in [`benchmarks/corpus/`](benchmarks/corpus/) (times conversion across public document corpora) and [`benchmarks/roundtrip/`](benchmarks/roundtrip/) (checks `Markdown → AST → Markdown` fidelity). See the [Performance Tuning docs](https://all2md.readthedocs.io/en/latest/performance.html) for details.
+For contributors evaluating parser changes, all2md ships benchmark harnesses: [`benchmarks/pmc/`](benchmarks/pmc/) (born-digital PDF fidelity against publisher JATS ground truth), [`benchmarks/omnidocbench/`](benchmarks/omnidocbench/) (scanned pages against human annotation), [`benchmarks/roundtrip/`](benchmarks/roundtrip/) (`Markdown → AST → Markdown` fidelity, the CI gate), and [`benchmarks/corpus/`](benchmarks/corpus/) (conversion timing across public corpora). See [Conversion Fidelity](https://all2md.readthedocs.io/en/latest/benchmarks.html) and the [Performance Tuning docs](https://all2md.readthedocs.io/en/latest/performance.html) for details.
 
 See [CONTRIBUTING.md](CONTRIBUTING.md) for development setup and guidelines.
 

--- a/docs/source/options.rst
+++ b/docs/source/options.rst
@@ -1245,12 +1245,12 @@ via file:// URLs and similar mechanisms.
 
 **figures_parsing**
 
-   How to parse <figure> elements: blockquote, paragraph, image_with_caption, caption_only, html, skip
+   How to parse <figure> elements: figure (Figure AST node), blockquote, paragraph, image_with_caption, caption_only, html, skip
 
-   :Type: ``Literal['blockquote', 'paragraph', 'image_with_caption', 'caption_only', 'html', 'skip']``
+   :Type: ``Literal['figure', 'blockquote', 'paragraph', 'image_with_caption', 'caption_only', 'html', 'skip']``
    :CLI flag: ``--chm-html-options-figures-parsing``
-   :Default: ``'blockquote'``
-   :Choices: ``blockquote``, ``paragraph``, ``image_with_caption``, ``caption_only``, ``html``, ``skip``
+   :Default: ``'figure'``
+   :Choices: ``figure``, ``blockquote``, ``paragraph``, ``image_with_caption``, ``caption_only``, ``html``, ``skip``
    :Importance: advanced
 
 **details_parsing**
@@ -3107,12 +3107,12 @@ via file:// URLs and similar mechanisms.
 
 **figures_parsing**
 
-   How to parse <figure> elements: blockquote, paragraph, image_with_caption, caption_only, html, skip
+   How to parse <figure> elements: figure (Figure AST node), blockquote, paragraph, image_with_caption, caption_only, html, skip
 
-   :Type: ``Literal['blockquote', 'paragraph', 'image_with_caption', 'caption_only', 'html', 'skip']``
+   :Type: ``Literal['figure', 'blockquote', 'paragraph', 'image_with_caption', 'caption_only', 'html', 'skip']``
    :CLI flag: ``--epub-html-options-figures-parsing``
-   :Default: ``'blockquote'``
-   :Choices: ``blockquote``, ``paragraph``, ``image_with_caption``, ``caption_only``, ``html``, ``skip``
+   :Default: ``'figure'``
+   :Choices: ``figure``, ``blockquote``, ``paragraph``, ``image_with_caption``, ``caption_only``, ``html``, ``skip``
    :Importance: advanced
 
 **details_parsing**
@@ -3766,12 +3766,12 @@ via file:// URLs and similar mechanisms.
 
 **figures_parsing**
 
-   How to parse <figure> elements: blockquote, paragraph, image_with_caption, caption_only, html, skip
+   How to parse <figure> elements: figure (Figure AST node), blockquote, paragraph, image_with_caption, caption_only, html, skip
 
-   :Type: ``Literal['blockquote', 'paragraph', 'image_with_caption', 'caption_only', 'html', 'skip']``
+   :Type: ``Literal['figure', 'blockquote', 'paragraph', 'image_with_caption', 'caption_only', 'html', 'skip']``
    :CLI flag: ``--html-figures-parsing``
-   :Default: ``'blockquote'``
-   :Choices: ``blockquote``, ``paragraph``, ``image_with_caption``, ``caption_only``, ``html``, ``skip``
+   :Default: ``'figure'``
+   :Choices: ``figure``, ``blockquote``, ``paragraph``, ``image_with_caption``, ``caption_only``, ``html``, ``skip``
    :Importance: advanced
 
 **details_parsing**
@@ -6341,12 +6341,12 @@ via file:// URLs and similar mechanisms.
 
 **figures_parsing**
 
-   How to parse <figure> elements: blockquote, paragraph, image_with_caption, caption_only, html, skip
+   How to parse <figure> elements: figure (Figure AST node), blockquote, paragraph, image_with_caption, caption_only, html, skip
 
-   :Type: ``Literal['blockquote', 'paragraph', 'image_with_caption', 'caption_only', 'html', 'skip']``
+   :Type: ``Literal['figure', 'blockquote', 'paragraph', 'image_with_caption', 'caption_only', 'html', 'skip']``
    :CLI flag: ``--mhtml-figures-parsing``
-   :Default: ``'blockquote'``
-   :Choices: ``blockquote``, ``paragraph``, ``image_with_caption``, ``caption_only``, ``html``, ``skip``
+   :Default: ``'figure'``
+   :Choices: ``figure``, ``blockquote``, ``paragraph``, ``image_with_caption``, ``caption_only``, ``html``, ``skip``
    :Importance: advanced
 
 **details_parsing**
@@ -8074,7 +8074,7 @@ including page selection, image handling, and formatting preferences.
 
 **header_min_occurrences**
 
-   Minimum occurrences of a font size to consider for headers
+   Minimum number of lines at a font size to consider it for headers
 
    :Type: ``int``
    :CLI flag: ``--pdf-header-min-occurrences``
@@ -8274,7 +8274,7 @@ including page selection, image handling, and formatting preferences.
 
 **include_image_captions**
 
-   Try to extract image captions
+   Try to extract image captions (under alt_text mode, only captioned figures are emitted)
 
    :Type: ``bool``
    :CLI flag: ``--pdf-no-include-image-captions``
@@ -10406,12 +10406,12 @@ via file:// URLs and similar mechanisms.
 
 **figures_parsing**
 
-   How to parse <figure> elements: blockquote, paragraph, image_with_caption, caption_only, html, skip
+   How to parse <figure> elements: figure (Figure AST node), blockquote, paragraph, image_with_caption, caption_only, html, skip
 
-   :Type: ``Literal['blockquote', 'paragraph', 'image_with_caption', 'caption_only', 'html', 'skip']``
+   :Type: ``Literal['figure', 'blockquote', 'paragraph', 'image_with_caption', 'caption_only', 'html', 'skip']``
    :CLI flag: ``--webarchive-figures-parsing``
-   :Default: ``'blockquote'``
-   :Choices: ``blockquote``, ``paragraph``, ``image_with_caption``, ``caption_only``, ``html``, ``skip``
+   :Default: ``'figure'``
+   :Choices: ``figure``, ``blockquote``, ``paragraph``, ``image_with_caption``, ``caption_only``, ``html``, ``skip``
    :Importance: advanced
 
 **details_parsing**

--- a/docs/source/pdf.rst
+++ b/docs/source/pdf.rst
@@ -118,6 +118,36 @@ corroboration were each tried as guards and each failed to separate real tables
 from gridded prose; whole-word integrity, measured against the page's own word
 segmentation, separates them cleanly.
 
+**Borderless tables are recovered from the geometry of their own words.** When
+neither ruling lines nor the grid fallback commit, a table-predicted region is
+swept for *word gutters* — vertical channels no word crosses, persistent down
+the region. Columns that never touch are what makes a table a table, so the
+gutters recover exactly the booktabs-style grid the line strategies cannot see.
+The same sweep runs a second time in the rotated frame, which is how a sideways
+table on a landscape page comes back as a table rather than a column of
+fragments. Two-column regions — the narrowest grid the sweep can claim — are
+admitted under measured guards: a numbered-bibliography test (the one
+two-column grid every reference list resembles) and a drawing-density gate
+(chart regions carry hundreds of vector paths where real tables carry a
+handful).
+
+Together these took the corpus from **4 tables emitted against 121 expected**
+to **173 against 121** — the surplus is real tables the ground truth does not
+place, not junk — with the residual deficit at 6, each miss with its own
+recorded cause.
+
+Figures
+-------
+
+A figure on a PDF page is an image (or a cluster of images, or bare vector
+drawings) with a caption set near it. The parser binds the two into a
+``Figure`` container — the image plus its caption as one block — rather than
+emitting an image here and an orphaned paragraph there. Grouped panels bind to
+one shared caption, and a vector-drawn figure with no raster image at all still
+gets its caption attached. This holds under the default attachment mode
+(``alt_text``): the caption survives as the figure's structure even when the
+image bytes themselves are not extracted.
+
 Reading order and columns
 -------------------------
 
@@ -143,9 +173,12 @@ otherwise look arbitrary:
 
 **A heading that wraps onto a second printed line is one heading.** A PDF has no
 notion of a wrapped heading — it has two lines of type. A second line continues
-the first when they share a level, nothing was emitted between them, and the gap
-is within a ratio of the line height. A line opening with its own numbering
-starts a new heading however tightly it is set.
+the first when they share a level, nothing was emitted between them, the gap is
+within a ratio of the line height, and the first line *filled the measure the
+two lines share* — a line only wraps because it ran out of room, which is what
+separates a wrap from a subsection heading printed directly under its section
+heading. A line opening with its own numbering starts a new heading however
+tightly it is set.
 
 **A heading must contain a letter or digit.** Large math delimiters are set in a
 symbol font well above body size, so they cleared every size and length gate. One


### PR DESCRIPTION
## Summary

The README's PDF bullet and `docs/source/pdf.rst` predated the entire born-digital measurement arc. This brings the user-facing story up to what's actually shipped and measured:

- **`pdf.rst`**: new subsection on word-gutter recovery of borderless/booktabs tables, the rotated-frame sweep, and the measured two-column admission guards (with the 4 → 173-of-121 corpus arc); a new Figures section (figure/caption binding, grouped panels, vector figures, `alt_text`-mode behavior); the heading-wrap paragraph now states the wrap-width rule (#400/#401).
- **`README.md`**: the PDF feature bullet rewritten around what's distinctive and measured; a new "How good is the conversion, measured?" section introducing the three ground-truth lanes and linking the Conversion Fidelity page; the contributor benchmarks paragraph now names all four harnesses.
- **`options.rst`**: regenerated options reference (picks up the `figures_parsing: figure` default from #382).

Deliberately **not** touched: `benchmarks.rst` — its figures quote the committed `benchmarks/pmc/reference.json`, and those get re-recorded (and that page updated) in a follow-up once the current PR batch merges and the born-digital workflow runs on main. A half-updated numbers page is worse than a stale one that's honest about its pin.

**Merge after #401**, whose wrap-width rule the pdf.rst heading paragraph describes.

## Verification

- `all2md roundtrip README.md --fail-under 100` — still 100 across all five dimensions (the README is CI-gated on this).
- Sphinx build with `-W` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
