### PR TITLE
fix(pdf): stop re-sorting OCR engine blocks into columns (#411)

### DIFF
--- a/benchmarks/omnidocbench/baseline.json
+++ b/benchmarks/omnidocbench/baseline.json
@@ -4,9 +4,9 @@
     "dataset_revision": "f5f559bddf50e36f7f9899d842d0006f13ce8afc",
     "annotation_sha256": "2fafe9329dc92fc426b30036aee51c716b3fcdcc1d20cb964dc7670579533817",
     "oracle_schema_version": 6,
-    "all2md_commit": "a8d4390faab271fa72bc29eeabdd8eb73262fde4",
+    "all2md_commit": "864e24ed61c8430365c736a62e2f438707910d8d",
     "worktree_dirty": false,
-    "created_at": "2026-08-19T20:23:53.906151+00:00",
+    "created_at": "2026-08-22T02:27:05.392576+00:00",
     "python": "3.12.3 (main, Jun 19 2026, 12:46:00) [GCC 13.3.0]",
     "platform": "linux",
     "parser_runtime": {
@@ -47,24 +47,24 @@
   },
   "dimensions": {
     "block_structure_similarity": {
-      "value": 0.3980186260883771,
+      "value": 0.39954160416237905,
       "direction": "higher",
       "eligible_items": 981,
-      "variance": 0.05723687167620211,
+      "variance": 0.05774153043119317,
       "tolerance": 0.005
     },
     "reading_order_similarity": {
-      "value": 0.5783906188735355,
+      "value": 0.6027693129436179,
       "direction": "higher",
       "eligible_items": 981,
-      "variance": 0.11597187815591176,
+      "variance": 0.1208575174060698,
       "tolerance": 0.005
     },
     "text_content_similarity": {
-      "value": 0.482004748396457,
+      "value": 0.5044261701847061,
       "direction": "higher",
       "eligible_items": 981,
-      "variance": 0.11198979449193469,
+      "variance": 0.11664570147471287,
       "tolerance": 0.005
     }
   },

--- a/docs/source/benchmarks.rst
+++ b/docs/source/benchmarks.rst
@@ -233,13 +233,13 @@ The ``omnidocbench`` lane scores 981 scanned pages against human annotation, fro
      - Value
      -
    * - ``text_content_similarity``
-     - 0.482
+     - 0.504
      - over 981 pages
    * - ``reading_order_similarity``
-     - 0.578
+     - 0.603
      - over 981 pages
    * - ``block_structure_similarity``
-     - 0.398
+     - 0.400
      - **not gated** — see below
 
 ``block_structure_similarity`` is recorded but excluded from the verdict. It compares
@@ -247,12 +247,15 @@ sequences of block *categories* without ever inspecting the text underneath, so 
 no correct content at all can score well on it. A measurement that cannot distinguish those
 two cases must not be allowed to support one.
 
-This baseline was re-recorded alongside the oracle correction described above, and the
-movement was attributed before being blessed: two record runs on the same runner image and
-corpus pin — one with the corrected oracle, one without — produced **byte-identical
-per-page scores on all 981 pages**, so the oracle contributes exactly zero here and the
-whole movement against the previous recording is the v1.12/v1.13 parser arc (tracked as
-issue #411 rather than silently absorbed). The payload now also reports every dimension
+This baseline carries the resolution of issue #411. An earlier re-recording had exposed
+a drift across the v1.12/v1.13 parser arc (text 0.506 → 0.482, order 0.603 → 0.578) —
+attributed cleanly, since two record runs on the same runner image and corpus pin, with
+and without the corrected oracle, produced **byte-identical per-page scores on all 981
+pages**. Bisecting the arc with further record runs put the entire movement on the OCR
+block-segmentation work, whose column re-sort scrambled blocks the engine had already
+emitted in reading order; removing that re-sort recovered 94% of the text movement and
+98% of the order movement while keeping the segmentation's block-structure gain whole.
+The payload also reports every dimension
 per corpus stratum: the whole-corpus mean averages handwritten notes scoring near zero
 with academic papers scoring far above it, and the strata are what make the number
 actionable.

--- a/src/all2md/parsers/pdf.py
+++ b/src/all2md/parsers/pdf.py
@@ -2272,10 +2272,23 @@ class PdfToAstConverter(BaseParser):
             if remainder is not None:
                 text_blocks.append(remainder)
 
-        # Apply column detection if enabled. It runs on OCR-derived blocks too: the engine
-        # numbers its blocks in its own order, which is not reading order on multi-column
-        # and poster layouts, and sorting them into columns measurably recovers it.
-        if self.options.detect_columns and self.options.column_detection_mode not in ("disabled", "force_single"):
+        # Apply column detection if enabled -- but not to OCR-derived blocks (#411).
+        # The engine already ran its own layout analysis and numbers its blocks in
+        # reading order; re-sorting them with born-digital column geometry loses to
+        # that order across the OmniDocBench raster corpus. Bisecting the v1.12/v1.13
+        # raster regression put 91% of the text_content bill (-21.05 of -23.01 summed
+        # per-page delta) on 72 pages whose old single-block output scored 0.73/0.83
+        # (text/order); on every locally reproducible one of them, skipping this pass
+        # restored the pre-regression score exactly -- including a newspaper page,
+        # the very layout the pass exists for -- while keeping the block_structure
+        # gain the segmentation bought. An explicit ``force_multi`` request still
+        # runs the pass: that mode is a user override, not a heuristic.
+        run_column_pass = (
+            self.options.detect_columns
+            and self.options.column_detection_mode not in ("disabled", "force_single")
+            and (self.options.column_detection_mode == "force_multi" or not ocr_applied)
+        )
+        if run_column_pass:
             force_multi = self.options.column_detection_mode == "force_multi"
             # PyMuPDF fuses both columns of a tight-gutter page into one block on some
             # pages; the fused block's interleaving is invisible to any block-level

--- a/tests/unit/parsers/test_pdf_ocr.py
+++ b/tests/unit/parsers/test_pdf_ocr.py
@@ -795,3 +795,95 @@ class TestEngineReadingOrderIsPreserved:
         items = converter._build_sorted_column_items(self._blocks(engine_segmented=True), [table])
 
         assert [item[1] for item in items] == [72.0, 72.0, 102.0, 102.0, 110.0, 132.0, 132.0]
+
+
+@pytest.mark.unit
+@pytest.mark.pdf
+class TestOCRBlocksKeepEngineOrder:
+    """OCR-derived blocks bypass the column re-sort; born-digital blocks do not (#411).
+
+    Tesseract runs its own layout analysis and numbers its blocks in reading
+    order. Re-sorting them with born-digital column geometry lost to that order
+    across the OmniDocBench raster corpus: 91% of the v1.12/v1.13 text_content
+    regression sat on 72 pages that the column pass alone had scrambled, and on
+    every locally reproducible one -- a newspaper page included -- skipping the
+    pass restored the pre-regression score exactly. The same two side-by-side
+    blocks are fed through both paths here: engine order survives when OCR
+    produced the blocks, and the geometric sort still applies when it did not.
+    """
+
+    @staticmethod
+    def _block(text: str, bbox: tuple[float, float, float, float], engine_segmented: bool = False) -> dict:
+        block = {
+            "type": 0,
+            "bbox": bbox,
+            "lines": [
+                {
+                    "bbox": bbox,
+                    "dir": (1, 0),
+                    "spans": [{"text": text, "bbox": bbox, "size": 12, "font": "Arial", "flags": 0}],
+                }
+            ],
+        }
+        if engine_segmented:
+            # The real OCR path stamps this marker (see _blocks_from_ocr_layout);
+            # the reading-order sort keys off it, so a faithful simulation must too.
+            block["_engine_segmented"] = True
+        return block
+
+    def _convert(self, ocr_applied: bool) -> list[str]:
+        from all2md.ast import Document
+
+        # Engine order deliberately right-column-first: a geometric column sort
+        # emits the left column first, so the output order tells the two apart.
+        right = self._block("RIGHT COLUMN TEXT FIRST", (320.0, 50.0, 560.0, 70.0), engine_segmented=ocr_applied)
+        left = self._block("LEFT COLUMN TEXT SECOND", (40.0, 50.0, 280.0, 70.0), engine_segmented=ocr_applied)
+
+        page = Mock()
+        page.get_text = Mock(return_value={"blocks": [right, left]})
+        page.rect = Mock()
+        page.rect.width = 612.0
+        page.rect.height = 792.0
+        page.number = 0
+        page.get_images = Mock(return_value=[])
+        page.find_tables = Mock(return_value=Mock(tables=[]))
+        page.get_drawings = Mock(return_value=[])
+        page.get_links = Mock(return_value=[])
+
+        document = Mock()
+        document.__iter__ = Mock(return_value=iter([page]))
+        document.__len__ = Mock(return_value=1)
+        document.__getitem__ = Mock(side_effect=lambda i: [page][i])
+        document.metadata = {}
+        document.page_count = 1
+
+        converter = PdfToAstConverter(PdfOptions(attachment_mode="skip"))
+        original = converter._apply_ocr_if_needed
+        converter._apply_ocr_if_needed = lambda p, blocks, text: (blocks, ocr_applied)  # type: ignore[method-assign]
+        try:
+            ast_doc: Document = converter.convert_to_ast(document, range(1), "test.pdf")
+        finally:
+            converter._apply_ocr_if_needed = original  # type: ignore[method-assign]
+
+        texts = []
+
+        def walk(node):
+            content = getattr(node, "content", None)
+            if isinstance(content, str):
+                texts.append(content)
+            elif isinstance(content, list):
+                for child in content:
+                    walk(child)
+            for child in getattr(node, "children", None) or []:
+                walk(child)
+
+        walk(ast_doc)
+        return [t for t in texts if "COLUMN TEXT" in t]
+
+    def test_ocr_blocks_come_out_in_engine_order(self) -> None:
+        ordered = self._convert(ocr_applied=True)
+        assert ordered and ordered[0].startswith("RIGHT"), ordered
+
+    def test_born_digital_blocks_still_get_the_column_sort(self) -> None:
+        ordered = self._convert(ocr_applied=False)
+        assert ordered and ordered[0].startswith("LEFT"), ordered


### PR DESCRIPTION
Closes #411.

## The regression, attributed

Five CI record dispatches at commits spanning the v1.12/v1.13 arc (the corpus is deterministic — the re-run of the pre-v1.12 endpoint reproduced the committed 2026-08-01 aggregates byte-for-byte) put **every moved point on two commits** and cleared the other ~87:

| commit | text | order | block |
| --- | --- | --- | --- |
| `0195b69` keep OCR engine paragraph segmentation | −0.050 | −0.031 | **+0.28** (the entire gain) |
| `0c356ce` keep OCR engine reading order | +0.027 | +0.006 | ~0 |

The residual sat 91% (−21.05 of −23.01 summed per-page delta) on 72 pages whose pre-arc single-block output scored 0.73/0.83 (text/order).

## The mechanism

Tesseract runs its own layout analysis and numbers its blocks in reading order. `0c356ce` already protects those blocks from the item-level y-sort (`_engine_segmented`), but the **column pass around it still ran**: `split_gutter_merged_blocks` regrouped engine blocks into y-band slices and `detect_columns` re-partitioned them with born-digital geometry — scrambling order the engine had right, and on the worst page dropping 47 words of list text outright. On every locally reproducible stuck page — a newspaper page included, the very layout the pass exists for — skipping the pass restored the pre-regression score exactly.

## The fix

One gate: OCR-derived blocks keep engine order; the column pass runs only on born-digital text. An explicit `force_multi` request still runs it — that mode is a user override, not a heuristic. Two unit tests pin both directions.

## Full-corpus verdict (CI record run 32542233479, same runner image / corpus pin / runtime identity)

| run | text | order | block |
| --- | --- | --- | --- |
| pre-v1.12 | 0.5058 | 0.6034 | 0.1176 |
| v1.13 (broken) | 0.4820 | 0.5784 | 0.3980 |
| **this PR** | **0.5044** | **0.6028** | **0.3995** |

**94% of the text bill and 98% of the order bill recovered; the block_structure gain kept whole.** The 74 pages that lost >0.1 text across the arc average 0.723 against 0.727 pre-arc. Remaining deficit: 44 pages summing −1.39 (worst −0.12), mostly PPT-derived rasters where the sort had helped slightly — two orders of magnitude smaller than what this closes. The re-recorded `baseline.json` from that run is the second commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)