### PR TITLE
fix(pdf): stop interleaving side-by-side columns with tight gutters (#405)

### DIFF
--- a/benchmarks/pmc/reference.json
+++ b/benchmarks/pmc/reference.json
@@ -5,9 +5,9 @@
     "bucket": "pmc-oa-opendata",
     "complete_corpus": true,
     "oracle_schema_version": 2,
-    "all2md_commit": "a8d4390faab271fa72bc29eeabdd8eb73262fde4",
+    "all2md_commit": "ea105c037779b0fc10ba239a493f37456228fc6e",
     "worktree_dirty": false,
-    "created_at": "2026-08-19T19:28:00.776586+00:00",
+    "created_at": "2026-08-20T01:03:43.003369+00:00",
     "python": "3.12.3 (main, Jun 19 2026, 12:46:00) [GCC 13.3.0]",
     "platform": "linux",
     "parser_runtime": {
@@ -68,13 +68,13 @@
     "unsplit_spans": 42
   },
   "article_recall": {
-    "recall": 0.6023582257158899,
-    "recovered": 5364,
+    "recall": 0.6195395845030881,
+    "recovered": 5517,
     "scored": 8905,
     "too_short": 2598,
     "ceiling": 0.624480628860191,
     "attainable": 5561,
-    "attainable_recall": 0.9543247617335011,
+    "attainable_recall": 0.9825570940478331,
     "by_kind": {
       "table": {
         "recovered": 77,
@@ -83,35 +83,35 @@
         "attainable_recall": 0.6909090909090909
       },
       "text_block": {
-        "recovered": 3141,
+        "recovered": 3155,
         "attainable": 3160,
         "scored": 6356,
-        "attainable_recall": 0.984493670886076
+        "attainable_recall": 0.9889240506329114
       },
       "title": {
-        "recovered": 2146,
+        "recovered": 2285,
         "attainable": 2291,
         "scored": 2426,
-        "attainable_recall": 0.9253601047577477
+        "attainable_recall": 0.9877782627673505
       }
     },
     "control_recall": 0.003593486805165637,
     "control_scored": 8905,
-    "discrimination": 0.5987647389107242
+    "discrimination": 0.6159460976979224
   },
   "article_precision": {
-    "precision": 0.9264827487562745,
-    "supported": 414551,
-    "emitted": 447446,
-    "resequenced": 28068,
-    "novel": 4827,
-    "novel_share": 0.01078789395815361,
-    "duplication": 0.02026025195707398,
-    "excess": 9770,
-    "occurrences": 482225,
-    "control_precision": 0.006957264116787277,
-    "control_emitted": 447446,
-    "discrimination": 0.9195254846394871
+    "precision": 0.9397992488598766,
+    "supported": 420391,
+    "emitted": 447320,
+    "resequenced": 22678,
+    "novel": 4251,
+    "novel_share": 0.009503263882679067,
+    "duplication": 0.02022487757425917,
+    "excess": 9751,
+    "occurrences": 482129,
+    "control_precision": 0.007012876687829741,
+    "control_emitted": 447320,
+    "discrimination": 0.9327863721720469
   },
   "figure_binding": {
     "binding_rate": 0.5255813953488372,
@@ -131,35 +131,35 @@
   "dimensions": {
     "block_structure_similarity": {
       "count": 706.0,
-      "mean": 0.5376131726173652,
-      "median": 0.5625,
-      "minimum": 0.016393442622950838,
+      "mean": 0.5420577473256009,
+      "median": 0.5656275635767023,
+      "minimum": 0.022727272727272707,
       "maximum": 1.0,
-      "stdev": 0.20910230767053464,
+      "stdev": 0.21246647137787839,
       "direction": "higher",
-      "control_mean": 0.4406226435897821,
-      "discrimination": 0.0969905290275831,
+      "control_mean": 0.4403768308558073,
+      "discrimination": 0.10168091646979355,
       "mutation_drop": {
-        "reversed": 0.011313431940310537,
-        "shuffled": 0.02215105004406372,
-        "halved": 0.06278276748452316
+        "reversed": 0.014850039809720163,
+        "shuffled": 0.03073238589012482,
+        "halved": 0.05961438938430722
       },
       "ungateable": "compares kind sequences without inspecting the text under a block, so content-free output scores 1.0 (issue #256); eleven text categories collapse to `text_block`, so fully reversed output scores exactly 1.0 on 153 of the 981 pinned pages; and on the born-digital lane it separates own-page from wrong-page output by only ~0.06 while *rising* when half the emitted content is deleted, which rewards dropping blocks"
     },
     "reading_order_similarity": {
       "count": 706.0,
-      "mean": 0.7686226098186316,
-      "median": 0.8,
+      "mean": 0.8217827559935488,
+      "median": 0.9,
       "minimum": 0.0,
       "maximum": 1.0,
-      "stdev": 0.21007253974973572,
+      "stdev": 0.21520731075755462,
       "direction": "higher",
-      "control_mean": 0.28738236693875924,
-      "discrimination": 0.4812402428798724,
+      "control_mean": 0.28801802793641296,
+      "discrimination": 0.5337647280571358,
       "mutation_drop": {
-        "reversed": 0.4201391234711173,
-        "shuffled": 0.2095946215811197,
-        "halved": 0.3112284307672439
+        "reversed": 0.5053984442937073,
+        "shuffled": 0.24732391181625454,
+        "halved": 0.33821752696770685
       }
     },
     "table_content_similarity": {
@@ -196,18 +196,18 @@
     },
     "text_content_similarity": {
       "count": 706.0,
-      "mean": 0.5582261645706342,
-      "median": 0.5330238627026651,
+      "mean": 0.6650094046176821,
+      "median": 0.6753701116624102,
       "minimum": 0.010652463382157085,
-      "maximum": 0.9901380670611439,
-      "stdev": 0.2192191157194943,
+      "maximum": 0.9930305215092525,
+      "stdev": 0.2214188305407939,
       "direction": "higher",
-      "control_mean": 0.23458798685548662,
-      "discrimination": 0.3236381777151476,
+      "control_mean": 0.2344655008641329,
+      "discrimination": 0.43054390375354923,
       "mutation_drop": {
-        "reversed": 0.17515444512156728,
-        "shuffled": 0.12488377402788574,
-        "halved": 0.22389428557224242
+        "reversed": 0.27629192773201244,
+        "shuffled": 0.2006449054953756,
+        "halved": 0.2961827527191879
       }
     }
   },

--- a/changelog.d/405-side-by-side-interleaving.fixed.md
+++ b/changelog.d/405-side-by-side-interleaving.fixed.md
@@ -1,0 +1,10 @@
+- **PDF: side-by-side columns no longer interleave line-by-line** (#405). Journal
+  reference pages print two columns with a 15–18pt gutter — under the 20pt threshold —
+  so the split never fired and the y-sort shredded every entry into the other column.
+  Three fixes, each behind structural evidence: a *channel* detector admits a
+  sub-threshold gutter only when an x-interval untouched by any block separates enough
+  y-overlapping content on both sides; blocks PyMuPDF fused *across* the gutter are
+  resegmented line-band by line-band (an undetected table cannot split — its bands are
+  many and narrow); and a word hyphenated at a block seam ("transcrip- tion") is joined
+  when the paragraphs merge. On the PMC dev corpus: 254 → 97 missing attainable
+  blocks (titles 171 → 28), zero blocks newly missing, table blocks untouched.

--- a/docs/source/benchmarks.rst
+++ b/docs/source/benchmarks.rst
@@ -74,13 +74,13 @@ Did the text survive?
      - Value
      -
    * - Raw recall
-     - 60.2%
+     - 62.0%
      - of 8,905 ground-truth blocks
    * - Attainable ceiling
      - 62.4%
      - what the PDF's own text layer reproduces
    * - **Recall of what is attainable**
-     - **95.4%**
+     - **98.3%**
      - the number worth reading
    * - Control: the *wrong* article
      - 0.4%
@@ -94,7 +94,14 @@ improved. On the held-out corpus, 101 of the 103 caption blocks the instruments 
 lost were in the output the whole time. The oracle now reads what the AST carries
 (oracle schema 6), and both lanes' artifacts are re-recorded against it.
 
-Raw recall is 60.2%, and that figure is close to meaningless on its own. A large share of
+The movement after that correction is the opposite kind: a parser fix (#405).
+Side-by-side regions with tight gutters — two-column reference lists above all — were
+read as one column and interleaved line-by-line, so every word survived while every
+adjacency died. Admitting those gutters on structural evidence and joining words
+hyphenated at block seams raised attainable recall from 95.4% to 98.3%, and the
+held-out corpus moved the same way it was never tuned against.
+
+Raw recall is 62.0%, and that figure is close to meaningless on its own. A large share of
 any JATS article cannot be recovered by *any* parser, because the markup records words in an
 order the page never prints — author affiliation blocks, structured metadata, citation
 fields. Charging a PDF parser for failing to reproduce text the PDF does not contain
@@ -116,12 +123,12 @@ By block kind:
      - Share of attainable
    * - Text blocks
      - 3,160 of 6,356
-     - 3,141
-     - **98.4%**
+     - 3,155
+     - **98.9%**
    * - Titles
      - 2,291 of 2,426
-     - 2,146
-     - **92.5%**
+     - 2,285
+     - **98.8%**
    * - Tables
      - 110 of 123
      - 77
@@ -153,13 +160,13 @@ Unsupported output is therefore split in two:
      - Share
      - Meaning
    * - Supported
-     - **92.6%**
+     - **94.0%**
      - the n-gram appears in the document's text layer
    * - Resequenced
-     - 6.3%
+     - 5.1%
      - every word is in the document, in a new adjacency
    * - **Novel**
-     - **1.1%**
+     - **1.0%**
      - at least one word appears nowhere — the number worth reading
    * - Duplication
      - 2.0%
@@ -168,8 +175,8 @@ Unsupported output is therefore split in two:
      - 0.7%
      - wants to be ~0%
 
-Over 447,446 emitted n-grams, 4,827 are novel. Reporting the raw unsupported figure instead
-would have made the result roughly seven times worse than the parser deserves.
+Over 447,320 emitted n-grams, 4,251 are novel. Reporting the raw unsupported figure instead
+would have made the result roughly six times worse than the parser deserves.
 
 Duplication is counted apart from both, because it is invisible to either. Text emitted
 twice is an unchanged *set* and a doubled *multiset* — no set-based score can see it at all.

--- a/src/all2md/constants.py
+++ b/src/all2md/constants.py
@@ -781,6 +781,26 @@ PDF_COLUMN_FREQ_THRESHOLD_RATIO = 0.3  # Ratio of max frequency for gap detectio
 PDF_COLUMN_MIN_BLOCKS_FOR_WIDTH_CHECK = 3  # Minimum blocks to perform median width check
 PDF_COLUMN_SINGLE_COLUMN_WIDTH_RATIO = 0.6  # Width ratio threshold for single column detection
 
+# Tight-gutter column admission (#405). Journal reference pages print two columns
+# separated by less than DEFAULT_COLUMN_GAP_THRESHOLD -- measured 14.9-17.9pt across
+# four different publishers on the PMC dev corpus -- so a raw gap test can never
+# admit them without also splitting on every indented quotation. A *channel* is
+# admitted on structural evidence instead: an x-interval no block touches anywhere
+# on the page, with enough blocks on both sides overlapping in y that a y-sort
+# would provably interleave them. The width floor only has to clear intra-column
+# word spacing, not distinguish columns from indentation -- the other guards do that.
+PDF_COLUMN_CHANNEL_MIN_WIDTH = 8.0  # Points; measured gutters bottom out at 14.9
+PDF_COLUMN_CHANNEL_MIN_BLOCKS_PER_SIDE = 3  # Sides with fewer blocks cannot interleave much
+PDF_COLUMN_CHANNEL_MIN_Y_OVERLAP_RATIO = 0.3  # Of the smaller side's y-span
+
+# Line-level resegmentation of gutter-merged blocks (#405). On 64 of 455 dev-corpus
+# pages PyMuPDF fuses both columns of a tight-gutter page into a single block, so no
+# block-level split can help; the lines themselves fall into disjoint x-bands and are
+# regrouped into one sub-block per band. A normal paragraph cannot split: its lines
+# all overlap in x, so interval clustering keeps them together.
+PDF_GUTTER_SPLIT_MIN_LINES_PER_BAND = 2
+PDF_GUTTER_SPLIT_MIN_BLOCK_WIDTH_RATIO = 0.5  # Narrower blocks cannot hold two columns
+
 # Reading order: how close two block tops must be to count as starting on the same
 # row, in which case they are read left-to-right instead of by a hairline y
 # difference. A fraction of the page's average line height rather than a constant,

--- a/src/all2md/parsers/_pdf_columns.py
+++ b/src/all2md/parsers/_pdf_columns.py
@@ -14,15 +14,21 @@ from __future__ import annotations
 from collections import defaultdict
 
 from all2md.constants import (
+    DEFAULT_COLUMN_GAP_THRESHOLD,
+    PDF_COLUMN_CHANNEL_MIN_BLOCKS_PER_SIDE,
+    PDF_COLUMN_CHANNEL_MIN_WIDTH,
+    PDF_COLUMN_CHANNEL_MIN_Y_OVERLAP_RATIO,
     PDF_COLUMN_FREQ_THRESHOLD_RATIO,
     PDF_COLUMN_GAP_QUANTIZATION,
     PDF_COLUMN_MIN_BLOCKS_FOR_WIDTH_CHECK,
     PDF_COLUMN_MIN_FREQ_COUNT,
     PDF_COLUMN_SINGLE_COLUMN_WIDTH_RATIO,
     PDF_COLUMN_X_TOLERANCE,
+    PDF_GUTTER_SPLIT_MIN_BLOCK_WIDTH_RATIO,
+    PDF_GUTTER_SPLIT_MIN_LINES_PER_BAND,
 )
 
-__all__ = ["detect_columns"]
+__all__ = ["detect_columns", "split_gutter_merged_blocks"]
 
 
 def _simple_kmeans_1d(values: list[float], k: int, max_iterations: int = 20) -> list[int]:
@@ -267,6 +273,227 @@ def _detect_columns_by_whitespace(
     return whitespace_columns if len(whitespace_columns) > 1 else None
 
 
+def _detect_columns_by_channel(
+    blocks: list,
+    block_ranges: list[tuple[float, float]],
+    page_width: float,
+    spanning_threshold: float,
+) -> list[list[dict]] | None:
+    """Admit tight-gutter columns on structural evidence (#405).
+
+    Journal reference pages print two columns whose gutter is narrower than
+    ``column_gap_threshold`` -- measured 14.9-17.9pt across four publishers on the
+    PMC dev corpus against the 20pt default -- so the whitespace detector finds
+    exactly the right x0 bands and then rejects the gap. Once the page is treated
+    as one column, the y-sort interleaves the sides line-by-line: every word
+    survives, every adjacency dies.
+
+    A raw lower threshold would also split on indented quotations and figure
+    labels. This detector demands what those cannot supply: a *channel* -- an
+    x-interval that no non-spanning block touches anywhere on the page -- with at
+    least `PDF_COLUMN_CHANNEL_MIN_BLOCKS_PER_SIDE` blocks on each side and enough
+    mutual y-overlap between the sides that a y-sort would provably interleave
+    them. An indented quotation overlaps its body text in x, so it can never
+    produce the channel in the first place.
+
+    Parameters
+    ----------
+    blocks : list
+        Text blocks.
+    block_ranges : list of tuple
+        (x0, x1) ranges for each block that has a bbox.
+    page_width : float
+        Width of the text area.
+    spanning_threshold : float
+        Blocks wider than this fraction of the page are treated as spanning
+        (headings, full-width paragraphs): they neither define nor veto a
+        channel, and are assigned to a column by center like the other
+        detectors do.
+
+    Returns
+    -------
+    list of list of dict or None
+        Detected columns, or None when no channel passes the guards.
+
+    """
+    spanning_width = spanning_threshold * page_width
+    narrow = [
+        tuple(block["bbox"])
+        for block in blocks
+        if block.get("bbox") and (block["bbox"][2] - block["bbox"][0]) <= spanning_width
+    ]
+    # Prune vertically isolated blocks -- a centered page number sitting *inside* the
+    # gutter, below both columns, would otherwise erase the channel. A block that
+    # y-overlaps no other block cannot be interleaved with anything by a y-sort, so it
+    # carries no evidence either way; it is still assigned to a column by center below.
+    kept = [a for a in narrow if any(min(a[3], b[3]) > max(a[1], b[1]) for b in narrow if b is not a)]
+    intervals = sorted((bbox[0], bbox[2]) for bbox in kept)
+    if len(intervals) < 2 * PDF_COLUMN_CHANNEL_MIN_BLOCKS_PER_SIDE:
+        return None
+
+    # Merge the x-intervals; the complement between merged runs is the channel space.
+    merged: list[tuple[float, float]] = [intervals[0]]
+    for x0, x1 in intervals[1:]:
+        last_x0, last_x1 = merged[-1]
+        if x0 <= last_x1 + PDF_COLUMN_CHANNEL_MIN_WIDTH:
+            merged[-1] = (last_x0, max(last_x1, x1))
+        else:
+            merged.append((x0, x1))
+    if len(merged) < 2:
+        return None
+
+    # y-extent of the evidence blocks on each side of each candidate channel.
+    def side_stats(lo: float, hi: float) -> tuple[int, float, float]:
+        count = 0
+        y0 = float("inf")
+        y1 = float("-inf")
+        for bbox in kept:
+            if bbox[0] >= lo and bbox[2] <= hi:
+                count += 1
+                y0 = min(y0, bbox[1])
+                y1 = max(y1, bbox[3])
+        return count, y0, y1
+
+    boundaries: list[float] = []
+    for (_, left_end), (right_start, _) in zip(merged, merged[1:], strict=False):
+        left_count, left_y0, left_y1 = side_stats(float("-inf"), left_end)
+        right_count, right_y0, right_y1 = side_stats(right_start, float("inf"))
+        if left_count < PDF_COLUMN_CHANNEL_MIN_BLOCKS_PER_SIDE or right_count < PDF_COLUMN_CHANNEL_MIN_BLOCKS_PER_SIDE:
+            continue
+        overlap = min(left_y1, right_y1) - max(left_y0, right_y0)
+        smaller_span = min(left_y1 - left_y0, right_y1 - right_y0)
+        if smaller_span <= 0 or overlap < PDF_COLUMN_CHANNEL_MIN_Y_OVERLAP_RATIO * smaller_span:
+            continue
+        boundaries.append((left_end + right_start) / 2)
+
+    # Exactly one admitted gutter -- a two-column page. Every measured tight-gutter
+    # page is two-column; layouts with more columns have wider gutters relative to
+    # their column width and clear the ordinary threshold path. Several qualifying
+    # channels on one page is the signature of an undetected table, not a layout.
+    if len(boundaries) != 1:
+        return None
+
+    content_top = min(bbox[1] for bbox in kept)
+    content_bottom = max(bbox[3] for bbox in kept)
+
+    columns: list[list[dict]] = [[] for _ in range(len(boundaries) + 1)]
+    for block in blocks:
+        if "bbox" not in block:
+            columns[0].append(block)
+            continue
+        bbox = block["bbox"]
+        if (bbox[2] - bbox[0]) > spanning_width:
+            # A spanning block reads in page order, not column order. Assigning it by
+            # center drops it *between* the columns at emission time: an untrimmed
+            # running header whose center fell a hair right of the boundary lands at
+            # the head of the right column -- exactly at the seam where the left
+            # column's last paragraph continues into the right one. Above all column
+            # content it belongs before both columns; below, after both.
+            block_middle = (bbox[1] + bbox[3]) / 2
+            if block_middle < content_top:
+                columns[0].append(block)
+                continue
+            if block_middle > content_bottom:
+                columns[-1].append(block)
+                continue
+        block_center = (bbox[0] + bbox[2]) / 2
+        for i, boundary in enumerate(boundaries):
+            if block_center < boundary:
+                columns[i].append(block)
+                break
+        else:
+            columns[-1].append(block)
+
+    for column in columns:
+        column.sort(key=lambda b: b.get("bbox", [0, 0, 0, 0])[1])
+
+    columns = [col for col in columns if col]
+    return columns if len(columns) > 1 else None
+
+
+def split_gutter_merged_blocks(blocks: list[dict], page_width: float) -> list[dict]:
+    """Resegment blocks PyMuPDF fused across a column gutter (#405).
+
+    On 64 of 455 PMC dev-corpus pages, ``page.get_text("dict")`` returns a single
+    block spanning both columns of a tight-gutter page -- up to 84 lines with the
+    two columns interleaved in y order. No block-level column split can recover
+    those: the interleaving is already inside the block. But the lines themselves
+    are honest about their geometry: they fall into disjoint x-bands separated by
+    the gutter. Each band becomes its own block, in the band's own line order.
+
+    A normal paragraph cannot be split by this: its lines all overlap in x
+    (including short last lines and indented first lines), so interval clustering
+    keeps them in one band. Any line that crosses the gutter -- a genuine
+    full-width line inside the block -- bridges the bands and vetoes the split of
+    the whole block, which is the conservative direction.
+
+    Parameters
+    ----------
+    blocks : list of dict
+        Text blocks from ``page.get_text("dict")``; non-text blocks pass through.
+    page_width : float
+        Page width, used to skip blocks too narrow to hold two columns.
+
+    Returns
+    -------
+    list of dict
+        The blocks, with each fused block replaced by one block per x-band
+        (left to right). All other blocks are returned untouched, in order.
+
+    """
+    min_band_lines = PDF_GUTTER_SPLIT_MIN_LINES_PER_BAND
+    result: list[dict] = []
+    for block in blocks:
+        lines = block.get("lines")
+        bbox = block.get("bbox")
+        if not lines or bbox is None or len(lines) < 2 * min_band_lines:
+            result.append(block)
+            continue
+        if (bbox[2] - bbox[0]) <= PDF_GUTTER_SPLIT_MIN_BLOCK_WIDTH_RATIO * page_width:
+            result.append(block)
+            continue
+        # Rotated text has bboxes that do not mean "reading columns"; leave it alone.
+        if any(line.get("dir", (1, 0))[:2] != (1, 0) for line in lines if isinstance(line.get("dir"), (tuple, list))):
+            result.append(block)
+            continue
+
+        # Cluster line x-intervals into bands separated by at least the channel floor.
+        order = sorted(range(len(lines)), key=lambda i: lines[i]["bbox"][0])
+        bands: list[dict] = []  # {"x0", "x1", "line_indices"}
+        for i in order:
+            lx0, _, lx1, _ = lines[i]["bbox"]
+            if bands and lx0 <= bands[-1]["x1"] + PDF_COLUMN_CHANNEL_MIN_WIDTH:
+                bands[-1]["x1"] = max(bands[-1]["x1"], lx1)
+                bands[-1]["line_indices"].append(i)
+            else:
+                bands.append({"x0": lx0, "x1": lx1, "line_indices": [i]})
+
+        # Exactly two bands, each wide enough to be a text column. An undetected
+        # borderless table also fuses into one wide block, but it splits into *many*
+        # *narrow* bands (measured 0.04-0.14 of the page width against 0.40-0.42 for
+        # real columns) -- and column-major order is precisely wrong for a table.
+        if (
+            len(bands) != 2
+            or any(len(band["line_indices"]) < min_band_lines for band in bands)
+            or any((band["x1"] - band["x0"]) < 0.25 * page_width for band in bands)
+        ):
+            result.append(block)
+            continue
+
+        for band in bands:  # bands are already left-to-right
+            band_lines = [lines[i] for i in sorted(band["line_indices"])]
+            sub_block = dict(block)
+            sub_block["lines"] = band_lines
+            sub_block["bbox"] = (
+                min(line["bbox"][0] for line in band_lines),
+                min(line["bbox"][1] for line in band_lines),
+                max(line["bbox"][2] for line in band_lines),
+                max(line["bbox"][3] for line in band_lines),
+            )
+            result.append(sub_block)
+    return result
+
+
 def _detect_columns_by_gaps(
     blocks: list,
     block_ranges: list[tuple[float, float]],
@@ -423,6 +650,14 @@ def detect_columns(
     )
     if columns:
         return columns
+
+    # Tight-gutter admission: gaps below the threshold, backed by structural evidence
+    # a raw gap test cannot demand (#405). A caller who *raised* the threshold above
+    # the default asked for less splitting, and that explicit dial wins.
+    if column_gap_threshold <= DEFAULT_COLUMN_GAP_THRESHOLD:
+        columns = _detect_columns_by_channel(blocks, block_ranges, page_width, spanning_threshold)
+        if columns:
+            return columns
 
     # Fallback to simple gap detection
     return _detect_columns_by_gaps(blocks, block_ranges, x_coords, column_gap_threshold, force_multi_column)

--- a/src/all2md/parsers/pdf.py
+++ b/src/all2md/parsers/pdf.py
@@ -70,7 +70,7 @@ from all2md.converter_metadata import ConverterMetadata
 from all2md.exceptions import DependencyError, MalformedFileError, PasswordProtectedError, ValidationError
 
 # Import from private submodules
-from all2md.parsers._pdf_columns import detect_columns
+from all2md.parsers._pdf_columns import detect_columns, split_gutter_merged_blocks
 from all2md.parsers._pdf_headers import IdentifyHeaders, compute_line_style
 from all2md.parsers._pdf_images import detect_image_caption, extract_page_images
 from all2md.parsers._pdf_layout import (
@@ -2252,6 +2252,10 @@ class PdfToAstConverter(BaseParser):
         # and poster layouts, and sorting them into columns measurably recovers it.
         if self.options.detect_columns and self.options.column_detection_mode not in ("disabled", "force_single"):
             force_multi = self.options.column_detection_mode == "force_multi"
+            # PyMuPDF fuses both columns of a tight-gutter page into one block on some
+            # pages; the fused block's interleaving is invisible to any block-level
+            # split, so its lines are regrouped into per-band blocks first (#405).
+            text_blocks = split_gutter_merged_blocks(text_blocks, page.rect.width)
             columns = detect_columns(
                 text_blocks,
                 self.options.column_gap_threshold,
@@ -4139,9 +4143,14 @@ class PdfToAstConverter(BaseParser):
                 )
 
                 if should_merge:
-                    # Merge: accumulate content
+                    # Merge: accumulate content. A word hyphenated across the seam --
+                    # the last line of one PyMuPDF block continuing in the next, which
+                    # dehyphenate_blocks cannot see because it works within a block --
+                    # is joined here under the same rules, instead of surviving as
+                    # "transcrip- tion" (#405).
                     if accumulated_content and node.content:
-                        accumulated_content.append(Text(content=" "))
+                        if not self._join_hyphenated_seam(accumulated_content, node.content):
+                            accumulated_content.append(Text(content=" "))
                     accumulated_content.extend(node.content)
                     if last_source_location is None:
                         last_source_location = node.source_location
@@ -4177,6 +4186,45 @@ class PdfToAstConverter(BaseParser):
             merged.append(AstParagraph(content=accumulated_content, source_location=last_source_location))
 
         return merged
+
+    def _join_hyphenated_seam(self, accumulated_content: list[Node], incoming: list[Node]) -> bool:
+        """Join a word hyphenated across two merged paragraphs, if one is split there.
+
+        Returns True when the seam was a hyphenated line break -- the caller must then
+        *not* insert the joining space. The hyphen and capitalization rules are
+        :func:`dehyphenate_blocks`'s exactly: an uppercase continuation keeps the
+        hyphen ("Anglo-" + "Saxon"), a lowercase one drops it ("transcrip-" + "tion").
+
+        Parameters
+        ----------
+        accumulated_content : list of Node
+            Content accumulated so far; its last `Text` node may end with a hyphen.
+        incoming : list of Node
+            The next paragraph's content; its first `Text` node may continue the word.
+
+        Returns
+        -------
+        bool
+            True if the hyphen seam was joined.
+
+        """
+        from all2md.parsers._pdf_ocr import _CONTINUATION_RE, _LINE_END_HYPHEN_RE
+
+        if not self.options.merge_hyphenated_words:
+            return False
+        last = accumulated_content[-1]
+        first = incoming[0]
+        if not isinstance(last, Text) or not isinstance(first, Text):
+            return False
+        hyphen = _LINE_END_HYPHEN_RE.search(last.content)
+        continuation = _CONTINUATION_RE.match(first.content.lstrip())
+        if not hyphen or not continuation:
+            return False
+        joiner = "-" if continuation.group(1)[0].isupper() else ""
+        accumulated_content[-1] = Text(content=_LINE_END_HYPHEN_RE.sub(rf"\1{joiner}", last.content))
+        if first.content != first.content.lstrip():
+            incoming[0] = Text(content=first.content.lstrip())
+        return True
 
     @staticmethod
     def _is_valid_list_marker(text: str) -> tuple[bool, str | None]:

--- a/tests/unit/formats/pdf/test_pdf_column_detection.py
+++ b/tests/unit/formats/pdf/test_pdf_column_detection.py
@@ -333,3 +333,215 @@ def test_column_detection_all_spanning_blocks():
     # Should return single column when all blocks span full width
     assert len(columns) == 1
     assert len(columns[0]) == 3
+
+
+# --- Tight-gutter channel admission (#405) ---------------------------------------
+#
+# Journal reference pages print two columns whose gutter is narrower than the
+# 20pt threshold (measured 14.9-17.9pt across four publishers on the PMC dev
+# corpus). The channel detector admits them on structural evidence a raw gap
+# test cannot demand.
+
+
+def _two_tight_columns(gap_start: float = 285.0, gap_end: float = 300.0) -> list[dict]:
+    """Two columns with a 15pt gutter, five multi-line blocks per side."""
+    blocks = []
+    for i in range(5):
+        y = 100 + i * 60
+        blocks.append({"bbox": [50, y, gap_start, y + 50], "text": f"L{i}"})
+        blocks.append({"bbox": [gap_end, y, 540, y + 50], "text": f"R{i}"})
+    return blocks
+
+
+def test_tight_gutter_two_columns_admitted():
+    """A 15pt gutter splits when both sides carry y-overlapping block stacks."""
+    columns = detect_columns(_two_tight_columns(), column_gap_threshold=20)
+
+    assert len(columns) == 2
+    assert {b["text"] for b in columns[0]} == {f"L{i}" for i in range(5)}
+    assert {b["text"] for b in columns[1]} == {f"R{i}" for i in range(5)}
+
+
+def test_tight_gutter_page_number_in_gutter_is_pruned():
+    """A centered page number below both columns must not erase the channel.
+
+    Measured on PMC5500034.1 p4 / PMC10500022.1 p6: the footer page number sits
+    *inside* the 15pt gutter. It y-overlaps nothing, so it cannot be interleaved
+    with anything and carries no evidence against the channel.
+    """
+    blocks = _two_tight_columns()
+    blocks.append({"bbox": [288, 460, 293, 470], "text": "4"})
+
+    columns = detect_columns(blocks, column_gap_threshold=20)
+
+    assert len(columns) == 2
+
+
+def test_tight_gutter_needs_blocks_on_both_sides():
+    """Two blocks on one side is not a column; it is a figure label or margin note."""
+    blocks = [{"bbox": [50, 100 + i * 60, 285, 150 + i * 60], "text": f"L{i}"} for i in range(5)]
+    blocks += [
+        {"bbox": [300, 100, 540, 150], "text": "R0"},
+        {"bbox": [300, 160, 540, 210], "text": "R1"},
+    ]
+
+    columns = detect_columns(blocks, column_gap_threshold=20)
+
+    assert len(columns) == 1
+
+
+def test_tight_gutter_needs_y_overlap():
+    """Left blocks above, right blocks below: a y-sort cannot interleave them."""
+    blocks = [{"bbox": [50, 100 + i * 30, 285, 120 + i * 30], "text": f"L{i}"} for i in range(4)]
+    blocks += [{"bbox": [300, 400 + i * 30, 540, 420 + i * 30], "text": f"R{i}"} for i in range(4)]
+
+    columns = detect_columns(blocks, column_gap_threshold=20)
+
+    assert len(columns) == 1
+
+
+def test_tight_gutter_indented_quotation_does_not_split():
+    """An indented block overlaps its body text in x; no channel can exist."""
+    blocks = [{"bbox": [50, 100 + i * 60, 540, 150 + i * 60], "text": f"B{i}"} for i in range(4)]
+    blocks += [{"bbox": [120, 340 + i * 30, 470, 360 + i * 30], "text": f"Q{i}"} for i in range(3)]
+
+    columns = detect_columns(blocks, column_gap_threshold=20)
+
+    assert len(columns) == 1
+
+
+def test_tight_gutter_multiple_channels_rejected():
+    """Several qualifying tight channels is a table signature, not a layout."""
+    blocks = []
+    for col, (x0, x1) in enumerate([(50, 180), (192, 322), (334, 464)]):
+        for i in range(5):
+            y = 100 + i * 60
+            blocks.append({"bbox": [x0, y, x1, y + 50], "text": f"C{col}"})
+
+    columns = detect_columns(blocks, column_gap_threshold=20)
+
+    assert len(columns) == 1
+
+
+# --- Gutter-merged block resegmentation (#405) ------------------------------------
+
+
+def _fused_two_column_block() -> dict:
+    """One block whose lines alternate between two disjoint x-bands (y order)."""
+    lines = []
+    for i in range(4):
+        y = 100 + i * 12
+        lines.append({"bbox": [50, y, 280, y + 10], "spans": [{"text": f"left {i}"}]})
+        lines.append({"bbox": [300, y + 1, 540, y + 11], "spans": [{"text": f"right {i}"}]})
+    return {"type": 0, "bbox": [50, 100, 540, 148], "lines": lines, "_layout_label": "text"}
+
+
+def test_split_fused_two_column_block():
+    """Lines regroup into one block per band, left band first, order preserved."""
+    from all2md.parsers.pdf import split_gutter_merged_blocks
+
+    result = split_gutter_merged_blocks([_fused_two_column_block()], page_width=595.0)
+
+    assert len(result) == 2
+    left, right = result
+    assert [s["text"] for line in left["lines"] for s in line["spans"]] == [f"left {i}" for i in range(4)]
+    assert [s["text"] for line in right["lines"] for s in line["spans"]] == [f"right {i}" for i in range(4)]
+    assert left["bbox"] == (50, 100, 280, 146)
+    assert right["bbox"] == (300, 101, 540, 147)
+    assert left["_layout_label"] == "text"
+
+
+def test_split_leaves_normal_paragraph_alone():
+    """A paragraph's lines all overlap in x -- including a short last line."""
+    from all2md.parsers.pdf import split_gutter_merged_blocks
+
+    lines = [
+        {"bbox": [50, 100, 540, 110], "spans": [{"text": "full line"}]},
+        {"bbox": [50, 112, 540, 122], "spans": [{"text": "full line"}]},
+        {"bbox": [50, 124, 540, 134], "spans": [{"text": "full line"}]},
+        {"bbox": [50, 136, 200, 146], "spans": [{"text": "short last"}]},
+    ]
+    block = {"type": 0, "bbox": [50, 100, 540, 146], "lines": lines}
+
+    result = split_gutter_merged_blocks([block], page_width=595.0)
+
+    assert result == [block]
+
+
+def test_split_leaves_fused_table_alone():
+    """Many narrow bands is a data grid; column-major order would be wrong for it."""
+    from all2md.parsers.pdf import split_gutter_merged_blocks
+
+    lines = []
+    for i in range(4):
+        y = 100 + i * 12
+        for x0, x1 in [(50, 100), (150, 200), (250, 300), (350, 400), (450, 500)]:
+            lines.append({"bbox": [x0, y, x1, y + 10], "spans": [{"text": "cell"}]})
+    block = {"type": 0, "bbox": [50, 100, 500, 146], "lines": lines}
+
+    result = split_gutter_merged_blocks([block], page_width=595.0)
+
+    assert result == [block]
+
+
+def test_split_leaves_narrow_block_alone():
+    """A block narrower than half the page cannot hold two columns."""
+    from all2md.parsers.pdf import split_gutter_merged_blocks
+
+    lines = [{"bbox": [50, 100 + i * 12, 130, 110 + i * 12], "spans": [{"text": "a"}]} for i in range(2)] + [
+        {"bbox": [160, 100 + i * 12, 240, 110 + i * 12], "spans": [{"text": "b"}]} for i in range(2)
+    ]
+    block = {"type": 0, "bbox": [50, 100, 240, 134], "lines": lines}
+
+    result = split_gutter_merged_blocks([block], page_width=595.0)
+
+    assert result == [block]
+
+
+# --- Hyphenated words across merged paragraph seams (#405) -------------------------
+
+
+def _seam_paragraphs(left_tail: str, right_head: str):
+    """Two Paragraph nodes as the PDF parser produces them at a block seam."""
+    from all2md.ast.nodes import Paragraph, SourceLocation, Text
+
+    return [
+        Paragraph(
+            content=[Text(content=left_tail)],
+            source_location=SourceLocation(format="pdf", page=1, metadata={"bbox": [50, 100, 280, 120]}),
+        ),
+        Paragraph(
+            content=[Text(content=right_head)],
+            source_location=SourceLocation(format="pdf", page=1, metadata={"bbox": [50, 122, 280, 142]}),
+        ),
+    ]
+
+
+def _merged_text(nodes) -> str:
+    from all2md.parsers.pdf import PdfToAstConverter
+
+    merged = PdfToAstConverter()._merge_adjacent_paragraphs(nodes)
+    assert len(merged) == 1
+    return "".join(t.content for t in merged[0].content)
+
+
+def test_merge_joins_hyphenated_word_across_blocks():
+    """dehyphenate_blocks cannot see across blocks; the paragraph merge must.
+
+    Measured on PMC7000152.1: tight-gutter reference columns fragment into 2-4
+    line PyMuPDF blocks, so words hyphenated at a block's last line survived as
+    "transcrip- tion" and cost every affected title its recall.
+    """
+    text = _merged_text(_seam_paragraphs("a farnesoic acid-responsive transcrip-", "tion factor"))
+    assert text == "a farnesoic acid-responsive transcription factor"
+
+
+def test_merge_keeps_hyphen_for_uppercase_continuation():
+    """An uppercase continuation signals a real compound: keep the hyphen."""
+    text = _merged_text(_seam_paragraphs("the Anglo-", "Saxon corpus"))
+    assert text == "the Anglo-Saxon corpus"
+
+
+def test_merge_without_hyphen_keeps_the_space():
+    text = _merged_text(_seam_paragraphs("a sentence that continues", "on the next block"))
+    assert text == "a sentence that continues on the next block"


### PR DESCRIPTION
Closes the dominant half of #405: two-column layouts whose gutter is narrower than `column_gap_threshold` were read as one column, and the y-sort interleaved the sides line-by-line — every word survived, every n-gram adjacency died. This was the largest recoverable text-recall class on both corpora.

## Measured mechanism (dev corpus, 66 articles)

- Reference pages across four publishers print gutters of **14.9–17.9pt against the 20pt default** — the whitespace detector found exactly the right x0 bands and rejected the gap every time.
- On **64 of 455 pages** PyMuPDF fuses both columns into a single block (up to 84 lines, columns interleaved inside the block) — invisible to any block-level split.
- Even with ordering fixed, words hyphenated at a block's last line survived as `transcrip- tion`: `dehyphenate_blocks` works within a block, and the continuation lives in the next one.

## The fixes (each behind structural evidence)

1. **Channel detector** (`_detect_columns_by_channel`): admits a sub-threshold gutter only when an x-interval untouched by any non-spanning block separates ≥3 y-overlapping blocks per side, exactly once per page (several qualifying channels = table signature). Vertically isolated blocks — a page number centered *inside* the gutter — neither define nor veto the channel. A spanning block above all column content is emitted before both columns rather than dropped at the seam where a column-crossing paragraph continues. An explicitly raised `column_gap_threshold` still wins.
2. **Fused-block resegmentation** (`split_gutter_merged_blocks`): lines regroup into bands, but only exactly 2 bands each ≥¼ page wide — an undetected borderless table also fuses, splits into many narrow bands, and column-major order would be precisely wrong for it.
3. **Hyphen joining at merge seams** (`_join_hyphenated_seam`): same rules as `dehyphenate_blocks` (`transcrip-`+`tion` joins; `Anglo-`+`Saxon` keeps the hyphen).

## Evidence

**Dev A/B** (attainable blocks not recovered): 254 → 97 (titles 171 → 28, tables 34 → 34 untouched), **zero blocks newly missing**. Worst article PMC7000152.1: 106 → 15.

**Holdout, untuned** (110 articles, scored once after dev tuning was frozen): 469 → 147 (**−69%, better than dev's −62% — no overfit signal**), block recall 94.9% → 98.4%, zero newly missing. The issue's worst articles: PMC10750000.1 52→2, PMC10750022.1 49→5, PMC6250044.1 37→0.

**Re-recorded artifact** (CI run 32318653737, same corpus pin, no schema bump — the measurement is untouched, the parser moved): attainable recall **95.4% → 98.3%** (titles 92.5% → 98.8%), raw recall 62.0% against the 62.4% ceiling, precision 92.6% → 94.0%, resequenced 6.3% → 5.1%, novel 1.08% → 0.95%. Duplication (2.0%, the #410 guard) and figure binding are **byte-identical**. Controls unchanged.

**Raster lane** (column detection runs on OCR-derived blocks too): gate dispatched on this branch (run 32318669339) — **passed**; text 0.4820 → 0.4837, order 0.5784 → 0.5806, block 0.3980 → 0.3970. Flat-to-slightly-better; nothing to attribute.

## Out of scope, tracked

- Flavor 2 of #405 (boxed sidebars needing y-segmentation) — largely fixed incidentally on holdout (PMC10750000.1 52→2); a few Elsevier abstract-box pages remain on dev.
- Table-block recall (34 dev blocks, 69.1% unchanged) — that's the docling table study (roadmap item 16).

## Testing

14 new unit tests (channel guards, splitter guards, hyphen seams — each encoding a measured failure). Full suite, golden, ruff, mypy, black all green locally. PDF goldens are Linux-recorded; if this ordering change moves them, CI will say so.

🤖 Generated with [Claude Code](https://claude.com/claude-code)