### PR TITLE
fix(pdf): one printed caption, one emitted caption (#410)

### DIFF
--- a/src/all2md/constants.py
+++ b/src/all2md/constants.py
@@ -849,6 +849,10 @@ PDF_CAPTION_MAX_LENGTH = 500
 # duplicate and is suppressed -- unless it is shorter than this, which keeps a bare
 # cross-reference ("Figure 1.") from being mistaken for a caption fragment.
 PDF_CAPTION_DEDUP_MIN_CHARS = 10
+# A block wholly inside a bound caption's own layout region is that caption's body copy
+# even when the two extraction routes disagree on glyph details (#410); the margin
+# absorbs the model box's boundary jitter around the text it drew.
+PDF_CAPTION_REGION_SUPPRESS_MARGIN = (-2.0, -2.0, 2.0, 2.0)
 # When the layout model is available, also drop images that fall inside a
 # page-header / page-footer region (recurring logos, signature blocks).
 DEFAULT_FILTER_HEADER_FOOTER_IMAGES = True

--- a/src/all2md/constants.py
+++ b/src/all2md/constants.py
@@ -840,8 +840,10 @@ PDF_CAPTION_SEARCH_GAP = 80.0
 # how far it may overhang the image horizontally.
 PDF_CAPTION_BAND_HEIGHT = 50.0
 PDF_CAPTION_BAND_OVERHANG = 20.0
-# A caption is long-form prose, but not unbounded. Bounds the text handed to the cue
-# pattern so a runaway region cannot turn matching into a ReDoS surface.
+# Bounds the text handed to the caption *cue pattern* so a runaway region cannot turn
+# matching into a ReDoS surface. The stored caption itself is not clipped: clipping it
+# cut real captions mid-sentence, and the clipped copy could never match its body-text
+# original, so the caption printed twice (#410).
 PDF_CAPTION_MAX_LENGTH = 500
 # A body text block whose whole text sits inside a bound caption is that caption's
 # duplicate and is suppressed -- unless it is shorter than this, which keeps a bare

--- a/src/all2md/parsers/_pdf_images.py
+++ b/src/all2md/parsers/_pdf_images.py
@@ -66,8 +66,15 @@ def _matches_caption_cue(text: str) -> bool:
 
 
 def _region_text(page: "pymupdf.Page", rect: Any) -> str:
-    """Return the text inside a rect as a single whitespace-collapsed line."""
-    return " ".join(page.get_textbox(rect).split())[:PDF_CAPTION_MAX_LENGTH]
+    """Return the text inside a rect as a single whitespace-collapsed line.
+
+    Deliberately not clipped to ``PDF_CAPTION_MAX_LENGTH``: that cap belongs to the
+    cue *matcher*, not the stored caption. Clipping the caption itself cut real
+    captions mid-sentence -- the figure then carried a 500-character prefix while
+    the body copy kept the full text, so the copies could never match and the
+    caption printed twice (#410).
+    """
+    return " ".join(page.get_textbox(rect).split())
 
 
 def _caption_from_layout(
@@ -160,12 +167,13 @@ def detect_image_caption(
         image_bbox.y0,
     )
     for search_rect in (below, above):
-        # Truncated by _region_text before matching, so the pattern never sees an
-        # unbounded string. A whitespace-only band collapses to "" and is skipped --
+        # The cue pattern sees at most PDF_CAPTION_MAX_LENGTH characters, so it
+        # never matches against an unbounded string; the *returned* caption stays
+        # whole (#410). A whitespace-only band collapses to "" and is skipped --
         # it used to reach `text[0]` and raise IndexError, which the caller swallowed
         # as "skip this image", silently deleting 1 image in 70 on the PMC corpus.
         text = _region_text(page, search_rect)
-        if text and _matches_caption_cue(text):
+        if text and _matches_caption_cue(text[:PDF_CAPTION_MAX_LENGTH]):
             return text
 
     return None

--- a/src/all2md/parsers/pdf.py
+++ b/src/all2md/parsers/pdf.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 
 import logging
 import re
+import unicodedata
 from datetime import datetime
 from pathlib import Path
 from typing import IO, TYPE_CHECKING, Any, Callable, Optional, Union
@@ -2094,7 +2095,30 @@ class PdfToAstConverter(BaseParser):
             used_captions.add(caption)
             plan.append((rect.y0, {"images": [], "caption": caption}))
 
-        return [item for _y, item in sorted(plan, key=lambda entry: entry[0])]
+        # One printed caption is one figure. The region loop emits one item per
+        # ``picture`` region, so a multi-panel figure whose panels the layout model
+        # drew as separate regions would become one Figure per panel, each
+        # re-binding the same caption and printing it once per panel (#410).
+        # Folding by verbatim caption here covers every path that can produce a
+        # duplicate -- region items, loose items, and the caption-only rescue --
+        # and cannot fuse distinct figures: two different figures on one page do
+        # not share a verbatim caption.
+        by_caption_final: dict[str, dict] = {}
+        ordered: list[dict] = []
+        for _y, item in sorted(plan, key=lambda entry: entry[0]):
+            caption = item["caption"]
+            if caption is None:
+                ordered.append(item)
+                continue
+            existing = by_caption_final.get(caption)
+            if existing is None:
+                by_caption_final[caption] = item
+                ordered.append(item)
+            else:
+                existing["images"].extend(item["images"])
+        for item in by_caption_final.values():
+            item["images"].sort(key=lambda member: (member["bbox"].y0, member["bbox"].x0))
+        return ordered
 
     def _process_page_to_ast(
         self,
@@ -3942,12 +3966,15 @@ class PdfToAstConverter(BaseParser):
         if block.get("type") != 0:
             return False
         text = " ".join(span.get("text", "") for line in block.get("lines", []) for span in line.get("spans", []))
-        text = " ".join(text.split())
+        # NFKC on both sides: the caption came through ``get_textbox``, which expands
+        # ligatures, while the block's spans preserve them -- "ﬁrst" vs "first" made
+        # the same text fail the containment test and print twice (#410).
+        text = " ".join(unicodedata.normalize("NFKC", text).split())
         # The floor keeps a short cross-reference ("Figure 1.") standing alone in the
         # body from being mistaken for the caption fragment it is contained in.
         if len(text) < PDF_CAPTION_DEDUP_MIN_CHARS:
             return False
-        return any(text in caption for caption in bound_captions)
+        return any(text in " ".join(unicodedata.normalize("NFKC", caption).split()) for caption in bound_captions)
 
     def _create_image_node(self, img_info: dict, page_num: int) -> AstParagraph | None:
         """Create an image node from image info.

--- a/src/all2md/parsers/pdf.py
+++ b/src/all2md/parsers/pdf.py
@@ -64,6 +64,7 @@ from all2md.constants import (
     DEPS_PDF,
     DEPS_PDF_LAYOUT,
     PDF_CAPTION_DEDUP_MIN_CHARS,
+    PDF_CAPTION_REGION_SUPPRESS_MARGIN,
     PDF_MIN_PYMUPDF_VERSION,
     PDF_READING_ORDER_MIN_ROW_TOLERANCE,
     PDF_READING_ORDER_ROW_TOLERANCE_RATIO,
@@ -325,6 +326,20 @@ def _consume_leading_chars(content: list[Node], count: int) -> tuple[list[Node],
             out.append(node)
             remaining = 0
     return out, remaining
+
+
+def _caption_comparison_key(text: str) -> str:
+    """Reduce text to the glyphs both extraction routes agree on, for caption dedup.
+
+    A bound caption and its body copy are the same printed glyphs read back through
+    different routes -- ``get_textbox`` for the caption, span text (or a rescued
+    region, which dehyphenates) for the copy. The routes disagree on what they
+    insert or keep *between* glyphs: ligature expansion ("ﬁrst" vs "first"),
+    spacing split mid-word ("enrich ment"), and wrap hyphens kept by one route and
+    consumed by the other ("knock- down" vs "knockdown"). NFKC plus dropping
+    whitespace and hyphens leaves what they agree on (#410).
+    """
+    return "".join(unicodedata.normalize("NFKC", text).replace("-", "").split())
 
 
 def _running_text_key(text: str) -> str:
@@ -1981,6 +1996,28 @@ class PdfToAstConverter(BaseParser):
                     if table_node:
                         nodes.append(table_node)
 
+        # A caption's body copy can reach the node list around the block-level
+        # suppression entirely: find_tables() can fire on a caption's aligned lines,
+        # its bbox removes the block from ordinary text, and when the grid is then
+        # rejected _region_text_as_paragraph re-emits the region verbatim -- so the
+        # caption prints beside the figure *and* as this rescued paragraph (#410).
+        # Catch every such path in one place: a paragraph whose entire text sits
+        # inside a caption bound on this page is that caption's body copy, whatever
+        # route it took here. Runs before the merges so a body copy cannot first
+        # fuse with real prose and escape.
+        bound_keys = [_caption_comparison_key(item["caption"]) for item in figure_plan if item["caption"]]
+        if bound_keys:
+            kept: list[Node] = []
+            for candidate in nodes:
+                if isinstance(candidate, AstParagraph):
+                    text = extract_node_text(candidate)
+                    if len(" ".join(text.split())) >= PDF_CAPTION_DEDUP_MIN_CHARS:
+                        key = _caption_comparison_key(text)
+                        if any(key in bound for bound in bound_keys):
+                            continue
+                kept.append(candidate)
+            nodes = kept
+
         # Post-processing
         nodes = self._merge_rotated_paragraphs(nodes)
         nodes = self._merge_adjacent_paragraphs(nodes)
@@ -2274,10 +2311,33 @@ class PdfToAstConverter(BaseParser):
         # page, so nothing that is not literally the caption can be dropped.
         bound_captions = [" ".join(item["caption"].split()) for item in figure_plan if item["caption"]]
 
+        # The caption's printed region suppresses geometrically what the textual rule
+        # cannot: ``get_textbox`` and the block spans read the same glyphs through
+        # different heuristics (wrap hyphens kept vs dehyphenated, spacing split mid-word,
+        # occasionally a dropped character), so the two strings can disagree while the
+        # geometry stays exact (#410). A region qualifies only when its entire text sits
+        # inside a caption actually bound on this page -- then every glyph a block inside
+        # it holds is already emitted on the figure, and dropping the block loses nothing.
+        bound_caption_rects: list[Any] = []
+        if bound_captions and layout:
+            region_bound_keys = [_caption_comparison_key(c) for c in bound_captions]
+            for pred in layout.get_predictions_by_label("caption"):
+                rect = pymupdf.Rect(pred.bbox)
+                region_key = _caption_comparison_key(page.get_textbox(rect))
+                if region_key and any(region_key in bound for bound in region_bound_keys):
+                    bound_caption_rects.append(rect + PDF_CAPTION_REGION_SUPPRESS_MARGIN)
+
         # Filter out blocks inside table regions
         text_blocks = []
         for block in all_blocks:
             if bound_captions and self._is_bound_caption_block(block, bound_captions):
+                continue
+            if (
+                bound_caption_rects
+                and block.get("type") == 0
+                and "bbox" in block
+                and any(rect.contains(pymupdf.Rect(block["bbox"])) for rect in bound_caption_rects)
+            ):
                 continue
             if "bbox" not in block:
                 text_blocks.append(block)
@@ -3966,15 +4026,15 @@ class PdfToAstConverter(BaseParser):
         if block.get("type") != 0:
             return False
         text = " ".join(span.get("text", "") for line in block.get("lines", []) for span in line.get("spans", []))
-        # NFKC on both sides: the caption came through ``get_textbox``, which expands
-        # ligatures, while the block's spans preserve them -- "ﬁrst" vs "first" made
-        # the same text fail the containment test and print twice (#410).
-        text = " ".join(unicodedata.normalize("NFKC", text).split())
         # The floor keeps a short cross-reference ("Figure 1.") standing alone in the
         # body from being mistaken for the caption fragment it is contained in.
-        if len(text) < PDF_CAPTION_DEDUP_MIN_CHARS:
+        if len(" ".join(text.split())) < PDF_CAPTION_DEDUP_MIN_CHARS:
             return False
-        return any(text in " ".join(unicodedata.normalize("NFKC", caption).split()) for caption in bound_captions)
+        # See _caption_comparison_key: the two extraction routes disagree on
+        # ligatures, inserted spaces, and wrap hyphens; comparing what they agree
+        # on is what lets the body copy be recognized at all (#410).
+        key = _caption_comparison_key(text)
+        return any(key in _caption_comparison_key(caption) for caption in bound_captions)
 
     def _create_image_node(self, img_info: dict, page_num: int) -> AstParagraph | None:
         """Create an image node from image info.

--- a/tests/unit/parsers/test_pdf_caption_detector.py
+++ b/tests/unit/parsers/test_pdf_caption_detector.py
@@ -220,6 +220,26 @@ class TestTheLayoutRegion:
         finally:
             document.close()
 
+    def test_a_long_caption_is_returned_whole(self, tmp_path: Path) -> None:
+        """The stored caption is not clipped to ``PDF_CAPTION_MAX_LENGTH`` (#410).
+
+        Clipping cut real ~550-character journal captions mid-sentence: the figure
+        carried the 500-character prefix while the body copy kept the full text, so
+        the two could never match and the caption printed twice. The cap now bounds
+        only the cue matcher's input.
+        """
+        sentence = "Figure 1. The assay grows steadily across every cohort we measured. "
+        lines = {250.0 + 12.0 * index: sentence.strip() for index in range(9)}
+        document, page, image_rect = _page(tmp_path, lines, name="long.pdf")
+        try:
+            region = [FakeRegion((60.0, 240.0, 560.0, 360.0))]
+            caption = detect_image_caption(page, image_rect, region)
+            assert caption is not None
+            assert len(caption) > 500
+            assert caption.endswith("measured.")
+        finally:
+            document.close()
+
     def test_an_empty_region_falls_through_to_the_cue(self, tmp_path: Path) -> None:
         document, page, bbox = _page(tmp_path, {250.0: CAPTION})
         try:

--- a/tests/unit/parsers/test_pdf_figure_plan.py
+++ b/tests/unit/parsers/test_pdf_figure_plan.py
@@ -108,6 +108,48 @@ class TestPanelGrouping:
         assert plan[0]["caption"] == _CAPTION
         assert len(plan[0]["images"]) == 2
 
+    def test_panels_in_separate_picture_regions_sharing_a_caption_fold_into_one_figure(self) -> None:
+        """One printed caption is one figure, even across layout regions (#410).
+
+        The layout model can draw one region per panel of a multi-panel figure;
+        each region then binds the same caption and the caption prints once per
+        panel. The fold at the end of the planner is what makes the docstring's
+        promise -- identical caption, one figure -- hold on the region path too.
+        """
+        top_region = LayoutPrediction(72.0, 100.0, 400.0, 200.0, "picture")
+        bottom_region = LayoutPrediction(72.0, 201.0, 400.0, 300.0, "picture")
+        plan = _plan(
+            [_image(_TOP_PANEL, caption=_CAPTION), _image(_BOTTOM_PANEL, caption=_CAPTION)],
+            predictions=[top_region, bottom_region, _CAPTION_REGION],
+        )
+
+        assert len(plan) == 1
+        assert plan[0]["caption"] == _CAPTION
+        assert [img["bbox"] for img in plan[0]["images"]] == [_TOP_PANEL, _BOTTOM_PANEL]
+
+    def test_regions_with_distinct_captions_stay_separate_figures(self) -> None:
+        top_region = LayoutPrediction(72.0, 100.0, 400.0, 200.0, "picture")
+        bottom_region = LayoutPrediction(72.0, 201.0, 400.0, 300.0, "picture")
+        plan = _plan(
+            [_image(_TOP_PANEL, caption=_CAPTION), _image(_BOTTOM_PANEL, caption=_OTHER_CAPTION)],
+            predictions=[top_region, bottom_region],
+        )
+
+        assert [item["caption"] for item in plan] == [_CAPTION, _OTHER_CAPTION]
+        assert all(len(item["images"]) == 1 for item in plan)
+
+    def test_a_region_item_and_a_loose_image_sharing_a_caption_fold_together(self) -> None:
+        """The fold is path-blind: region-grouped and loose images with one caption merge."""
+        top_region = LayoutPrediction(72.0, 100.0, 400.0, 200.0, "picture")
+        loose_panel = pymupdf.Rect(80, 500, 200, 560)
+        plan = _plan(
+            [_image(_TOP_PANEL, caption=_CAPTION), _image(loose_panel, caption=_CAPTION)],
+            predictions=[top_region],
+        )
+
+        assert len(plan) == 1
+        assert [img["bbox"] for img in plan[0]["images"]] == [_TOP_PANEL, loose_panel]
+
     def test_uncaptioned_images_stay_bare(self) -> None:
         """No caption anywhere means no container: the paragraphs they always were."""
         plan = _plan([_image(_TOP_PANEL), _image(_BOTTOM_PANEL)])

--- a/tests/unit/parsers/test_pdf_parser.py
+++ b/tests/unit/parsers/test_pdf_parser.py
@@ -738,6 +738,29 @@ class TestDetectedCaptionsReachTheFigureNode:
 
         assert PdfToAstConverter._is_bound_caption_block(block, [caption])
 
+    def test_a_dehyphenated_body_copy_still_matches_the_caption_keeping_the_wrap_hyphen(self) -> None:
+        """The rescued-region route dehyphenates; ``get_textbox`` keeps the wrap hyphen.
+
+        "knock- down" in the bound caption against "knockdown" in the body copy is
+        the same printed word read through two policies; the comparison key drops
+        hyphens so the copy is recognized (#410).
+        """
+        from all2md.parsers.pdf import PdfToAstConverter
+
+        caption = "Figure 3. The CCT3 knock- down efficiencies were evaluated by western blot."
+        block = _create_mock_text_block("Figure 3. The CCT3 knockdown efficiencies were evaluated by western blot.")
+
+        assert PdfToAstConverter._is_bound_caption_block(block, [caption])
+
+    def test_a_body_copy_with_spacing_artifacts_still_matches_the_caption(self) -> None:
+        """``get_textbox`` can split a word ("enrich ment"); the block keeps it whole (#410)."""
+        from all2md.parsers.pdf import PdfToAstConverter
+
+        caption = "Figure 5. Pathway enrich ment analysis of the knockdown cells."
+        block = _create_mock_text_block("Figure 5. Pathway enrichment analysis of the knockdown cells.")
+
+        assert PdfToAstConverter._is_bound_caption_block(block, [caption])
+
     def test_a_block_holding_caption_plus_other_prose_keeps_its_place(self) -> None:
         """The conservative rule survives the NFKC change: only a pure body copy drops."""
         from all2md.parsers.pdf import PdfToAstConverter

--- a/tests/unit/parsers/test_pdf_parser.py
+++ b/tests/unit/parsers/test_pdf_parser.py
@@ -724,6 +724,29 @@ class TestDetectedCaptionsReachTheFigureNode:
         assert len(images) == 1
         assert images[0].caption is None
 
+    def test_a_ligature_in_the_body_copy_still_matches_the_bound_caption(self) -> None:
+        """NFKC applies to both sides of the containment test (#410).
+
+        The bound caption comes through ``get_textbox``, which expands ligatures;
+        the body block's spans preserve them. "ﬁrst" against "first" made the same
+        printed text fail the substring test and the caption printed twice.
+        """
+        from all2md.parsers.pdf import PdfToAstConverter
+
+        caption = "Figure 1. The first dataset to include the movement of every animal."
+        block = _create_mock_text_block("Figure 1. The ﬁrst dataset to include the movement of every animal.")
+
+        assert PdfToAstConverter._is_bound_caption_block(block, [caption])
+
+    def test_a_block_holding_caption_plus_other_prose_keeps_its_place(self) -> None:
+        """The conservative rule survives the NFKC change: only a pure body copy drops."""
+        from all2md.parsers.pdf import PdfToAstConverter
+
+        caption = "Figure 1. The first dataset to include the movement of every animal."
+        block = _create_mock_text_block(caption + " The cohort was measured for twelve weeks.")
+
+        assert not PdfToAstConverter._is_bound_caption_block(block, [caption])
+
     def test_the_bound_caption_appears_once_and_body_prose_survives(self, tmp_path) -> None:
         """Binding must not double the caption: its body copy is suppressed.
 


### PR DESCRIPTION
Closes #410.

A multi-panel figure's caption printed once per panel, and often once more as a prose paragraph. Two commits, five mechanisms, each traced on the dev corpus:

## Commit 1 — binding and folding
1. **Region items never folded by caption**: `_plan_page_figures` folded loose images sharing a caption, but each layout `picture` region produced its own Figure — a figure whose panels the model drew as separate regions bound the same caption once per panel. The plan now folds by verbatim caption across every path (19 duplicate captioned containers eliminated corpus-wide).
2. **Ligature mismatch**: the bound caption comes via `get_textbox` (expands `ﬁ`→`fi`); the body block's spans keep the ligature, so the containment test failed and the body copy survived.
3. **500-char caption clipping**: `_region_text` clipped stored captions at `PDF_CAPTION_MAX_LENGTH`; a ~550-char journal caption bound as a prefix its full body copy could never match — and the figure's own caption lost its tail. The cap now bounds only the cue matcher's input (its stated ReDoS purpose).

## Commit 2 — suppression that holds on every route
4. **Route-blind comparison keys**: a caption and its body copy are one set of printed glyphs read through different routes that disagree on ligatures, inserted spaces (`enrich ment`/`enrichment`), and wrap hyphens (`knock- down`/`knockdown`, the rescued-region route dehyphenates). `_caption_comparison_key` compares what the routes agree on; a geometric rule (block wholly inside the bound caption's own layout region, 2pt jitter margin) covers what strings cannot.
5. **The bypass**: `find_tables()` can fire on a caption's aligned lines; text in a table bbox leaves the prose stream, and when the grid is rejected `_region_text_as_paragraph` re-emits the region verbatim — around all block-level suppression. A node-level pass before the paragraph merges closes every such route in one place.

## Measured (dev corpus, 66 articles, local A/B against main)
| metric | main | this PR |
| --- | --- | --- |
| **duplication** | 2.03% | **0.75%** |
| **binding_rate** | 52.6% | **67.0%** |
| caption_recall | 94.42% | 94.42% (held) |
| precision | 0.9497 | 0.9505 |
| novel_share | 0.79% | 0.77% |
| attainable recall | 98.56% | 98.56% |
| reading_order | 0.8217 | 0.8148 |

The +31 newly bound captions are exactly the >500-char captions the old clip broke. The reading_order dip is traced, not incidental: the in-position duplicate paragraph used to mask the figures' pre-existing page-tail placement, which the metric now sees — emitting figures at their printed position is the follow-up lever. Exemplar PMC10000026.1: 'Figure 3' caption 4 printings → 1 (excess 464→2).

Known residual: a mis-drawn layout caption region (PMC9000022 p8) yields a mid-word caption fragment ('o roups w') that can neither bind nor suppress — a region-quality defect, separate from dedup.

Full pdf suite green locally; ruff/mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)