### PR TITLE
docs(benchmarks): re-record the PMC artifact after the caption and table repairs

### DIFF
--- a/benchmarks/pmc/reference.json
+++ b/benchmarks/pmc/reference.json
@@ -5,14 +5,14 @@
     "bucket": "pmc-oa-opendata",
     "complete_corpus": true,
     "oracle_schema_version": 2,
-    "all2md_commit": "2587cc4",
+    "all2md_commit": "dbf18363a5aa33219eff2222876ac174cd7415bc",
     "worktree_dirty": false,
-    "created_at": "2026-08-20T23:25:52.879341+00:00",
-    "python": "3.13.14 (main, Jul 18 2026, 17:10:39) [MSC v.1944 64 bit (AMD64)]",
-    "platform": "win32",
+    "created_at": "2026-08-22T04:08:55.143064+00:00",
+    "python": "3.12.3 (main, Jun 19 2026, 12:46:00) [GCC 13.3.0]",
+    "platform": "linux",
     "parser_runtime": {
       "pymupdf": "1.28.0",
-      "python": "3.13.14"
+      "python": "3.12.3"
     },
     "parser_config": {
       "layout_analysis_mode": "enabled",
@@ -68,19 +68,19 @@
     "unsplit_spans": 42
   },
   "article_recall": {
-    "recall": 0.6207748455923638,
-    "recovered": 5528,
+    "recall": 0.6214486243683324,
+    "recovered": 5534,
     "scored": 8905,
     "too_short": 2598,
     "ceiling": 0.624480628860191,
     "attainable": 5561,
-    "attainable_recall": 0.9845351555475634,
+    "attainable_recall": 0.9856140981837799,
     "by_kind": {
       "table": {
-        "recovered": 86,
+        "recovered": 92,
         "attainable": 110,
         "scored": 123,
-        "attainable_recall": 0.7727272727272727
+        "attainable_recall": 0.8272727272727273
       },
       "text_block": {
         "recovered": 3155,
@@ -97,122 +97,125 @@
     },
     "control_recall": 0.003593486805165637,
     "control_scored": 8905,
-    "discrimination": 0.6171813587871982
+    "discrimination": 0.6178551375631667
   },
   "article_precision": {
-    "precision": 0.9489242676353148,
-    "supported": 423726,
-    "emitted": 446533,
-    "resequenced": 19213,
-    "novel": 3594,
-    "novel_share": 0.00804867725341688,
-    "duplication": 0.020250372776321746,
-    "excess": 9751,
-    "occurrences": 481522,
-    "control_precision": 0.0070252366566412785,
-    "control_emitted": 446533,
-    "discrimination": 0.9418990309786736
+    "precision": 0.9495318391919717,
+    "supported": 423796,
+    "emitted": 446321,
+    "resequenced": 18708,
+    "novel": 3817,
+    "novel_share": 0.008552140723828814,
+    "duplication": 0.007485203300648296,
+    "excess": 3555,
+    "occurrences": 474937,
+    "control_precision": 0.007035295224737352,
+    "control_emitted": 446321,
+    "discrimination": 0.9424965439672344
   },
   "figure_binding": {
-    "binding_rate": 0.5255813953488372,
-    "bound": 113,
+    "binding_rate": 0.6697674418604651,
+    "bound": 144,
     "scored": 215,
     "too_short": 13,
     "misfiled_rate": 0.0,
     "misfiled": 0,
     "caption_recall": 0.9441860465116279,
     "present": 203,
-    "images_emitted": 452,
-    "captioned_emitted": 210,
+    "images_emitted": 429,
+    "captioned_emitted": 190,
     "control_binding_rate": 0.0,
     "control_scored": 215,
-    "discrimination": 0.5255813953488372
+    "discrimination": 0.6697674418604651
   },
   "dimensions": {
     "block_structure_similarity": {
       "count": 706.0,
-      "mean": 0.5420577473256009,
-      "median": 0.5656275635767023,
-      "minimum": 0.022727272727272707,
+      "mean": 0.5480422694597025,
+      "median": 0.5714285714285714,
+      "minimum": 0.023255813953488413,
       "maximum": 1.0,
-      "stdev": 0.21246647137787839,
+      "stdev": 0.2087060377636029,
       "direction": "higher",
-      "control_mean": 0.4403958981907386,
-      "discrimination": 0.10166184913486226,
+      "control_mean": 0.4443440525120394,
+      "discrimination": 0.10369821694766307,
       "mutation_drop": {
-        "reversed": 0.014850039809720163,
-        "shuffled": 0.03073238589012482,
-        "halved": 0.05961438938430722
+        "reversed": 0.014170808424083711,
+        "shuffled": 0.03105127188848035,
+        "halved": 0.0625283634989346
       },
       "ungateable": "compares kind sequences without inspecting the text under a block, so content-free output scores 1.0 (issue #256); eleven text categories collapse to `text_block`, so fully reversed output scores exactly 1.0 on 153 of the 981 pinned pages; and on the born-digital lane it separates own-page from wrong-page output by only ~0.06 while *rising* when half the emitted content is deleted, which rewards dropping blocks"
     },
     "reading_order_similarity": {
       "count": 706.0,
-      "mean": 0.8217827559935488,
+      "mean": 0.8148196176210619,
       "median": 0.9,
       "minimum": 0.0,
       "maximum": 1.0,
-      "stdev": 0.21520731075755462,
+      "stdev": 0.2235681649860168,
       "direction": "higher",
-      "control_mean": 0.2887614680681385,
-      "discrimination": 0.5330212879254103,
+      "control_mean": 0.290101336624721,
+      "discrimination": 0.5247182809963409,
       "mutation_drop": {
-        "reversed": 0.5053984442937073,
-        "shuffled": 0.24732391181625454,
-        "halved": 0.3380994910847984
+        "reversed": 0.5010109644458876,
+        "shuffled": 0.24130959823794626,
+        "halved": 0.3378600923783364
       }
     },
     "table_content_similarity": {
       "count": 124.0,
-      "mean": 0.6023251531199547,
-      "median": 0.8575583772952193,
+      "mean": 0.6061920572219988,
+      "median": 0.8626465084211563,
       "minimum": 0.0,
       "maximum": 1.0,
-      "stdev": 0.4165178045842487,
+      "stdev": 0.41772482140166467,
       "direction": "higher",
-      "control_mean": 0.03932533751061294,
-      "discrimination": 0.5629998156093418,
+      "control_mean": 0.03925294997010633,
+      "discrimination": 0.5669391072518924,
       "mutation_drop": {
         "reversed": 0.0,
         "shuffled": 0.0,
-        "halved": 0.5971055650590734
+        "halved": 0.6007476653916105
       }
     },
     "table_structure_similarity": {
       "count": 124.0,
-      "mean": 0.6092903299457294,
+      "mean": 0.6133126964680959,
       "median": 0.8333333333333333,
       "minimum": 0.0,
       "maximum": 1.0,
-      "stdev": 0.410802364983521,
+      "stdev": 0.4139273643367654,
       "direction": "higher",
-      "control_mean": 0.09518734363105522,
-      "discrimination": 0.5141029863146742,
+      "control_mean": 0.09460228054599214,
+      "discrimination": 0.5187104159221038,
       "mutation_drop": {
         "reversed": 0.0,
         "shuffled": 0.0,
-        "halved": 0.6043917440619428
+        "halved": 0.6074885964352613
       }
     },
     "text_content_similarity": {
       "count": 706.0,
-      "mean": 0.6675657518856521,
-      "median": 0.6812093910291699,
+      "mean": 0.6666341152025155,
+      "median": 0.6866240142184139,
       "minimum": 0.010652463382157085,
       "maximum": 0.9930305215092525,
-      "stdev": 0.2216696012719043,
+      "stdev": 0.2287185508163264,
       "direction": "higher",
-      "control_mean": 0.2342800942129644,
-      "discrimination": 0.4332856576726878,
+      "control_mean": 0.2338503391986872,
+      "discrimination": 0.4327837760038283,
       "mutation_drop": {
-        "reversed": 0.2772502518901822,
-        "shuffled": 0.2011811988117425,
-        "halved": 0.2969507893933271
+        "reversed": 0.2666231737248577,
+        "shuffled": 0.19463664295320596,
+        "halved": 0.3018014821717125
       }
     }
   },
   "conversion_failures": {},
-  "ocr_articles": [],
+  "ocr_articles": [
+    "PMC10500011.1",
+    "PMC8500015.1"
+  ],
   "degraded_events": {
     "table_rejected": {
       "occurrences": 247,

--- a/docs/source/benchmarks.rst
+++ b/docs/source/benchmarks.rst
@@ -80,7 +80,7 @@ Did the text survive?
      - 62.4%
      - what the PDF's own text layer reproduces
    * - **Recall of what is attainable**
-     - **98.5%**
+     - **98.6%**
      - the number worth reading
    * - Control: the *wrong* article
      - 0.4%
@@ -98,7 +98,7 @@ The movement after that correction is the opposite kind: a parser fix (#405).
 Side-by-side regions with tight gutters — two-column reference lists above all — were
 read as one column and interleaved line-by-line, so every word survived while every
 adjacency died. Admitting those gutters on structural evidence and joining words
-hyphenated at block seams raised attainable recall from 95.4% to 98.3% (98.5% after
+hyphenated at block seams raised attainable recall from 95.4% to 98.3% (98.6% after
 the table repairs below), and the held-out corpus moved the same way it was never
 tuned against.
 
@@ -132,8 +132,8 @@ By block kind:
      - **98.9%**
    * - Tables
      - 110 of 123
-     - 86
-     - **77.3%**
+     - 92
+     - **82.7%**
 
 Table blocks are the outlier, and deliberately so — their text now routes through
 structured table extraction rather than flowing out as prose. What that buys and what it
@@ -161,33 +161,33 @@ Unsupported output is therefore split in two:
      - Share
      - Meaning
    * - Supported
-     - **94.9%**
+     - **95.0%**
      - the n-gram appears in the document's text layer
    * - Resequenced
-     - 4.3%
+     - 4.2%
      - every word is in the document, in a new adjacency
    * - **Novel**
-     - **0.8%**
+     - **0.9%**
      - at least one word appears nowhere — the number worth reading
    * - Duplication
-     - 2.0%
+     - 0.7%
      - supported text emitted more than once
    * - Control: the *wrong* article
      - 0.7%
      - wants to be ~0%
 
-Over 446,533 emitted n-grams, 3,594 are novel. Reporting the raw unsupported figure instead
+Over 446,321 emitted n-grams, 3,817 are novel. Reporting the raw unsupported figure instead
 would have made the result roughly six times worse than the parser deserves.
 
 Duplication is counted apart from both, because it is invisible to either. Text emitted
 twice is an unchanged *set* and a doubled *multiset* — no set-based score can see it at all.
 
-The duplication figure jumped from 0.5% to 2.0% at the same re-record that corrected the
-caption-blind oracle, and the jump is real output, not a scoring artifact: with caption
-text visible to the instruments at all, they can finally see that multi-panel figures
-re-bind the shared caption to every panel, so one printed caption is emitted several
-times (issue #410). The honest ordering matters here — the defect predates the
-re-record; what changed is that a measurement became able to report it.
+Duplication is now 0.7%, and the path it took there is the point. It read 0.5% while the
+oracle was blind to captions, jumped to 2.0% when the corrected oracle could finally see
+that multi-panel figures re-bound one printed caption to every panel, and fell to 0.7%
+when that defect was fixed (issue #410). The middle figure was the honest one: the defect
+predated the re-record, and what changed first was only that a measurement became able to
+report it.
 
 Tables
 ~~~~~~
@@ -213,11 +213,13 @@ order, and n-grams reward that order; a committed table re-cuts the same words a
 cell boundary, and each boundary in the wrong place breaks a run of them. The two
 mechanisms that dominated — every printed line emitted as its own row, splitting wrapped
 cells mid-sentence, and ``Table.extract()`` clipping characters at cell rects — were
-measured, fixed behind guards (#416, #417), and the figure recovered to **77.3%**. The
-trade still stands with eyes open — a table recovered *as a table* is what downstream
-consumers need, and the residual gap now sits in named mechanisms (#419) rather than a
-vague deficit — but it is a trade, and the artifact says so rather than netting the two
-effects into one flattering number.
+measured, fixed behind guards (#416, #417), and the figure recovered to 77.3%. A third
+mechanism followed the same route: ``find_tables()`` drew column boundaries and bbox edges
+straight through cell content, cutting values mid-word where neither guard could see it —
+dissolving those boundaries on structural evidence and healing the cut values in place
+(#419) took the figure to **82.7%**. The trade still stands with eyes open — a table
+recovered *as a table* is what downstream consumers need — but it is a trade, and the
+artifact says so rather than netting the two effects into one flattering number.
 
 Scanned pages
 -------------


### PR DESCRIPTION
Re-records `benchmarks/pmc/reference.json` from the born-digital workflow on main at `dbf1836` (run 32549606289) — the first recording carrying #419, #410 and #411 together — and updates the published figures, which the verbatim figure gate requires to match the artifact field-for-field.

| measure | previous artifact | this artifact |
| --- | --- | --- |
| **Tables** (share of attainable) | 77.3% | **82.7%** (86 → 92 recovered of 110) |
| **Duplication** | 2.03% | **0.75%** |
| **Figure binding rate** | 52.6% | **67.0%** |
| Attainable recall | 98.45% | **98.56%** |
| Precision | 0.9489 | 0.9495 |
| Caption recall | 94.42% | 94.42% (held) |
| Text blocks / titles | 98.9% / 98.9% | unchanged |

Two narrative changes beyond the numbers:

- **Duplication gets its ending.** It read 0.5% while the oracle was caption-blind, 2.0% once the corrected oracle could see that multi-panel figures re-bound one caption to every panel, and 0.7% now that the defect is fixed. The middle figure was the honest one — the page says so.
- **The tables section records the third mechanism.** #416/#417 (row shredding, cell clipping) took it to 77.3%; #419 (boundaries drawn through cell content, bbox edges cutting values) takes it to 82.7%.

`novel_share` moved 0.80% → 0.86%. Small, but it is the hallucination number, so it is flagged rather than absorbed: the working hypothesis is that un-clipping stored captions (#410) admits more text from mis-drawn caption regions — the defect already filed for the caption-region leg. Published as measured either way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)