### PR TITLE
feat(benchmarks): third-party comparison lane with its first dated reading

### DIFF
--- a/README.md
+++ b/README.md
@@ -487,6 +487,8 @@ all2md's conversion quality is measured, not asserted — against three independ
 
 Current figures, their controls, and — just as important — what each lane structurally *cannot* see are documented in [Conversion Fidelity](https://all2md.readthedocs.io/en/latest/benchmarks.html).
 
+**How does it compare to other converters?** A fourth lane ([`benchmarks/comparison/`](benchmarks/comparison/)) scores pymupdf4llm and Docling with the same instruments, on a held-out 110-article corpus the development work has never tuned against, with every tool's output re-parsed through one normalization path. The 2026-08 reading: all2md has by far the lowest invented-text rate (0.84%, vs 5.5% for pymupdf4llm — whose defaults now auto-OCR born-digital pages — and 2.9% for Docling) and is the fastest of the three, while pymupdf4llm leads raw text survival and Docling leads table cell preservation. Full results, ground rules, and the caveats that bound them are in that lane's [README](benchmarks/comparison/README.md) and dated `results-*.json` snapshots.
+
 ## Frequently asked questions
 
 **How is all2md different from Pandoc?**
@@ -520,7 +522,7 @@ Use parallel processing: `all2md ./docs -r --output-dir ./output -p 8`, or `--wa
 
 Contributions are welcome — bug reports, feature requests, documentation improvements, and code. Ways to help: report bugs, improve docs, add support for new formats via the plugin system, create new AST transforms, or fix bugs in existing converters.
 
-For contributors evaluating parser changes, all2md ships benchmark harnesses: [`benchmarks/pmc/`](benchmarks/pmc/) (born-digital PDF fidelity against publisher JATS ground truth), [`benchmarks/omnidocbench/`](benchmarks/omnidocbench/) (scanned pages against human annotation), [`benchmarks/roundtrip/`](benchmarks/roundtrip/) (`Markdown → AST → Markdown` fidelity, the CI gate), and [`benchmarks/corpus/`](benchmarks/corpus/) (conversion timing across public corpora). See [Conversion Fidelity](https://all2md.readthedocs.io/en/latest/benchmarks.html) and the [Performance Tuning docs](https://all2md.readthedocs.io/en/latest/performance.html) for details.
+For contributors evaluating parser changes, all2md ships benchmark harnesses: [`benchmarks/pmc/`](benchmarks/pmc/) (born-digital PDF fidelity against publisher JATS ground truth), [`benchmarks/omnidocbench/`](benchmarks/omnidocbench/) (scanned pages against human annotation), [`benchmarks/roundtrip/`](benchmarks/roundtrip/) (`Markdown → AST → Markdown` fidelity, the CI gate), [`benchmarks/corpus/`](benchmarks/corpus/) (conversion timing across public corpora), and [`benchmarks/comparison/`](benchmarks/comparison/) (third-party converters scored with the same instruments on a held-out corpus). See [Conversion Fidelity](https://all2md.readthedocs.io/en/latest/benchmarks.html) and the [Performance Tuning docs](https://all2md.readthedocs.io/en/latest/performance.html) for details.
 
 See [CONTRIBUTING.md](CONTRIBUTING.md) for development setup and guidelines.
 

--- a/benchmarks/comparison/.gitignore
+++ b/benchmarks/comparison/.gitignore
@@ -1,0 +1,7 @@
+# Everything a run produces stays local; only dated results-*.json snapshots
+# and the scripts themselves are committed.
+articles.json
+comparison.json
+lost_blocks.json
+out/
+*.log

--- a/benchmarks/comparison/README.md
+++ b/benchmarks/comparison/README.md
@@ -1,0 +1,129 @@
+# Third-party converter comparison
+
+Scores other PDF→Markdown converters with the PMC lane's own instruments, on the
+held-out corpus, so all2md's numbers get the context a single-tool benchmark cannot
+provide: what do the strongest alternatives recover that we lose, and at what cost in
+invented text?
+
+**This lane never runs in CI.** It exists to be run by hand when a reading is wanted —
+each run downloads nothing from this repo's pins that isn't already pinned, but it does
+execute two third-party ML stacks and takes hours of CPU. Its job is to produce
+*targets* (see below), not a gate.
+
+## Ground rules
+
+The numbers are only comparable because of four rules, all of which cost us something:
+
+1. **Held-out corpus only.** The 110 articles of
+   `benchmarks/pmc/manifest-holdout.json` — the corpus development work has never tuned
+   against. Comparing on the 66-article development corpus would flatter all2md with
+   in-sample numbers.
+2. **Baselines run at their defaults.** The comparison is against what a user of each
+   tool gets without tuning. all2md runs the PMC lane's parser policy (layout analysis
+   enabled, OCR auto) — its own measured configuration, disclosed rather than hidden.
+3. **One normalization path.** Every tool's markdown — all2md's included — is re-parsed
+   through all2md's markdown parser and projected with the shared oracle before scoring.
+   Nobody is scored on raw strings. The identical-path check measured what this costs:
+   all2md's re-parsed markdown scores 0.3pp below its direct payload figure, novel share
+   unchanged, so the re-parse does not tilt the field. `reparse_word_ratio` in the
+   output is the per-tool guard: far below ~0.9 means the re-parse is eating that tool's
+   content (e.g. raw HTML blocks) and its recall is understated — investigate before
+   quoting.
+4. **Versions are pinned.** `baselines.txt` records the exact baseline versions each
+   committed `results-*.json` was recorded against. A new reading against new versions
+   is a new dated file, never an edit to an old one.
+
+**What this lane measures is deliberately narrow: article-level text survival and
+invented text.** Those are the two instruments with published false-positive controls
+that third-party output can enter. The page-level instruments (reading order, table
+*structure*, heading fidelity) require all2md's page attribution and cannot score other
+tools — and text survival alone structurally favors low-structure converters: the
+highest-recall converter imaginable dumps the raw text layer with no structure at all.
+Quote these numbers with that asymmetry attached.
+
+## Reading, 2026-08-19 (`results-2026-08-19.json`)
+
+110 of 110 articles converted by every tool; zero conversion failures anywhere.
+
+| | all2md @ 99a0eb0 | pymupdf4llm 1.28.2 | docling 2.120.3 |
+| --- | --- | --- | --- |
+| Recall of attainable | 93.5% | **98.3%** | 95.5% |
+| — titles | 93.4% | 99.3% | 95.4% |
+| — table text | 69.9% | 65.1% | **82.2%** |
+| **Novel (invented) share** | **0.84%** | 5.49% | 2.87% |
+| Duplication | 0.61% | 0.19% | 0.62% |
+| Tables emitted / expected | 228 / 166 | 208 / 166 | 201 / 166 |
+| Seconds per article (CPU) | ~10 | ~35 | ~92 |
+
+(The all2md row is the re-parsed figure per rule 3; its direct payload figure on the
+same corpus is 93.8%. Docling's timing mean is inflated by model warmup and by the run
+being suspended mid-flight; treat all timings as rough.)
+
+The honest positioning, with each tool's structural advantage named:
+
+- **pymupdf4llm wins raw text survival and loses trustworthiness.** Its 5.5% novel
+  share — 6.5× ours — is not a scoring artifact: pymupdf4llm 1.28+ bundles
+  `pymupdf-layout` and auto-fires RapidOCR on born-digital pages, and OCR of pages that
+  already have a text layer mints text the document never contained. This is the same
+  misfire class the PMC lane measured and gated out of all2md with the
+  largest-single-image threshold.
+- **Docling has the best table cell preservation** (82.2% vs our 69.9%) at ~9× our
+  runtime. Its table extraction keeps cell text ours drops — a study target, not a
+  mystery to live with.
+- **all2md wins invented text decisively** (0.84%) and is the fastest of the three.
+
+## What the reading produced
+
+The point of the lane is the diff, not the leaderboard. `lost_blocks.py` names every
+truth block a baseline recovers that all2md loses; the 2026-08-19 run (528 blocks
+against pymupdf4llm) became:
+
+- **#405** — side-by-side regions interleaved line-by-line (~405 of 528 blocks at
+  partial containment 0.4–0.8): two-column reference lists with tight gutters, and boxed
+  sidebars beside body columns. Words survive; adjacency is destroyed.
+- **#406** — figure captions absent entirely (66 caption blocks at share ~0: the words
+  appear nowhere in the output, so this is not a binding failure).
+- Docling table-extraction study — what does it preserve that our cell extraction drops?
+
+## Caveats that bound the numbers
+
+- **The recording machine had no Tesseract binary**, so all2md's would-be OCR firings
+  fall back silently. Do not quote OCR misfire counts from this lane; the PMC lane on
+  Linux is the instrument for that.
+- **These results never go on the docs fidelity page.** `docs/source/benchmarks.rst` is
+  verbatim-gated against committed artifacts of *this repo's* lanes; third-party numbers
+  age with every baseline release and belong here, dated, instead.
+- Article-level text survival favors low-structure output (the asymmetry under
+  "deliberately narrow" above). A tool
+  "beating" all2md on attainable recall while inventing 6× more text is not ahead; the
+  two columns must travel together.
+
+## Running it
+
+```bash
+# 1. Materialize the held-out corpus (project venv, digest-verified).
+.venv/Scripts/python.exe -m benchmarks.pmc load --manifest benchmarks/pmc/manifest-holdout.json
+
+# 2. Export the article list for the baselines venv.
+.venv/Scripts/python.exe benchmarks/comparison/export_articles.py
+
+# 3. Create the baselines venv — SHORT path on Windows (transformers vs MAX_PATH),
+#    and never the project venv: the separation keeps baseline deps out of the lockfile.
+uv venv C:/Users/<you>/AppData/Local/Temp/a2mbl --python 3.13
+uv pip install -r benchmarks/comparison/baselines.txt --python C:/Users/<you>/AppData/Local/Temp/a2mbl
+
+# 4. Convert. Each script skips articles already converted, so reruns resume.
+C:/Users/<you>/AppData/Local/Temp/a2mbl/Scripts/python.exe benchmarks/comparison/convert_pymupdf4llm.py
+C:/Users/<you>/AppData/Local/Temp/a2mbl/Scripts/python.exe benchmarks/comparison/convert_docling.py
+.venv/Scripts/python.exe benchmarks/comparison/convert_all2md.py
+
+# 5. Score everything through the one normalization path.
+.venv/Scripts/python.exe benchmarks/comparison/score.py
+
+# 6. Diff: what does a baseline keep that we lose?
+.venv/Scripts/python.exe benchmarks/comparison/lost_blocks.py pymupdf4llm
+```
+
+Publishing a reading: copy `comparison.json` to `results-YYYY-MM-DD.json`, add a
+`provenance` block (date, corpus pin, all2md commit, platform, policy note), update the
+table above, and bump `baselines.txt` if versions moved.

--- a/benchmarks/comparison/__init__.py
+++ b/benchmarks/comparison/__init__.py
@@ -1,0 +1,7 @@
+#  Copyright (c) 2025 Tom Villani, Ph.D.
+"""Third-party converter comparison on the held-out PMC corpus.
+
+Scripts here are run by hand, never in CI. See README.md for the ground rules
+that make the numbers comparable and for the caveats that bound what they can
+support.
+"""

--- a/benchmarks/comparison/baselines.txt
+++ b/benchmarks/comparison/baselines.txt
@@ -1,0 +1,5 @@
+# The baseline converters, pinned to the versions the committed results were
+# recorded against. Install into a venv that does NOT contain this repository
+# (see README.md -- the separation is the point).
+pymupdf4llm==1.28.2
+docling==2.120.3

--- a/benchmarks/comparison/convert_all2md.py
+++ b/benchmarks/comparison/convert_all2md.py
@@ -1,0 +1,72 @@
+#  Copyright (c) 2025 Tom Villani, Ph.D.
+"""Convert every article with all2md into markdown files, like the other tools.
+
+Runs in the project venv. Same parser policy as the PMC benchmark lane (layout analysis
+on, OCR auto) except ``attachment_mode`` stays at its default so the markdown is not
+bloated with base64 images -- images contribute no text to the instruments either way.
+
+Output feeds ``score.py`` as the tool ``all2md``. This column exists for fairness, not
+convenience: it puts all2md's own text through the same markdown re-parse the baselines
+go through, so any loss on that path is charged to every tool equally (measured cost:
+0.3pp of attainable recall, novel share unchanged).
+"""
+
+from __future__ import annotations
+
+import importlib.metadata
+import json
+import sys
+import time
+import traceback
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+REPO = HERE.parents[1]
+sys.path.insert(0, str(REPO))
+
+from all2md import to_markdown  # noqa: E402
+from all2md.options.common import OCROptions  # noqa: E402
+from all2md.options.pdf import PdfOptions  # noqa: E402
+
+OUT = HERE / "out" / "all2md"
+OUT.mkdir(parents=True, exist_ok=True)
+
+articles = json.loads((HERE / "articles.json").read_text(encoding="utf-8"))["articles"]
+
+options = PdfOptions(
+    layout_analysis_mode="enabled",
+    ocr=OCROptions(enabled=True, mode="auto", engine="tesseract", languages="eng", dpi=200),
+)
+
+timings: dict[str, float] = {}
+failures: dict[str, str] = {}
+for index, article in enumerate(articles):
+    article_id = article["article_id"]
+    target = OUT / f"{article_id}.md"
+    if target.exists():
+        continue
+    started = time.perf_counter()
+    try:
+        markdown = to_markdown(article["pdf_path"], parser_options=options)
+    except Exception:
+        failures[article_id] = traceback.format_exc(limit=3)
+        print(f"[{index + 1}/{len(articles)}] {article_id} FAILED", flush=True)
+        continue
+    timings[article_id] = time.perf_counter() - started
+    target.write_text(markdown, encoding="utf-8")
+    print(f"[{index + 1}/{len(articles)}] {article_id} {timings[article_id]:.1f}s", flush=True)
+
+    (OUT / "run.json").write_text(
+        json.dumps(
+            {
+                "tool": "all2md",
+                "versions": {"all2md": importlib.metadata.version("all2md")},
+                "settings": "lane policy (layout enabled, ocr auto); attachment_mode default",
+                "timings": timings,
+                "failures": failures,
+            },
+            indent=2,
+        ),
+        encoding="utf-8",
+    )
+print(f"done: {len(timings)} converted, {len(failures)} failed", flush=True)

--- a/benchmarks/comparison/convert_docling.py
+++ b/benchmarks/comparison/convert_docling.py
@@ -1,0 +1,64 @@
+#  Copyright (c) 2025 Tom Villani, Ph.D.
+"""Convert every article with Docling at its defaults; dump markdown + timings.
+
+Runs in the baselines venv (see baselines.txt), not the project venv. One
+``DocumentConverter`` is reused across articles so model load is paid once. Defaults on
+purpose, as with pymupdf4llm.
+
+Windows note: the baselines venv must live at a SHORT path (e.g.
+``C:/Users/<you>/AppData/Local/Temp/a2mbl``) -- transformers exceeds MAX_PATH under a
+deep venv path and fails with a missing-file error that does not name the real cause.
+A transient HF-hub symlink failure (WinError 1314) on the first model download heals on
+rerun; the script skips articles it already converted.
+"""
+
+from __future__ import annotations
+
+import importlib.metadata
+import json
+import time
+import traceback
+from pathlib import Path
+
+from docling.document_converter import DocumentConverter
+
+HERE = Path(__file__).resolve().parent
+OUT = HERE / "out" / "docling"
+OUT.mkdir(parents=True, exist_ok=True)
+
+articles = json.loads((HERE / "articles.json").read_text(encoding="utf-8"))["articles"]
+
+converter = DocumentConverter()
+timings: dict[str, float] = {}
+failures: dict[str, str] = {}
+for index, article in enumerate(articles):
+    article_id = article["article_id"]
+    target = OUT / f"{article_id}.md"
+    if target.exists():
+        continue
+    started = time.perf_counter()
+    try:
+        result = converter.convert(article["pdf_path"])
+        markdown = result.document.export_to_markdown()
+    except Exception:
+        failures[article_id] = traceback.format_exc(limit=3)
+        print(f"[{index + 1}/{len(articles)}] {article_id} FAILED", flush=True)
+        continue
+    timings[article_id] = time.perf_counter() - started
+    target.write_text(markdown, encoding="utf-8")
+    print(f"[{index + 1}/{len(articles)}] {article_id} {timings[article_id]:.1f}s", flush=True)
+
+    (OUT / "run.json").write_text(
+        json.dumps(
+            {
+                "tool": "docling",
+                "versions": {"docling": importlib.metadata.version("docling")},
+                "settings": "defaults",
+                "timings": timings,
+                "failures": failures,
+            },
+            indent=2,
+        ),
+        encoding="utf-8",
+    )
+print(f"done: {len(timings)} converted, {len(failures)} failed", flush=True)

--- a/benchmarks/comparison/convert_pymupdf4llm.py
+++ b/benchmarks/comparison/convert_pymupdf4llm.py
@@ -1,0 +1,60 @@
+#  Copyright (c) 2025 Tom Villani, Ph.D.
+"""Convert every article with pymupdf4llm at its defaults; dump markdown + timings.
+
+Runs in the baselines venv (see baselines.txt), not the project venv. Output:
+``out/pymupdf4llm/<article_id>.md`` plus a ``run.json`` with versions, per-article
+timing, and failures. Defaults on purpose: the comparison is against what a user of
+each tool gets without tuning.
+"""
+
+from __future__ import annotations
+
+import json
+import time
+import traceback
+from pathlib import Path
+
+import pymupdf
+import pymupdf4llm
+
+HERE = Path(__file__).resolve().parent
+OUT = HERE / "out" / "pymupdf4llm"
+OUT.mkdir(parents=True, exist_ok=True)
+
+articles = json.loads((HERE / "articles.json").read_text(encoding="utf-8"))["articles"]
+
+timings: dict[str, float] = {}
+failures: dict[str, str] = {}
+for index, article in enumerate(articles):
+    article_id = article["article_id"]
+    target = OUT / f"{article_id}.md"
+    if target.exists():
+        continue
+    started = time.perf_counter()
+    try:
+        markdown = pymupdf4llm.to_markdown(article["pdf_path"])
+    except Exception:
+        failures[article_id] = traceback.format_exc(limit=3)
+        print(f"[{index + 1}/{len(articles)}] {article_id} FAILED", flush=True)
+        continue
+    timings[article_id] = time.perf_counter() - started
+    target.write_text(markdown, encoding="utf-8")
+    print(f"[{index + 1}/{len(articles)}] {article_id} {timings[article_id]:.1f}s", flush=True)
+
+    (OUT / "run.json").write_text(
+        json.dumps(
+            {
+                "tool": "pymupdf4llm",
+                "versions": {
+                    "pymupdf4llm": pymupdf4llm.__version__,
+                    "pymupdf": pymupdf.__doc__,
+                },
+                "settings": "defaults",
+                "timings": timings,
+                "failures": failures,
+            },
+            indent=2,
+        ),
+        encoding="utf-8",
+    )
+print(f"done: {len(timings)} converted, {len(failures)} failed", flush=True)

--- a/benchmarks/comparison/export_articles.py
+++ b/benchmarks/comparison/export_articles.py
@@ -1,0 +1,42 @@
+#  Copyright (c) 2025 Tom Villani, Ph.D.
+"""Export the held-out corpus article list (id, pdf, xml) as JSON for the baselines venv.
+
+Runs in the project venv (needs ``benchmarks.pmc``). The baseline converters run in a
+separate venv that has pymupdf4llm/docling but not this repository, so they read the
+``articles.json`` this writes instead of importing anything from here.
+
+The corpus must already be materialized: ``python -m benchmarks.pmc load --manifest
+benchmarks/pmc/manifest-holdout.json``.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+REPO = HERE.parents[1]
+sys.path.insert(0, str(REPO))
+
+from benchmarks.pmc import corpus  # noqa: E402
+
+snapshot = corpus.load_corpus(
+    REPO / "benchmarks" / "pmc" / ".cache",
+    manifest_path=REPO / "benchmarks" / "pmc" / "manifest-holdout.json",
+)
+payload = {
+    "manifest_sha256": snapshot.manifest_sha256,
+    "complete": snapshot.complete,
+    "articles": [
+        {
+            "article_id": article.article_id,
+            "pdf_path": str(article.pdf_path),
+            "xml_path": str(article.xml_path),
+        }
+        for article in snapshot.articles
+    ],
+}
+out = HERE / "articles.json"
+out.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+print(f"wrote {out} with {len(payload['articles'])} articles; complete={snapshot.complete}")

--- a/benchmarks/comparison/export_articles.py
+++ b/benchmarks/comparison/export_articles.py
@@ -25,18 +25,19 @@ snapshot = corpus.load_corpus(
     REPO / "benchmarks" / "pmc" / ".cache",
     manifest_path=REPO / "benchmarks" / "pmc" / "manifest-holdout.json",
 )
+rows = [
+    {
+        "article_id": article.article_id,
+        "pdf_path": str(article.pdf_path),
+        "xml_path": str(article.xml_path),
+    }
+    for article in snapshot.articles
+]
 payload = {
     "manifest_sha256": snapshot.manifest_sha256,
     "complete": snapshot.complete,
-    "articles": [
-        {
-            "article_id": article.article_id,
-            "pdf_path": str(article.pdf_path),
-            "xml_path": str(article.xml_path),
-        }
-        for article in snapshot.articles
-    ],
+    "articles": rows,
 }
 out = HERE / "articles.json"
 out.write_text(json.dumps(payload, indent=2), encoding="utf-8")
-print(f"wrote {out} with {len(payload['articles'])} articles; complete={snapshot.complete}")
+print(f"wrote {out} with {len(rows)} articles; complete={snapshot.complete}")

--- a/benchmarks/comparison/lost_blocks.py
+++ b/benchmarks/comparison/lost_blocks.py
@@ -1,0 +1,96 @@
+#  Copyright (c) 2025 Tom Villani, Ph.D.
+"""Name the truth blocks a baseline recovers that all2md loses, and sketch why.
+
+For each article: a block counts as LOST if it is attainable (contained in the PDF's own
+text layer), contained in the baseline's output, and NOT contained in all2md's output --
+all at the instruments' own ``RECALL_MIN`` threshold. Writes ``lost_blocks.json`` with
+every lost block (article, kind, text) plus the all2md containment score so near-misses
+are visible: a block at share 0.6 was shredded, a block at share 0.0 never made it out.
+
+This is the diff that turned the 2026-08-19 reading into issues #405 (side-by-side
+regions interleaved line-by-line) and #406 (figure captions absent entirely).
+
+Usage: ``python benchmarks/comparison/lost_blocks.py [baseline]`` (default:
+``pymupdf4llm``; any tool directory under ``out/`` works).
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from collections import Counter
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+REPO = HERE.parents[1]
+sys.path.insert(0, str(REPO))
+
+import fitz  # noqa: E402
+
+from all2md import to_ast  # noqa: E402
+from benchmarks.omnidocbench.oracles import project_ast  # noqa: E402
+from benchmarks.pmc.alignment import MIN_NGRAMS, ngrams, normalize  # noqa: E402
+from benchmarks.pmc.article import RECALL_MIN  # noqa: E402
+from benchmarks.pmc.corpus import _parse_jats  # noqa: E402
+from benchmarks.pmc.oracles import project_jats  # noqa: E402
+
+articles = json.loads((HERE / "articles.json").read_text(encoding="utf-8"))["articles"]
+baseline = sys.argv[1] if len(sys.argv) > 1 else "pymupdf4llm"
+
+
+def emitted_ngrams(tool: str, article_id: str) -> set:
+    md_path = HERE / "out" / tool / f"{article_id}.md"
+    projection = project_ast(to_ast(str(md_path), source_format="markdown"))
+    return ngrams(normalize(" ".join(projection.text_blocks)))
+
+
+lost: list[dict] = []
+kind_counts: Counter[str] = Counter()
+article_counts: Counter[str] = Counter()
+for article in articles:
+    article_id = article["article_id"]
+    root, _ = _parse_jats(Path(article["xml_path"]).read_bytes())
+    blocks, _whole = project_jats(root)
+    with fitz.open(article["pdf_path"]) as document:
+        ceiling = ngrams(normalize(" ".join(page.get_text() for page in document)))
+    ours = emitted_ngrams("all2md", article_id)
+    theirs = emitted_ngrams(baseline, article_id)
+    for block in blocks:
+        if not block.text:
+            continue
+        grams = ngrams(normalize(block.text))
+        if len(grams) < MIN_NGRAMS:
+            continue
+        if len(grams & ceiling) / len(grams) < RECALL_MIN:
+            continue  # not attainable; nobody is charged for it
+        ours_share = len(grams & ours) / len(grams)
+        theirs_share = len(grams & theirs) / len(grams)
+        if theirs_share >= RECALL_MIN and ours_share < RECALL_MIN:
+            kind_counts[block.kind] += 1
+            article_counts[article_id] += 1
+            lost.append(
+                {
+                    "article_id": article_id,
+                    "kind": block.kind,
+                    "all2md_share": round(ours_share, 3),
+                    f"{baseline}_share": round(theirs_share, 3),
+                    "text": block.text[:400],
+                }
+            )
+    print(f"{article_id}: cumulative lost={len(lost)}", flush=True)
+
+(HERE / "lost_blocks.json").write_text(
+    json.dumps(
+        {
+            "definition": f"attainable + recovered by {baseline} + not recovered by all2md, at RECALL_MIN",
+            "total": len(lost),
+            "by_kind": dict(kind_counts.most_common()),
+            "by_article_top": dict(article_counts.most_common(15)),
+            "blocks": lost,
+        },
+        indent=2,
+        ensure_ascii=False,
+    ),
+    encoding="utf-8",
+)
+print(f"total lost blocks: {len(lost)}; by kind: {dict(kind_counts)}")

--- a/benchmarks/comparison/results-2026-08-19.json
+++ b/benchmarks/comparison/results-2026-08-19.json
@@ -1,0 +1,1771 @@
+{
+  "provenance": {
+    "recorded": "2026-08-19",
+    "corpus": "benchmarks/pmc/manifest-holdout.json (110 held-out articles)",
+    "corpus_pin": "93fb2c78ec99af5c84620155eef10c8dd616c5fdf0c69c58338e1aafbe4918cb",
+    "all2md_commit": "99a0eb0",
+    "platform": "Windows 11, CPU only, no Tesseract binary installed",
+    "note": "all2md ran the PMC lane parser policy; baselines ran their defaults. Every tool's markdown was re-parsed through all2md's markdown parser before scoring, so all three share one normalization path."
+  },
+  "tools": {
+    "all2md": {
+      "versions": {
+        "all2md": "1.12.0"
+      },
+      "articles_scored": 110,
+      "articles_missing": 0,
+      "parse_failures": {},
+      "conversion_failures": [],
+      "attainable_recall": 0.9352775368603643,
+      "recall_raw": 0.5847949316438813,
+      "ceiling": 0.61513837945982,
+      "by_kind": {
+        "table": {
+          "attainable_recall": 0.6986301369863014,
+          "attainable": 146
+        },
+        "text_block": {
+          "attainable_recall": 0.9428684784764928,
+          "attainable": 5041
+        },
+        "title": {
+          "attainable_recall": 0.9343571959375774,
+          "attainable": 4037
+        }
+      },
+      "control_recall": 0.003667889296432144,
+      "novel_share": 0.00841107606496084,
+      "precision_raw": 0.9221142134129997,
+      "duplication": 0.006068750440758182,
+      "tables_emitted": 228,
+      "tables_expected": 166,
+      "seconds_per_article_mean": 10.065760722726752,
+      "reparse_word_ratio": 0.9565632036505047,
+      "per_article": {
+        "PMC10250014.1": {
+          "attainable_recall": 0.9387755102040817,
+          "tables_emitted": 1,
+          "tables_expected": 1
+        },
+        "PMC10250036.1": {
+          "attainable_recall": 1.0,
+          "tables_emitted": 0,
+          "tables_expected": 0
+        },
+        "PMC10250047.1": {
+          "attainable_recall": 1.0,
+          "tables_emitted": 0,
+          "tables_expected": 0
+        },
+        "PMC10250057.1": {
+          "attainable_recall": 0.7191011235955056,
+          "tables_emitted": 1,
+          "tables_expected": 1
+        },
+        "PMC10250068.1": {
+          "attainable_recall": 1.0,
+          "tables_emitted": 0,
+          "tables_expected": 0
+        },
+        "PMC10750000.1": {
+          "attainable_recall": 0.5175438596491229,
+          "tables_emitted": 1,
+          "tables_expected": 1
+        },
+        "PMC10750011.1": {
+          "attainable_recall": 0.8403361344537815,
+          "tables_emitted": 1,
+          "tables_expected": 1
+        },
+        "PMC10750022.1": {
+          "attainable_recall": 0.4157303370786517,
+          "tables_emitted": 13,
+          "tables_expected": 5
+        },
+        "PMC10750033.1": {
+          "attainable_recall": 0.6883116883116883,
+          "tables_emitted": 5,
+          "tables_expected": 5
+        },
+        "PMC10750044.1": {
+          "attainable_recall": 0.9523809523809523,
+          "tables_emitted": 6,
+          "tables_expected": 6
+        },
+        "PMC11250000.1": {
+          "attainable_recall": 1.0,
+          "tables_emitted": 2,
+          "tables_expected": 2
+        },
+        "PMC11250011.1": {
+          "attainable_recall": 0.9841269841269841,
+          "tables_emitted": 6,
+          "tables_expected": 1
+        },
+        "PMC11250022.1": {
+          "attainable_recall": 1.0,
+          "tables_emitted": 0,
+          "tables_expected": 0
+        },
+        "PMC11250033.1": {
+          "attainable_recall": 0.9560439560439561,
+          "tables_emitted": 3,
+          "tables_expected": 3
+        },
+        "PMC11250047.1": {
+          "attainable_recall": 0.9696969696969697,
+          "tables_emitted": 1,
+          "tables_expected": 1
+        },
+        "PMC11750000.1": {
+          "attainable_recall": 0.8923076923076924,
+          "tables_emitted": 5,
+          "tables_expected": 7
+        },
+        "PMC11750013.1": {
+          "attainable_recall": 0.9626168224299065,
+          "tables_emitted": 1,
+          "tables_expected": 0
+        },
+        "PMC11750023.1": {
+          "attainable_recall": 0.875,
+          "tables_emitted": 5,
+          "tables_expected": 4
+        },
+        "PMC11750034.1": {
+          "attainable_recall": 0.896551724137931,
+          "tables_emitted": 1,
+          "tables_expected": 0
+        },
+        "PMC11750046.1": {
+          "attainable_recall": 0.9512195121951219,
+          "tables_emitted": 0,
+          "tables_expected": 0
+        },
+        "PMC12250000.1": {
+          "attainable_recall": 0.9961904761904762,
+          "tables_emitted": 1,
+          "tables_expected": 1
+        },
+        "PMC12250011.1": {
+          "attainable_recall": 0.9907407407407407,
+          "tables_emitted": 0,
+          "tables_expected": 0
+        },
+        "PMC12250022.1": {
+          "attainable_recall": 0.9934640522875817,
+          "tables_emitted": 0,
+          "tables_expected": 0
+        },
+        "PMC12250033.1": {
+          "attainable_recall": 0.9735099337748344,
+          "tables_emitted": 4,
+          "tables_expected": 4
+        },
+        "PMC12250044.1": {
+          "attainable_recall": 0.9888888888888889,
+          "tables_emitted": 6,
+          "tables_expected": 3
+        },
+        "PMC1750924.1": {
+          "attainable_recall": 1.0,
+          "tables_emitted": 0,
+          "tables_expected": 0
+        },
+        "PMC1750935.1": {
+          "attainable_recall": 1.0,
+          "tables_emitted": 0,
+          "tables_expected": 0
+        },
+        "PMC1750972.1": {
+          "attainable_recall": 1.0,
+          "tables_emitted": 1,
+          "tables_expected": 1
+        },
+        "PMC1750983.1": {
+          "attainable_recall": 1.0,
+          "tables_emitted": 1,
+          "tables_expected": 1
+        },
+        "PMC1750994.1": {
+          "attainable_recall": 1.0,
+          "tables_emitted": 0,
+          "tables_expected": 0
+        },
+        "PMC2250455.1": {
+          "attainable_recall": 0.2,
+          "tables_emitted": 1,
+          "tables_expected": 0
+        },
+        "PMC2250466.1": {
+          "attainable_recall": 1.0,
+          "tables_emitted": 0,
+          "tables_expected": 0
+        },
+        "PMC2253494.1": {
+          "attainable_recall": 0.9787234042553191,
+          "tables_emitted": 0,
+          "tables_expected": 0
+        },
+        "PMC2253505.1": {
+          "attainable_recall": 0.974025974025974,
+          "tables_emitted": 3,
+          "tables_expected": 3
+        },
+        "PMC2253516.1": {
+          "attainable_recall": 0.8775510204081632,
+          "tables_emitted": 5,
+          "tables_expected": 0
+        },
+        "PMC2750101.1": {
+          "attainable_recall": 1.0,
+          "tables_emitted": 1,
+          "tables_expected": 1
+        },
+        "PMC2750112.1": {
+          "attainable_recall": 0.9929577464788732,
+          "tables_emitted": 7,
+          "tables_expected": 6
+        },
+        "PMC2750123.1": {
+          "attainable_recall": 1.0,
+          "tables_emitted": 0,
+          "tables_expected": 0
+        },
+        "PMC2750134.1": {
+          "attainable_recall": 1.0,
+          "tables_emitted": 1,
+          "tables_expected": 1
+        },
+        "PMC2750145.1": {
+          "attainable_recall": 1.0,
+          "tables_emitted": 0,
+          "tables_expected": 0
+        },
+        "PMC3250000.1": {
+          "attainable_recall": 0.9444444444444444,
+          "tables_emitted": 1,
+          "tables_expected": 0
+        },
+        "PMC3250011.1": {
+          "attainable_recall": 0.6428571428571429,
+          "tables_emitted": 2,
+          "tables_expected": 0
+        },
+        "PMC3250022.1": {
+          "attainable_recall": 1.0,
+          "tables_emitted": 1,
+          "tables_expected": 0
+        },
+        "PMC3250033.1": {
+          "attainable_recall": 0.9672131147540983,
+          "tables_emitted": 6,
+          "tables_expected": 0
+        },
+        "PMC3250055.1": {
+          "attainable_recall": 0.8795180722891566,
+          "tables_emitted": 4,
+          "tables_expected": 4
+        },
+        "PMC3750000.1": {
+          "attainable_recall": 0.9206349206349206,
+          "tables_emitted": 5,
+          "tables_expected": 5
+        },
+        "PMC3750011.1": {
+          "attainable_recall": 0.975609756097561,
+          "tables_emitted": 0,
+          "tables_expected": 0
+        },
+        "PMC3750022.1": {
+          "attainable_recall": 1.0,
+          "tables_emitted": 0,
+          "tables_expected": 0
+        },
+        "PMC3750033.1": {
+          "attainable_recall": 0.9863013698630136,
+          "tables_emitted": 1,
+          "tables_expected": 2
+        },
+        "PMC3750044.1": {
+          "attainable_recall": 0.9574468085106383,
+          "tables_emitted": 1,
+          "tables_expected": 1
+        },
+        "PMC4250000.1": {
+          "attainable_recall": 0.9696969696969697,
+          "tables_emitted": 1,
+          "tables_expected": 1
+        },
+        "PMC4250011.1": {
+          "attainable_recall": 1.0,
+          "tables_emitted": 0,
+          "tables_expected": 0
+        },
+        "PMC4250022.1": {
+          "attainable_recall": 0.9180327868852459,
+          "tables_emitted": 1,
+          "tables_expected": 1
+        },
+        "PMC4250033.1": {
+          "attainable_recall": 0.8055555555555556,
+          "tables_emitted": 3,
+          "tables_expected": 1
+        },
+        "PMC4250054.1": {
+          "attainable_recall": 0.961038961038961,
+          "tables_emitted": 0,
+          "tables_expected": 4
+        },
+        "PMC4750000.1": {
+          "attainable_recall": 1.0,
+          "tables_emitted": 0,
+          "tables_expected": 0
+        },
+        "PMC4750011.1": {
+          "attainable_recall": 0.9285714285714286,
+          "tables_emitted": 0,
+          "tables_expected": 0
+        },
+        "PMC4750022.1": {
+          "attainable_recall": 1.0,
+          "tables_emitted": 1,
+          "tables_expected": 6
+        },
+        "PMC4750033.1": {
+          "attainable_recall": 0.953125,
+          "tables_emitted": 1,
+          "tables_expected": 1
+        },
+        "PMC4750044.1": {
+          "attainable_recall": 1.0,
+          "tables_emitted": 0,
+          "tables_expected": 0
+        },
+        "PMC5250590.1": {
+          "attainable_recall": 0.9886363636363636,
+          "tables_emitted": 6,
+          "tables_expected": 2
+        },
+        "PMC5250601.1": {
+          "attainable_recall": 0.9375,
+          "tables_emitted": 1,
+          "tables_expected": 1
+        },
+        "PMC5250623.1": {
+          "attainable_recall": 1.0,
+          "tables_emitted": 0,
+          "tables_expected": 0
+        },
+        "PMC5250635.1": {
+          "attainable_recall": 0.971830985915493,
+          "tables_emitted": 3,
+          "tables_expected": 2
+        },
+        "PMC5250647.1": {
+          "attainable_recall": 0.9846153846153847,
+          "tables_emitted": 4,
+          "tables_expected": 5
+        },
+        "PMC5750000.1": {
+          "attainable_recall": 1.0,
+          "tables_emitted": 0,
+          "tables_expected": 0
+        },
+        "PMC5750011.1": {
+          "attainable_recall": 0.9857142857142858,
+          "tables_emitted": 1,
+          "tables_expected": 1
+        },
+        "PMC5750022.1": {
+          "attainable_recall": 1.0,
+          "tables_emitted": 0,
+          "tables_expected": 0
+        },
+        "PMC5750033.1": {
+          "attainable_recall": 0.987012987012987,
+          "tables_emitted": 0,
+          "tables_expected": 3
+        },
+        "PMC5750208.1": {
+          "attainable_recall": 1.0,
+          "tables_emitted": 0,
+          "tables_expected": 0
+        },
+        "PMC6250000.1": {
+          "attainable_recall": 0.7945205479452054,
+          "tables_emitted": 5,
+          "tables_expected": 4
+        },
+        "PMC6250011.1": {
+          "attainable_recall": 0.865546218487395,
+          "tables_emitted": 3,
+          "tables_expected": 2
+        },
+        "PMC6250022.1": {
+          "attainable_recall": 0.8235294117647058,
+          "tables_emitted": 0,
+          "tables_expected": 0
+        },
+        "PMC6250033.1": {
+          "attainable_recall": 1.0,
+          "tables_emitted": 0,
+          "tables_expected": 0
+        },
+        "PMC6250044.1": {
+          "attainable_recall": 0.8162393162393162,
+          "tables_emitted": 2,
+          "tables_expected": 2
+        },
+        "PMC6750044.1": {
+          "attainable_recall": 0.8,
+          "tables_emitted": 1,
+          "tables_expected": 0
+        },
+        "PMC6750072.1": {
+          "attainable_recall": 0.7631578947368421,
+          "tables_emitted": 2,
+          "tables_expected": 1
+        },
+        "PMC6750083.1": {
+          "attainable_recall": 0.7530864197530864,
+          "tables_emitted": 0,
+          "tables_expected": 0
+        },
+        "PMC6750094.1": {
+          "attainable_recall": 0.8426966292134831,
+          "tables_emitted": 0,
+          "tables_expected": 0
+        },
+        "PMC6750105.1": {
+          "attainable_recall": 0.835820895522388,
+          "tables_emitted": 0,
+          "tables_expected": 0
+        },
+        "PMC7250000.1": {
+          "attainable_recall": 0.9923664122137404,
+          "tables_emitted": 4,
+          "tables_expected": 3
+        },
+        "PMC7250011.1": {
+          "attainable_recall": 0.7849462365591398,
+          "tables_emitted": 2,
+          "tables_expected": 2
+        },
+        "PMC7250022.1": {
+          "attainable_recall": 0.8028169014084507,
+          "tables_emitted": 2,
+          "tables_expected": 1
+        },
+        "PMC7250033.1": {
+          "attainable_recall": 0.9862385321100917,
+          "tables_emitted": 0,
+          "tables_expected": 0
+        },
+        "PMC7250055.2": {
+          "attainable_recall": 0.9879032258064516,
+          "tables_emitted": 2,
+          "tables_expected": 0
+        },
+        "PMC7750000.1": {
+          "attainable_recall": 1.0,
+          "tables_emitted": 0,
+          "tables_expected": 0
+        },
+        "PMC7750009.1": {
+          "attainable_recall": 1.0,
+          "tables_emitted": 1,
+          "tables_expected": 5
+        },
+        "PMC7750019.1": {
+          "attainable_recall": 0.9642857142857143,
+          "tables_emitted": 3,
+          "tables_expected": 1
+        },
+        "PMC7750040.1": {
+          "attainable_recall": 0.9642857142857143,
+          "tables_emitted": 3,
+          "tables_expected": 2
+        },
+        "PMC7750051.1": {
+          "attainable_recall": 0.9090909090909091,
+          "tables_emitted": 3,
+          "tables_expected": 3
+        },
+        "PMC8250041.1": {
+          "attainable_recall": 0.5689655172413793,
+          "tables_emitted": 6,
+          "tables_expected": 5
+        },
+        "PMC8250095.2": {
+          "attainable_recall": 0.925,
+          "tables_emitted": 5,
+          "tables_expected": 5
+        },
+        "PMC8250106.1": {
+          "attainable_recall": 1.0,
+          "tables_emitted": 0,
+          "tables_expected": 0
+        },
+        "PMC8250133.1": {
+          "attainable_recall": 1.0,
+          "tables_emitted": 0,
+          "tables_expected": 0
+        },
+        "PMC8250144.1": {
+          "attainable_recall": 0.9746835443037974,
+          "tables_emitted": 1,
+          "tables_expected": 0
+        },
+        "PMC8750000.1": {
+          "attainable_recall": 0.9873417721518988,
+          "tables_emitted": 0,
+          "tables_expected": 0
+        },
+        "PMC8750011.1": {
+          "attainable_recall": 0.9817073170731707,
+          "tables_emitted": 7,
+          "tables_expected": 7
+        },
+        "PMC8750022.1": {
+          "attainable_recall": 0.976,
+          "tables_emitted": 4,
+          "tables_expected": 4
+        },
+        "PMC8750036.1": {
+          "attainable_recall": 0.98989898989899,
+          "tables_emitted": 3,
+          "tables_expected": 3
+        },
+        "PMC8750048.1": {
+          "attainable_recall": 0.993006993006993,
+          "tables_emitted": 0,
+          "tables_expected": 0
+        },
+        "PMC9250000.1": {
+          "attainable_recall": 1.0,
+          "tables_emitted": 0,
+          "tables_expected": 0
+        },
+        "PMC9250014.1": {
+          "attainable_recall": 0.9928057553956835,
+          "tables_emitted": 11,
+          "tables_expected": 1
+        },
+        "PMC9250025.1": {
+          "attainable_recall": 1.0,
+          "tables_emitted": 15,
+          "tables_expected": 1
+        },
+        "PMC9250036.1": {
+          "attainable_recall": 1.0,
+          "tables_emitted": 2,
+          "tables_expected": 3
+        },
+        "PMC9250060.1": {
+          "attainable_recall": 0.9871794871794872,
+          "tables_emitted": 2,
+          "tables_expected": 2
+        },
+        "PMC9750000.1": {
+          "attainable_recall": 0.9878048780487805,
+          "tables_emitted": 3,
+          "tables_expected": 3
+        },
+        "PMC9750011.1": {
+          "attainable_recall": 0.978021978021978,
+          "tables_emitted": 3,
+          "tables_expected": 2
+        },
+        "PMC9750022.1": {
+          "attainable_recall": 0.9716981132075472,
+          "tables_emitted": 5,
+          "tables_expected": 3
+        },
+        "PMC9750033.1": {
+          "attainable_recall": 0.9438202247191011,
+          "tables_emitted": 2,
+          "tables_expected": 2
+        },
+        "PMC9750044.1": {
+          "attainable_recall": 0.9259259259259259,
+          "tables_emitted": 0,
+          "tables_expected": 0
+        }
+      }
+    },
+    "pymupdf4llm": {
+      "versions": {
+        "pymupdf4llm": "1.28.2",
+        "pymupdf": "PyMuPDF 1.28.2: Python bindings for the MuPDF 1.28.2 library.\nPython 3.13 running on win32 (64-bit).\n"
+      },
+      "articles_scored": 110,
+      "articles_missing": 0,
+      "parse_failures": {},
+      "conversion_failures": [],
+      "attainable_recall": 0.9826539462272333,
+      "recall_raw": 0.6144714904968323,
+      "ceiling": 0.61513837945982,
+      "by_kind": {
+        "table": {
+          "attainable_recall": 0.6506849315068494,
+          "attainable": 146
+        },
+        "text_block": {
+          "attainable_recall": 0.9841301329101368,
+          "attainable": 5041
+        },
+        "title": {
+          "attainable_recall": 0.9928164478573198,
+          "attainable": 4037
+        }
+      },
+      "control_recall": 0.0038679559853284427,
+      "novel_share": 0.05494534783616878,
+      "precision_raw": 0.883717893019822,
+      "duplication": 0.0018671572186505056,
+      "tables_emitted": 208,
+      "tables_expected": 166,
+      "seconds_per_article_mean": 34.95711638818294,
+      "reparse_word_ratio": 1.036465047099653,
+      "per_article": {
+        "PMC10250014.1": {
+          "attainable_recall": 0.9387755102040817,
+          "tables_emitted": 1,
+          "tables_expected": 1
+        },
+        "PMC10250036.1": {
+          "attainable_recall": 1.0,
+          "tables_emitted": 0,
+          "tables_expected": 0
+        },
+        "PMC10250047.1": {
+          "attainable_recall": 1.0,
+          "tables_emitted": 0,
+          "tables_expected": 0
+        },
+        "PMC10250057.1": {
+          "attainable_recall": 1.0,
+          "tables_emitted": 1,
+          "tables_expected": 1
+        },
+        "PMC10250068.1": {
+          "attainable_recall": 0.6,
+          "tables_emitted": 0,
+          "tables_expected": 0
+        },
+        "PMC10750000.1": {
+          "attainable_recall": 1.0,
+          "tables_emitted": 1,
+          "tables_expected": 1
+        },
+        "PMC10750011.1": {
+          "attainable_recall": 0.9915966386554622,
+          "tables_emitted": 1,
+          "tables_expected": 1
+        },
+        "PMC10750022.1": {
+          "attainable_recall": 0.9662921348314607,
+          "tables_emitted": 7,
+          "tables_expected": 5
+        },
+        "PMC10750033.1": {
+          "attainable_recall": 0.948051948051948,
+          "tables_emitted": 5,
+          "tables_expected": 5
+        },
+        "PMC10750044.1": {
+          "attainable_recall": 0.9809523809523809,
+          "tables_emitted": 6,
+          "tables_expected": 6
+        },
+        "PMC11250000.1": {
+          "attainable_recall": 1.0,
+          "tables_emitted": 2,
+          "tables_expected": 2
+        },
+        "PMC11250011.1": {
+          "attainable_recall": 1.0,
+          "tables_emitted": 5,
+          "tables_expected": 1
+        },
+        "PMC11250022.1": {
+          "attainable_recall": 1.0,
+          "tables_emitted": 0,
+          "tables_expected": 0
+        },
+        "PMC11250033.1": {
+          "attainable_recall": 0.978021978021978,
+          "tables_emitted": 4,
+          "tables_expected": 3
+        },
+        "PMC11250047.1": {
+          "attainable_recall": 1.0,
+          "tables_emitted": 2,
+          "tables_expected": 1
+        },
+        "PMC11750000.1": {
+          "attainable_recall": 0.9538461538461539,
+          "tables_emitted": 8,
+          "tables_expected": 7
+        },
+        "PMC11750013.1": {
+          "attainable_recall": 0.9813084112149533,
+          "tables_emitted": 1,
+          "tables_expected": 0
+        },
+        "PMC11750023.1": {
+          "attainable_recall": 0.8958333333333334,
+          "tables_emitted": 5,
+          "tables_expected": 4
+        },
+        "PMC11750034.1": {
+          "attainable_recall": 0.9655172413793104,
+          "tables_emitted": 0,
+          "tables_expected": 0
+        },
+        "PMC11750046.1": {
+          "attainable_recall": 1.0,
+          "tables_emitted": 0,
+          "tables_expected": 0
+        },
+        "PMC12250000.1": {
+          "attainable_recall": 0.9961904761904762,
+          "tables_emitted": 2,
+          "tables_expected": 1
+        },
+        "PMC12250011.1": {
+          "attainable_recall": 1.0,
+          "tables_emitted": 0,
+          "tables_expected": 0
+        },
+        "PMC12250022.1": {
+          "attainable_recall": 0.9934640522875817,
+          "tables_emitted": 0,
+          "tables_expected": 0
+        },
+        "PMC12250033.1": {
+          "attainable_recall": 0.9735099337748344,
+          "tables_emitted": 4,
+          "tables_expected": 4
+        },
+        "PMC12250044.1": {
+          "attainable_recall": 0.9888888888888889,
+          "tables_emitted": 5,
+          "tables_expected": 3
+        },
+        "PMC1750924.1": {
+          "attainable_recall": 1.0,
+          "tables_emitted": 0,
+          "tables_expected": 0
+        },
+        "PMC1750935.1": {
+          "attainable_recall": 1.0,
+          "tables_emitted": 0,
+          "tables_expected": 0
+        },
+        "PMC1750972.1": {
+          "attainable_recall": 1.0,
+          "tables_emitted": 1,
+          "tables_expected": 1
+        },
+        "PMC1750983.1": {
+          "attainable_recall": 1.0,
+          "tables_emitted": 1,
+          "tables_expected": 1
+        },
+        "PMC1750994.1": {
+          "attainable_recall": 1.0,
+          "tables_emitted": 0,
+          "tables_expected": 0
+        },
+        "PMC2250455.1": {
+          "attainable_recall": 1.0,
+          "tables_emitted": 0,
+          "tables_expected": 0
+        },
+        "PMC2250466.1": {
+          "attainable_recall": 0.5,
+          "tables_emitted": 0,
+          "tables_expected": 0
+        },
+        "PMC2253494.1": {
+          "attainable_recall": 0.9574468085106383,
+          "tables_emitted": 0,
+          "tables_expected": 0
+        },
+        "PMC2253505.1": {
+          "attainable_recall": 1.0,
+          "tables_emitted": 3,
+          "tables_expected": 3
+        },
+        "PMC2253516.1": {
+          "attainable_recall": 1.0,
+          "tables_emitted": 0,
+          "tables_expected": 0
+        },
+        "PMC2750101.1": {
+          "attainable_recall": 1.0,
+          "tables_emitted": 1,
+          "tables_expected": 1
+        },
+        "PMC2750112.1": {
+          "attainable_recall": 0.9929577464788732,
+          "tables_emitted": 7,
+          "tables_expected": 6
+        },
+        "PMC2750123.1": {
+          "attainable_recall": 1.0,
+          "tables_emitted": 0,
+          "tables_expected": 0
+        },
+        "PMC2750134.1": {
+          "attainable_recall": 1.0,
+          "tables_emitted": 1,
+          "tables_expected": 1
+        },
+        "PMC2750145.1": {
+          "attainable_recall": 1.0,
+          "tables_emitted": 0,
+          "tables_expected": 0
+        },
+        "PMC3250000.1": {
+          "attainable_recall": 1.0,
+          "tables_emitted": 0,
+          "tables_expected": 0
+        },
+        "PMC3250011.1": {
+          "attainable_recall": 1.0,
+          "tables_emitted": 1,
+          "tables_expected": 0
+        },
+        "PMC3250022.1": {
+          "attainable_recall": 1.0,
+          "tables_emitted": 1,
+          "tables_expected": 0
+        },
+        "PMC3250033.1": {
+          "attainable_recall": 1.0,
+          "tables_emitted": 7,
+          "tables_expected": 0
+        },
+        "PMC3250055.1": {
+          "attainable_recall": 0.7590361445783133,
+          "tables_emitted": 5,
+          "tables_expected": 4
+        },
+        "PMC3750000.1": {
+          "attainable_recall": 0.9682539682539683,
+          "tables_emitted": 5,
+          "tables_expected": 5
+        },
+        "PMC3750011.1": {
+          "attainable_recall": 0.9878048780487805,
+          "tables_emitted": 0,
+          "tables_expected": 0
+        },
+        "PMC3750022.1": {
+          "attainable_recall": 1.0,
+          "tables_emitted": 0,
+          "tables_expected": 0
+        },
+        "PMC3750033.1": {
+          "attainable_recall": 0.9863013698630136,
+          "tables_emitted": 2,
+          "tables_expected": 2
+        },
+        "PMC3750044.1": {
+          "attainable_recall": 0.9893617021276596,
+          "tables_emitted": 1,
+          "tables_expected": 1
+        },
+        "PMC4250000.1": {
+          "attainable_recall": 1.0,
+          "tables_emitted": 2,
+          "tables_expected": 1
+        },
+        "PMC4250011.1": {
+          "attainable_recall": 1.0,
+          "tables_emitted": 0,
+          "tables_expected": 0
+        },
+        "PMC4250022.1": {
+          "attainable_recall": 1.0,
+          "tables_emitted": 1,
+          "tables_expected": 1
+        },
+        "PMC4250033.1": {
+          "attainable_recall": 0.9166666666666666,
+          "tables_emitted": 2,
+          "tables_expected": 1
+        },
+        "PMC4250054.1": {
+          "attainable_recall": 1.0,
+          "tables_emitted": 4,
+          "tables_expected": 4
+        },
+        "PMC4750000.1": {
+          "attainable_recall": 1.0,
+          "tables_emitted": 0,
+          "tables_expected": 0
+        },
+        "PMC4750011.1": {
+          "attainable_recall": 1.0,
+          "tables_emitted": 0,
+          "tables_expected": 0
+        },
+        "PMC4750022.1": {
+          "attainable_recall": 0.9743589743589743,
+          "tables_emitted": 6,
+          "tables_expected": 6
+        },
+        "PMC4750033.1": {
+          "attainable_recall": 1.0,
+          "tables_emitted": 1,
+          "tables_expected": 1
+        },
+        "PMC4750044.1": {
+          "attainable_recall": 0.9887640449438202,
+          "tables_emitted": 0,
+          "tables_expected": 0
+        },
+        "PMC5250590.1": {
+          "attainable_recall": 1.0,
+          "tables_emitted": 2,
+          "tables_expected": 2
+        },
+        "PMC5250601.1": {
+          "attainable_recall": 1.0,
+          "tables_emitted": 2,
+          "tables_expected": 1
+        },
+        "PMC5250623.1": {
+          "attainable_recall": 1.0,
+          "tables_emitted": 0,
+          "tables_expected": 0
+        },
+        "PMC5250635.1": {
+          "attainable_recall": 0.9014084507042254,
+          "tables_emitted": 3,
+          "tables_expected": 2
+        },
+        "PMC5250647.1": {
+          "attainable_recall": 0.9923076923076923,
+          "tables_emitted": 4,
+          "tables_expected": 5
+        },
+        "PMC5750000.1": {
+          "attainable_recall": 0.8461538461538461,
+          "tables_emitted": 2,
+          "tables_expected": 0
+        },
+        "PMC5750011.1": {
+          "attainable_recall": 0.9571428571428572,
+          "tables_emitted": 1,
+          "tables_expected": 1
+        },
+        "PMC5750022.1": {
+          "attainable_recall": 1.0,
+          "tables_emitted": 0,
+          "tables_expected": 0
+        },
+        "PMC5750033.1": {
+          "attainable_recall": 0.8831168831168831,
+          "tables_emitted": 5,
+          "tables_expected": 3
+        },
+        "PMC5750208.1": {
+          "attainable_recall": 1.0,
+          "tables_emitted": 0,
+          "tables_expected": 0
+        },
+        "PMC6250000.1": {
+          "attainable_recall": 0.9726027397260274,
+          "tables_emitted": 5,
+          "tables_expected": 4
+        },
+        "PMC6250011.1": {
+          "attainable_recall": 1.0,
+          "tables_emitted": 2,
+          "tables_expected": 2
+        },
+        "PMC6250022.1": {
+          "attainable_recall": 1.0,
+          "tables_emitted": 0,
+          "tables_expected": 0
+        },
+        "PMC6250033.1": {
+          "attainable_recall": 1.0,
+          "tables_emitted": 0,
+          "tables_expected": 0
+        },
+        "PMC6250044.1": {
+          "attainable_recall": 0.9914529914529915,
+          "tables_emitted": 2,
+          "tables_expected": 2
+        },
+        "PMC6750044.1": {
+          "attainable_recall": 1.0,
+          "tables_emitted": 0,
+          "tables_expected": 0
+        },
+        "PMC6750072.1": {
+          "attainable_recall": 0.9868421052631579,
+          "tables_emitted": 1,
+          "tables_expected": 1
+        },
+        "PMC6750083.1": {
+          "attainable_recall": 0.9876543209876543,
+          "tables_emitted": 0,
+          "tables_expected": 0
+        },
+        "PMC6750094.1": {
+          "attainable_recall": 0.9887640449438202,
+          "tables_emitted": 0,
+          "tables_expected": 0
+        },
+        "PMC6750105.1": {
+          "attainable_recall": 1.0,
+          "tables_emitted": 0,
+          "tables_expected": 0
+        },
+        "PMC7250000.1": {
+          "attainable_recall": 1.0,
+          "tables_emitted": 4,
+          "tables_expected": 3
+        },
+        "PMC7250011.1": {
+          "attainable_recall": 0.978494623655914,
+          "tables_emitted": 2,
+          "tables_expected": 2
+        },
+        "PMC7250022.1": {
+          "attainable_recall": 0.9647887323943662,
+          "tables_emitted": 3,
+          "tables_expected": 1
+        },
+        "PMC7250033.1": {
+          "attainable_recall": 0.9908256880733946,
+          "tables_emitted": 0,
+          "tables_expected": 0
+        },
+        "PMC7250055.2": {
+          "attainable_recall": 0.9879032258064516,
+          "tables_emitted": 0,
+          "tables_expected": 0
+        },
+        "PMC7750000.1": {
+          "attainable_recall": 0.9880952380952381,
+          "tables_emitted": 0,
+          "tables_expected": 0
+        },
+        "PMC7750009.1": {
+          "attainable_recall": 0.9647058823529412,
+          "tables_emitted": 5,
+          "tables_expected": 5
+        },
+        "PMC7750019.1": {
+          "attainable_recall": 0.9880952380952381,
+          "tables_emitted": 1,
+          "tables_expected": 1
+        },
+        "PMC7750040.1": {
+          "attainable_recall": 0.9880952380952381,
+          "tables_emitted": 2,
+          "tables_expected": 2
+        },
+        "PMC7750051.1": {
+          "attainable_recall": 0.9848484848484849,
+          "tables_emitted": 3,
+          "tables_expected": 3
+        },
+        "PMC8250041.1": {
+          "attainable_recall": 0.896551724137931,
+          "tables_emitted": 5,
+          "tables_expected": 5
+        },
+        "PMC8250095.2": {
+          "attainable_recall": 0.95,
+          "tables_emitted": 5,
+          "tables_expected": 5
+        },
+        "PMC8250106.1": {
+          "attainable_recall": 0.7894736842105263,
+          "tables_emitted": 0,
+          "tables_expected": 0
+        },
+        "PMC8250133.1": {
+          "attainable_recall": 1.0,
+          "tables_emitted": 0,
+          "tables_expected": 0
+        },
+        "PMC8250144.1": {
+          "attainable_recall": 1.0,
+          "tables_emitted": 0,
+          "tables_expected": 0
+        },
+        "PMC8750000.1": {
+          "attainable_recall": 0.9873417721518988,
+          "tables_emitted": 0,
+          "tables_expected": 0
+        },
+        "PMC8750011.1": {
+          "attainable_recall": 0.9939024390243902,
+          "tables_emitted": 7,
+          "tables_expected": 7
+        },
+        "PMC8750022.1": {
+          "attainable_recall": 0.976,
+          "tables_emitted": 4,
+          "tables_expected": 4
+        },
+        "PMC8750036.1": {
+          "attainable_recall": 0.98989898989899,
+          "tables_emitted": 3,
+          "tables_expected": 3
+        },
+        "PMC8750048.1": {
+          "attainable_recall": 1.0,
+          "tables_emitted": 0,
+          "tables_expected": 0
+        },
+        "PMC9250000.1": {
+          "attainable_recall": 1.0,
+          "tables_emitted": 0,
+          "tables_expected": 0
+        },
+        "PMC9250014.1": {
+          "attainable_recall": 1.0,
+          "tables_emitted": 3,
+          "tables_expected": 1
+        },
+        "PMC9250025.1": {
+          "attainable_recall": 1.0,
+          "tables_emitted": 4,
+          "tables_expected": 1
+        },
+        "PMC9250036.1": {
+          "attainable_recall": 0.9857142857142858,
+          "tables_emitted": 3,
+          "tables_expected": 3
+        },
+        "PMC9250060.1": {
+          "attainable_recall": 1.0,
+          "tables_emitted": 2,
+          "tables_expected": 2
+        },
+        "PMC9750000.1": {
+          "attainable_recall": 0.9878048780487805,
+          "tables_emitted": 3,
+          "tables_expected": 3
+        },
+        "PMC9750011.1": {
+          "attainable_recall": 0.989010989010989,
+          "tables_emitted": 3,
+          "tables_expected": 2
+        },
+        "PMC9750022.1": {
+          "attainable_recall": 0.9811320754716981,
+          "tables_emitted": 3,
+          "tables_expected": 3
+        },
+        "PMC9750033.1": {
+          "attainable_recall": 1.0,
+          "tables_emitted": 2,
+          "tables_expected": 2
+        },
+        "PMC9750044.1": {
+          "attainable_recall": 1.0,
+          "tables_emitted": 0,
+          "tables_expected": 0
+        }
+      }
+    },
+    "docling": {
+      "versions": {
+        "docling": "2.120.3"
+      },
+      "articles_scored": 110,
+      "articles_missing": 0,
+      "parse_failures": {},
+      "conversion_failures": [],
+      "attainable_recall": 0.9550086730268864,
+      "recall_raw": 0.6076025341780593,
+      "ceiling": 0.61513837945982,
+      "by_kind": {
+        "table": {
+          "attainable_recall": 0.821917808219178,
+          "attainable": 146
+        },
+        "text_block": {
+          "attainable_recall": 0.9593334655822258,
+          "attainable": 5041
+        },
+        "title": {
+          "attainable_recall": 0.9544216001981669,
+          "attainable": 4037
+        }
+      },
+      "control_recall": 0.0038012670890296765,
+      "novel_share": 0.028657929252586214,
+      "precision_raw": 0.9105295560430023,
+      "duplication": 0.006164097959466427,
+      "tables_emitted": 201,
+      "tables_expected": 166,
+      "seconds_per_article_mean": 91.86291282363617,
+      "reparse_word_ratio": 0.9564599307954796,
+      "per_article": {
+        "PMC10250014.1": {
+          "attainable_recall": 0.9183673469387755,
+          "tables_emitted": 1,
+          "tables_expected": 1
+        },
+        "PMC10250036.1": {
+          "attainable_recall": 0.875,
+          "tables_emitted": 2,
+          "tables_expected": 0
+        },
+        "PMC10250047.1": {
+          "attainable_recall": 0.875,
+          "tables_emitted": 1,
+          "tables_expected": 0
+        },
+        "PMC10250057.1": {
+          "attainable_recall": 1.0,
+          "tables_emitted": 2,
+          "tables_expected": 1
+        },
+        "PMC10250068.1": {
+          "attainable_recall": 1.0,
+          "tables_emitted": 0,
+          "tables_expected": 0
+        },
+        "PMC10750000.1": {
+          "attainable_recall": 0.9210526315789473,
+          "tables_emitted": 1,
+          "tables_expected": 1
+        },
+        "PMC10750011.1": {
+          "attainable_recall": 0.9411764705882353,
+          "tables_emitted": 1,
+          "tables_expected": 1
+        },
+        "PMC10750022.1": {
+          "attainable_recall": 0.9325842696629213,
+          "tables_emitted": 7,
+          "tables_expected": 5
+        },
+        "PMC10750033.1": {
+          "attainable_recall": 0.935064935064935,
+          "tables_emitted": 5,
+          "tables_expected": 5
+        },
+        "PMC10750044.1": {
+          "attainable_recall": 0.9904761904761905,
+          "tables_emitted": 6,
+          "tables_expected": 6
+        },
+        "PMC11250000.1": {
+          "attainable_recall": 1.0,
+          "tables_emitted": 2,
+          "tables_expected": 2
+        },
+        "PMC11250011.1": {
+          "attainable_recall": 1.0,
+          "tables_emitted": 5,
+          "tables_expected": 1
+        },
+        "PMC11250022.1": {
+          "attainable_recall": 0.9897959183673469,
+          "tables_emitted": 0,
+          "tables_expected": 0
+        },
+        "PMC11250033.1": {
+          "attainable_recall": 0.978021978021978,
+          "tables_emitted": 3,
+          "tables_expected": 3
+        },
+        "PMC11250047.1": {
+          "attainable_recall": 1.0,
+          "tables_emitted": 1,
+          "tables_expected": 1
+        },
+        "PMC11750000.1": {
+          "attainable_recall": 1.0,
+          "tables_emitted": 7,
+          "tables_expected": 7
+        },
+        "PMC11750013.1": {
+          "attainable_recall": 1.0,
+          "tables_emitted": 0,
+          "tables_expected": 0
+        },
+        "PMC11750023.1": {
+          "attainable_recall": 0.9583333333333334,
+          "tables_emitted": 4,
+          "tables_expected": 4
+        },
+        "PMC11750034.1": {
+          "attainable_recall": 1.0,
+          "tables_emitted": 0,
+          "tables_expected": 0
+        },
+        "PMC11750046.1": {
+          "attainable_recall": 0.9512195121951219,
+          "tables_emitted": 0,
+          "tables_expected": 0
+        },
+        "PMC12250000.1": {
+          "attainable_recall": 0.9866666666666667,
+          "tables_emitted": 3,
+          "tables_expected": 1
+        },
+        "PMC12250011.1": {
+          "attainable_recall": 0.9907407407407407,
+          "tables_emitted": 0,
+          "tables_expected": 0
+        },
+        "PMC12250022.1": {
+          "attainable_recall": 0.9803921568627451,
+          "tables_emitted": 1,
+          "tables_expected": 0
+        },
+        "PMC12250033.1": {
+          "attainable_recall": 0.9933774834437086,
+          "tables_emitted": 4,
+          "tables_expected": 4
+        },
+        "PMC12250044.1": {
+          "attainable_recall": 0.9925925925925926,
+          "tables_emitted": 6,
+          "tables_expected": 3
+        },
+        "PMC1750924.1": {
+          "attainable_recall": 1.0,
+          "tables_emitted": 0,
+          "tables_expected": 0
+        },
+        "PMC1750935.1": {
+          "attainable_recall": 1.0,
+          "tables_emitted": 0,
+          "tables_expected": 0
+        },
+        "PMC1750972.1": {
+          "attainable_recall": 1.0,
+          "tables_emitted": 1,
+          "tables_expected": 1
+        },
+        "PMC1750983.1": {
+          "attainable_recall": 1.0,
+          "tables_emitted": 1,
+          "tables_expected": 1
+        },
+        "PMC1750994.1": {
+          "attainable_recall": 1.0,
+          "tables_emitted": 0,
+          "tables_expected": 0
+        },
+        "PMC2250455.1": {
+          "attainable_recall": 1.0,
+          "tables_emitted": 0,
+          "tables_expected": 0
+        },
+        "PMC2250466.1": {
+          "attainable_recall": 1.0,
+          "tables_emitted": 0,
+          "tables_expected": 0
+        },
+        "PMC2253494.1": {
+          "attainable_recall": 0.9787234042553191,
+          "tables_emitted": 0,
+          "tables_expected": 0
+        },
+        "PMC2253505.1": {
+          "attainable_recall": 0.974025974025974,
+          "tables_emitted": 3,
+          "tables_expected": 3
+        },
+        "PMC2253516.1": {
+          "attainable_recall": 0.9591836734693877,
+          "tables_emitted": 0,
+          "tables_expected": 0
+        },
+        "PMC2750101.1": {
+          "attainable_recall": 1.0,
+          "tables_emitted": 1,
+          "tables_expected": 1
+        },
+        "PMC2750112.1": {
+          "attainable_recall": 0.9929577464788732,
+          "tables_emitted": 7,
+          "tables_expected": 6
+        },
+        "PMC2750123.1": {
+          "attainable_recall": 1.0,
+          "tables_emitted": 0,
+          "tables_expected": 0
+        },
+        "PMC2750134.1": {
+          "attainable_recall": 1.0,
+          "tables_emitted": 1,
+          "tables_expected": 1
+        },
+        "PMC2750145.1": {
+          "attainable_recall": 1.0,
+          "tables_emitted": 0,
+          "tables_expected": 0
+        },
+        "PMC3250000.1": {
+          "attainable_recall": 1.0,
+          "tables_emitted": 0,
+          "tables_expected": 0
+        },
+        "PMC3250011.1": {
+          "attainable_recall": 1.0,
+          "tables_emitted": 0,
+          "tables_expected": 0
+        },
+        "PMC3250022.1": {
+          "attainable_recall": 1.0,
+          "tables_emitted": 1,
+          "tables_expected": 0
+        },
+        "PMC3250033.1": {
+          "attainable_recall": 1.0,
+          "tables_emitted": 7,
+          "tables_expected": 0
+        },
+        "PMC3250055.1": {
+          "attainable_recall": 0.9397590361445783,
+          "tables_emitted": 4,
+          "tables_expected": 4
+        },
+        "PMC3750000.1": {
+          "attainable_recall": 0.9682539682539683,
+          "tables_emitted": 7,
+          "tables_expected": 5
+        },
+        "PMC3750011.1": {
+          "attainable_recall": 0.9878048780487805,
+          "tables_emitted": 0,
+          "tables_expected": 0
+        },
+        "PMC3750022.1": {
+          "attainable_recall": 1.0,
+          "tables_emitted": 0,
+          "tables_expected": 0
+        },
+        "PMC3750033.1": {
+          "attainable_recall": 0.9863013698630136,
+          "tables_emitted": 2,
+          "tables_expected": 2
+        },
+        "PMC3750044.1": {
+          "attainable_recall": 0.9680851063829787,
+          "tables_emitted": 1,
+          "tables_expected": 1
+        },
+        "PMC4250000.1": {
+          "attainable_recall": 0.9696969696969697,
+          "tables_emitted": 1,
+          "tables_expected": 1
+        },
+        "PMC4250011.1": {
+          "attainable_recall": 1.0,
+          "tables_emitted": 0,
+          "tables_expected": 0
+        },
+        "PMC4250022.1": {
+          "attainable_recall": 0.9672131147540983,
+          "tables_emitted": 1,
+          "tables_expected": 1
+        },
+        "PMC4250033.1": {
+          "attainable_recall": 1.0,
+          "tables_emitted": 1,
+          "tables_expected": 1
+        },
+        "PMC4250054.1": {
+          "attainable_recall": 1.0,
+          "tables_emitted": 4,
+          "tables_expected": 4
+        },
+        "PMC4750000.1": {
+          "attainable_recall": 0.9,
+          "tables_emitted": 0,
+          "tables_expected": 0
+        },
+        "PMC4750011.1": {
+          "attainable_recall": 1.0,
+          "tables_emitted": 0,
+          "tables_expected": 0
+        },
+        "PMC4750022.1": {
+          "attainable_recall": 0.7692307692307693,
+          "tables_emitted": 6,
+          "tables_expected": 6
+        },
+        "PMC4750033.1": {
+          "attainable_recall": 0.984375,
+          "tables_emitted": 1,
+          "tables_expected": 1
+        },
+        "PMC4750044.1": {
+          "attainable_recall": 0.9887640449438202,
+          "tables_emitted": 0,
+          "tables_expected": 0
+        },
+        "PMC5250590.1": {
+          "attainable_recall": 0.9886363636363636,
+          "tables_emitted": 2,
+          "tables_expected": 2
+        },
+        "PMC5250601.1": {
+          "attainable_recall": 1.0,
+          "tables_emitted": 1,
+          "tables_expected": 1
+        },
+        "PMC5250623.1": {
+          "attainable_recall": 0.75,
+          "tables_emitted": 0,
+          "tables_expected": 0
+        },
+        "PMC5250635.1": {
+          "attainable_recall": 0.9577464788732394,
+          "tables_emitted": 2,
+          "tables_expected": 2
+        },
+        "PMC5250647.1": {
+          "attainable_recall": 0.9846153846153847,
+          "tables_emitted": 4,
+          "tables_expected": 5
+        },
+        "PMC5750000.1": {
+          "attainable_recall": 1.0,
+          "tables_emitted": 0,
+          "tables_expected": 0
+        },
+        "PMC5750011.1": {
+          "attainable_recall": 0.9857142857142858,
+          "tables_emitted": 1,
+          "tables_expected": 1
+        },
+        "PMC5750022.1": {
+          "attainable_recall": 1.0,
+          "tables_emitted": 0,
+          "tables_expected": 0
+        },
+        "PMC5750033.1": {
+          "attainable_recall": 0.987012987012987,
+          "tables_emitted": 3,
+          "tables_expected": 3
+        },
+        "PMC5750208.1": {
+          "attainable_recall": 0.8444444444444444,
+          "tables_emitted": 0,
+          "tables_expected": 0
+        },
+        "PMC6250000.1": {
+          "attainable_recall": 0.958904109589041,
+          "tables_emitted": 5,
+          "tables_expected": 4
+        },
+        "PMC6250011.1": {
+          "attainable_recall": 0.6554621848739496,
+          "tables_emitted": 2,
+          "tables_expected": 2
+        },
+        "PMC6250022.1": {
+          "attainable_recall": 0.7764705882352941,
+          "tables_emitted": 0,
+          "tables_expected": 0
+        },
+        "PMC6250033.1": {
+          "attainable_recall": 1.0,
+          "tables_emitted": 0,
+          "tables_expected": 0
+        },
+        "PMC6250044.1": {
+          "attainable_recall": 0.5555555555555556,
+          "tables_emitted": 3,
+          "tables_expected": 2
+        },
+        "PMC6750044.1": {
+          "attainable_recall": 0.98,
+          "tables_emitted": 0,
+          "tables_expected": 0
+        },
+        "PMC6750072.1": {
+          "attainable_recall": 0.9736842105263158,
+          "tables_emitted": 1,
+          "tables_expected": 1
+        },
+        "PMC6750083.1": {
+          "attainable_recall": 0.9753086419753086,
+          "tables_emitted": 0,
+          "tables_expected": 0
+        },
+        "PMC6750094.1": {
+          "attainable_recall": 0.9550561797752809,
+          "tables_emitted": 0,
+          "tables_expected": 0
+        },
+        "PMC6750105.1": {
+          "attainable_recall": 0.9701492537313433,
+          "tables_emitted": 0,
+          "tables_expected": 0
+        },
+        "PMC7250000.1": {
+          "attainable_recall": 0.9847328244274809,
+          "tables_emitted": 4,
+          "tables_expected": 3
+        },
+        "PMC7250011.1": {
+          "attainable_recall": 0.956989247311828,
+          "tables_emitted": 2,
+          "tables_expected": 2
+        },
+        "PMC7250022.1": {
+          "attainable_recall": 0.9366197183098591,
+          "tables_emitted": 4,
+          "tables_expected": 1
+        },
+        "PMC7250033.1": {
+          "attainable_recall": 0.963302752293578,
+          "tables_emitted": 0,
+          "tables_expected": 0
+        },
+        "PMC7250055.2": {
+          "attainable_recall": 0.9919354838709677,
+          "tables_emitted": 0,
+          "tables_expected": 0
+        },
+        "PMC7750000.1": {
+          "attainable_recall": 0.8571428571428571,
+          "tables_emitted": 0,
+          "tables_expected": 0
+        },
+        "PMC7750009.1": {
+          "attainable_recall": 0.9764705882352941,
+          "tables_emitted": 1,
+          "tables_expected": 5
+        },
+        "PMC7750019.1": {
+          "attainable_recall": 1.0,
+          "tables_emitted": 1,
+          "tables_expected": 1
+        },
+        "PMC7750040.1": {
+          "attainable_recall": 0.7857142857142857,
+          "tables_emitted": 2,
+          "tables_expected": 2
+        },
+        "PMC7750051.1": {
+          "attainable_recall": 0.9393939393939394,
+          "tables_emitted": 3,
+          "tables_expected": 3
+        },
+        "PMC8250041.1": {
+          "attainable_recall": 0.8793103448275862,
+          "tables_emitted": 5,
+          "tables_expected": 5
+        },
+        "PMC8250095.2": {
+          "attainable_recall": 0.9625,
+          "tables_emitted": 5,
+          "tables_expected": 5
+        },
+        "PMC8250106.1": {
+          "attainable_recall": 0.9473684210526315,
+          "tables_emitted": 0,
+          "tables_expected": 0
+        },
+        "PMC8250133.1": {
+          "attainable_recall": 0.875,
+          "tables_emitted": 0,
+          "tables_expected": 0
+        },
+        "PMC8250144.1": {
+          "attainable_recall": 0.8607594936708861,
+          "tables_emitted": 0,
+          "tables_expected": 0
+        },
+        "PMC8750000.1": {
+          "attainable_recall": 0.9936708860759493,
+          "tables_emitted": 0,
+          "tables_expected": 0
+        },
+        "PMC8750011.1": {
+          "attainable_recall": 0.9939024390243902,
+          "tables_emitted": 7,
+          "tables_expected": 7
+        },
+        "PMC8750022.1": {
+          "attainable_recall": 0.952,
+          "tables_emitted": 4,
+          "tables_expected": 4
+        },
+        "PMC8750036.1": {
+          "attainable_recall": 0.98989898989899,
+          "tables_emitted": 3,
+          "tables_expected": 3
+        },
+        "PMC8750048.1": {
+          "attainable_recall": 0.993006993006993,
+          "tables_emitted": 0,
+          "tables_expected": 0
+        },
+        "PMC9250000.1": {
+          "attainable_recall": 0.9444444444444444,
+          "tables_emitted": 0,
+          "tables_expected": 0
+        },
+        "PMC9250014.1": {
+          "attainable_recall": 1.0,
+          "tables_emitted": 3,
+          "tables_expected": 1
+        },
+        "PMC9250025.1": {
+          "attainable_recall": 0.9836065573770492,
+          "tables_emitted": 4,
+          "tables_expected": 1
+        },
+        "PMC9250036.1": {
+          "attainable_recall": 0.9857142857142858,
+          "tables_emitted": 4,
+          "tables_expected": 3
+        },
+        "PMC9250060.1": {
+          "attainable_recall": 1.0,
+          "tables_emitted": 2,
+          "tables_expected": 2
+        },
+        "PMC9750000.1": {
+          "attainable_recall": 0.9878048780487805,
+          "tables_emitted": 3,
+          "tables_expected": 3
+        },
+        "PMC9750011.1": {
+          "attainable_recall": 0.989010989010989,
+          "tables_emitted": 3,
+          "tables_expected": 2
+        },
+        "PMC9750022.1": {
+          "attainable_recall": 0.9811320754716981,
+          "tables_emitted": 3,
+          "tables_expected": 3
+        },
+        "PMC9750033.1": {
+          "attainable_recall": 0.9662921348314607,
+          "tables_emitted": 2,
+          "tables_expected": 2
+        },
+        "PMC9750044.1": {
+          "attainable_recall": 1.0,
+          "tables_emitted": 0,
+          "tables_expected": 0
+        }
+      }
+    }
+  }
+}

--- a/benchmarks/comparison/score.py
+++ b/benchmarks/comparison/score.py
@@ -1,0 +1,137 @@
+#  Copyright (c) 2025 Tom Villani, Ph.D.
+"""Score every tool's markdown output with the PMC lane's own instruments.
+
+Runs in the project venv. Each tool's markdown -- all2md's included -- is re-parsed
+through all2md's markdown parser and projected with the shared oracle, so every tool's
+text goes through one normalization path. Ground truth and the attainable ceiling are
+identical across tools by construction (JATS blocks, the PDF's own text layer).
+
+Usage: ``python benchmarks/comparison/score.py [tool ...]`` (default: every directory
+under ``out/``). Writes ``comparison.json``; copy it to a dated ``results-*.json`` when
+publishing a reading.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+import traceback
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+REPO = HERE.parents[1]
+sys.path.insert(0, str(REPO))
+
+import fitz  # noqa: E402
+
+from all2md import to_ast  # noqa: E402
+from benchmarks.omnidocbench.oracles import project_ast  # noqa: E402
+from benchmarks.pmc.article import measure_precision, measure_recall  # noqa: E402
+from benchmarks.pmc.corpus import _parse_jats  # noqa: E402
+from benchmarks.pmc.oracles import project_jats  # noqa: E402
+
+articles = json.loads((HERE / "articles.json").read_text(encoding="utf-8"))["articles"]
+
+print(f"preparing ground truth for {len(articles)} articles...", flush=True)
+truth: dict[str, dict] = {}
+for article in articles:
+    root, _ = _parse_jats(Path(article["xml_path"]).read_bytes())
+    blocks, _whole = project_jats(root)
+    with fitz.open(article["pdf_path"]) as document:
+        pdf_text = " ".join(page.get_text() for page in document)
+    truth[article["article_id"]] = {
+        "pairs": tuple((block.kind, block.text) for block in blocks if block.text),
+        "pdf_text": pdf_text,
+        "truth_tables": sum(1 for block in blocks if block.kind == "table"),
+    }
+print("ground truth ready", flush=True)
+
+out_root = HERE / "out"
+tools = sys.argv[1:] or sorted(d.name for d in out_root.iterdir() if d.is_dir())
+report: dict[str, dict] = {}
+
+for tool in tools:
+    tool_dir = out_root / tool
+    run_meta = {}
+    run_path = tool_dir / "run.json"
+    if run_path.exists():
+        run_meta = json.loads(run_path.read_text(encoding="utf-8"))
+
+    scored_rows = []
+    per_article: dict[str, dict] = {}
+    parse_failures: dict[str, str] = {}
+    tables_emitted = 0
+    truth_tables = 0
+    raw_words = projected_words = 0
+    for article in articles:
+        article_id = article["article_id"]
+        md_path = tool_dir / f"{article_id}.md"
+        if not md_path.exists():
+            continue
+        raw = md_path.read_text(encoding="utf-8")
+        try:
+            document = to_ast(str(md_path), source_format="markdown")
+            projection = project_ast(document)
+        except Exception:
+            parse_failures[article_id] = traceback.format_exc(limit=3)
+            continue
+        emitted_text = " ".join(projection.text_blocks)
+        raw_words += len(raw.split())
+        projected_words += len(emitted_text.split())
+        entry = truth[article_id]
+        tables_emitted += len(projection.tables)
+        truth_tables += entry["truth_tables"]
+        scored_rows.append((article_id, entry["pairs"], emitted_text, entry["pdf_text"]))
+        single = measure_recall([(article_id, entry["pairs"], emitted_text, entry["pdf_text"])])
+        per_article[article_id] = {
+            "attainable_recall": single.attainable_recall,
+            "tables_emitted": len(projection.tables),
+            "tables_expected": entry["truth_tables"],
+        }
+
+    if not scored_rows:
+        print(f"{tool}: no outputs yet", flush=True)
+        continue
+
+    recall = measure_recall(scored_rows)
+    precision = measure_precision(scored_rows)
+    timings = run_meta.get("timings", {})
+    report[tool] = {
+        "versions": run_meta.get("versions"),
+        "articles_scored": len(scored_rows),
+        "articles_missing": len(articles) - len(scored_rows) - len(parse_failures),
+        "parse_failures": parse_failures,
+        "conversion_failures": sorted(run_meta.get("failures", {})),
+        "attainable_recall": recall.attainable_recall,
+        "recall_raw": recall.recall,
+        "ceiling": recall.ceiling,
+        "by_kind": {
+            kind: {"attainable_recall": counts.attainable_recall, "attainable": counts.attainable}
+            for kind, counts in recall.by_kind.items()
+        },
+        "control_recall": recall.control_recall,
+        "novel_share": precision.novel_share,
+        "precision_raw": precision.precision,
+        "duplication": precision.duplication,
+        "tables_emitted": tables_emitted,
+        "tables_expected": truth_tables,
+        "seconds_per_article_mean": (sum(timings.values()) / len(timings)) if timings else None,
+        # Words surviving the markdown->AST->projection path over raw markdown words.
+        # Far below ~0.9 means the re-parse is eating content (e.g. raw HTML blocks) and
+        # the tool's recall is understated -- investigate before quoting.
+        "reparse_word_ratio": (projected_words / raw_words) if raw_words else None,
+        "per_article": per_article,
+    }
+    title = recall.by_kind["title"].attainable_recall if "title" in recall.by_kind else float("nan")
+    table = recall.by_kind["table"].attainable_recall if "table" in recall.by_kind else float("nan")
+    print(
+        f"{tool}: attainable_recall={recall.attainable_recall:.3f} "
+        f"(title={title:.3f} table={table:.3f}) "
+        f"novel={precision.novel_share:.4f} dup={precision.duplication:.4f} "
+        f"tables {tables_emitted}/{truth_tables} n={len(scored_rows)}",
+        flush=True,
+    )
+
+out = HERE / "comparison.json"
+out.write_text(json.dumps(report, indent=2), encoding="utf-8")
+print(f"wrote {out}")

--- a/changelog.d/comparison-lane.added.md
+++ b/changelog.d/comparison-lane.added.md
@@ -1,0 +1,7 @@
+- **Third-party comparison lane** (`benchmarks/comparison/`): scores pymupdf4llm and
+  Docling with the PMC lane's own text-survival and invented-text instruments, on the
+  held-out 110-article corpus, with every tool's markdown re-parsed through one
+  normalization path. Ships the 2026-08-19 reading (`results-2026-08-19.json`), pinned
+  baseline versions, and a lost-block diff (`lost_blocks.py`) that names the truth
+  blocks a baseline recovers that all2md loses — the diff that produced #405 and #406.
+  Run by hand only; never in CI.


### PR DESCRIPTION
## Summary

Commits the comparison lane that produced the 2026-08-19 pymupdf4llm/Docling reading, as `benchmarks/comparison/` — run by hand only, never in CI.

- **Scripts**: corpus export for a separate baselines venv, one convert script per tool (baselines at their defaults, all2md at the PMC lane policy, disclosed), a scorer that re-parses every tool's markdown through all2md's own markdown parser so all three share one normalization path, and `lost_blocks.py` — the diff that names truth blocks a baseline recovers that all2md loses (it produced #405 and #406).
- **First dated reading** committed as `results-2026-08-19.json` with a provenance block (corpus pin, all2md commit, platform, policy note). Headline: all2md 93.5% attainable recall / **0.84% novel**, pymupdf4llm 98.3% / 5.49% (defaults now auto-OCR born-digital pages), Docling 95.5% / 2.87% with the best table cell preservation (82.2%).
- **Pinned baselines** in `baselines.txt` (pymupdf4llm 1.28.2, docling 2.120.3); a new reading against new versions is a new dated file.
- **README paragraph** in the repo README pointing at the lane, with the invented-text asymmetry stated rather than a bare leaderboard.
- Third-party numbers deliberately stay **off** `docs/source/benchmarks.rst` — that page is verbatim-gated against this repo's own artifacts, and baseline numbers age with every upstream release.

Ground rules and caveats (held-out corpus only; article-level text survival favors low-structure output; recording machine had no Tesseract) are documented in the lane README.

## Test plan
- [x] `ruff check` / `ruff format --check` on the lane
- [x] `python -m benchmarks.roundtrip` (README.md is fidelity-gated) — 39 passed
- [x] `compile_changelog.py --check` — fragment well-formed
- [x] Functional smoke: `score.py` and `lost_blocks.py` run from their committed location on 2 articles

🤖 Generated with [Claude Code](https://claude.com/claude-code)