### PR TITLE
docs(benchmarks): re-record the PMC reference on post-merge main

### DIFF
--- a/benchmarks/pmc/reference.json
+++ b/benchmarks/pmc/reference.json
@@ -1,247 +1,251 @@
 {
-  "article_precision": {
-    "control_emitted": 443281,
-    "control_precision": 0.007024889404237944,
-    "discrimination": 0.9315513184639089,
-    "duplication": 0.004527158697335614,
-    "emitted": 443281,
-    "excess": 2128,
-    "novel": 4287,
-    "novel_share": 0.009671066434158018,
-    "occurrences": 470052,
-    "precision": 0.9385762078681469,
-    "resequenced": 22941,
-    "supported": 416053
-  },
-  "article_recall": {
-    "attainable": 5561,
-    "attainable_recall": 0.9534256428699874,
-    "by_kind": {
-      "table": {
-        "attainable": 110,
-        "attainable_recall": 0.8363636363636363,
-        "recovered": 93,
-        "scored": 123
-      },
-      "text_block": {
-        "attainable": 3160,
-        "attainable_recall": 0.9762658227848101,
-        "recovered": 3115,
-        "scored": 6356
-      },
-      "title": {
-        "attainable": 2291,
-        "attainable_recall": 0.9275425578350065,
-        "recovered": 2151,
-        "scored": 2426
-      }
+  "schema_version": 5,
+  "provenance": {
+    "corpus_pin": "9ba5c0cd59067bda102b9e27a7c1e613987c145f9fb61a4c26b811d9fd24dc58",
+    "bucket": "pmc-oa-opendata",
+    "complete_corpus": true,
+    "oracle_schema_version": 1,
+    "all2md_commit": "e7c0b9deea39701a5aba425421807b636b9d8ed0",
+    "worktree_dirty": false,
+    "created_at": "2026-08-19T04:24:08.445968+00:00",
+    "python": "3.12.3 (main, Jun 19 2026, 12:46:00) [GCC 13.3.0]",
+    "platform": "linux",
+    "parser_runtime": {
+      "pymupdf": "1.28.0",
+      "python": "3.12.3"
     },
-    "ceiling": 0.624480628860191,
-    "control_recall": 0.003593486805165637,
-    "control_scored": 8905,
-    "discrimination": 0.5982032565974171,
-    "recall": 0.6017967434025828,
-    "recovered": 5359,
-    "scored": 8905,
-    "too_short": 2598
+    "parser_config": {
+      "layout_analysis_mode": "enabled",
+      "include_page_numbers": true,
+      "ocr": {
+        "enabled": true,
+        "mode": "auto",
+        "engine": "tesseract",
+        "dpi": 200
+      },
+      "attachment_mode": "base64"
+    },
+    "placement_config": {
+      "token_placement_min": 0.65,
+      "recall_min": 0.8
+    }
   },
-  "conversion_failures": {},
   "corpus": {
-    "articles_converted": 66,
     "articles_expected": 66,
-    "articles_scored": 66,
     "articles_unavailable": [],
+    "articles_scored": 66,
+    "articles_converted": 66,
+    "pages_scored": 706,
+    "ground_truth_blocks": 11503,
     "coverage": {
       "count": 66.0,
-      "maximum": 1.1974210089736823,
       "mean": 0.9650180243987616,
       "median": 0.9844624081486973,
       "minimum": 0.09476843910806175,
+      "maximum": 1.1974210089736823,
       "stdev": 0.13519930586338003
     },
-    "ground_truth_blocks": 11503,
-    "pages_scored": 706,
-    "pages_with_emitted_table": 69,
+    "tables_expected": 121,
+    "tables_emitted": 164,
     "pages_with_expected_table": 94,
-    "tables_emitted": 92,
-    "tables_expected": 121
+    "pages_with_emitted_table": 120
   },
-  "degraded_events": {
-    "table_rejected": {
-      "articles": 45,
-      "by_reason": {
-        "degenerate_grid": {
-          "articles": 16,
-          "occurrences": 24
-        },
-        "layout_region_not_tabular": {
-          "articles": 1,
-          "occurrences": 2
-        },
-        "mostly_empty": {
-          "articles": 20,
-          "occurrences": 118
-        },
-        "oversized_grid": {
-          "articles": 1,
-          "occurrences": 1
-        },
-        "text_grid_splits_words": {
-          "articles": 32,
-          "occurrences": 92
-        }
-      },
-      "occurrences": 237
-    }
-  },
-  "dimensions": {
-    "block_structure_similarity": {
-      "control_mean": 0.444062500305806,
-      "count": 706.0,
-      "direction": "higher",
-      "discrimination": 0.09821699469080908,
-      "maximum": 1.0,
-      "mean": 0.5422794949966151,
-      "median": 0.563858695652174,
-      "minimum": 0.016393442622950838,
-      "mutation_drop": {
-        "halved": 0.0660754154821242,
-        "reversed": 0.007900606406820655,
-        "shuffled": 0.019971909881816467
-      },
-      "stdev": 0.2060450206343589,
-      "ungateable": "compares kind sequences without inspecting the text under a block, so content-free output scores 1.0 (issue #256); eleven text categories collapse to `text_block`, so fully reversed output scores exactly 1.0 on 153 of the 981 pinned pages; and on the born-digital lane it separates own-page from wrong-page output by only ~0.06 while *rising* when half the emitted content is deleted, which rewards dropping blocks"
-    },
-    "reading_order_similarity": {
-      "control_mean": 0.28872975957995617,
-      "count": 706.0,
-      "direction": "higher",
-      "discrimination": 0.47600569800761094,
-      "maximum": 1.0,
-      "mean": 0.7647354575875671,
-      "median": 0.7968697968697969,
-      "minimum": 0.0,
-      "mutation_drop": {
-        "halved": 0.32680517032583656,
-        "reversed": 0.43991109322823835,
-        "shuffled": 0.21344156351079682
-      },
-      "stdev": 0.2183936420081225
-    },
-    "table_content_similarity": {
-      "control_mean": 0.026460610945399348,
-      "count": 114.0,
-      "direction": "higher",
-      "discrimination": 0.2868819009496966,
-      "maximum": 1.0,
-      "mean": 0.313342511895096,
-      "median": 0.0,
-      "minimum": 0.0,
-      "mutation_drop": {
-        "halved": 0.28757152934921126,
-        "reversed": 0.0,
-        "shuffled": 0.0
-      },
-      "stdev": 0.40510101310490293
-    },
-    "table_structure_similarity": {
-      "control_mean": 0.06397272420063532,
-      "count": 114.0,
-      "direction": "higher",
-      "discrimination": 0.22939706403622856,
-      "maximum": 1.0,
-      "mean": 0.2933697882368639,
-      "median": 0.0,
-      "minimum": 0.0,
-      "mutation_drop": {
-        "halved": 0.26441861305506026,
-        "reversed": 0.0,
-        "shuffled": 0.0
-      },
-      "stdev": 0.373158289883106
-    },
-    "text_content_similarity": {
-      "control_mean": 0.23194245079400155,
-      "count": 706.0,
-      "direction": "higher",
-      "discrimination": 0.3379984238661681,
-      "maximum": 0.9901380670611439,
-      "mean": 0.5699408746601696,
-      "median": 0.5440650241687568,
-      "minimum": 0.010652463382157085,
-      "mutation_drop": {
-        "halved": 0.24829681578792712,
-        "reversed": 0.18663777322996467,
-        "shuffled": 0.12969326210192544
-      },
-      "stdev": 0.23081827781970696
-    }
-  },
-  "figure_binding": {
-    "binding_rate": 0.0,
-    "bound": 0,
-    "caption_recall": 0.8325581395348837,
-    "captioned_emitted": 0,
-    "control_binding_rate": 0.0,
-    "control_scored": 215,
-    "discrimination": 0.0,
-    "images_emitted": 433,
-    "misfiled": 0,
-    "misfiled_rate": 0.0,
-    "present": 179,
-    "scored": 215,
-    "too_short": 13
-  },
-  "ocr_articles": [
-    "PMC10500011.1",
-    "PMC8500015.1"
-  ],
   "projection": {
     "assignments": {
       "clean": 7167,
-      "excluded": 476,
-      "inherited": 1078,
-      "phrase": 1476,
       "spans": 319,
-      "tokens": 987
+      "tokens": 987,
+      "phrase": 1476,
+      "inherited": 1078,
+      "excluded": 476
     },
-    "error_budget": 0.041380509432322,
     "excluded_reasons": {
       "missing": 328,
       "split": 104,
       "too_short": 44
     },
+    "error_budget": 0.041380509432322,
     "unsplit_spans": 42
   },
-  "provenance": {
-    "all2md_commit": "e2e8ff38b1e507ca2ba10a38a1062792016258fb",
-    "bucket": "pmc-oa-opendata",
-    "complete_corpus": true,
-    "corpus_pin": "9ba5c0cd59067bda102b9e27a7c1e613987c145f9fb61a4c26b811d9fd24dc58",
-    "created_at": "2026-08-13T03:37:43.750812+00:00",
-    "oracle_schema_version": 1,
-    "parser_config": {
-      "attachment_mode": "base64",
-      "include_page_numbers": true,
-      "layout_analysis_mode": "enabled",
-      "ocr": {
-        "dpi": 200,
-        "enabled": true,
-        "engine": "tesseract",
-        "mode": "auto"
+  "article_recall": {
+    "recall": 0.5979786636720943,
+    "recovered": 5325,
+    "scored": 8905,
+    "too_short": 2598,
+    "ceiling": 0.624480628860191,
+    "attainable": 5561,
+    "attainable_recall": 0.9473116345980939,
+    "by_kind": {
+      "table": {
+        "recovered": 77,
+        "attainable": 110,
+        "scored": 123,
+        "attainable_recall": 0.6909090909090909
+      },
+      "text_block": {
+        "recovered": 3102,
+        "attainable": 3160,
+        "scored": 6356,
+        "attainable_recall": 0.9721518987341772
+      },
+      "title": {
+        "recovered": 2146,
+        "attainable": 2291,
+        "scored": 2426,
+        "attainable_recall": 0.9253601047577477
       }
     },
-    "parser_runtime": {
-      "pymupdf": "1.28.0",
-      "python": "3.12.3"
-    },
-    "placement_config": {
-      "recall_min": 0.8,
-      "token_placement_min": 0.65
-    },
-    "platform": "linux",
-    "python": "3.12.3 (main, Jun 19 2026, 12:46:00) [GCC 13.3.0]",
-    "worktree_dirty": false
+    "control_recall": 0.003593486805165637,
+    "control_scored": 8905,
+    "discrimination": 0.5943851768669286
   },
-  "schema_version": 5
+  "article_precision": {
+    "precision": 0.9288223298267049,
+    "supported": 413560,
+    "emitted": 445252,
+    "resequenced": 27245,
+    "novel": 4447,
+    "novel_share": 0.009987602526209876,
+    "duplication": 0.004508978776666829,
+    "excess": 2129,
+    "occurrences": 472169,
+    "control_precision": 0.006991546360263401,
+    "control_emitted": 445252,
+    "discrimination": 0.9218307834664414
+  },
+  "figure_binding": {
+    "binding_rate": 0.5255813953488372,
+    "bound": 113,
+    "scored": 215,
+    "too_short": 13,
+    "misfiled_rate": 0.0,
+    "misfiled": 0,
+    "caption_recall": 0.7674418604651163,
+    "present": 165,
+    "images_emitted": 448,
+    "captioned_emitted": 209,
+    "control_binding_rate": 0.0,
+    "control_scored": 215,
+    "discrimination": 0.5255813953488372
+  },
+  "dimensions": {
+    "block_structure_similarity": {
+      "count": 706.0,
+      "mean": 0.5470754250291459,
+      "median": 0.5714285714285714,
+      "minimum": 0.016393442622950838,
+      "maximum": 1.0,
+      "stdev": 0.20799760103847226,
+      "direction": "higher",
+      "control_mean": 0.4437154372652199,
+      "discrimination": 0.10335998776392596,
+      "mutation_drop": {
+        "reversed": 0.01103409330041826,
+        "shuffled": 0.022710520984149166,
+        "halved": 0.07254480684009222
+      },
+      "ungateable": "compares kind sequences without inspecting the text under a block, so content-free output scores 1.0 (issue #256); eleven text categories collapse to `text_block`, so fully reversed output scores exactly 1.0 on 153 of the 981 pinned pages; and on the born-digital lane it separates own-page from wrong-page output by only ~0.06 while *rising* when half the emitted content is deleted, which rewards dropping blocks"
+    },
+    "reading_order_similarity": {
+      "count": 706.0,
+      "mean": 0.7688915915868425,
+      "median": 0.8,
+      "minimum": 0.0,
+      "maximum": 1.0,
+      "stdev": 0.21193232179555213,
+      "direction": "higher",
+      "control_mean": 0.287408784914641,
+      "discrimination": 0.4814828066722015,
+      "mutation_drop": {
+        "reversed": 0.4354260297670871,
+        "shuffled": 0.21052865446162583,
+        "halved": 0.329007185336738
+      }
+    },
+    "table_content_similarity": {
+      "count": 124.0,
+      "mean": 0.5810238553687591,
+      "median": 0.7664603595638078,
+      "minimum": 0.0,
+      "maximum": 1.0,
+      "stdev": 0.4057498854785179,
+      "direction": "higher",
+      "control_mean": 0.03844985429158866,
+      "discrimination": 0.5425740010771705,
+      "mutation_drop": {
+        "reversed": 0.0,
+        "shuffled": 0.0,
+        "halved": 0.5740699890428559
+      }
+    },
+    "table_structure_similarity": {
+      "count": 124.0,
+      "mean": 0.5616681270778533,
+      "median": 0.6652046783625731,
+      "minimum": 0.0,
+      "maximum": 1.0,
+      "stdev": 0.38739957416658566,
+      "direction": "higher",
+      "control_mean": 0.095778552369815,
+      "discrimination": 0.46588957470803827,
+      "mutation_drop": {
+        "reversed": 0.0,
+        "shuffled": 0.0,
+        "halved": 0.5511944677246836
+      }
+    },
+    "text_content_similarity": {
+      "count": 706.0,
+      "mean": 0.5692277212303014,
+      "median": 0.5394443962523008,
+      "minimum": 0.010652463382157085,
+      "maximum": 0.9901380670611439,
+      "stdev": 0.22795083520466647,
+      "direction": "higher",
+      "control_mean": 0.23289228137998044,
+      "discrimination": 0.336335439850321,
+      "mutation_drop": {
+        "reversed": 0.18623164337477574,
+        "shuffled": 0.1300649551596,
+        "halved": 0.24614047911720185
+      }
+    }
+  },
+  "conversion_failures": {},
+  "ocr_articles": [
+    "PMC10500011.1",
+    "PMC8500015.1"
+  ],
+  "degraded_events": {
+    "table_rejected": {
+      "occurrences": 247,
+      "articles": 45,
+      "by_reason": {
+        "text_grid_splits_words": {
+          "occurrences": 92,
+          "articles": 32
+        },
+        "degenerate_grid": {
+          "occurrences": 87,
+          "articles": 26
+        },
+        "mostly_empty": {
+          "occurrences": 56,
+          "articles": 20
+        },
+        "numbered_bibliography": {
+          "occurrences": 10,
+          "articles": 8
+        },
+        "oversized_grid": {
+          "occurrences": 1,
+          "articles": 1
+        },
+        "two_column_chart_region": {
+          "occurrences": 1,
+          "articles": 1
+        }
+      }
+    }
+  }
 }

--- a/changelog.d/pmc-reference-rerecord.changed.md
+++ b/changelog.d/pmc-reference-rerecord.changed.md
@@ -1,7 +1,7 @@
-Re-recorded `benchmarks/pmc/reference.json` on post-merge `main` and brought every figure
-on the fidelity page up to date with it. The tables story inverted: 164 tables emitted
-against 121 expected (was 92), with the surplus mostly continuation tables the expected
-count does not yet credit, and table-block text recall fell to 69.1% (was 83.6%) because
-table text now routes through structured cell extraction instead of flowing out as prose —
-a trade the page now states instead of netting away. The page also documents the new
-110-article held-out corpus and its first validation result.
+- Re-recorded `benchmarks/pmc/reference.json` on post-merge `main` and brought every
+  figure on the fidelity page up to date with it. The tables story inverted: 164 tables
+  emitted against 121 expected (was 92), with the surplus mostly continuation tables the
+  expected count does not yet credit, and table-block text recall fell to 69.1% (was
+  83.6%) because table text now routes through structured cell extraction instead of
+  flowing out as prose — a trade the page now states instead of netting away. The page
+  also documents the new 110-article held-out corpus and its first validation result.

--- a/changelog.d/pmc-reference-rerecord.changed.md
+++ b/changelog.d/pmc-reference-rerecord.changed.md
@@ -1,0 +1,7 @@
+Re-recorded `benchmarks/pmc/reference.json` on post-merge `main` and brought every figure
+on the fidelity page up to date with it. The tables story inverted: 164 tables emitted
+against 121 expected (was 92), with the surplus mostly continuation tables the expected
+count does not yet credit, and table-block text recall fell to 69.1% (was 83.6%) because
+table text now routes through structured cell extraction instead of flowing out as prose —
+a trade the page now states instead of netting away. The page also documents the new
+110-article held-out corpus and its first validation result.

--- a/docs/source/benchmarks.rst
+++ b/docs/source/benchmarks.rst
@@ -57,6 +57,12 @@ pinned by a committed manifest of per-file SHA-256 digests, revalidated on every
 The figures below are :file:`benchmarks/pmc/reference.json`, recorded on Linux with
 dependencies resolved from the lockfile. It covers **66 articles and 706 pages**.
 
+A second manifest, :file:`benchmarks/pmc/manifest-holdout.json`, pins a 110-article
+**held-out** corpus drawn from bucket regions the committed manifest never touched.
+Development tunes against the 66; the held-out set exists to be scored and never tuned
+against, so the figures here can be checked for overfitting. Its first validation run
+landed within a point of the development corpus on every text instrument.
+
 Did the text survive?
 ~~~~~~~~~~~~~~~~~~~~~
 
@@ -68,19 +74,19 @@ Did the text survive?
      - Value
      -
    * - Raw recall
-     - 60.2%
+     - 59.8%
      - of 8,905 ground-truth blocks
    * - Attainable ceiling
      - 62.4%
      - what the PDF's own text layer reproduces
    * - **Recall of what is attainable**
-     - **95.3%**
+     - **94.7%**
      - the number worth reading
    * - Control: the *wrong* article
      - 0.4%
      - wants to be ~0%
 
-Raw recall is 60.2%, and that figure is close to meaningless on its own. A large share of
+Raw recall is 59.8%, and that figure is close to meaningless on its own. A large share of
 any JATS article cannot be recovered by *any* parser, because the markup records words in an
 order the page never prints — author affiliation blocks, structured metadata, citation
 fields. Charging a PDF parser for failing to reproduce text the PDF does not contain
@@ -102,16 +108,20 @@ By block kind:
      - Share of attainable
    * - Text blocks
      - 3,160 of 6,356
-     - 3,115
-     - **97.6%**
+     - 3,102
+     - **97.2%**
    * - Titles
      - 2,291 of 2,426
-     - 2,151
-     - **92.8%**
+     - 2,146
+     - **92.5%**
    * - Tables
      - 110 of 123
-     - 93
-     - **83.6%**
+     - 77
+     - **69.1%**
+
+Table blocks are the outlier, and deliberately so — their text now routes through
+structured table extraction rather than flowing out as prose. What that buys and what it
+costs is the subject of the Tables section below.
 
 Did the output invent anything?
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -135,10 +145,10 @@ Unsupported output is therefore split in two:
      - Share
      - Meaning
    * - Supported
-     - **93.9%**
+     - **92.9%**
      - the n-gram appears in the document's text layer
    * - Resequenced
-     - 5.2%
+     - 6.1%
      - every word is in the document, in a new adjacency
    * - **Novel**
      - **1.0%**
@@ -150,8 +160,8 @@ Unsupported output is therefore split in two:
      - 0.7%
      - wants to be ~0%
 
-Over 443,281 emitted n-grams, 4,287 are novel. Reporting the raw unsupported figure instead
-would have made the result roughly six times worse than the parser deserves.
+Over 445,252 emitted n-grams, 4,447 are novel. Reporting the raw unsupported figure instead
+would have made the result roughly seven times worse than the parser deserves.
 
 Duplication is counted apart from both, because it is invisible to either. Text emitted
 twice is an unchanged *set* and a doubled *multiset* — no set-based score can see it at all.
@@ -159,15 +169,25 @@ twice is an unchanged *set* and a doubled *multiset* — no set-based score can 
 Tables
 ~~~~~~
 
-Tables are the weakest area and the artifact says so plainly: **92 emitted against 121
-expected**, on 69 of 94 pages that should carry one.
+The bottleneck has moved. An earlier recording under-emitted — 92 tables against 121
+expected, with detection refusing to commit on the borderless *booktabs*-style tables
+journals actually print — and after word-gutter grids and two-column regions were admitted
+behind measured guards, the artifact reads **164 emitted against 121
+expected**, with tables emitted on 120 pages
+against the 94 that carry one in the ground truth.
 
-The bottleneck is detection rather than extraction. On the pages that miss, the table's text
-is usually present in the output as ordinary prose — the content survived, the *structure*
-did not. Missed tables skew narrow and sparse compared with matched ones, which is
-consistent with a detector that needs enough ruling lines or column evidence to commit.
-Some are not recoverable as tables at all: a share of JATS ``<table-wrap>`` elements hold
-what is really a list.
+The surplus is mostly an accounting gap rather than invention: a table that continues
+across pages is one JATS ``<table-wrap>`` but several printed tables, and the expected
+count does not yet credit continuations. The remaining deficit is a handful of table
+classes with no shared mechanism.
+
+The cost sits one section up: table blocks are the one kind whose attainable-recall figure
+*fell* across those recordings, from 83.6% to 69.1%. When a table was missed, its text
+flowed out as ordinary prose and survived nearly verbatim; committed as a table, the same
+region's text passes through cell extraction, which does not yet preserve every word of
+every cell. The trade is accepted with eyes open — a table recovered *as a table* is what
+downstream consumers need — but it is a trade, and the artifact says so rather than
+netting the two effects into one flattering number.
 
 Scanned pages
 -------------

--- a/tests/unit/test_published_benchmark_figures.py
+++ b/tests/unit/test_published_benchmark_figures.py
@@ -74,10 +74,14 @@ def _pmc_figures(pmc: dict[str, Any]) -> list[tuple[str, str]]:
             f"Over {precision['emitted']:,} emitted n-grams, {precision['novel']:,} are novel.",
         ),
         (
+            # Phrased for a surplus rather than a deficit: since the word-gutter and
+            # two-column admissions the lane emits tables on more pages than the ground
+            # truth expects, and "on 120 of 94 pages that should carry one" stopped
+            # parsing as English.
             "tables",
             f"**{corpus['tables_emitted']} emitted against {corpus['tables_expected']}\n"
-            f"expected**, on {corpus['pages_with_emitted_table']} of "
-            f"{corpus['pages_with_expected_table']} pages that should carry one.",
+            f"expected**, with tables emitted on {corpus['pages_with_emitted_table']} pages\n"
+            f"against the {corpus['pages_with_expected_table']} that carry one in the ground truth.",
         ),
     ]
     for label, kind in (("text blocks", "text_block"), ("titles", "title"), ("tables", "table")):


### PR DESCRIPTION
## What

Replaces `benchmarks/pmc/reference.json` with the artifact from the `pmc-borndigital` dispatch on post-merge `main` ([run 32213696566](https://github.com/thomas-villani/all2md/actions/runs/32213696566), commit e7c0b9d — i.e. after the #397–#403 batch), and brings `docs/source/benchmarks.rst` up to date with it. The verbatim figure gate (`test_published_benchmark_figures.py`) passes against the new artifact.

## Figure movement (old reference → new)

| Figure | Old | New |
|---|---|---|
| Attainable recall | 95.3% | 94.7% |
| — text blocks | 97.6% | 97.2% |
| — titles | 92.8% | 92.5% |
| — table blocks | 83.6% | **69.1%** |
| Supported share | 93.9% | 92.9% |
| Novel share | 1.0% | 1.0% |
| Tables emitted / expected | 92 / 121 | **164 / 121** |
| Figure binding | 0% (by construction) | 52.6% |

## The story change

The old page called tables "the weakest area" with detection as the bottleneck (92/121 under-emitted). The new artifact inverts that: after the word-gutter and two-column admissions, the lane **over**-emits (164/121, on 120 pages against the 94 expected), with the surplus mostly continuation tables the JATS-side count doesn't credit yet. The visible cost is table-block *text survival* (83.6% → 69.1%): text that used to flow out as prose and survive verbatim now routes through cell extraction, which doesn't yet keep every word. The page now states that trade explicitly instead of netting it.

The tables-claim template in the verbatim gate is rephrased for a surplus ("on 120 of 94 pages that should carry one" stopped parsing as English).

Also adds the held-out corpus paragraph (110 articles, `manifest-holdout.json`, first validation within a point of the dev corpus on every text instrument — see the [#403 validation comment](https://github.com/thomas-villani/all2md/pull/403#issuecomment-5337306403)).

🤖 Generated with [Claude Code](https://claude.com/claude-code)