### PR TITLE
ci(semgrep): triage the findings outside src/ and widen the scan to the repo root (#328)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -502,20 +502,15 @@ jobs:
           fi
           echo "control passed: the ruleset loads and the scanner can fail"
 
-      # Scoped to `src/`, which is the only thing the wheel ships. The first working run
-      # of this job reported 18 findings; 16 of them are in `tests/`, `benchmarks/` and
-      # `stubs/` -- e2e tests calling `urlopen` against their own localhost server, the
-      # benchmark corpus fetchers parsing digest-pinned XML, an MD5 in a fixture
-      # generator, and a type stub that never executes. None of that reaches a user, and
-      # blocking releases on it would train everyone to ignore this job.
+      # Scans `src/` (what the wheel ships) and `benchmarks/` (which fetches and parses
+      # third-party XML, so it is the one tree outside `src/` with untrusted input).
+      # `tests/` and `stubs/` are excluded in `.semgrepignore`, with the reasoning kept
+      # there next to the exclusion -- their findings are rule-shaped audit hits on code
+      # that never ships and never sees untrusted input (#328).
       #
-      # They are not swept under the rug: they are triaged in the follow-up issue linked
-      # from the PR, and `defusedxml` for the JATS parser is worth doing on its own merits.
-      # Widening this back to `.` is a deliberate decision to make, not a default to drift
-      # into.
-      #
-      # False positives inside `src/` are suppressed per-line with `# nosemgrep: <rule-id>`
-      # -- see `src/all2md/renderers/jinja.py:489`.
+      # False positives inside the scanned trees are suppressed per-line with
+      # `# nosemgrep: <rule-id>` -- see `src/all2md/renderers/jinja.py:489` and
+      # `benchmarks/pmc/corpus.py` (`_open_url`).
       - name: Run Semgrep
         run: |
           semgrep scan \
@@ -523,7 +518,7 @@ jobs:
             --config p/security-audit \
             --error \
             --metrics off \
-            src/
+            .
 
   security-bandit:
     name: Security Scan (Bandit)

--- a/.semgrepignore
+++ b/.semgrepignore
@@ -13,3 +13,16 @@ __pycache__/
 
 # Example files (not production code)
 examples/
+
+# Triaged out of the blocking scan (#328). The scan covers `src/` and `benchmarks/`;
+# these two trees are excluded here rather than suppressed per line because the
+# findings are rule-shaped, not site-shaped:
+#   - tests/: `urlopen` against the test's own localhost server (audit rule
+#     `dynamic-urllib-use-detected`, 9 sites), `xml.etree` parsing of fixture XML the
+#     test wrote itself, and an MD5 used as a content hash in a fixture generator.
+#     None of it ships and none of it sees untrusted input.
+#   - stubs/: type stubs never execute; the `xml.etree` import is an annotation.
+# Remove an entry here only by re-running the scan with it included and triaging
+# whatever it reports.
+tests/
+stubs/

--- a/benchmarks/pmc/corpus.py
+++ b/benchmarks/pmc/corpus.py
@@ -51,6 +51,7 @@ from uuid import uuid4
 # disclosure or memory exhaustion. `Element` is imported from the stdlib because
 # defusedxml does not re-export it -- it is the node type, not a parser, and
 # nothing here constructs one, it is only used in annotations.
+# nosemgrep: python.lang.security.use-defused-xml.use-defused-xml
 from xml.etree.ElementTree import Element
 
 from defusedxml import ElementTree
@@ -652,6 +653,9 @@ def _object_url(article_id: str, suffix: str) -> str:
 
 def _open_url(url: str, *, timeout: int = DEFAULT_TIMEOUT) -> Any:
     request = urllib.request.Request(url, headers={"User-Agent": USER_AGENT})
+    # The URL is always built from BUCKET_BASE, a fixed https host; the same judgement
+    # bandit accepts under S310, restated for semgrep's audit rule (#328).
+    # nosemgrep: python.lang.security.audit.dynamic-urllib-use-detected.dynamic-urllib-use-detected
     return urllib.request.urlopen(request, timeout=timeout)  # noqa: S310 - fixed https bucket
 
 

--- a/changelog.d/328-semgrep-triage.security.md
+++ b/changelog.d/328-semgrep-triage.security.md
@@ -1,0 +1,10 @@
+- **The Semgrep gate now scans `benchmarks/` as well as `src/`** (#328). The first
+  working run of the gate (#325) scoped it to `src/` and parked 16 findings outside
+  shipped code for triage. Triaged: the two benchmark corpus fetchers already parse
+  third-party XML through `defusedxml`; their one remaining `urlopen` against a fixed
+  https host and the annotation-only `xml.etree` import carry per-line suppressions
+  with the reasoning beside them. `tests/` and `stubs/` are excluded in
+  `.semgrepignore` -- the findings there are audit-rule hits on localhost test
+  servers, fixture XML and a content-hash MD5, none of which ships or sees untrusted
+  input -- with the exclusion documented next to the entry rather than as eleven
+  inline comments. The scan is widened to the repository root and verified clean.


### PR DESCRIPTION
Closes #328.

The three decisions from the issue, resolved:

1. **`defusedxml` for the benchmark XML fetchers** — already landed since the issue was filed; both `benchmarks/corpus/download.py` and `benchmarks/pmc/corpus.py` parse through `defusedxml` with the rationale in place. The one remaining stdlib import (`Element`, annotation-only, not re-exported by defusedxml) gets a per-line `nosemgrep` with the full rule id.
2. **Suppression style** — `tests/` and `stubs/` excluded in `.semgrepignore` with the reasoning kept next to the entry; the findings there are rule-shaped (localhost `urlopen` in e2e tests, fixture XML, a content-hash MD5, a type stub), not site-shaped, so eleven inline comments would be noise.
3. **`benchmarks/pmc/corpus.py` `urlopen`** — `nosemgrep` beside the existing bandit `noqa: S310`, same judgement under a second tool.

With those in place the scan is widened from `src/` to `.`, so `benchmarks/` — the only tree outside `src/` that fetches and parses third-party input — is actually scanned. Verified locally with the CI-pinned `semgrep==1.145.0` on the same rulesets: **0 findings, exit 0** over the repository root.

🤖 Generated with [Claude Code](https://claude.com/claude-code)