### PR TITLE
fix(pdf): repair find_tables cell text from word boxes and recover its logical rows (#417)

### DIFF
--- a/changelog.d/417-table-extract-truncation.fixed.md
+++ b/changelog.d/417-table-extract-truncation.fixed.md
@@ -1,0 +1,19 @@
+- **PDF: `find_tables()` grids no longer trust `Table.extract()`'s text assembly
+  blindly.** Two damage classes measured on the PMC dev corpus, both inside grids
+  whose geometry the ruling lines corroborate: cell text clipped mid-character
+  ("Contro", "0.7" for 0.75 — much of it numeric, which the letters-only split-word
+  guard ignores by design), and wrapped cells shredded into one row per printed
+  line. Extracted grids are now checked both ways — for tokens the page does not
+  contain (the existing fragment test, run on every strategy) and for page words
+  the grid lost (a new digit-aware containment test) — and on failure the cell
+  text is rebuilt from the page's own word boxes, which cannot be cut by
+  construction; a rebuild that comes back lighter than the extract is discarded
+  (rotated pages put cell rects and word boxes in different coordinate frames).
+  Logical rows are then recovered with the same guarded continuation merge the
+  word-gutter path uses, with two find_tables-specific guards: overlapping row
+  bboxes (row spans) disable the merge outright, and — because find_tables row
+  boxes tile, leaving gap geometry inert — a line only folds upward when its
+  filled columns are a subset of those its row already fills, keeping two-tier
+  headers apart. On the PMC dev corpus: 26 → 25 attainable table blocks below the
+  recall bar (table-block recall 76.4% → 77.3%), mean per-table text survival
+  0.837 → 0.853, no table regressing across the bar.

--- a/src/all2md/parsers/_pdf_tables.py
+++ b/src/all2md/parsers/_pdf_tables.py
@@ -18,6 +18,8 @@ if TYPE_CHECKING:
 
 __all__ = [
     "MAX_DOT_LEADER_CELL_RATIO",
+    "MAX_EXTRACT_LOSS_SHARE",
+    "MIN_REBUILD_CHAR_RATIO",
     "MAX_GUTTER_INTRUSION_SHARE",
     "MAX_TABLE_COLS",
     "MIN_TABLE_COLS",
@@ -29,15 +31,19 @@ __all__ = [
     "MIN_GUTTER_LINES",
     "MIN_GUTTER_WIDTH_PT",
     "MAX_ROTATED_WORD_SHARE",
+    "MAX_ROW_EXTENT_OVERLAP_PT",
     "MAX_TWO_COLUMN_REGION_DRAWINGS",
     "MIN_WORD_GUTTER_COLS",
     "TABLE_REGION_STRATEGIES",
     "TABLE_SIGNAL_RULING_THRESHOLD",
     "detect_tables_by_ruling_lines",
+    "extract_loss_share",
     "group_words_into_lines",
     "is_dot_leader_cell",
     "looks_like_numbered_bibliography",
+    "merge_continuation_lines",
     "page_has_table_signals",
+    "rebuild_cells_from_words",
     "split_word_ratio",
     "word_gutter_grid",
 ]
@@ -195,6 +201,32 @@ ROW_ANCHOR_TRUSTED_FILL = 0.6
 # guard (its cells are prose), while its row-label column showed 15 separate runs.
 ROW_GROUP_MAX_COLUMN_RUNS = 2
 
+# Row bboxes may overlap by at most this much before the merge distrusts them as
+# line geometry. Printed lines never overlap beyond font-box slop; find_tables()
+# rows on a rowspan table overlap by whole rows (measured: -17pt on a
+# two-axis-header table whose spans stretched one row's bbox over three).
+MAX_ROW_EXTENT_OVERLAP_PT = 1.0
+
+# Maximum share of the page's own words (centered inside a grid's bbox) that may be
+# missing from the extracted cell text before the grid's text assembly is distrusted
+# and rebuilt from word boxes. The complement of MAX_SPLIT_WORD_RATIO: that guard asks
+# "does the grid hold tokens the page does not?", this one asks "does the page hold
+# words the grid lost?" -- and unlike the fragment test it counts numbers, because
+# ``Table.extract()``'s clipping eats numeric cells ("0.75", "(-0.04-0.28)") that the
+# letters-only fragment tokenizer is blind to by design. Measured on the PMC dev
+# corpus with the per-cell containment rule: intact grids 0.000-0.029 (subscript and
+# ligature noise), grids with clipped cell text 0.055-0.441, so the threshold sits in
+# the gap between them.
+MAX_EXTRACT_LOSS_SHARE = 0.04
+
+# A rebuilt grid must carry at least this share of the extracted grid's non-whitespace
+# characters to replace it. The rebuild exists to *recover* clipped text; when it comes
+# back lighter than the extract, it lost text instead -- measured on rotated (landscape)
+# pages, where find_tables() cell rects and the page's word boxes do not share a
+# coordinate frame, so nearly every cell came back empty (27/121 filled), the gutted
+# grid died at the mostly-empty guard, and three intact tables were destroyed outright.
+MIN_REBUILD_CHAR_RATIO = 0.9
+
 
 def split_word_ratio(page: "pymupdf.Page", table_data: list[list[str | None]]) -> float:
     """Share of a grid's word tokens that are not whole words of the page.
@@ -241,6 +273,124 @@ def split_word_ratio(page: "pymupdf.Page", table_data: list[list[str | None]]) -
         return 0.0
 
     return sum(1 for token in tokens if token not in vocabulary) / len(tokens)
+
+
+def extract_loss_share(
+    page: "pymupdf.Page", table_data: list[list[str | None]], bbox: tuple[float, float, float, float]
+) -> float:
+    """Share of the page's words inside *bbox* that the extracted grid does not contain.
+
+    ``split_word_ratio`` catches invented column boundaries by finding tokens in the grid
+    that are whole words nowhere on the page. This is its complement for the opposite
+    damage: ``Table.extract()`` clipping cell text, which *removes* words from the grid --
+    most of them numeric, which the fragment tokenizer deliberately ignores. A word counts
+    as lost when its exact text is not among the grid's whitespace-split tokens.
+
+    Parameters
+    ----------
+    page : pymupdf.Page
+        Page the grid was extracted from.
+    table_data : list of list of (str or None)
+        Extracted cell text, as returned by ``Table.extract()``.
+    bbox : tuple of float
+        The table's bounding box; only words centered inside it are judged.
+
+    Returns
+    -------
+    float
+        Lost-word share in ``0.0..1.0``; ``0.0`` when the region holds no words, and on
+        error -- the same fail-open posture as :func:`split_word_ratio`.
+
+    """
+    # A page word is judged against whitespace-stripped cell text, cell by cell: a
+    # cell wrapping "(-0.04-0.28)" across two printed lines still *contains* the word,
+    # while a cell truncated to "(-0.04-0." does not. Token equality was measured
+    # first and misfires on exactly the wrapped-cell shape (0.10-0.44 "loss" on
+    # undamaged landscape grids); per-cell containment keeps the truncation signal
+    # without it. Cells are tested individually so two adjacent cells cannot
+    # accidentally concatenate into a word neither of them holds.
+    cell_texts = [
+        "".join(str(cell).lower().split()) for row in table_data for cell in row if cell is not None and str(cell)
+    ]
+    try:
+        words = page.get_text("words")
+    except Exception:
+        return 0.0
+    x0, y0, x1, y1 = bbox
+    lost = 0
+    total = 0
+    for word in words:
+        center_x = (word[0] + word[2]) / 2
+        center_y = (word[1] + word[3]) / 2
+        if not (x0 <= center_x < x1 and y0 <= center_y < y1):
+            continue
+        total += 1
+        needle = "".join(str(word[4]).lower().split())
+        if needle and not any(needle in cell for cell in cell_texts):
+            lost += 1
+    return lost / total if total else 0.0
+
+
+def rebuild_cells_from_words(page: "pymupdf.Page", table: object) -> list[list[str]] | None:
+    """Rebuild a ``find_tables()`` grid's cell text from the page's own word boxes.
+
+    ``Table.extract()`` assembles cell text from the characters its cell rects clip,
+    so a glyph straddling a cell boundary is cut mid-character: the PMC dev corpus
+    holds tables whose extracted cells read ``"Contro"`` / ``"perce ntage"`` while the
+    page itself spells every word whole. The grid geometry is right -- the rulings
+    corroborate it -- only the text assembly is wrong.
+
+    Word boxes cannot be cut by construction: each of the page's words lands whole in
+    the cell holding its center, exactly the guarantee the word-gutter path is built
+    on. Within a cell, words keep the page's reading order, joined by spaces within a
+    printed line and newlines across lines so the caller's hyphenation repair can run
+    across wraps.
+
+    Parameters
+    ----------
+    page : pymupdf.Page
+        Page the table was found on.
+    table : PyMuPDF Table
+        Table object from ``find_tables()`` whose ``rows[].cells`` rects define the
+        grid.
+
+    Returns
+    -------
+    list of list of str or None
+        The rebuilt grid, or ``None`` when the table exposes no usable cell
+        geometry -- the caller keeps the extracted text it already has.
+
+    """
+    try:
+        rows = list(table.rows)  # type: ignore[attr-defined]
+        words = page.get_text("words")
+    except Exception:
+        return None
+    if not rows:
+        return None
+
+    rebuilt: list[list[str]] = []
+    for row in rows:
+        cells = getattr(row, "cells", None)
+        if not cells:
+            return None
+        row_texts: list[str] = []
+        for cell in cells:
+            if cell is None:
+                row_texts.append("")
+                continue
+            x0, y0, x1, y1 = cell[:4]
+            lines: dict[tuple[int, int], list[str]] = {}
+            for word in words:
+                center_x = (word[0] + word[2]) / 2
+                center_y = (word[1] + word[3]) / 2
+                # Half-open on the far edges so a word centered exactly on a shared
+                # boundary lands in exactly one of the two cells meeting there.
+                if x0 <= center_x < x1 and y0 <= center_y < y1:
+                    lines.setdefault((word[5], word[6]), []).append(str(word[4]))
+            row_texts.append("\n".join(" ".join(parts) for _key, parts in sorted(lines.items())))
+        rebuilt.append(row_texts)
+    return rebuilt
 
 
 def is_dot_leader_cell(text: str) -> bool:
@@ -727,7 +877,7 @@ def _gutter_grid_core(words: list[tuple]) -> list[list[str]] | None:
             cells[column].append(str(word[4]))
         line_rows.append([" ".join(parts) for parts in cells])
         line_extents.append((min(word[1] for word in line), max(word[3] for word in line)))
-    return _merge_continuation_lines(line_rows, line_extents)
+    return merge_continuation_lines(line_rows, line_extents)
 
 
 def _mostly_numeric_cell(cell: str) -> bool:
@@ -844,8 +994,11 @@ def _rows_from_groups(line_rows: list[list[str]], groups: list[list[int]]) -> li
     return merged
 
 
-def _merge_continuation_lines(
-    line_rows: list[list[str]], line_extents: list[tuple[float, float]] | None = None
+def merge_continuation_lines(
+    line_rows: list[list[str]],
+    line_extents: list[tuple[float, float]] | None = None,
+    *,
+    continuation_within_start_columns: bool = False,
 ) -> list[list[str]]:
     """Fold wrapped cell lines into their logical row.
 
@@ -870,6 +1023,18 @@ def _merge_continuation_lines(
 
     Fully-dense numeric tables have uniform gaps, no single-column lines, and every
     anchor cell filled, so nothing merges and the per-line rows stand.
+
+    ``continuation_within_start_columns`` extends the sparse-anchor path's
+    no-new-columns test to *every* anchor continuation: a line only folds into the row
+    above when its filled columns are a subset of the columns that row already fills.
+    The find_tables() path asks for this because its row bboxes tile the grid -- every
+    gap is exactly zero -- so the geometric rules above are inert and the anchor rule
+    carries the whole merge unaided. Measured on the PMC dev corpus: a two-tier header
+    whose second row ("# | Acc | # | Acc") has an empty label cell fused into the tier
+    above, interleaving both rows' grams (0.87 -> 0.79); its filled columns were
+    exactly the ones the first tier left empty. Word-gutter callers keep the default:
+    their middle-aligned continuation shape legitimately fills fresh columns, and
+    their real inter-line gaps give the guards above their say first.
 
     Cell fragments join with a newline rather than a space so the caller can run its
     hyphenation repair across the join, exactly as the paragraph path does.
@@ -939,6 +1104,9 @@ def _merge_continuation_lines(
             and gaps[index - 1] < median_gap
         )
         anchor_continuation = merged and not (anchor < len(row) and row[anchor])
+        if anchor_continuation and continuation_within_start_columns:
+            row_columns = {column for column, cell in enumerate(merged[-1]) if cell}
+            anchor_continuation = all(column in row_columns for column in filled_columns)
         if not (single_column_wrap or anchor_continuation):
             merged.append(list(row))
             continue

--- a/src/all2md/parsers/pdf.py
+++ b/src/all2md/parsers/pdf.py
@@ -26,6 +26,7 @@ if TYPE_CHECKING:
 
     from all2md.parsers._ocr import OcrParagraph
 
+from collections.abc import Sequence
 from dataclasses import dataclass, field, replace
 
 from all2md.ast import (
@@ -92,19 +93,25 @@ from all2md.parsers._pdf_ocr import (
 )
 from all2md.parsers._pdf_tables import (
     MAX_DOT_LEADER_CELL_RATIO,
+    MAX_EXTRACT_LOSS_SHARE,
+    MAX_ROW_EXTENT_OVERLAP_PT,
     MAX_SPLIT_WORD_RATIO,
     MAX_TABLE_COLS,
     MAX_TABLE_EMPTY_RATIO,
     MAX_TABLE_ROWS,
     MAX_TWO_COLUMN_REGION_DRAWINGS,
     MIN_FILLED_FOR_UNIFORMITY_CHECK,
+    MIN_REBUILD_CHAR_RATIO,
     MIN_TABLE_COLS,
     MIN_TABLE_ROWS,
     TABLE_REGION_STRATEGIES,
     detect_tables_by_ruling_lines,
+    extract_loss_share,
     is_dot_leader_cell,
     looks_like_numbered_bibliography,
+    merge_continuation_lines,
     page_has_table_signals,
+    rebuild_cells_from_words,
     split_word_ratio,
     word_gutter_grid,
 )
@@ -3071,6 +3078,52 @@ class PdfToAstConverter(BaseParser):
             return ""
         return str(cell_text).strip()
 
+    @staticmethod
+    def _char_mass(table_data: "Sequence[Sequence[str | None]]") -> int:
+        """Non-whitespace character count of a grid -- the mass a rebuild must preserve."""
+        return sum(len("".join(str(cell).split())) for row in table_data for cell in row if cell is not None)
+
+    @staticmethod
+    def _table_row_extents(table: Any, n_rows: int) -> list[tuple[float, float]] | None:
+        """Vertical extents of a find_tables() grid's rows, for continuation merging.
+
+        Parameters
+        ----------
+        table : PyMuPDF Table
+            Table object from ``find_tables()``.
+        n_rows : int
+            Number of rows in the extracted grid; the extents are only meaningful
+            when they describe exactly those rows.
+
+        Returns
+        -------
+        list of (float, float) or None
+            ``(top, bottom)`` per row, or ``None`` when the table's row geometry
+            is missing, does not match the extracted grid, or is not line-like --
+            the caller then skips the merge rather than merging on wrong geometry.
+
+        """
+        try:
+            rows = list(table.rows)
+            if len(rows) != n_rows:
+                return None
+            extents = [(float(row.bbox[1]), float(row.bbox[3])) for row in rows]
+        except Exception:
+            return None
+        # The merge reads inter-line gaps, which only mean anything when the rows
+        # are stacked printed lines. On tables with row spans, find_tables() hands
+        # back overlapping row bboxes -- one row's box containing whole later rows,
+        # gaps of -17pt -- and every gap statistic computed over them is garbage
+        # (measured: a rowspan table's 5 true rows fused to 4, another's 42 to 31).
+        # Printed lines never overlap by more than font-box slop, so anything past
+        # 1pt of overlap means this is not line geometry, and extract()'s own row
+        # structure -- which already understands the spans -- is left alone.
+        if any(
+            extents[index][0] < extents[index - 1][1] - MAX_ROW_EXTENT_OVERLAP_PT for index in range(1, len(extents))
+        ):
+            return None
+        return extents
+
     def _process_table_to_ast(self, table: Any, page: "pymupdf.Page", page_num: int) -> Node | None:
         """Process a PyMuPDF table to AST Table node.
 
@@ -3105,6 +3158,36 @@ class PdfToAstConverter(BaseParser):
             if not table_data or len(table_data) == 0:
                 logger.debug("Table has no data")
                 return None
+
+            # ``Table.extract()`` assembles cell text from the characters its cell
+            # rects clip, so a glyph straddling a boundary is cut mid-character --
+            # on the PMC dev corpus it produced cells reading "Contro" and
+            # "perce ntage" inside grids whose geometry the rulings corroborate.
+            # The split-word guard that already protects the text-alignment
+            # strategy detects exactly this damage, so run it on every grid; but
+            # where the text strategy's failure means the *columns* are invented
+            # (reject), a line-corroborated grid's failure means only the text
+            # assembly is wrong -- so repair it from the page's own word boxes,
+            # which cannot be cut by construction.
+            repaired = False
+            fragments = split_word_ratio(page, table_data)
+            lost = extract_loss_share(page, table_data, table.bbox)
+            if fragments > MAX_SPLIT_WORD_RATIO or lost > MAX_EXTRACT_LOSS_SHARE:
+                rebuilt = rebuild_cells_from_words(page, table)
+                # The rebuild must come back at least as heavy as what it replaces:
+                # on rotated pages the cell rects and word boxes do not share a
+                # coordinate frame, and a rebuild that misses the words would gut
+                # the table it was meant to repair.
+                if rebuilt is not None and self._char_mass(rebuilt) >= MIN_REBUILD_CHAR_RATIO * self._char_mass(
+                    table_data
+                ):
+                    logger.debug(
+                        f"Rebuilt table cell text from word boxes on page {page_num + 1}: "
+                        f"{fragments:.0%} of extracted tokens were fragments, "
+                        f"{lost:.0%} of the region's words were missing from the grid"
+                    )
+                    table_data = rebuilt
+                    repaired = True
 
             # Reject pathological detections (PyMuPDF's find_tables() can fire on
             # decorative frames / TOC dot-leader regions / non-tabular content,
@@ -3165,17 +3248,45 @@ class PdfToAstConverter(BaseParser):
                 self._record_table_rejection("dot_leader_toc")
                 return self._region_text_as_paragraph(page, pymupdf.Rect(table.bbox), page_num)
 
-            # Separate header row (first row) from data rows
-            header_row_data = table_data[0] if table_data else []
-            data_rows_data = table_data[1:] if len(table_data) > 1 else []
+            # A find_tables() grid can shred wrapped cells the same way the
+            # word-gutter grid did before #416: where the rulings only mark
+            # columns, PyMuPDF snaps its rows to printed lines, and a cell
+            # wrapping to a second line splits mid-sentence. The row bboxes
+            # carry the same inter-line geometry the gutter path merges on, so
+            # the same guarded merge runs here. Dense grids with real row
+            # rulings have uniform gaps and filled anchors, and pass through
+            # untouched.
+            line_rows = [[self._extract_cell_text(c) for c in row] for row in table_data]
+            row_extents = self._table_row_extents(table, len(line_rows))
+            merged = (
+                merge_continuation_lines(line_rows, row_extents, continuation_within_start_columns=True)
+                if row_extents is not None
+                else line_rows
+            )
+            if len(merged) < MIN_TABLE_ROWS:
+                # The merge collapsed the grid below two rows: whatever this
+                # region is, it is one logical row of text, not a table.
+                logger.debug(
+                    f"Rejecting pymupdf table on page {page_num + 1}: "
+                    f"{len(line_rows)} printed lines merge into {len(merged)} logical rows"
+                )
+                self._record_table_rejection("degenerate_grid")
+                return self._region_text_as_paragraph(page, pymupdf.Rect(table.bbox), page_num)
 
-            header_cells = [TableCell(content=[Text(content=self._extract_cell_text(c))]) for c in header_row_data]
-            header_row = TableRow(cells=header_cells, is_header=True)
+            # Untouched tables keep the exact text extract() gave them. Repaired
+            # or merged ones get the word-gutter path's cell treatment: newline
+            # joins feed hyphenation repair, then whitespace collapses.
+            changed = repaired or len(merged) != len(line_rows)
 
-            data_rows = []
-            for row_data in data_rows_data:
-                row_cells = [TableCell(content=[Text(content=self._extract_cell_text(c))]) for c in row_data]
-                data_rows.append(TableRow(cells=row_cells))
+            def make_cell(cell_text: str) -> TableCell:
+                if changed:
+                    if self.options.merge_hyphenated_words:
+                        cell_text = dehyphenate_text(cell_text)
+                    cell_text = " ".join(cell_text.split())
+                return TableCell(content=[Text(content=cell_text)])
+
+            header_row = TableRow(cells=[make_cell(cell_text) for cell_text in merged[0]], is_header=True)
+            data_rows = [TableRow(cells=[make_cell(cell_text) for cell_text in row]) for row in merged[1:]]
 
             return AstTable(
                 header=header_row, rows=data_rows, source_location=SourceLocation(format="pdf", page=page_num + 1)

--- a/tests/unit/formats/pdf/test_pdf_find_tables_repair.py
+++ b/tests/unit/formats/pdf/test_pdf_find_tables_repair.py
@@ -1,0 +1,301 @@
+#  Copyright (c) 2025 Tom Villani, Ph.D.
+#
+# tests/unit/formats/pdf/test_pdf_find_tables_repair.py
+"""A ``find_tables()`` grid is trusted for its geometry, not for its text assembly.
+
+``Table.extract()`` builds cell text from the characters its cell rects clip, so a
+glyph straddling a boundary is cut mid-character ("Contro", "perce ntage") inside a
+grid whose columns the rulings corroborate; and where the rulings mark only columns,
+PyMuPDF snaps its rows to printed lines, so a wrapped cell shreds into two rows. Both
+were measured on the PMC dev corpus (#417): eight tables below the recall bar for
+truncation, six for row shred, every word of them present whole on the page.
+
+The repair rebuilds cell text from the page's own word boxes (each word lands whole in
+the cell holding its center) and folds wrapped lines with the same guarded merge the
+word-gutter path uses (#416). Tables that need neither must come through byte-identical.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from all2md.ast import Table as AstTable
+from all2md.ast.nodes import Text, get_node_children
+from all2md.parsers.pdf import PdfToAstConverter
+
+pytestmark = [pytest.mark.unit, pytest.mark.pdf, pytest.mark.table]
+
+
+class _FakeRow:
+    def __init__(self, bbox, cells):
+        self.bbox = bbox
+        self.cells = cells
+
+
+class _FakeTable:
+    """A PyMuPDF table with the geometry the repair reads: ``rows[].bbox`` and ``rows[].cells``."""
+
+    def __init__(self, grid, row_extents, column_edges):
+        self._grid = grid
+        self.rows = []
+        for (top, bottom), _row in zip(row_extents, grid, strict=True):
+            cells = [
+                (column_edges[index], top, column_edges[index + 1], bottom) for index in range(len(column_edges) - 1)
+            ]
+            self.rows.append(_FakeRow((column_edges[0], top, column_edges[-1], bottom), cells))
+        self.bbox = (column_edges[0], row_extents[0][0], column_edges[-1], row_extents[-1][1])
+
+    def extract(self):
+        return self._grid
+
+
+class _FakePage:
+    """A page whose words are placed by the test; ``get_text('words')`` is the only thing read."""
+
+    def __init__(self, words):
+        # (x0, y0, x1, y1, text, block, line, word) as PyMuPDF returns them.
+        self._words = [(*box, text, 0, line, index) for index, (box, text, line) in enumerate(words)]
+
+    def get_text(self, kind):
+        assert kind == "words"
+        return list(self._words)
+
+    def get_textbox(self, rect):
+        return " ".join(word[4] for word in self._words)
+
+
+def _cells(node: AstTable) -> list[list[str]]:
+    def text_of(cell) -> str:
+        parts: list[str] = []
+
+        def walk(current) -> None:
+            if isinstance(current, Text):
+                parts.append(current.content)
+                return
+            for child in get_node_children(current):
+                walk(child)
+
+        walk(cell)
+        return "".join(parts)
+
+    rows = [node.header, *node.rows]
+    return [[text_of(cell) for cell in row.cells] for row in rows]
+
+
+def _word(x0, top, text, line):
+    """A word box 6pt per character wide, sitting on the printed line at *top*."""
+    return ((x0, top + 1, x0 + 6 * len(text), top + 9), text, line)
+
+
+EDGES = [0.0, 60.0, 120.0]
+
+
+def test_clipped_cell_text_is_rebuilt_from_whole_words():
+    """A grid whose extract() cut words at cell edges comes back spelled as the page spells them."""
+    extents = [(0.0, 10.0), (14.0, 24.0), (28.0, 38.0)]
+    # What the page says ...
+    page = _FakePage(
+        [
+            _word(2, 0, "Group", 0),
+            _word(62, 0, "Percentage", 0),
+            _word(2, 14, "Control", 1),
+            _word(62, 14, "12.5", 1),
+            _word(2, 28, "Treated", 2),
+            _word(62, 28, "40.0", 2),
+        ]
+    )
+    # ... and what extract() clipped it to.
+    grid = [["Group", "Perce ntage"], ["Contro", "12.5"], ["Treate", "40.0"]]
+
+    node = PdfToAstConverter()._process_table_to_ast(_FakeTable(grid, extents, EDGES), page, page_num=0)
+
+    assert isinstance(node, AstTable)
+    assert _cells(node) == [["Group", "Percentage"], ["Control", "12.5"], ["Treated", "40.0"]]
+
+
+def test_a_clean_grid_keeps_its_extracted_text_verbatim():
+    """No fragments and no wraps: the table is exactly what extract() returned, whitespace and all."""
+    extents = [(0.0, 10.0), (14.0, 24.0), (28.0, 38.0)]
+    page = _FakePage(
+        [
+            _word(2, 0, "Model", 0),
+            _word(62, 0, "Score", 0),
+            _word(2, 14, "baseline", 1),
+            _word(62, 14, "0.62", 1),
+            _word(2, 28, "ours", 2),
+            _word(62, 28, "0.81", 2),
+        ]
+    )
+    grid = [["Model", "Score"], ["baseline", "0.62"], ["ours", "0.81"]]
+
+    node = PdfToAstConverter()._process_table_to_ast(_FakeTable(grid, extents, EDGES), page, page_num=0)
+
+    assert isinstance(node, AstTable)
+    assert _cells(node) == grid
+
+
+def test_printed_line_rows_fold_into_logical_rows_and_repair_the_hyphen():
+    """Rows snapped to printed lines merge on the gap jump, and the wrap's hyphen heals across the join."""
+    # Wraps sit 1.5pt below their row; the next row sits 4-4.5pt below.
+    extents = [(0.0, 10.0), (14.0, 24.0), (25.5, 35.5), (40.0, 50.0), (51.5, 61.5), (66.0, 76.0)]
+    page = _FakePage(
+        [
+            _word(2, 0, "Drug", 0),
+            _word(62, 0, "Effect", 0),
+            _word(2, 14, "Aspirin", 1),
+            _word(62, 14, "reduces", 1),
+            _word(62, 25.5, "inflammation", 2),
+            _word(2, 40, "Ibuprofen", 3),
+            _word(62, 40, "eases", 3),
+            _word(62, 51.5, "fever", 4),
+            _word(2, 66, "Statin", 5),
+            _word(62, 66, "lipids", 5),
+        ]
+    )
+    grid = [
+        ["Drug", "Effect"],
+        ["Aspirin", "reduces inflam-"],
+        ["", "mation"],
+        ["Ibuprofen", "eases"],
+        ["", "fever"],
+        ["Statin", "lipids"],
+    ]
+
+    node = PdfToAstConverter()._process_table_to_ast(_FakeTable(grid, extents, EDGES), page, page_num=0)
+
+    assert isinstance(node, AstTable)
+    assert _cells(node) == [
+        ["Drug", "Effect"],
+        ["Aspirin", "reduces inflammation"],
+        ["Ibuprofen", "eases fever"],
+        ["Statin", "lipids"],
+    ]
+
+
+def test_a_table_without_row_geometry_is_not_merged():
+    """Without ``rows`` to read extents from, the grid is emitted as extracted -- never merged blind."""
+
+    class _Bare:
+        bbox = (0, 0, 120, 40)
+
+        def extract(self):
+            return [["Drug", "Effect"], ["Aspirin", "reduces"], ["", "inflammation"]]
+
+    page = _FakePage(
+        [
+            _word(2, 0, "Drug", 0),
+            _word(62, 0, "Effect", 0),
+            _word(2, 14, "Aspirin", 1),
+            _word(62, 14, "reduces", 1),
+            _word(62, 28, "inflammation", 2),
+        ]
+    )
+    node = PdfToAstConverter()._process_table_to_ast(_Bare(), page, page_num=0)
+
+    assert isinstance(node, AstTable)
+    assert len(node.rows) == 2
+
+
+def test_overlapping_row_boxes_disable_the_merge():
+    """A rowspan table's overlapping row bboxes are not line geometry: nothing merges.
+
+    find_tables() hands back overlapping row boxes when a spanning cell stretches
+    one row's bbox over its neighbours; every gap statistic computed over those is
+    garbage, and a row with an empty first cell would fold into the span above.
+    extract() already understands the spans, so its rows stand.
+    """
+    # Row 1's box swallows row 2 entirely -- and row 2's leading cell is empty,
+    # exactly the shape the anchor rule would otherwise merge.
+    extents = [(0.0, 10.0), (14.0, 60.0), (24.0, 40.0), (64.0, 74.0)]
+    page = _FakePage(
+        [
+            _word(2, 0, "Site", 0),
+            _word(62, 0, "Count", 0),
+            _word(2, 14, "Liver", 1),
+            _word(62, 14, "four", 1),
+            _word(62, 24, "seven", 2),
+            _word(2, 64, "Lung", 3),
+            _word(62, 64, "two", 3),
+        ]
+    )
+    grid = [["Site", "Count"], ["Liver", "four"], ["", "seven"], ["Lung", "two"]]
+
+    node = PdfToAstConverter()._process_table_to_ast(_FakeTable(grid, extents, EDGES), page, page_num=0)
+
+    assert isinstance(node, AstTable)
+    assert _cells(node) == grid
+
+
+def test_a_rebuild_that_loses_text_is_discarded():
+    """When the cell rects miss the page's words, the gutted rebuild must not replace the extract.
+
+    On rotated pages find_tables() cell rects and the word boxes do not share a
+    coordinate frame, so the rebuild comes back nearly empty. Measured before the
+    char-mass guard: three intact landscape tables were gutted, died at the
+    mostly-empty guard, and were destroyed outright (1.00 -> 0.00).
+    """
+    extents = [(0.0, 10.0), (14.0, 24.0), (28.0, 38.0)]
+    # The words sit far outside every cell rect, as a rotated frame would put them.
+    page = _FakePage(
+        [
+            _word(402, 0, "Group", 0),
+            _word(462, 0, "Percentage", 0),
+            _word(402, 14, "Control", 1),
+            _word(462, 14, "12.5", 1),
+            _word(402, 28, "Treated", 2),
+            _word(462, 28, "40.0", 2),
+        ]
+    )
+    # Extract text is damaged enough to fire the trigger (fragments + lost words).
+    grid = [["Group", "Perce ntage"], ["Contro", "12.5"], ["Treate", "40.0"]]
+
+    node = PdfToAstConverter()._process_table_to_ast(_FakeTable(grid, extents, EDGES), page, page_num=0)
+
+    assert isinstance(node, AstTable)
+    # The damaged extract survives -- worse than the page, better than nothing.
+    assert _cells(node) == grid
+
+
+def test_a_second_header_tier_with_an_empty_label_cell_stays_its_own_row():
+    """A "# | Acc" sub-header fills columns the tier above left empty: it must not fold up.
+
+    find_tables() row bboxes tile the grid -- every gap is zero -- so the anchor rule
+    carries the merge alone, and an empty label cell is its whole test. Measured: a
+    two-tier header fused (0.87 -> 0.79) because the second tier's filled columns were
+    exactly the ones the first tier left empty. Empty separator lines (no columns at
+    all) still fold away.
+    """
+    extents = [(0.0, 10.0), (10.0, 20.0), (20.0, 30.0), (30.0, 40.0)]
+    edges = [0.0, 60.0, 120.0, 180.0, 240.0, 300.0]
+    page = _FakePage(
+        [
+            _word(2, 0, "modalities", 0),
+            _word(62, 0, "visual", 0),
+            _word(182, 0, "audio", 0),
+            _word(122, 10, "Acc", 1),
+            _word(242, 10, "Acc", 1),
+            _word(2, 20, "one", 2),
+            _word(62, 20, "1", 2),
+            _word(122, 20, "70", 2),
+            _word(182, 20, "2", 2),
+            _word(242, 20, "60", 2),
+        ]
+    )
+    # The top tier spans column pairs, so the sub-header's "Acc" cells sit in
+    # columns the top tier leaves empty -- the real two-tier geometry.
+    grid = [
+        ["modalities", "visual", "", "audio", ""],
+        ["", "", "Acc", "", "Acc"],
+        ["", "", "", "", ""],
+        ["one", "1", "70", "2", "60"],
+    ]
+
+    node = PdfToAstConverter()._process_table_to_ast(_FakeTable(grid, extents, edges), page, page_num=0)
+
+    assert isinstance(node, AstTable)
+    # The sub-header keeps its row; only the fully-empty separator line folds.
+    assert _cells(node) == [
+        ["modalities", "visual", "", "audio", ""],
+        ["", "", "Acc", "", "Acc"],
+        ["one", "1", "70", "2", "60"],
+    ]


### PR DESCRIPTION
Closes #417. Second leg of the docling table study's fix arc (after #418): the same two damage classes, now on the `find_tables()` path, which previously took `Table.extract()`'s output verbatim.

## The defects (measured on the PMC dev census)

1. **Truncation** — `extract()` assembles cell text from the characters its cell rects clip, cutting glyphs mid-character (`"Contro"`, `"0.7"` for 0.75). 8 dev tables below the recall bar; most of the clipped text is numeric, which the letters-only split-word guard ignores **by design**, so no existing guard could see it.
2. **Row shred** — where rulings mark only columns, find_tables snaps rows to printed lines, splitting every wrapped cell (the #416 mechanism, one path over).

## The fix

- **Both directions of the word test.** Every accepted grid is checked for tokens the page doesn't contain (fragment test, now on all strategies) *and* for page words the grid lost — `extract_loss_share`, a digit-aware per-cell containment test. Threshold 0.04 sits in the measured gap (intact grids 0.000–0.029, clipped ones 0.055–0.441).
- **Word-box rebuild on failure.** Cell text is rebuilt from the page's own word boxes via cell rects — whole words by construction. A rebuild below 90% of the extract's character mass is **discarded**: on rotated pages cell rects and word boxes don't share a coordinate frame, and an unguarded rebuild gutted three intact landscape tables to 0.00 in an early A/B round.
- **Row recovery with find_tables-specific guards.** The #416 continuation merge runs on the grid's row bboxes, with two guards this geometry demands (each from a traced regression): overlapping row boxes (row spans) disable the merge outright; and since find_tables row boxes *tile* — every gap exactly zero, the geometric rules inert — an anchor continuation only folds when its filled columns are a subset of those its row already fills, keeping two-tier headers (`# | Acc | # | Acc`) apart.
- Untouched tables stay byte-identical by construction; repaired ones get the gutter path's newline-join + hyphenation repair.

## Evidence (dev corpus, holdout untouched)

| | baseline (#418) | this PR |
|---|---|---|
| attainable tables below recall bar | 26 | **25** |
| table-block recall | 76.4% | **77.3%** |
| mean per-table text survival | 0.837 | **0.853** |
| tables ≥0.95 | 49 | **52** |
| lane precision | 94.8% | **94.9%** |
| lane novel share | 0.84% | **0.80%** |

Attainable recall (98.4%), duplication, and both controls unchanged. **No table regresses across the bar.** Four A/B rounds, every regression traced to mechanism before the next round; the two intermediate designs that failed (token-equality loss test, unguarded rebuild) are documented in the constants' comments.

Three below-bar tables sit under their baseline share while their *row structure improved* — the residual mechanism is find_tables drawing column boundaries through cell content (`Vitamin B | 12, μg`), which no word-presence test can see. Filed as #419 with a fix shape.

7 new unit tests; full suite green locally (6 durable known XFAILs only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)