### PR TITLE
fix(pdf): dissolve column boundaries drawn through cell content, heal cut values in place (#419)

### DIFF
--- a/src/all2md/parsers/_pdf_tables.py
+++ b/src/all2md/parsers/_pdf_tables.py
@@ -43,6 +43,9 @@ __all__ = [
     "looks_like_numbered_bibliography",
     "merge_continuation_lines",
     "page_has_table_signals",
+    "MIN_COLUMN_CUT_ROWS",
+    "boundaries_to_dissolve",
+    "contradicted_column_boundaries",
     "rebuild_cells_from_words",
     "split_word_ratio",
     "word_gutter_grid",
@@ -227,6 +230,44 @@ MAX_EXTRACT_LOSS_SHARE = 0.04
 # grid died at the mostly-empty guard, and three intact tables were destroyed outright.
 MIN_REBUILD_CHAR_RATIO = 0.9
 
+# A grid column boundary is *contradicted* when the page prints a word straddling it on a
+# row whose cells really do abut there -- the grid claims two cells where the page wrote
+# one word ("Vitamin B12," cut into "Vitamin B" | "12,"). Both existing text guards are
+# blind to this by design: the fragment tokenizer drops digits, so "B12," reduces to "b"
+# and passes, and nothing is *lost* -- every character lands in one cell or the other.
+# The word boxes are the evidence, exactly as in the gutter path and the rebuild above.
+#
+# A word crossing an x-position where that row's cell *spans* is no contradiction: a
+# two-tier header ("Intraobserver variability" over three columns) legitimately crosses
+# the boundaries beneath it, and find_tables() records the span by omitting the edge on
+# that row. Counting only edge-bearing rows separates the two cases cleanly -- measured
+# on the PMC dev corpus, spanning headers show 0 contradicted rows while mis-split
+# columns show 2, 3, and 15+ -- and the threshold sits in that gap. A single
+# contradicted row is left alone: observed only on degenerate one-row detections, where
+# demotion to a paragraph already handles it.
+MIN_COLUMN_CUT_ROWS = 2
+
+# A word must extend at least this far beyond both sides of a boundary before it counts
+# as cut, so glyph-box slop against a real boundary is not read as a contradiction.
+COLUMN_CUT_MARGIN_PT = 1.0
+
+# Two x-positions within this distance are the same column edge (find_tables() emits
+# cell rects whose shared edges agree to well under a point).
+COLUMN_EDGE_TOLERANCE_PT = 0.5
+
+# A contradicted boundary names the damage, not the repair. Two shapes produce cut
+# words, and they need opposite treatment. A *spurious* boundary splits one printed
+# column in two ("Vitamin A, | μg"): away from the rows whose words it cut, the text
+# still runs straight across it -- the space between the words on either side is an
+# ordinary inter-word space. A *real* boundary with a wide value overhanging it
+# ("<0.001" protruding into the neighbour) lives where every column boundary lives:
+# in a gutter, with clear air on both sides on every row it does not cut. So the
+# arbiter is the same physical quantity the word-gutter path is built on -- the
+# median horizontal gap across the boundary on uncut rows, against
+# MIN_GUTTER_WIDTH_PT. Dissolve when the gap is a space; keep when it is a gutter,
+# because the word-box rebuild already lands an overhanging value whole in the cell
+# holding its center, and dissolving there would fuse two true columns.
+
 
 def split_word_ratio(page: "pymupdf.Page", table_data: list[list[str | None]]) -> float:
     """Share of a grid's word tokens that are not whole words of the page.
@@ -331,7 +372,216 @@ def extract_loss_share(
     return lost / total if total else 0.0
 
 
-def rebuild_cells_from_words(page: "pymupdf.Page", table: object) -> list[list[str]] | None:
+def _dissolve_cell_edges(
+    cells: "list[tuple[float, float, float, float] | None]", boundaries: list[float]
+) -> "list[tuple[float, float, float, float] | None]":
+    """Union a row's adjacent cell rects wherever they abut at a dissolved boundary."""
+    out: list[tuple[float, float, float, float] | None] = []
+    for cell in cells:
+        rect = None if cell is None else tuple(cell[:4])
+        previous = out[-1] if out else None
+        if (
+            rect is not None
+            and previous is not None
+            and any(
+                abs(previous[2] - boundary) <= COLUMN_EDGE_TOLERANCE_PT
+                and abs(rect[0] - boundary) <= COLUMN_EDGE_TOLERANCE_PT
+                for boundary in boundaries
+            )
+        ):
+            out[-1] = (previous[0], min(previous[1], rect[1]), rect[2], max(previous[3], rect[3]))
+        else:
+            out.append(rect)  # type: ignore[arg-type]
+    return out
+
+
+def contradicted_column_boundaries(
+    page: "pymupdf.Page", table: object, table_data: "list[list[str | None]] | None" = None
+) -> list[tuple[float, tuple[int, ...]]]:
+    """Interior column boundaries the page's own words contradict.
+
+    For every interior x-edge of a ``find_tables()`` grid, count the rows where the
+    grid draws the edge -- both neighbouring cells abut at it -- while the page prints
+    a word straddling it. Rows whose cell spans across the position (merged headers)
+    do not count, and neither do words that merely graze the edge; see
+    ``MIN_COLUMN_CUT_ROWS`` for the measured gap the threshold sits in.
+
+    Parameters
+    ----------
+    page : pymupdf.Page
+        Page the table was found on.
+    table : PyMuPDF Table
+        Table object from ``find_tables()`` whose ``rows[].cells`` rects define the
+        grid.
+    table_data : list of list of str or None, optional
+        The grid ``table.extract()`` returned. When given, a crossing word that one of
+        the two adjacent cells already holds **whole** does not count: the damage this
+        detector exists to find is ``extract()`` cutting a word across the boundary,
+        and a wide value merely overhanging its correct column ("<0.001" protruding
+        into the neighbour on two rows of an otherwise-aligned grid, measured on the
+        PMC dev corpus) arrives intact in its own cell.
+
+    Returns
+    -------
+    list of tuple of (float, tuple of int)
+        The contradicted boundary x-positions, ascending, each with the indices of
+        the rows whose words it cuts -- ``boundaries_to_dissolve`` reads the fill
+        pattern *away* from those rows. Empty when the grid's columns fall between
+        the page's words, or when the table exposes no usable cell geometry.
+
+    """
+    import pymupdf
+
+    try:
+        rows = list(table.rows)  # type: ignore[attr-defined]
+        bbox = pymupdf.Rect(table.bbox)  # type: ignore[attr-defined]
+        words = [word for word in page.get_text("words") if pymupdf.Rect(word[:4]).intersects(bbox)]
+    except Exception:
+        return []
+    if not rows or not words:
+        return []
+
+    row_cells: list[list[tuple[float, float, float, float]]] = []
+    row_tokens: list[list[tuple[tuple[float, float, float, float], set[str]]]] = []
+    edges: set[float] = set()
+    for row_index, row in enumerate(rows):
+        raw_cells = list(getattr(row, "cells", None) or [])
+        cells = [cell[:4] for cell in raw_cells if cell is not None]
+        row_cells.append(cells)
+        extracted_row = table_data[row_index] if table_data is not None and row_index < len(table_data) else []
+        cell_tokens: list[tuple[tuple[float, float, float, float], set[str]]] = []
+        for cell_index, cell in enumerate(raw_cells):
+            if cell is None:
+                continue
+            text = extracted_row[cell_index] if cell_index < len(extracted_row) else None
+            cell_tokens.append((cell[:4], set(str(text).split()) if text else set()))
+        row_tokens.append(cell_tokens)
+        xs = sorted({cell[0] for cell in cells} | {cell[2] for cell in cells})
+        edges.update(xs[1:-1])
+
+    def same_edge(a: float, b: float) -> bool:
+        return abs(a - b) <= COLUMN_EDGE_TOLERANCE_PT
+
+    contradicted: list[tuple[float, tuple[int, ...]]] = []
+    for boundary in sorted(edges):
+        if any(same_edge(boundary, seen) for seen, _rows in contradicted):
+            continue
+        cut_rows: list[int] = []
+        for row_index, (cells, cell_tokens) in enumerate(zip(row_cells, row_tokens, strict=True)):
+            if not cells:
+                continue
+            # The row bears this edge only if a cell ends (or the next begins) there;
+            # a spanning cell omits it, and its words may cross freely.
+            bears = any(same_edge(cell[2], boundary) for cell in cells[:-1]) or any(
+                same_edge(cell[0], boundary) for cell in cells[1:]
+            )
+            if not bears:
+                continue
+            # Tokens the two cells meeting at this boundary hold: a crossing word
+            # either delivered whole was not cut by it.
+            adjacent: set[str] = set()
+            for rect, tokens in cell_tokens:
+                if same_edge(rect[2], boundary) or same_edge(rect[0], boundary):
+                    adjacent |= tokens
+            top = min(cell[1] for cell in cells)
+            bottom = max(cell[3] for cell in cells)
+            for word in words:
+                if not (word[0] + COLUMN_CUT_MARGIN_PT < boundary < word[2] - COLUMN_CUT_MARGIN_PT):
+                    continue
+                center_y = (word[1] + word[3]) / 2
+                if top <= center_y < bottom and str(word[4]) not in adjacent:
+                    cut_rows.append(row_index)
+                    break
+        if len(cut_rows) >= MIN_COLUMN_CUT_ROWS:
+            contradicted.append((boundary, tuple(cut_rows)))
+    return contradicted
+
+
+def boundaries_to_dissolve(
+    page: "pymupdf.Page", table: object, boundaries: list[tuple[float, tuple[int, ...]]]
+) -> list[float]:
+    """Select the contradicted boundaries that split one column rather than two.
+
+    For each boundary, measure the horizontal gap between the nearest word ending
+    left of it and the nearest word starting right of it, within the pair's own cell
+    rects, on every row the boundary did not cut. A spurious boundary runs through a
+    line of text, so those gaps are ordinary inter-word spaces; a real boundary sits
+    in a column gutter. The median gap decides, against the same
+    ``MIN_GUTTER_WIDTH_PT`` the word-gutter path trusts. A boundary with no
+    measurable uncut row -- every row it bears either has its words cut or is blank
+    on one side -- runs through printed content wherever it is tested, which is the
+    spurious shape.
+
+    Parameters
+    ----------
+    page : pymupdf.Page
+        Page the table was found on.
+    table : PyMuPDF Table
+        Table object whose ``rows[].cells`` rects define the grid.
+    boundaries : list of tuple of (float, tuple of int)
+        Contradicted boundaries from ``contradicted_column_boundaries``: each an
+        x-position with the indices of the rows whose words it cuts.
+
+    Returns
+    -------
+    list of float
+        The boundary x-positions whose crossings are spaces, not gutters --
+        dissolving them merges the two halves of one printed column back together.
+
+    """
+    import pymupdf
+
+    try:
+        rows = list(table.rows)  # type: ignore[attr-defined]
+        bbox = pymupdf.Rect(table.bbox)  # type: ignore[attr-defined]
+        words = [word for word in page.get_text("words") if pymupdf.Rect(word[:4]).intersects(bbox)]
+    except Exception:
+        return []
+    dissolve: list[float] = []
+    for boundary, cut_row_indices in boundaries:
+        cut = set(cut_row_indices)
+        gaps: list[float] = []
+        for row_index, row in enumerate(rows):
+            if row_index in cut:
+                continue
+            cells = list(getattr(row, "cells", None) or [])
+            left = right = None
+            for cell in cells:
+                if cell is None:
+                    continue
+                if abs(cell[2] - boundary) <= COLUMN_EDGE_TOLERANCE_PT:
+                    left = cell
+                elif abs(cell[0] - boundary) <= COLUMN_EDGE_TOLERANCE_PT:
+                    right = cell
+            if left is None or right is None:
+                continue
+            top = min(left[1], right[1])
+            bottom = max(left[3], right[3])
+            nearest_end: float | None = None
+            nearest_start: float | None = None
+            for word in words:
+                center_y = (word[1] + word[3]) / 2
+                if not top <= center_y < bottom:
+                    continue
+                if word[2] <= boundary + COLUMN_CUT_MARGIN_PT and word[0] >= left[0] - COLUMN_EDGE_TOLERANCE_PT:
+                    nearest_end = word[2] if nearest_end is None else max(nearest_end, word[2])
+                elif word[0] >= boundary - COLUMN_CUT_MARGIN_PT and word[2] <= right[2] + COLUMN_EDGE_TOLERANCE_PT:
+                    nearest_start = word[0] if nearest_start is None else min(nearest_start, word[0])
+            if nearest_end is not None and nearest_start is not None:
+                gaps.append(nearest_start - nearest_end)
+        if not gaps:
+            dissolve.append(boundary)
+            continue
+        gaps.sort()
+        median = gaps[len(gaps) // 2]
+        if median < MIN_GUTTER_WIDTH_PT:
+            dissolve.append(boundary)
+    return dissolve
+
+
+def rebuild_cells_from_words(
+    page: "pymupdf.Page", table: object, dissolve_boundaries: list[float] | None = None
+) -> list[list[str]] | None:
     """Rebuild a ``find_tables()`` grid's cell text from the page's own word boxes.
 
     ``Table.extract()`` assembles cell text from the characters its cell rects clip,
@@ -353,6 +603,12 @@ def rebuild_cells_from_words(page: "pymupdf.Page", table: object) -> list[list[s
     table : PyMuPDF Table
         Table object from ``find_tables()`` whose ``rows[].cells`` rects define the
         grid.
+    dissolve_boundaries : list of float, optional
+        Contradicted column boundaries (from ``contradicted_column_boundaries``) to
+        dissolve while rebuilding: each row's cells abutting at one of these
+        x-positions are unioned into a single cell before words are assigned, so a
+        word the boundary cut lands whole in the reunited cell. Rows whose cells
+        span across the position are unaffected.
 
     Returns
     -------
@@ -374,6 +630,8 @@ def rebuild_cells_from_words(page: "pymupdf.Page", table: object) -> list[list[s
         cells = getattr(row, "cells", None)
         if not cells:
             return None
+        if dissolve_boundaries:
+            cells = _dissolve_cell_edges(cells, dissolve_boundaries)
         row_texts: list[str] = []
         for cell in cells:
             if cell is None:

--- a/src/all2md/parsers/_pdf_tables.py
+++ b/src/all2md/parsers/_pdf_tables.py
@@ -44,6 +44,7 @@ __all__ = [
     "merge_continuation_lines",
     "page_has_table_signals",
     "MIN_COLUMN_CUT_ROWS",
+    "adjacent_clipped_column",
     "bbox_clipped_rows",
     "boundaries_to_dissolve",
     "contradicted_column_boundaries",
@@ -255,6 +256,22 @@ COLUMN_CUT_MARGIN_PT = 1.0
 # Two x-positions within this distance are the same column edge (find_tables() emits
 # cell rects whose shared edges agree to well under a point).
 COLUMN_EDGE_TOLERANCE_PT = 0.5
+
+# find_tables() can also draw its bbox short of a whole column: on the PMC dev corpus
+# a four-column table was detected as three, with the fourth ("3rd trimester ...")
+# printed just outside the bbox. The evidence that a band of outside words is the
+# table's own clipped column and not a neighbour: it sits a column gutter away, not a
+# page-layout gutter (measured 3.0-4.7pt against 13.7+ for prose neighbours and
+# captions); its words line up with essentially every grid row (measured full
+# coverage against <=0.73 for prose and <=0.45 for captions); and nothing continues
+# beyond it (measured 0-1 further words against 62+ where a prose column runs on, and
+# 100+ where a second table sits alongside -- both of which must not be swallowed).
+# Each threshold sits inside its measured gap.
+MAX_ADJACENT_COLUMN_GAP_PT = 8.0
+MIN_ADJACENT_COLUMN_ROW_COVERAGE = 0.8
+MAX_ADJACENT_COLUMN_FAR_WORDS = 2
+ADJACENT_COLUMN_SEARCH_PT = 40.0
+ADJACENT_COLUMN_FAR_SEARCH_PT = 150.0
 
 # A contradicted boundary names the damage, not the repair. Two shapes produce cut
 # words, and they need opposite treatment. A *spurious* boundary splits one printed
@@ -496,6 +513,93 @@ def contradicted_column_boundaries(
         if len(cut_rows) >= MIN_COLUMN_CUT_ROWS:
             contradicted.append((boundary, tuple(cut_rows)))
     return contradicted
+
+
+def adjacent_clipped_column(page: "pymupdf.Page", table: object) -> "tuple[pymupdf.Rect, str] | None":
+    """Find a whole column of the table printed just outside its bbox.
+
+    Scans the bbox's vertical band on each side for words the bbox excluded, and
+    admits them as the table's own clipped column only on three measured signals
+    together: they sit a column gutter away (not a page-layout gutter), they align
+    with essentially every grid row, and nothing continues beyond them. See the
+    constants above for the measured gaps; prose neighbours, captions, and
+    side-by-side tables each fail at least one.
+
+    Parameters
+    ----------
+    page : pymupdf.Page
+        Page the table was found on.
+    table : PyMuPDF Table
+        Table object from ``find_tables()`` whose ``rows[].cells`` rects define the
+        grid.
+
+    Returns
+    -------
+    tuple of (pymupdf.Rect, str) or None
+        The rectangle holding the clipped column's words and which side of the
+        table it sits on (``"left"`` or ``"right"``), or ``None`` when no side
+        qualifies.
+
+    """
+    import pymupdf
+
+    try:
+        rows = list(table.rows)  # type: ignore[attr-defined]
+        bbox = pymupdf.Rect(table.bbox)  # type: ignore[attr-defined]
+        words = page.get_text("words")
+    except Exception:
+        return None
+    row_bands = []
+    for row in rows:
+        cells = [cell[:4] for cell in (getattr(row, "cells", None) or []) if cell is not None]
+        if cells:
+            row_bands.append((min(cell[1] for cell in cells), max(cell[3] for cell in cells)))
+    if not row_bands:
+        return None
+
+    for side in ("right", "left"):
+        near = []
+        n_far = 0
+        for word in words:
+            center_y = (word[1] + word[3]) / 2
+            if not (bbox.y0 - 2 <= center_y <= bbox.y1 + 2):
+                continue
+            rect = pymupdf.Rect(word[:4])
+            if rect.intersects(bbox):
+                continue
+            if side == "right" and word[0] >= bbox.x1:
+                gap = word[0] - bbox.x1
+            elif side == "left" and word[2] <= bbox.x0:
+                gap = bbox.x0 - word[2]
+            else:
+                continue
+            if gap <= ADJACENT_COLUMN_SEARCH_PT:
+                near.append((word, gap))
+            elif gap <= ADJACENT_COLUMN_FAR_SEARCH_PT:
+                n_far += 1
+        if not near:
+            continue
+        if min(gap for _word, gap in near) > MAX_ADJACENT_COLUMN_GAP_PT:
+            continue
+        if n_far > MAX_ADJACENT_COLUMN_FAR_WORDS:
+            continue
+        covered = set()
+        for word, _gap in near:
+            center_y = (word[1] + word[3]) / 2
+            for index, (top, bottom) in enumerate(row_bands):
+                if top <= center_y <= bottom:
+                    covered.add(index)
+                    break
+        if len(covered) / len(row_bands) < MIN_ADJACENT_COLUMN_ROW_COVERAGE:
+            continue
+        rect = pymupdf.Rect(
+            min(word[0] for word, _gap in near),
+            min(word[1] for word, _gap in near),
+            max(word[2] for word, _gap in near),
+            max(word[3] for word, _gap in near),
+        )
+        return rect, side
+    return None
 
 
 def bbox_clipped_rows(page: "pymupdf.Page", table: object) -> int:

--- a/src/all2md/parsers/_pdf_tables.py
+++ b/src/all2md/parsers/_pdf_tables.py
@@ -44,6 +44,7 @@ __all__ = [
     "merge_continuation_lines",
     "page_has_table_signals",
     "MIN_COLUMN_CUT_ROWS",
+    "bbox_clipped_rows",
     "boundaries_to_dissolve",
     "contradicted_column_boundaries",
     "rebuild_cells_from_words",
@@ -497,6 +498,58 @@ def contradicted_column_boundaries(
     return contradicted
 
 
+def bbox_clipped_rows(page: "pymupdf.Page", table: object) -> int:
+    """Count the rows whose words the table's own outer edge cuts through.
+
+    ``find_tables()`` sometimes draws its bbox through the middle of the last
+    column's values ("0.454 \u00b1 0.024" clipped to "4 \u00b1 0"): the word begins inside
+    the row's outer cell but extends past the table edge. ``extract_loss_share``
+    cannot see it -- the word's center lies outside the bbox, so it is not counted
+    against the grid -- and no interior boundary is contradicted. The rebuild's
+    outer-cell rule heals exactly these words, so rows carrying them are the
+    trigger for it.
+
+    Parameters
+    ----------
+    page : pymupdf.Page
+        Page the table was found on.
+    table : PyMuPDF Table
+        Table object from ``find_tables()`` whose ``rows[].cells`` rects define the
+        grid.
+
+    Returns
+    -------
+    int
+        Rows where a word begins inside the row's outermost cell and extends more
+        than ``COLUMN_CUT_MARGIN_PT`` beyond it.
+
+    """
+    try:
+        rows = list(table.rows)  # type: ignore[attr-defined]
+        words = page.get_text("words")
+    except Exception:
+        return 0
+    clipped = 0
+    for row in rows:
+        cells = [cell[:4] for cell in (getattr(row, "cells", None) or []) if cell is not None]
+        if not cells:
+            continue
+        first = cells[0]
+        last = cells[-1]
+        top = min(cell[1] for cell in cells)
+        bottom = max(cell[3] for cell in cells)
+        for word in words:
+            center_y = (word[1] + word[3]) / 2
+            if not top <= center_y < bottom:
+                continue
+            cut_right = word[0] < last[2] and word[0] >= last[0] and word[2] > last[2] + COLUMN_CUT_MARGIN_PT
+            cut_left = word[2] > first[0] and word[2] <= first[2] and word[0] < first[0] - COLUMN_CUT_MARGIN_PT
+            if cut_right or cut_left:
+                clipped += 1
+                break
+    return clipped
+
+
 def boundaries_to_dissolve(
     page: "pymupdf.Page", table: object, boundaries: list[tuple[float, tuple[int, ...]]]
 ) -> list[float]:
@@ -632,8 +685,11 @@ def rebuild_cells_from_words(
             return None
         if dissolve_boundaries:
             cells = _dissolve_cell_edges(cells, dissolve_boundaries)
+        filled = [index for index, cell in enumerate(cells) if cell is not None]
+        first_filled = filled[0] if filled else -1
+        last_filled = filled[-1] if filled else -1
         row_texts: list[str] = []
-        for cell in cells:
+        for cell_index, cell in enumerate(cells):
             if cell is None:
                 row_texts.append("")
                 continue
@@ -642,9 +698,21 @@ def rebuild_cells_from_words(
             for word in words:
                 center_x = (word[0] + word[2]) / 2
                 center_y = (word[1] + word[3]) / 2
+                if not y0 <= center_y < y1:
+                    continue
                 # Half-open on the far edges so a word centered exactly on a shared
                 # boundary lands in exactly one of the two cells meeting there.
-                if x0 <= center_x < x1 and y0 <= center_y < y1:
+                inside = x0 <= center_x < x1
+                # A word that *begins* inside the row's outer cell belongs to it even
+                # when its center leaks past the table edge: find_tables() draws its
+                # bbox through the middle of such words ("0.454" clipped to "4" by
+                # extract()), and the center rule alone would drop them into no cell
+                # at all. Interior boundaries are untouched -- there the neighbouring
+                # cell owns the center by the same rule.
+                leaked = (cell_index == last_filled and center_x >= x1 and word[0] < x1) or (
+                    cell_index == first_filled and center_x < x0 and word[2] > x0
+                )
+                if inside or leaked:
                     lines.setdefault((word[5], word[6]), []).append(str(word[4]))
             row_texts.append("\n".join(" ".join(parts) for _key, parts in sorted(lines.items())))
         rebuilt.append(row_texts)

--- a/src/all2md/parsers/pdf.py
+++ b/src/all2md/parsers/pdf.py
@@ -106,6 +106,7 @@ from all2md.parsers._pdf_tables import (
     MIN_TABLE_COLS,
     MIN_TABLE_ROWS,
     TABLE_REGION_STRATEGIES,
+    adjacent_clipped_column,
     bbox_clipped_rows,
     boundaries_to_dissolve,
     contradicted_column_boundaries,
@@ -1587,7 +1588,18 @@ class PdfToAstConverter(BaseParser):
                 # causing t.bbox to fail with "min() iterable argument is empty".
                 # Skip these empty tables.
                 continue
-            table_info.append({"bbox": bbox, "idx": i, "type": "pymupdf", "table_obj": t})
+            # A whole column of the table can be printed just outside the detected
+            # bbox (#419). Admitting it must happen here, not at emission time: the
+            # recorded bbox is what excludes the region's text from the ordinary
+            # blocks, so a column admitted later would be emitted twice -- once in
+            # the table and once as a paragraph beside it.
+            clipped = adjacent_clipped_column(page, t)
+            entry = {"bbox": bbox, "idx": i, "type": "pymupdf", "table_obj": t}
+            if clipped is not None:
+                extension_rect, side = clipped
+                entry["bbox"] = bbox | extension_rect
+                entry["clip_extension"] = (extension_rect, side)
+            table_info.append(entry)
         for i, rect in enumerate(fallback_table_rects):
             table_info.append({"bbox": rect, "idx": i, "type": "fallback", "lines": fallback_table_lines[i]})
 
@@ -1891,7 +1903,9 @@ class PdfToAstConverter(BaseParser):
 
         """
         if item_data["type"] == "pymupdf":
-            return self._process_table_to_ast(item_data["table_obj"], page, page_num)
+            return self._process_table_to_ast(
+                item_data["table_obj"], page, page_num, clip_extension=item_data.get("clip_extension")
+            )
         elif item_data["type"] == "fallback":
             h_lines, v_lines = item_data["lines"]
             return self._extract_table_from_ruling_rect(page, item_data["bbox"], h_lines, v_lines, page_num)
@@ -3128,7 +3142,13 @@ class PdfToAstConverter(BaseParser):
             return None
         return extents
 
-    def _process_table_to_ast(self, table: Any, page: "pymupdf.Page", page_num: int) -> Node | None:
+    def _process_table_to_ast(
+        self,
+        table: Any,
+        page: "pymupdf.Page",
+        page_num: int,
+        clip_extension: "tuple[pymupdf.Rect, str] | None" = None,
+    ) -> Node | None:
         """Process a PyMuPDF table to AST Table node.
 
         Directly accesses table cell data from PyMuPDF table object instead of
@@ -3143,6 +3163,11 @@ class PdfToAstConverter(BaseParser):
             detection is rejected as a degenerate grid.
         page_num : int
             Page number for source tracking
+        clip_extension : tuple of (pymupdf.Rect, str), optional
+            A clipped column admitted at detection time (see
+            ``adjacent_clipped_column``): the rectangle holding its words and the
+            side of the table it sits on. Its words join the grid as one more cell
+            per row.
 
         Returns
         -------
@@ -3217,6 +3242,36 @@ class PdfToAstConverter(BaseParser):
                         f"{len(cut_boundaries)} column boundaries contradicted by word boxes"
                     )
                     table_data = rebuilt
+                    repaired = True
+
+            # A clipped column admitted at detection time joins the grid here: its
+            # words, grouped by the grid's own row bands, become one more cell per
+            # row on the side the bbox cut it from. The bbox recorded in table_info
+            # already covers the region, so the text appears nowhere else.
+            if clip_extension is not None:
+                extension_rect, side = clip_extension
+                extension_words = [
+                    word for word in page.get_text("words") if pymupdf.Rect(word[:4]).intersects(extension_rect)
+                ]
+                extension_cells: list[str] = []
+                for row in getattr(table, "rows", []) or []:
+                    row_cells = [cell[:4] for cell in (getattr(row, "cells", None) or []) if cell is not None]
+                    if not row_cells:
+                        extension_cells.append("")
+                        continue
+                    top = min(cell[1] for cell in row_cells)
+                    bottom = max(cell[3] for cell in row_cells)
+                    lines: dict[tuple[int, int], list[str]] = {}
+                    for word in extension_words:
+                        center_y = (word[1] + word[3]) / 2
+                        if top <= center_y <= bottom:
+                            lines.setdefault((word[5], word[6]), []).append(str(word[4]))
+                    extension_cells.append("\n".join(" ".join(parts) for _key, parts in sorted(lines.items())))
+                if len(extension_cells) == len(table_data) and any(cell.strip() for cell in extension_cells):
+                    table_data = [
+                        [*row, cell] if side == "right" else [cell, *row]
+                        for row, cell in zip(table_data, extension_cells, strict=True)
+                    ]
                     repaired = True
 
             # Reject pathological detections (PyMuPDF's find_tables() can fire on

--- a/src/all2md/parsers/pdf.py
+++ b/src/all2md/parsers/pdf.py
@@ -105,6 +105,8 @@ from all2md.parsers._pdf_tables import (
     MIN_TABLE_COLS,
     MIN_TABLE_ROWS,
     TABLE_REGION_STRATEGIES,
+    boundaries_to_dissolve,
+    contradicted_column_boundaries,
     detect_tables_by_ruling_lines,
     extract_loss_share,
     is_dot_leader_cell,
@@ -3172,8 +3174,23 @@ class PdfToAstConverter(BaseParser):
             repaired = False
             fragments = split_word_ratio(page, table_data)
             lost = extract_loss_share(page, table_data, table.bbox)
-            if fragments > MAX_SPLIT_WORD_RATIO or lost > MAX_EXTRACT_LOSS_SHARE:
-                rebuilt = rebuild_cells_from_words(page, table)
+            # A third failure mode is invisible to both guards above (#419): a column
+            # boundary drawn *through* cell content splits "Vitamin B12," into
+            # "Vitamin B" | "12," -- no word is lost, and the fragment tokenizer is
+            # digit-blind by design. The page's word boxes are the evidence again: a
+            # boundary the grid draws on a row while the page prints a word across it
+            # is contradicted. Spanning header cells omit the edge on their row and
+            # are left untouched -- see MIN_COLUMN_CUT_ROWS for the measured gap.
+            cut_boundaries = contradicted_column_boundaries(page, table, table_data)
+            if fragments > MAX_SPLIT_WORD_RATIO or lost > MAX_EXTRACT_LOSS_SHARE or cut_boundaries:
+                # Rebuilding fixes the *text* either way -- a cut word lands whole in
+                # the cell holding its center. Whether the boundary itself should go
+                # depends on which shape cut it: dissolve the ones whose uncut rows
+                # read straight across them (one printed column split in two), and
+                # keep the real boundaries wide values merely overhang. See
+                # boundaries_to_dissolve for the gutter-width arbiter.
+                dissolve = boundaries_to_dissolve(page, table, cut_boundaries) if cut_boundaries else []
+                rebuilt = rebuild_cells_from_words(page, table, dissolve_boundaries=dissolve or None)
                 # The rebuild must come back at least as heavy as what it replaces:
                 # on rotated pages the cell rects and word boxes do not share a
                 # coordinate frame, and a rebuild that misses the words would gut
@@ -3184,7 +3201,8 @@ class PdfToAstConverter(BaseParser):
                     logger.debug(
                         f"Rebuilt table cell text from word boxes on page {page_num + 1}: "
                         f"{fragments:.0%} of extracted tokens were fragments, "
-                        f"{lost:.0%} of the region's words were missing from the grid"
+                        f"{lost:.0%} of the region's words were missing from the grid, "
+                        f"{len(cut_boundaries)} column boundaries contradicted by word boxes"
                     )
                     table_data = rebuilt
                     repaired = True

--- a/src/all2md/parsers/pdf.py
+++ b/src/all2md/parsers/pdf.py
@@ -100,11 +100,13 @@ from all2md.parsers._pdf_tables import (
     MAX_TABLE_EMPTY_RATIO,
     MAX_TABLE_ROWS,
     MAX_TWO_COLUMN_REGION_DRAWINGS,
+    MIN_COLUMN_CUT_ROWS,
     MIN_FILLED_FOR_UNIFORMITY_CHECK,
     MIN_REBUILD_CHAR_RATIO,
     MIN_TABLE_COLS,
     MIN_TABLE_ROWS,
     TABLE_REGION_STRATEGIES,
+    bbox_clipped_rows,
     boundaries_to_dissolve,
     contradicted_column_boundaries,
     detect_tables_by_ruling_lines,
@@ -3182,7 +3184,17 @@ class PdfToAstConverter(BaseParser):
             # is contradicted. Spanning header cells omit the edge on their row and
             # are left untouched -- see MIN_COLUMN_CUT_ROWS for the measured gap.
             cut_boundaries = contradicted_column_boundaries(page, table, table_data)
-            if fragments > MAX_SPLIT_WORD_RATIO or lost > MAX_EXTRACT_LOSS_SHARE or cut_boundaries:
+            # The bbox's own outer edge can cut words the same way ("0.454 \u00b1 0.024"
+            # extracted as "4 \u00b1 0"): extract_loss_share cannot see those words -- their
+            # centers lie outside the bbox -- so rows carrying them are their own
+            # trigger, and the rebuild's outer-cell rule heals them in place.
+            clipped_rows = bbox_clipped_rows(page, table) if not cut_boundaries else 0
+            if (
+                fragments > MAX_SPLIT_WORD_RATIO
+                or lost > MAX_EXTRACT_LOSS_SHARE
+                or cut_boundaries
+                or clipped_rows >= MIN_COLUMN_CUT_ROWS
+            ):
                 # Rebuilding fixes the *text* either way -- a cut word lands whole in
                 # the cell holding its center. Whether the boundary itself should go
                 # depends on which shape cut it: dissolve the ones whose uncut rows

--- a/tests/unit/formats/pdf/test_pdf_find_tables_repair.py
+++ b/tests/unit/formats/pdf/test_pdf_find_tables_repair.py
@@ -494,3 +494,33 @@ def test_a_cut_value_in_a_real_gutter_keeps_the_boundary_and_heals_the_word():
         ["Attitude", "<0.001"],
         ["Practice", "0.20"],
     ]
+
+
+def test_a_word_clipped_by_the_table_bbox_joins_the_outer_cell():
+    """A word beginning inside the last cell survives even when its center leaks past the edge (#419).
+
+    find_tables() drew its bbox through the middle of "0.024": extract() clipped it
+    to "0", and the center-assignment rule alone would have dropped the word into no
+    cell at all. Beginning inside the outer cell is the evidence that it belongs
+    there.
+    """
+    extents = [(0.0, 10.0), (14.0, 24.0), (28.0, 38.0)]
+    page = _FakePage(
+        [
+            _word(2, 0, "Method", 0),
+            _word(62, 0, "mAP", 0),
+            _word(2, 14, "Image", 1),
+            # 6pt/char * 5 chars from x=86: box 86..116 -- starts inside the last
+            # cell (ends at x=90) but its center (101) leaks past the table edge.
+            _word(86, 14, "0.024", 1),
+            _word(2, 28, "Video", 2),
+            _word(86, 28, "0.090", 2),
+        ]
+    )
+    # extract() kept only what its cell rects clip.
+    grid = [["Method", "mAP"], ["Image", "0"], ["Video", "0"]]
+
+    node = PdfToAstConverter()._process_table_to_ast(_FakeTable(grid, extents, [0.0, 60.0, 90.0]), page, 0)
+
+    assert isinstance(node, AstTable)
+    assert _cells(node) == [["Method", "mAP"], ["Image", "0.024"], ["Video", "0.090"]]

--- a/tests/unit/formats/pdf/test_pdf_find_tables_repair.py
+++ b/tests/unit/formats/pdf/test_pdf_find_tables_repair.py
@@ -524,3 +524,66 @@ def test_a_word_clipped_by_the_table_bbox_joins_the_outer_cell():
 
     assert isinstance(node, AstTable)
     assert _cells(node) == [["Method", "mAP"], ["Image", "0.024"], ["Video", "0.090"]]
+
+
+def test_a_whole_column_outside_the_bbox_is_detected_and_admitted():
+    """A column the bbox excluded entirely is found by its three signals and joins the grid (#419).
+
+    The words sit a column gutter away (5pt), align with every grid row, and nothing
+    continues beyond them -- a prose neighbour or caption fails at least one of the
+    three. Admitted through clip_extension, they become the last cell of every row.
+    """
+    from all2md.parsers._pdf_tables import adjacent_clipped_column
+
+    extents = [(0.0, 10.0), (14.0, 24.0), (28.0, 38.0)]
+    words = [
+        _word(2, 0, "Group", 0),
+        _word(62, 0, "Mean", 0),
+        _word(125, 0, "SD", 0),  # x=125..137: 5pt past the bbox edge at 120
+        _word(2, 14, "Control", 1),
+        _word(62, 14, "4.1", 1),
+        _word(125, 14, "0.7", 1),
+        _word(2, 28, "Treated", 2),
+        _word(62, 28, "5.9", 2),
+        _word(125, 28, "0.9", 2),
+    ]
+    page = _FakePage(words)
+    grid = [["Group", "Mean"], ["Control", "4.1"], ["Treated", "5.9"]]
+    table = _FakeTable(grid, extents, EDGES)
+
+    found = adjacent_clipped_column(page, table)
+    assert found is not None
+    rect, side = found
+    assert side == "right"
+
+    node = PdfToAstConverter()._process_table_to_ast(table, page, 0, clip_extension=(rect, side))
+    assert isinstance(node, AstTable)
+    assert _cells(node) == [
+        ["Group", "Mean", "SD"],
+        ["Control", "4.1", "0.7"],
+        ["Treated", "5.9", "0.9"],
+    ]
+
+
+def test_a_prose_neighbour_is_not_admitted_as_a_column():
+    """Words that keep going past the near band are a prose column, not a clipped one."""
+    from all2md.parsers._pdf_tables import adjacent_clipped_column
+
+    extents = [(0.0, 10.0), (14.0, 24.0), (28.0, 38.0)]
+    words = [
+        _word(2, 0, "Group", 0),
+        _word(62, 0, "Mean", 0),
+        _word(2, 14, "Control", 1),
+        _word(62, 14, "4.1", 1),
+        _word(2, 28, "Treated", 2),
+        _word(62, 28, "5.9", 2),
+    ]
+    # A neighbouring prose column: near words on every row, but text runs on far
+    # past them, which no clipped table column does.
+    for row, top in enumerate((0, 14, 28)):
+        for k in range(6):
+            words.append(_word(126 + 24 * k, top, "word", row))
+    page = _FakePage(words)
+    grid = [["Group", "Mean"], ["Control", "4.1"], ["Treated", "5.9"]]
+
+    assert adjacent_clipped_column(page, _FakeTable(grid, extents, EDGES)) is None

--- a/tests/unit/formats/pdf/test_pdf_find_tables_repair.py
+++ b/tests/unit/formats/pdf/test_pdf_find_tables_repair.py
@@ -299,3 +299,198 @@ def test_a_second_header_tier_with_an_empty_label_cell_stays_its_own_row():
         ["", "", "Acc", "", "Acc"],
         ["one", "1", "70", "2", "60"],
     ]
+
+
+def test_a_boundary_cutting_words_on_edge_bearing_rows_is_dissolved():
+    """A column boundary the page's words contradict on two rows merges its cell pair (#419).
+
+    The grid claims three columns, but the middle boundary at x=60 runs through
+    "B12," and "(B1)," on the two data rows -- the page wrote one word where the grid
+    drew two cells. Neither existing guard can see it: no character is lost, and the
+    fragment tokenizer is digit-blind. The rebuilt table reunites the pair.
+    """
+    extents = [(0.0, 10.0), (14.0, 24.0), (28.0, 38.0)]
+    page = _FakePage(
+        [
+            _word(2, 0, "Nutrient", 0),
+            _word(92, 0, "Amt", 0),
+            # "B12," spans x=32..56... make it straddle x=60: start at 44, 6pt/char * 4 = 44..68.
+            _word(2, 14, "Vitamin", 1),
+            _word(44, 14, "B12,", 1),
+            _word(92, 14, "2.8", 1),
+            _word(2, 28, "Thiamine", 2),
+            _word(50, 28, "(B1),", 2),
+            _word(92, 28, "800", 2),
+        ]
+    )
+    # extract() clipped the straddling words at the x=60 boundary.
+    grid = [
+        ["Nutrient", "", "Amt"],
+        ["Vitamin B1", "2,", "2.8"],
+        ["Thiamine (B", "1),", "800"],
+    ]
+
+    node = PdfToAstConverter()._process_table_to_ast(_FakeTable(grid, extents, [0.0, 60.0, 90.0, 120.0]), page, 0)
+
+    assert isinstance(node, AstTable)
+    assert _cells(node) == [
+        ["Nutrient", "Amt"],
+        ["Vitamin B12,", "2.8"],
+        ["Thiamine (B1),", "800"],
+    ]
+
+
+def test_words_crossing_under_a_spanning_header_do_not_dissolve_the_boundary():
+    """A two-tier header spanning two columns crosses their boundary legitimately.
+
+    The span row omits the edge, so its crossing words are no contradiction; the data
+    rows bear the edge and their words fall inside their cells. The grid keeps all
+    three columns and its extracted text verbatim.
+    """
+    top = _FakeRow(
+        (0.0, 0.0, 120.0, 10.0),
+        # First cell spans x=0..90 across the interior boundary at x=60.
+        [(0.0, 0.0, 90.0, 10.0), (90.0, 0.0, 120.0, 10.0)],
+    )
+    body_edges = [0.0, 60.0, 90.0, 120.0]
+    body_rows = []
+    grid = [
+        ["Interobserver variability", "p"],
+        ["mean", "sd", "0.05"],
+        ["1.2", "0.4", "0.01"],
+    ]
+    for (t, b), _row in zip([(14.0, 24.0), (28.0, 38.0)], grid[1:], strict=True):
+        cells = [(body_edges[i], t, body_edges[i + 1], b) for i in range(3)]
+        body_rows.append(_FakeRow((0.0, t, 120.0, b), cells))
+
+    class _SpanTable:
+        rows = [top, *body_rows]
+        bbox = (0.0, 0.0, 120.0, 38.0)
+
+        def extract(self):
+            return grid
+
+    page = _FakePage(
+        [
+            # Header words straddle x=60 -- inside the spanning cell.
+            _word(30, 0, "Interobserver", 0),
+            _word(56, 0, "variability", 0),
+            _word(94, 0, "p", 0),
+            _word(2, 14, "mean", 1),
+            _word(62, 14, "sd", 1),
+            _word(94, 14, "0.05", 1),
+            _word(2, 28, "1.2", 2),
+            _word(62, 28, "0.4", 2),
+            _word(94, 28, "0.01", 2),
+        ]
+    )
+
+    node = PdfToAstConverter()._process_table_to_ast(_SpanTable(), page, page_num=0)
+
+    assert isinstance(node, AstTable)
+    assert _cells(node) == grid
+
+
+def test_a_single_contradicted_row_does_not_dissolve_the_boundary():
+    """One crossing word is not evidence of a mis-split column: both columns survive.
+
+    The extract-loss guard may still rebuild the cell *text* from word boxes (here the
+    clipped "B12," is missing from the grid, so it does) -- but the boundary itself
+    stays, where a dissolve would have collapsed the grid to one column and demoted it
+    to a paragraph.
+    """
+    extents = [(0.0, 10.0), (14.0, 24.0), (28.0, 38.0)]
+    page = _FakePage(
+        [
+            _word(2, 0, "Name", 0),
+            _word(62, 0, "Value", 0),
+            # Only this row's word straddles x=60 (44..68).
+            _word(44, 14, "B12,", 1),
+            _word(92, 14, "2.8", 1),
+            _word(2, 28, "iron", 2),
+            _word(62, 28, "20", 2),
+        ]
+    )
+    grid = [["Name", "Value"], ["B1", "2, 2.8"], ["iron", "20"]]
+
+    node = PdfToAstConverter()._process_table_to_ast(_FakeTable(grid, extents, EDGES), page, page_num=0)
+
+    assert isinstance(node, AstTable)
+    assert _cells(node) == [["Name", "Value"], ["B12,", "2.8"], ["iron", "20"]]
+
+
+def test_an_overhanging_value_delivered_whole_does_not_dissolve_the_boundary():
+    """A wide value protruding past a correct boundary is not a mis-split (#419).
+
+    "<0.001" physically overhangs the boundary at x=60 on both data rows, but
+    extract() delivered it whole in its own cell -- nothing was cut, so the grid
+    keeps all three columns and its text verbatim. This is the case that separates
+    overhang from mis-split: dissolving here would fuse two real columns.
+    """
+    extents = [(0.0, 10.0), (14.0, 24.0), (28.0, 38.0)]
+    page = _FakePage(
+        [
+            _word(2, 0, "Metric", 0),
+            _word(62, 0, "P", 0),
+            _word(92, 0, "Q", 0),
+            # 6pt/char * 6 chars from x=40: box 40..76, straddling x=60 by >1pt each side.
+            _word(2, 14, "Knowledge", 1),
+            _word(40, 14, "<0.001", 1),
+            _word(92, 14, "0.4", 1),
+            _word(2, 28, "Attitude", 2),
+            _word(40, 28, "<0.001", 2),
+            _word(92, 28, "0.7", 2),
+        ]
+    )
+    grid = [
+        ["Metric", "P", "Q"],
+        ["Knowledge", "<0.001", "0.4"],
+        ["Attitude", "<0.001", "0.7"],
+    ]
+
+    node = PdfToAstConverter()._process_table_to_ast(_FakeTable(grid, extents, [0.0, 60.0, 90.0, 120.0]), page, 0)
+
+    assert isinstance(node, AstTable)
+    assert _cells(node) == grid
+
+
+def test_a_cut_value_in_a_real_gutter_keeps_the_boundary_and_heals_the_word():
+    """A wide value cut by a real boundary is healed in place, not fused (#419).
+
+    extract() clipped "<0.001" across the boundary at x=60 on two rows, so the
+    boundary is contradicted -- but on the uncut rows the words on either side sit a
+    gutter apart, which is what a real column boundary looks like. The repair keeps
+    both columns and the rebuild lands "<0.001" whole in the cell holding its
+    center.
+    """
+    extents = [(0.0, 10.0), (14.0, 24.0), (28.0, 38.0), (42.0, 52.0)]
+    page = _FakePage(
+        [
+            _word(2, 0, "Metric", 0),
+            _word(80, 0, "P", 0),
+            # 6pt/char * 6 chars from x=52: box 52..88, straddling x=60 by >1pt each side.
+            _word(2, 14, "Knowledge", 1),
+            _word(52, 14, "<0.001", 1),
+            _word(2, 28, "Attitude", 2),
+            _word(52, 28, "<0.001", 2),
+            _word(2, 42, "Practice", 3),
+            _word(80, 42, "0.20", 3),
+        ]
+    )
+    # extract() split "<0.001" at the boundary on the two cut rows.
+    grid = [
+        ["Metric", "P"],
+        ["Knowledge <0.0", "01"],
+        ["Attitude <0.0", "01"],
+        ["Practice", "0.20"],
+    ]
+
+    node = PdfToAstConverter()._process_table_to_ast(_FakeTable(grid, extents, [0.0, 60.0, 120.0]), page, 0)
+
+    assert isinstance(node, AstTable)
+    assert _cells(node) == [
+        ["Metric", "P"],
+        ["Knowledge", "<0.001"],
+        ["Attitude", "<0.001"],
+        ["Practice", "0.20"],
+    ]


### PR DESCRIPTION
All three of #419's mechanisms, one per commit: column boundaries drawn *through* content, the bbox's own edge drawn through words, and a whole column left outside the bbox.

## Mechanism 1: column boundaries through cell content

`find_tables()` — especially the layout-region path under the `"text"` alignment strategy — sometimes draws a column boundary through printed words: `"Vitamin B12,"` extracted as `"Vitamin B" | "12,"`. Both existing guards are blind by design: the split-word tokenizer drops digits, and `extract_loss_share` sees nothing lost.

**Detection** (`contradicted_column_boundaries`): a boundary is *contradicted* when a word straddles it on ≥ 2 rows whose cells really abut there. Spanning headers omit the edge on their row and show **zero** contradictions (measured gap: 0 vs 2/3/15+). A crossing word `extract()` delivered whole is discounted — a wide value overhanging its correct column is not a cut.

**Arbiter** (`boundaries_to_dissolve`): on the rows a boundary did *not* cut, a **spurious** boundary has ordinary word spaces running straight across it; a **real** boundary lives in a gutter (`MIN_GUTTER_WIDTH_PT`). Spurious → dissolve so the word-box rebuild reunites the pair; real → keep, and the rebuild lands the cut value whole in the cell holding its center.

## Mechanism 2: the bbox's own edge through words

`"0.454 ± 0.024"` reaches `extract()` as `"4 ± 0"` — clipped words' centers lie **outside** the bbox, so `extract_loss_share` is structurally blind and the rebuild dropped them. The outer-cell rule: a word that *begins inside* the row's outermost cell belongs to it even when its center leaks past the edge; `bbox_clipped_rows` gives such rows a trigger of their own.

## Mechanism 3: a whole column outside the bbox

A four-column table detected as three, the fourth (`3rd trimester …`) printed just beyond the edge. Admitted at detection time (`adjacent_clipped_column`) — where the recorded bbox also excludes the region's text from ordinary blocks, so nothing is emitted twice — on three signals together, each threshold inside its measured gap: a column-gutter distance (3.0–4.7pt vs 13.7+ for prose/captions), essentially full grid-row coverage (1.0 vs ≤0.73), and nothing continuing beyond (0–1 words vs 62+ for prose, 100+ for a second table alongside — neither may be swallowed).

## Measured (dev census, 66 articles)

| | below bar | recovered of 110 attainable |
|---|---|---|
| before | 25 | 85 (77.3%) |
| commit 1 | 23 | 87 |
| commit 2 | 20 | 90 |
| commit 3 | **19** | **91 (82.7%)** |

- PMC4000057 Nutrient panel: true **6 columns**; t3 0.625 → **0.833**; t0 → **1.0**
- PMC10000026 t4/t5: 0.600/0.418 → **1.000** at their true 3-column shapes
- PMC5000413 t2: 0.622 → **0.930**; PMC2000230 t0: 0.789 → **0.857**
- PMC11500000 t0: 0.438 → **0.918** at its true 7×4 shape — commit 3's census shows *exactly one change across the whole corpus*
- PMC8500047.2's two p-value columns cut by overhanging `<0.001` keep **all 8 columns**, values healed in place
- No table crosses the bar downward anywhere.

## Tests

Eight new unit tests in `test_pdf_find_tables_repair.py` (15 total): mis-split dissolved, spanning header untouched, single contradicted row left alone, overhanging whole value keeps its boundary, cut value in a real gutter healed in place, bbox-clipped word joins the outer cell, whole outside column detected and admitted, prose neighbour refused. Full `-m pdf` suite green; ruff + mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)