### PR TITLE
feat(benchmarks): caption-aware oracle, stratified raster lane, and both artifacts re-recorded (#406, #257)

### DIFF
--- a/.github/workflows/omnidocbench-gate.yml
+++ b/.github/workflows/omnidocbench-gate.yml
@@ -52,7 +52,11 @@ jobs:
           sudo apt-get install --yes tesseract-ocr tesseract-ocr-eng tesseract-ocr-chi-sim
 
       - name: Install all2md from the lockfile
-        run: uv sync --frozen --extra pdf_layout --extra ocr
+        # --extra benchmarks carries what the benchmark modules import at top level
+        # (defusedxml); this lane inherits it through benchmarks.corpus.download, and
+        # syncing without it crashed the run at import (the exact failure the extra's
+        # pyproject comment predicted, in the sibling workflow that wasn't updated).
+        run: uv sync --frozen --extra pdf_layout --extra ocr --extra benchmarks
 
       - name: Run fidelity gate
         if: ${{ !inputs.record_baseline }}

--- a/benchmarks/omnidocbench/baseline.json
+++ b/benchmarks/omnidocbench/baseline.json
@@ -1,12 +1,12 @@
 {
-  "schema_version": 2,
+  "schema_version": 3,
   "provenance": {
     "dataset_revision": "f5f559bddf50e36f7f9899d842d0006f13ce8afc",
     "annotation_sha256": "2fafe9329dc92fc426b30036aee51c716b3fcdcc1d20cb964dc7670579533817",
-    "oracle_schema_version": 5,
-    "all2md_commit": "935df18319be42a27f1e5ab85a762695a9094f3a",
+    "oracle_schema_version": 6,
+    "all2md_commit": "a8d4390faab271fa72bc29eeabdd8eb73262fde4",
     "worktree_dirty": false,
-    "created_at": "2026-08-01T20:28:28.830972+00:00",
+    "created_at": "2026-08-19T20:23:53.906151+00:00",
     "python": "3.12.3 (main, Jun 19 2026, 12:46:00) [GCC 13.3.0]",
     "platform": "linux",
     "parser_runtime": {
@@ -17,6 +17,14 @@
       "tessdata_chi_sim_sha256": "a5fcb6f0db1e1d6d8522f39db4e848f05984669172e584e8d76b6b3141e1f730",
       "tessdata_eng_sha256": "7d4322bd2a7749724879683fc3912cb542f19906c83bcc1a52132556427170b2",
       "tesseract": "tesseract 5.3.4"
+    },
+    "corpus_characterization": {
+      "documents_characterized": 981,
+      "pages_characterized": 981,
+      "pages_with_text_layer": 0,
+      "pages_with_vector_drawings": 0,
+      "pages_with_one_full_page_image": 981,
+      "documents_ocr_applied": 926
     },
     "parser_config": {
       "layout_analysis_mode": "enabled",
@@ -39,24 +47,24 @@
   },
   "dimensions": {
     "block_structure_similarity": {
-      "value": 0.11760506580643935,
+      "value": 0.3980186260883771,
       "direction": "higher",
       "eligible_items": 981,
-      "variance": 0.018084814915713822,
+      "variance": 0.05723687167620211,
       "tolerance": 0.005
     },
     "reading_order_similarity": {
-      "value": 0.603428009731495,
+      "value": 0.5783906188735355,
       "direction": "higher",
       "eligible_items": 981,
-      "variance": 0.12070405573312774,
+      "variance": 0.11597187815591176,
       "tolerance": 0.005
     },
     "text_content_similarity": {
-      "value": 0.5058411056348215,
+      "value": 0.482004748396457,
       "direction": "higher",
       "eligible_items": 981,
-      "variance": 0.11687727263164714,
+      "variance": 0.11198979449193469,
       "tolerance": 0.005
     }
   },

--- a/benchmarks/omnidocbench/benchmark.py
+++ b/benchmarks/omnidocbench/benchmark.py
@@ -19,8 +19,19 @@ from .oracles import GroundTruthPage, PageProjection, project_annotation, projec
 if TYPE_CHECKING:
     from all2md.options.pdf import PdfOptions
 
-SCHEMA_VERSION = 2
-ORACLE_SCHEMA_VERSION = 5
+#: 3 adds ``strata``: per-data-source aggregates of every scored dimension. Under 2 the
+#: payload averaged newspapers, handwritten notes, slides, textbooks and papers into one
+#: number per dimension, which could not drive work because it could not say *where* a
+#: score was earned or lost (#257). The strata are evidence, not identity: the gate does
+#: not compare them, and ``emit_baseline`` does not copy them.
+SCHEMA_VERSION = 3
+#: 6 projects caption *attributes* (``Figure.caption``, ``Table.caption``,
+#: ``Image.caption``) into the AST-side text stream as synthesized paragraphs. Under 5
+#: the projection read children only, so a caption the parser correctly bound to its
+#: figure vanished from measurement while an unbound one counted -- recall fell as
+#: binding improved (#406). The annotation side always counted captions as text blocks,
+#: so this removes an asymmetry rather than adding a credit.
+ORACLE_SCHEMA_VERSION = 6
 
 
 class DegradedConversionError(RuntimeError):
@@ -342,6 +353,26 @@ def normalize_results(
         if dimension is not None:
             dimensions[name] = dimension
 
+    # Per-stratum aggregates of the same dimensions. Evidence, not identity: the gate does
+    # not compare these and `emit_baseline` does not copy them, so a stratum shifting does
+    # not invalidate a baseline -- but a reader can finally see whether a mean moved on
+    # newspapers or on handwritten notes (#257). `sample_scores` and `direction` are not
+    # repeated per stratum; both live on the corresponding top-level dimension.
+    strata: dict[str, dict[str, Any]] = {}
+    for stratum in sorted({page.stratum for page in ground_truth.values()}):
+        member_ids = {page_id for page_id, page in ground_truth.items() if page.stratum == stratum}
+        members = [result for result in evaluations if result.page_id in member_ids]
+        stratum_dimensions: dict[str, dict[str, Any]] = {}
+        for name in sorted(metric_names):
+            dimension = _dimension(members, name)
+            if dimension is not None:
+                stratum_dimensions[name] = {
+                    "value": dimension["value"],
+                    "eligible_items": dimension["eligible_items"],
+                    "variance": dimension["variance"],
+                }
+        strata[stratum] = {"pages": len(members), "dimensions": stratum_dimensions}
+
     failures = {
         result.page_id: f"{result.error_type}: {result.error}"
         for result in evaluations
@@ -401,6 +432,7 @@ def normalize_results(
             "unique_ids": len({result.page_id for result in evaluations}),
         },
         "dimensions": dimensions,
+        "strata": strata,
         "conversion_failures": failures,
         "unsupported_dimensions": unsupported,
         "unscored_annotation_categories": dict(sorted(unscored.items())),

--- a/benchmarks/omnidocbench/gate.py
+++ b/benchmarks/omnidocbench/gate.py
@@ -18,8 +18,8 @@ HERE = Path(__file__).resolve().parent
 DEFAULT_BASELINE = HERE / "baseline.json"
 _DATASET_REVISION_RE = re.compile(r"[0-9a-f]{40}\Z")
 _SHA256_RE = re.compile(r"[0-9a-f]{64}\Z")
-_SUPPORTED_SCHEMA_VERSION = 2
-_SUPPORTED_ORACLE_SCHEMA_VERSION = 5
+_SUPPORTED_SCHEMA_VERSION = 3
+_SUPPORTED_ORACLE_SCHEMA_VERSION = 6
 
 _IDENTITY_FIELDS = (
     "schema_version",

--- a/benchmarks/omnidocbench/oracles.py
+++ b/benchmarks/omnidocbench/oracles.py
@@ -97,6 +97,11 @@ class GroundTruthPage:
     projection: PageProjection
     unscored_categories: Mapping[str, int]
     explicitly_ignored: int
+    #: The corpus stratum this page was drawn from (``page_info.page_attribute.data_source``).
+    #: The corpus spans nine sources with very different characteristics -- newspapers,
+    #: handwritten notes, slides, textbooks, papers -- and a single mean over all of them is
+    #: not actionable (#257). Recorded here so the payload can report per-stratum aggregates.
+    stratum: str
 
 
 class _TableHTMLParser(HTMLParser):
@@ -179,12 +184,43 @@ def _node_text(node: Node) -> str:
     return content if isinstance(content, str) else ""
 
 
+def _caption_paragraph(caption: str) -> Paragraph:
+    return Paragraph(content=[Text(content=caption)])
+
+
+def _attached_captions(block: Node) -> Iterable[Paragraph]:
+    """Yield the caption attributes carried by ``block`` or anything inside it.
+
+    ``Table.caption`` and an inline ``Image.caption`` live on the yielded block's own
+    subtree, which ``_semantic_blocks`` never descends -- it yields the block whole.
+    """
+    for candidate in _all_nodes(block):
+        caption = getattr(candidate, "caption", None)
+        if isinstance(caption, str) and caption.strip():
+            yield _caption_paragraph(caption)
+
+
 def _semantic_blocks(node: Node) -> Iterable[Node]:
+    # A caption is document text the AST carries as a string *attribute* --
+    # ``Figure.caption``, ``Table.caption``, ``Image.caption`` -- not as a child node, so a
+    # child walk alone is blind to it. That blindness inverted an incentive (#406): the
+    # better the parser *bound* captions to their figures, the more caption text left the
+    # Paragraph stream for an attribute this projection never read, and measured recall
+    # fell for doing the right thing. 101 of the 103 "lost" captions on the held-out
+    # corpus were sitting in the output the whole time. Captions are projected as
+    # synthesized paragraphs because that is exactly how the annotation side reads them:
+    # ``project_annotation`` collapses figure_caption/table_caption to ``text_block``.
     if isinstance(node, (Heading, Paragraph, CodeBlock, Table, MathBlock)):
         yield node
+        yield from _attached_captions(node)
         return
     for child in get_node_children(node):
         yield from _semantic_blocks(child)
+    caption = getattr(node, "caption", None)
+    if isinstance(caption, str) and caption.strip():
+        # Containers (Figure) carry their caption after their content, matching where a
+        # figure caption prints and where the markdown renderer emits it.
+        yield _caption_paragraph(caption)
 
 
 def _all_nodes(node: Node) -> Iterable[Node]:
@@ -264,6 +300,21 @@ def _annotation_page_id(record: Mapping[str, Any]) -> str:
         raise ValueError("annotation record has no page_info.image_path")
     filename = image_path.replace("\\", "/").rsplit("/", 1)[-1]
     return filename.rsplit(".", 1)[0]
+
+
+def _annotation_stratum(record: Mapping[str, Any], page_id: str) -> str:
+    """Read the page's data source, failing rather than pooling unattributed pages.
+
+    ``page_attribute`` is already required and validated by the corpus loader; this reads
+    the one key stratification needs. Fail-closed on purpose: a page silently binned as
+    "unknown" would make the per-stratum figures quietly stop covering the corpus.
+    """
+    page_info = record.get("page_info")
+    attributes = page_info.get("page_attribute") if isinstance(page_info, Mapping) else None
+    source = attributes.get("data_source") if isinstance(attributes, Mapping) else None
+    if not isinstance(source, str) or not source:
+        raise ValueError(f"annotation page {page_id!r} has no page_attribute.data_source")
+    return source
 
 
 def _annotation_inline_formulas(
@@ -386,6 +437,7 @@ def project_annotation(record: Mapping[str, Any]) -> GroundTruthPage:
         ),
         unscored_categories=dict(sorted(unscored.items())),
         explicitly_ignored=explicitly_ignored,
+        stratum=_annotation_stratum(record, page_id),
     )
 
 

--- a/benchmarks/pmc/benchmark.py
+++ b/benchmarks/pmc/benchmark.py
@@ -65,8 +65,15 @@ from benchmarks.pmc.pages import ASSIGNMENTS, assign_pages, index_pages
 #: default ``alt_text`` attachment mode, which returns before extraction runs, so it emitted
 #: no figures at all and no figure defect was observable -- and the ~100% caption text recall
 #: it did report was being read as though it said something about figures, which it does not.
-SCHEMA_VERSION = 5
-ORACLE_SCHEMA_VERSION = 1
+#: 6 records the caption-aware oracle (shared ``project_ast``, oracle schema 2). Under 5 a
+#: caption the parser bound to its figure left the projected text stream for a string
+#: attribute the oracle never read, so recall *fell* as figure binding improved -- 101 of
+#: the 103 "lost" captions on the held-out corpus were in the output the whole time (#406).
+#: No payload key changes shape; the measurement underneath every recall figure does.
+SCHEMA_VERSION = 6
+#: 2 = the shared projection reads caption attributes (see schema 6 above and
+#: ``benchmarks.omnidocbench.oracles._semantic_blocks``).
+ORACLE_SCHEMA_VERSION = 2
 
 #: Fixed seed: a control that scrambles differently every run cannot be compared across
 #: runs, and a resolution change would be indistinguishable from a parser change.

--- a/benchmarks/pmc/manifest.json
+++ b/benchmarks/pmc/manifest.json
@@ -509,7 +509,7 @@
       "paragraphs": 87,
       "pdf_sha256": "962d05583d2b20c9b6aafa5f399c656588c8423c6fc50fc22a51d085af4b6751",
       "pdf_size_bytes": 17229770,
-      "xml_sha256": "442e7af5433a953af0d0b37a8e07b8c0680d0b8e3fb928ebb9c07278f1f86ba6",
+      "xml_sha256": "a6ef662a770ef4d33acf178efac7a6b3e4e5ec99b5369b9c78259d2ff823ec69",
       "xml_size_bytes": 126450
     },
     "PMC9500026.1": {

--- a/benchmarks/pmc/reference.json
+++ b/benchmarks/pmc/reference.json
@@ -1,13 +1,13 @@
 {
-  "schema_version": 5,
+  "schema_version": 6,
   "provenance": {
-    "corpus_pin": "9ba5c0cd59067bda102b9e27a7c1e613987c145f9fb61a4c26b811d9fd24dc58",
+    "corpus_pin": "2710aef0f1a7133550a358b58a46aa89037c0f855cf9d22a719d82e100e91eb9",
     "bucket": "pmc-oa-opendata",
     "complete_corpus": true,
-    "oracle_schema_version": 1,
-    "all2md_commit": "e7c0b9deea39701a5aba425421807b636b9d8ed0",
+    "oracle_schema_version": 2,
+    "all2md_commit": "a8d4390faab271fa72bc29eeabdd8eb73262fde4",
     "worktree_dirty": false,
-    "created_at": "2026-08-19T04:24:08.445968+00:00",
+    "created_at": "2026-08-19T19:28:00.776586+00:00",
     "python": "3.12.3 (main, Jun 19 2026, 12:46:00) [GCC 13.3.0]",
     "platform": "linux",
     "parser_runtime": {
@@ -68,13 +68,13 @@
     "unsplit_spans": 42
   },
   "article_recall": {
-    "recall": 0.5979786636720943,
-    "recovered": 5325,
+    "recall": 0.6023582257158899,
+    "recovered": 5364,
     "scored": 8905,
     "too_short": 2598,
     "ceiling": 0.624480628860191,
     "attainable": 5561,
-    "attainable_recall": 0.9473116345980939,
+    "attainable_recall": 0.9543247617335011,
     "by_kind": {
       "table": {
         "recovered": 77,
@@ -83,10 +83,10 @@
         "attainable_recall": 0.6909090909090909
       },
       "text_block": {
-        "recovered": 3102,
+        "recovered": 3141,
         "attainable": 3160,
         "scored": 6356,
-        "attainable_recall": 0.9721518987341772
+        "attainable_recall": 0.984493670886076
       },
       "title": {
         "recovered": 2146,
@@ -97,21 +97,21 @@
     },
     "control_recall": 0.003593486805165637,
     "control_scored": 8905,
-    "discrimination": 0.5943851768669286
+    "discrimination": 0.5987647389107242
   },
   "article_precision": {
-    "precision": 0.9288223298267049,
-    "supported": 413560,
-    "emitted": 445252,
-    "resequenced": 27245,
-    "novel": 4447,
-    "novel_share": 0.009987602526209876,
-    "duplication": 0.004508978776666829,
-    "excess": 2129,
-    "occurrences": 472169,
-    "control_precision": 0.006991546360263401,
-    "control_emitted": 445252,
-    "discrimination": 0.9218307834664414
+    "precision": 0.9264827487562745,
+    "supported": 414551,
+    "emitted": 447446,
+    "resequenced": 28068,
+    "novel": 4827,
+    "novel_share": 0.01078789395815361,
+    "duplication": 0.02026025195707398,
+    "excess": 9770,
+    "occurrences": 482225,
+    "control_precision": 0.006957264116787277,
+    "control_emitted": 447446,
+    "discrimination": 0.9195254846394871
   },
   "figure_binding": {
     "binding_rate": 0.5255813953488372,
@@ -120,8 +120,8 @@
     "too_short": 13,
     "misfiled_rate": 0.0,
     "misfiled": 0,
-    "caption_recall": 0.7674418604651163,
-    "present": 165,
+    "caption_recall": 0.9441860465116279,
+    "present": 203,
     "images_emitted": 448,
     "captioned_emitted": 209,
     "control_binding_rate": 0.0,
@@ -131,35 +131,35 @@
   "dimensions": {
     "block_structure_similarity": {
       "count": 706.0,
-      "mean": 0.5470754250291459,
-      "median": 0.5714285714285714,
+      "mean": 0.5376131726173652,
+      "median": 0.5625,
       "minimum": 0.016393442622950838,
       "maximum": 1.0,
-      "stdev": 0.20799760103847226,
+      "stdev": 0.20910230767053464,
       "direction": "higher",
-      "control_mean": 0.4437154372652199,
-      "discrimination": 0.10335998776392596,
+      "control_mean": 0.4406226435897821,
+      "discrimination": 0.0969905290275831,
       "mutation_drop": {
-        "reversed": 0.01103409330041826,
-        "shuffled": 0.022710520984149166,
-        "halved": 0.07254480684009222
+        "reversed": 0.011313431940310537,
+        "shuffled": 0.02215105004406372,
+        "halved": 0.06278276748452316
       },
       "ungateable": "compares kind sequences without inspecting the text under a block, so content-free output scores 1.0 (issue #256); eleven text categories collapse to `text_block`, so fully reversed output scores exactly 1.0 on 153 of the 981 pinned pages; and on the born-digital lane it separates own-page from wrong-page output by only ~0.06 while *rising* when half the emitted content is deleted, which rewards dropping blocks"
     },
     "reading_order_similarity": {
       "count": 706.0,
-      "mean": 0.7688915915868425,
+      "mean": 0.7686226098186316,
       "median": 0.8,
       "minimum": 0.0,
       "maximum": 1.0,
-      "stdev": 0.21193232179555213,
+      "stdev": 0.21007253974973572,
       "direction": "higher",
-      "control_mean": 0.287408784914641,
-      "discrimination": 0.4814828066722015,
+      "control_mean": 0.28738236693875924,
+      "discrimination": 0.4812402428798724,
       "mutation_drop": {
-        "reversed": 0.4354260297670871,
-        "shuffled": 0.21052865446162583,
-        "halved": 0.329007185336738
+        "reversed": 0.4201391234711173,
+        "shuffled": 0.2095946215811197,
+        "halved": 0.3112284307672439
       }
     },
     "table_content_similarity": {
@@ -196,18 +196,18 @@
     },
     "text_content_similarity": {
       "count": 706.0,
-      "mean": 0.5692277212303014,
-      "median": 0.5394443962523008,
+      "mean": 0.5582261645706342,
+      "median": 0.5330238627026651,
       "minimum": 0.010652463382157085,
       "maximum": 0.9901380670611439,
-      "stdev": 0.22795083520466647,
+      "stdev": 0.2192191157194943,
       "direction": "higher",
-      "control_mean": 0.23289228137998044,
-      "discrimination": 0.336335439850321,
+      "control_mean": 0.23458798685548662,
+      "discrimination": 0.3236381777151476,
       "mutation_drop": {
-        "reversed": 0.18623164337477574,
-        "shuffled": 0.1300649551596,
-        "halved": 0.24614047911720185
+        "reversed": 0.17515444512156728,
+        "shuffled": 0.12488377402788574,
+        "halved": 0.22389428557224242
       }
     }
   },

--- a/changelog.d/257-omnidocbench-strata.added.md
+++ b/changelog.d/257-omnidocbench-strata.added.md
@@ -1,0 +1,5 @@
+- **OmniDocBench lane: per-data-source strata** (#257). The scanned-page payload now
+  reports every dimension per corpus stratum (newspapers, notes, slides, textbooks,
+  papers, …) alongside the whole-corpus mean, which could not say *where* a score was
+  earned or lost. Strata are evidence, not identity: the gate does not compare them and
+  a baseline never copies them.

--- a/changelog.d/406-oracle-caption-blindness.fixed.md
+++ b/changelog.d/406-oracle-caption-blindness.fixed.md
@@ -1,0 +1,7 @@
+- **Benchmark oracle: bound captions count as text again** (#406). The shared AST
+  projection read children only, so a caption the parser correctly bound to
+  `Figure.caption`/`Table.caption`/`Image.caption` vanished from measurement — recall
+  *fell* as figure binding improved, and 101 of the 103 "lost" captions on the held-out
+  corpus were in the output the whole time. Captions now project as text blocks on both
+  lanes (PMC schema 6, OmniDocBench oracle schema 6), and both evidence artifacts are
+  re-recorded against the corrected instrument.

--- a/docs/source/benchmarks.rst
+++ b/docs/source/benchmarks.rst
@@ -218,19 +218,29 @@ The ``omnidocbench`` lane scores 981 scanned pages against human annotation, fro
      - Value
      -
    * - ``text_content_similarity``
-     - 0.506
+     - 0.482
      - over 981 pages
    * - ``reading_order_similarity``
-     - 0.603
+     - 0.578
      - over 981 pages
    * - ``block_structure_similarity``
-     - 0.118
+     - 0.398
      - **not gated** — see below
 
 ``block_structure_similarity`` is recorded but excluded from the verdict. It compares
 sequences of block *categories* without ever inspecting the text underneath, so output with
 no correct content at all can score well on it. A measurement that cannot distinguish those
 two cases must not be allowed to support one.
+
+This baseline was re-recorded alongside the oracle correction described above, and the
+movement was attributed before being blessed: two record runs on the same runner image and
+corpus pin — one with the corrected oracle, one without — produced **byte-identical
+per-page scores on all 981 pages**, so the oracle contributes exactly zero here and the
+whole movement against the previous recording is the v1.12/v1.13 parser arc (tracked as
+issue #411 rather than silently absorbed). The payload now also reports every dimension
+per corpus stratum: the whole-corpus mean averages handwritten notes scoring near zero
+with academic papers scoring far above it, and the strata are what make the number
+actionable.
 
 Round-trip fidelity
 -------------------

--- a/docs/source/benchmarks.rst
+++ b/docs/source/benchmarks.rst
@@ -74,19 +74,27 @@ Did the text survive?
      - Value
      -
    * - Raw recall
-     - 59.8%
+     - 60.2%
      - of 8,905 ground-truth blocks
    * - Attainable ceiling
      - 62.4%
      - what the PDF's own text layer reproduces
    * - **Recall of what is attainable**
-     - **94.7%**
+     - **95.4%**
      - the number worth reading
    * - Control: the *wrong* article
      - 0.4%
      - wants to be ~0%
 
-Raw recall is 59.8%, and that figure is close to meaningless on its own. A large share of
+Part of the most recent movement in these figures is a *measurement* correction, not a
+parser change, and it is flagged as such: the shared oracle was blind to captions the
+parser had correctly bound to their figures — the text left the paragraph stream for a
+``caption`` attribute the projection never read, so recall *fell* as figure binding
+improved. On the held-out corpus, 101 of the 103 caption blocks the instruments called
+lost were in the output the whole time. The oracle now reads what the AST carries
+(oracle schema 6), and both lanes' artifacts are re-recorded against it.
+
+Raw recall is 60.2%, and that figure is close to meaningless on its own. A large share of
 any JATS article cannot be recovered by *any* parser, because the markup records words in an
 order the page never prints — author affiliation blocks, structured metadata, citation
 fields. Charging a PDF parser for failing to reproduce text the PDF does not contain
@@ -108,8 +116,8 @@ By block kind:
      - Share of attainable
    * - Text blocks
      - 3,160 of 6,356
-     - 3,102
-     - **97.2%**
+     - 3,141
+     - **98.4%**
    * - Titles
      - 2,291 of 2,426
      - 2,146
@@ -145,26 +153,33 @@ Unsupported output is therefore split in two:
      - Share
      - Meaning
    * - Supported
-     - **92.9%**
+     - **92.6%**
      - the n-gram appears in the document's text layer
    * - Resequenced
-     - 6.1%
+     - 6.3%
      - every word is in the document, in a new adjacency
    * - **Novel**
-     - **1.0%**
+     - **1.1%**
      - at least one word appears nowhere — the number worth reading
    * - Duplication
-     - 0.5%
+     - 2.0%
      - supported text emitted more than once
    * - Control: the *wrong* article
      - 0.7%
      - wants to be ~0%
 
-Over 445,252 emitted n-grams, 4,447 are novel. Reporting the raw unsupported figure instead
+Over 447,446 emitted n-grams, 4,827 are novel. Reporting the raw unsupported figure instead
 would have made the result roughly seven times worse than the parser deserves.
 
 Duplication is counted apart from both, because it is invisible to either. Text emitted
 twice is an unchanged *set* and a doubled *multiset* — no set-based score can see it at all.
+
+The duplication figure jumped from 0.5% to 2.0% at the same re-record that corrected the
+caption-blind oracle, and the jump is real output, not a scoring artifact: with caption
+text visible to the instruments at all, they can finally see that multi-panel figures
+re-bind the shared caption to every panel, so one printed caption is emitted several
+times (issue #410). The honest ordering matters here — the defect predates the
+re-record; what changed is that a measurement became able to report it.
 
 Tables
 ~~~~~~

--- a/tests/unit/test_omnidocbench_benchmark.py
+++ b/tests/unit/test_omnidocbench_benchmark.py
@@ -38,7 +38,7 @@ def _snapshot(tmp_path: Path, page_ids: tuple[str, ...] = ("page-a", "page-b")) 
 
 def _annotation(page_id: str, text: str = "Body") -> dict[str, object]:
     return {
-        "page_info": {"image_path": f"images/{page_id}.jpg"},
+        "page_info": {"image_path": f"images/{page_id}.jpg", "page_attribute": {"data_source": "testsource"}},
         "layout_dets": [
             {
                 "category_type": "text_block",
@@ -50,12 +50,13 @@ def _annotation(page_id: str, text: str = "Body") -> dict[str, object]:
     }
 
 
-def _truth(page_id: str) -> GroundTruthPage:
+def _truth(page_id: str, stratum: str = "testsource") -> GroundTruthPage:
     return GroundTruthPage(
         page_id=page_id,
         projection=PageProjection(("Body",), ("text_block",), (), ()),
         unscored_categories={"figure": 1},
         explicitly_ignored=1,
+        stratum=stratum,
     )
 
 
@@ -263,7 +264,7 @@ def test_normalization_records_variance_failures_and_unsupported_dimensions(tmp_
         parser_runtime={"pymupdf": "1.28.0", "tesseract": "tesseract 5.3.0"},
     )
 
-    assert payload["schema_version"] == 2
+    assert payload["schema_version"] == 3
     assert payload["pages"] == {
         "expected": 2,
         "annotations": 2,
@@ -291,13 +292,67 @@ def test_normalization_records_variance_failures_and_unsupported_dimensions(tmp_
     assert payload["conversion_failures"] == {"page-b": "RuntimeError: broken PDF"}
     assert payload["unscored_annotation_categories"] == {"figure": 2}
     assert payload["explicitly_ignored_annotations"] == 2
-    assert payload["provenance"]["oracle_schema_version"] == 5
+    assert payload["provenance"]["oracle_schema_version"] == 6
     assert payload["provenance"]["parser_config"]["layout_analysis_mode"] == "enabled"
     assert payload["provenance"]["parser_runtime"] == {
         "pymupdf": "1.28.0",
         "tesseract": "tesseract 5.3.0",
     }
     assert payload["provenance"]["parser_config"]["ocr"]["languages"] == "eng+chi_sim"
+
+
+def test_normalization_stratifies_every_dimension_by_data_source(tmp_path: Path) -> None:
+    """A mean over newspapers, notes and slides cannot drive work; per-stratum ones can (#257).
+
+    The strata must partition the corpus (every page in exactly one), aggregate only that
+    stratum's samples, and stay out of the gate's identity: ``emit_baseline`` must not copy
+    them, so a stratum shifting can never invalidate a recorded baseline by itself.
+    """
+    from benchmarks.omnidocbench import gate
+
+    snapshot = _snapshot(tmp_path, ("page-a", "page-b", "page-c"))
+    truth = {
+        "page-a": _truth("page-a", stratum="newspaper"),
+        "page-b": _truth("page-b", stratum="newspaper"),
+        "page-c": _truth("page-c", stratum="notes"),
+    }
+    evaluations = [
+        benchmark.PageEvaluation(
+            page_id=page_id,
+            scores={"text_content_similarity": score},
+            predicted_tables=1,
+            predicted_formulas=1,
+            duration_seconds=0.1,
+        )
+        for page_id, score in (("page-a", 0.2), ("page-b", 0.6), ("page-c", 1.0))
+    ]
+
+    payload = benchmark.normalize_results(
+        snapshot=snapshot,
+        ground_truth=truth,
+        evaluations=evaluations,
+        all2md_commit="all2md-commit",
+        parser_runtime={"pymupdf": "1.28.0", "tesseract": "tesseract 5.3.0"},
+    )
+
+    assert set(payload["strata"]) == {"newspaper", "notes"}
+    assert sum(entry["pages"] for entry in payload["strata"].values()) == len(evaluations)
+    newspaper = payload["strata"]["newspaper"]
+    assert newspaper["pages"] == 2
+    assert newspaper["dimensions"]["text_content_similarity"] == {
+        "value": pytest.approx(0.4),
+        "eligible_items": 2,
+        "variance": pytest.approx(0.04),
+    }
+    assert payload["strata"]["notes"]["dimensions"]["text_content_similarity"]["value"] == pytest.approx(1.0)
+    # The whole-corpus aggregate is unchanged by stratification.
+    assert payload["dimensions"]["text_content_similarity"]["value"] == pytest.approx(0.6)
+
+    # The fixture snapshot's revision is not a real 40-hex pin; make identity valid so the
+    # emission exercises the strata question rather than failing on provenance shape.
+    payload["provenance"]["dataset_revision"] = "a" * 40
+    baseline = gate.emit_baseline(payload)
+    assert "strata" not in baseline
 
 
 def test_strict_result_json_rejects_non_finite_scores(tmp_path: Path) -> None:
@@ -426,6 +481,7 @@ def test_an_erased_dimension_reports_the_input_shape_not_a_parser_verdict(tmp_pa
             projection=PageProjection(("Body",), ("text_block",), ("<table><tr><td>1</td></tr></table>",), ()),
             unscored_categories={},
             explicitly_ignored=0,
+            stratum="testsource",
         )
     }
     evaluations = [

--- a/tests/unit/test_omnidocbench_gate.py
+++ b/tests/unit/test_omnidocbench_gate.py
@@ -14,11 +14,11 @@ pytestmark = pytest.mark.unit
 
 
 RESULTS = {
-    "schema_version": 2,
+    "schema_version": 3,
     "provenance": {
         "dataset_revision": "f5f559bddf50e36f7f9899d842d0006f13ce8afc",
         "annotation_sha256": "2fafe9329dc92fc426b30036aee51c716b3fcdcc1d20cb964dc7670579533817",
-        "oracle_schema_version": 5,
+        "oracle_schema_version": 6,
         "parser_config": {
             "layout_analysis_mode": "auto",
             "ocr": {
@@ -611,7 +611,7 @@ def test_baseline_emission_copies_identity_metrics_tolerances_and_failures() -> 
     """Emission must preserve the complete ratchet identity and produce its own green baseline."""
     emitted = gate.emit_baseline(_results(), {"text_similarity": 0.02}, default_tolerance=0.005)
     assert emitted == {
-        "schema_version": 2,
+        "schema_version": 3,
         "provenance": RESULTS["provenance"],
         "pages": RESULTS["pages"],
         "dimensions": {
@@ -700,10 +700,10 @@ def test_matching_malformed_baseline_identity_is_red(path: tuple[str, ...], valu
             "INVALID_BASELINE",
             ".".join(path),
             {
-                ("schema_version",): "must be integer 2",
+                ("schema_version",): "must be integer 3",
                 ("provenance", "dataset_revision"): "must be a 40-character lowercase hexadecimal revision",
                 ("provenance", "annotation_sha256"): "must be a 64-character lowercase hexadecimal digest",
-                ("provenance", "oracle_schema_version"): "must be integer 5",
+                ("provenance", "oracle_schema_version"): "must be integer 6",
                 ("provenance", "parser_config"): "must be a mapping",
                 ("provenance", "parser_runtime"): "must be a non-empty mapping",
             }[path],
@@ -876,7 +876,7 @@ def test_regression_at_the_tolerance_boundary_is_green(metric: str, value: float
 def test_cli_rejects_duplicate_json_keys(tmp_path, capsys) -> None:
     """Ambiguous JSON objects must fail before comparison."""
     results_path = tmp_path / "results.json"
-    results_path.write_text('{"schema_version": null, "schema_version": 2}', encoding="utf-8")
+    results_path.write_text('{"schema_version": null, "schema_version": 3}', encoding="utf-8")
 
     assert gate.main([str(results_path), "--emit-baseline"]) == 2
     captured = capsys.readouterr()
@@ -905,7 +905,7 @@ def test_emit_baseline_rejects_invalid_identity() -> None:
     results = _results()
     results["schema_version"] = None
 
-    with pytest.raises(ValueError, match="INVALID_BASELINE schema_version: must be integer 2"):
+    with pytest.raises(ValueError, match="INVALID_BASELINE schema_version: must be integer 3"):
         gate.emit_baseline(results)
 
 

--- a/tests/unit/test_omnidocbench_oracles.py
+++ b/tests/unit/test_omnidocbench_oracles.py
@@ -9,7 +9,9 @@ from hypothesis import strategies as st
 from all2md.ast.nodes import (
     CodeBlock,
     Document,
+    Figure,
     Heading,
+    Image,
     MathBlock,
     MathInline,
     Paragraph,
@@ -35,7 +37,7 @@ pytestmark = pytest.mark.unit
 def test_annotation_projection_uses_order_and_supported_ground_truth() -> None:
     """External facts must come from annotation fields, not from an all2md renderer."""
     record = {
-        "page_info": {"image_path": "nested/page-7.jpg"},
+        "page_info": {"image_path": "nested/page-7.jpg", "page_attribute": {"data_source": "testsource"}},
         "layout_dets": [
             {
                 "category_type": "text_block",
@@ -146,6 +148,72 @@ def test_ast_projection_reads_nodes_directly_in_document_order() -> None:
     )
 
 
+def test_bound_captions_are_projected_text_not_invisible_attributes() -> None:
+    """A caption bound to a Figure, Table, or Image must count as page text (#406).
+
+    The annotation side has always collapsed ``figure_caption``/``table_caption`` to
+    ``text_block``; the AST side used to descend children only, so a caption the parser
+    correctly folded into a ``caption`` attribute vanished from measurement -- recall fell
+    as figure binding improved. 101 of the 103 "lost" captions on the held-out PMC corpus
+    were in the output the whole time.
+    """
+    document = Document(
+        children=[
+            Figure(
+                children=[Paragraph(content=[Image(url="fig1.png")])],
+                caption="Fig. 1 A bound figure caption.",
+            ),
+            Table(
+                rows=[TableRow(cells=[TableCell(content=[Text(content="A")])])],
+                caption="Table 1 A bound table caption.",
+            ),
+            Paragraph(content=[Image(url="fig2.png", caption="An inline image caption.")]),
+        ]
+    )
+
+    projection = project_ast(document)
+
+    # Every caption lands as an ordinary text block, in document order, content before its
+    # caption -- exactly how the annotation side reads a printed caption. The empty
+    # strings are the image-bearing paragraphs themselves, unchanged from before.
+    assert projection.text_blocks == (
+        "",
+        "Fig. 1 A bound figure caption.",
+        "A",
+        "Table 1 A bound table caption.",
+        "",
+        "An inline image caption.",
+    )
+    assert projection.block_kinds == (
+        "text_block",
+        "text_block",
+        "table",
+        "text_block",
+        "text_block",
+        "text_block",
+    )
+    # The caption must not leak into the table's *cell* text: the annotation side keeps
+    # table_caption outside the table HTML, so folding it in would corrupt the
+    # table-content dimension while flattering the text one.
+    assert projection.tables == (TableProjection(1, 1, 1, "A"),)
+
+
+def test_a_caption_free_ast_projects_exactly_as_before() -> None:
+    """The caption path must not disturb documents that carry none."""
+    document = Document(
+        children=[
+            Heading(level=1, content=[Text(content="Title")]),
+            Figure(children=[Paragraph(content=[Text(content="Panel text")])]),
+            Paragraph(content=[Image(url="plain.png")]),
+        ]
+    )
+
+    projection = project_ast(document)
+
+    assert projection.text_blocks == ("Title", "Panel text", "")
+    assert projection.block_kinds == ("title", "text_block", "text_block")
+
+
 def test_page_scores_have_exact_independent_dimension_semantics() -> None:
     """Each metric must react to the fact it names rather than a shared output-length proxy."""
     expected = PageProjection(
@@ -219,7 +287,13 @@ def test_every_text_bearing_annotation_category_is_ground_truth() -> None:
     } <= oracles.TEXT_CATEGORIES
 
     record = {
-        "page_info": {"page_no": 0, "image_path": "p.jpg", "height": 10, "width": 10},
+        "page_info": {
+            "page_no": 0,
+            "image_path": "p.jpg",
+            "height": 10,
+            "width": 10,
+            "page_attribute": {"data_source": "testsource"},
+        },
         "layout_dets": [
             {"category_type": "header", "text": "Journal of Things", "order": 0},
             {"category_type": "text_block", "text": "Body", "order": 1},
@@ -400,7 +474,13 @@ def test_recovering_table_text_beats_deleting_the_table() -> None:
     html = "<table><tr><td>Alpha</td><td>Beta</td></tr></table>"
     truth = oracles.project_annotation(
         {
-            "page_info": {"page_no": 0, "image_path": "p.jpg", "height": 100, "width": 100},
+            "page_info": {
+                "page_no": 0,
+                "image_path": "p.jpg",
+                "height": 100,
+                "width": 100,
+                "page_attribute": {"data_source": "testsource"},
+            },
             "layout_dets": [
                 {"category_type": "text_block", "text": "Body", "order": 0, "poly": [0, 10] * 4},
                 {"category_type": "table", "html": html, "order": 1, "poly": [0, 50] * 4},
@@ -429,7 +509,13 @@ def test_unordered_running_content_is_placed_by_geometry() -> None:
     about one page number in seven sits at the top of the page.
     """
     record = {
-        "page_info": {"page_no": 0, "image_path": "p.jpg", "height": 1000, "width": 800},
+        "page_info": {
+            "page_no": 0,
+            "image_path": "p.jpg",
+            "height": 1000,
+            "width": 800,
+            "page_attribute": {"data_source": "testsource"},
+        },
         "layout_dets": [
             {"category_type": "text_block", "text": "Body", "order": 5, "poly": [0, 400] * 4},
             {"category_type": "header", "text": "Journal", "order": None, "poly": [0, 40] * 4},
@@ -493,7 +579,13 @@ def test_inline_equations_inside_code_are_not_ground_truth() -> None:
     before reaching the guard and would pass with the guard deleted.
     """
     record = {
-        "page_info": {"page_no": 0, "image_path": "p.jpg", "height": 100, "width": 100},
+        "page_info": {
+            "page_no": 0,
+            "image_path": "p.jpg",
+            "height": 100,
+            "width": 100,
+            "page_attribute": {"data_source": "testsource"},
+        },
         "layout_dets": [
             {
                 "category_type": "code_txt",

--- a/tests/unit/test_omnidocbench_pipeline.py
+++ b/tests/unit/test_omnidocbench_pipeline.py
@@ -58,6 +58,7 @@ def _real_result(tmp_path: Path, scores: tuple[float, ...]) -> dict[str, object]
                 projection=PageProjection(("Body",), ("text_block",), (), ()),
                 unscored_categories={},
                 explicitly_ignored=0,
+                stratum="testsource",
             )
             for page_id in page_ids
         },

--- a/tests/unit/test_published_benchmark_figures.py
+++ b/tests/unit/test_published_benchmark_figures.py
@@ -68,7 +68,20 @@ def _pmc_figures(pmc: dict[str, Any]) -> list[tuple[str, str]]:
         ("recall of attainable", f"     - **{_percent(recall['attainable_recall'])}**\n"),
         ("recall control", f"     - {_percent(recall['control_recall'])}\n"),
         ("supported share", f"     - **{_percent(precision['precision'])}**\n"),
+        (
+            # Rendered with its label because a bare percentage cell collides with other
+            # rows at coarse precision.
+            "resequenced share",
+            f"   * - Resequenced\n     - {_percent(precision['resequenced'] / precision['emitted'])}\n",
+        ),
         ("novel share", f"     - **{_percent(precision['novel_share'])}**\n"),
+        (
+            # This row moved 0.5% -> 2.0% when the caption-blind oracle was corrected
+            # (#406/#410); it was not in the inventory then, which is exactly how a stale
+            # figure would have survived. Gated now.
+            "duplication share",
+            f"   * - Duplication\n     - {_percent(precision['duplication'])}\n",
+        ),
         (
             "emitted n-grams",
             f"Over {precision['emitted']:,} emitted n-grams, {precision['novel']:,} are novel.",


### PR DESCRIPTION
## Summary

The #406 diagnosis refuted that issue as filed: 101 of the 103 "lost" captions on the held-out corpus were in the output the whole time. The shared oracle read children only, so a caption the parser correctly bound to `Figure.caption`/`Table.caption`/`Image.caption` vanished from measurement — **recall fell as figure binding improved**. This PR corrects the instrument and re-records everything it touches, batching #257's stratification so the ~80-minute re-baseline is paid once, as its demotion stipulated.

### The oracle (#406)
- `project_ast` projects caption attributes as synthesized text-block paragraphs — exactly how `project_annotation` has always counted `figure_caption`/`table_caption`. Table captions stay out of the table's *cell* text so the table-content dimension is not polluted.
- Schema bumps: PMC 5→6 (oracle 1→2), OmniDocBench 2→3 (oracle 5→6), gate supported versions likewise. Tests prove the caption path and that caption-free ASTs project exactly as before.

### PMC re-record
- Attainable recall **94.7% → 95.4%** (text blocks 98.4%); titles and tables unchanged, exactly as the holdout diagnosis predicted. Caption recall inside figure_binding 76.7% → **94.4%**.
- **Duplication 0.5% → 2.0% — real output, not a scoring artifact**: with caption text visible at all, the instruments can see that multi-panel figures re-bind the shared caption to every panel (filed as #410; one caption prints 4× in `PMC10000026.1`). The fidelity page explains both movements as what they are; the resequenced and duplication rows join the verbatim inventory so they can never go stale again.
- Corpus event en route: upstream re-stamped `PMC9500000.1`'s JATS (byte diff = one `pmc-last-change` timestamp; PDF unchanged) — re-pinned with the evidence in the commit.

### OmniDocBench (#257)
- Payload now reports **every dimension per corpus stratum** (`page_info.page_attribute.data_source`, fail-closed). Current reading: note 0.047 → academic_literature 0.766 — the whole-corpus mean hid a 16× spread. Strata are evidence, not identity: the gate never compares them and `emit_baseline` never copies them.
- Baseline re-recorded **with attribution, not absorption**: two record dispatches on the same runner image and pin — v1.13 main vs main+oracle — produced **byte-identical per-page scores on all 981 pages**. The oracle contributes exactly zero here; the movement vs the 2026-08-01 baseline (text 0.506→0.482, order 0.603→0.578, block_structure 0.118→0.398) is the v1.12/v1.13 parser arc, ledgered as #411.
- The workflow was missing `--extra benchmarks` and crashed at import on defusedxml — the exact failure the extra's pyproject comment predicted, in the sibling workflow that wasn't updated. Fixed.

### Riders
- #347 closed (markdown/org/rst fixed; dokuwiki inexpressible, documented in the strict-xfail allowlist).
- #296 re-measure posted: 171 of 1,225 dev-corpus section titles residual; only ~16 confirmed run-in — the residual is dominated by short abstract/back-matter labels, so the parked status stands.

## Test plan
- [x] Full unit suite green locally (including new caption-projection and strata tests)
- [x] Verbatim figure gate green against both re-recorded artifacts (corpus pin + schema + figures)
- [x] ruff / black / mypy over `benchmarks/` and touched tests
- [x] Attribution runs: PMC dispatch and two OmniDocBench record dispatches, all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)