### PR TITLE
fix(benchmarks): publish the numerator of attainable_recall so the ratio is checkable

### DIFF
--- a/benchmarks/pmc/benchmark.py
+++ b/benchmarks/pmc/benchmark.py
@@ -467,11 +467,19 @@ def normalize_results(
             # it is mostly JATS recording words in an order the page never prints.
             "ceiling": recall.ceiling,
             "attainable": recall.attainable,
+            # `attainable_recall` is recovered_attainable / attainable, NOT recovered /
+            # attainable: a block can be recovered from the output while the PDF's own text
+            # layer does not reproduce it, and that block belongs in neither side of the
+            # share. Publishing the numerator is what makes the ratio checkable from the
+            # artifact alone -- without it a reader divides the two counts that *are*
+            # published, gets a different number, and has no way to tell which is wrong.
+            "recovered_attainable": recall.recovered_attainable,
             "attainable_recall": recall.attainable_recall,
             "by_kind": {
                 kind: {
                     "recovered": counts.recovered,
                     "attainable": counts.attainable,
+                    "recovered_attainable": counts.recovered_attainable,
                     "scored": counts.scored,
                     "attainable_recall": counts.attainable_recall,
                 }

--- a/tests/unit/test_pmc_oracle.py
+++ b/tests/unit/test_pmc_oracle.py
@@ -799,3 +799,41 @@ def test_an_event_with_no_reason_still_totals() -> None:
     summary = benchmark._degraded_summary([_FakeEvaluation((_fact("ocr_failed", None, 3),))])
 
     assert summary["ocr_failed"] == {"occurrences": 3, "articles": 1}
+
+
+# ---------------------------------------------------------------------------
+# The published payload must be checkable from its own fields
+# ---------------------------------------------------------------------------
+
+
+def test_attainable_recall_is_reproducible_from_the_published_counts() -> None:
+    """The share's numerator ships beside it, per kind and overall.
+
+    ``attainable_recall`` is ``recovered_attainable / attainable``, and those are
+    different blocks from ``recovered``: a block can be recovered from the output
+    while the PDF's own text layer does not reproduce it, so it counts in
+    ``recovered`` and in neither side of the share. While the numerator was not
+    published, dividing the two counts that *were* gave a plausible wrong answer
+    -- 92/110 reads as 83.6% where the artifact says 82.7% -- and nothing in the
+    payload could settle which was right. A published figure nobody can check
+    against the artifact is the failure this lane exists to prevent.
+    """
+    # One block per case: recovered and attainable, attainable but not recovered,
+    # recovered though the layer never had it (the block the two counts disagree on).
+    layer = "alpha beta gamma delta epsilon zeta eta theta iota kappa"
+    missing_from_layer = "one two three four five six seven eight nine ten"
+    blocks = [
+        ("text_block", layer),
+        ("text_block", "lambda mu nu xi omicron pi rho sigma tau upsilon"),
+        ("text_block", missing_from_layer),
+    ]
+    emitted = f"{layer} {missing_from_layer}"
+    pdf_text = f"{layer} lambda mu nu xi omicron pi rho sigma tau upsilon"
+
+    report = article.measure_recall([("PMC1.1", blocks, emitted, pdf_text)])
+
+    assert report.recovered == 2, "both the layer block and the layer-less block were emitted"
+    assert report.attainable == 2, "the layer reproduces two of the three blocks"
+    assert report.recovered_attainable == 1, "only one block is on both sides of the share"
+    assert report.attainable_recall == pytest.approx(report.recovered_attainable / report.attainable)
+    assert report.attainable_recall != pytest.approx(report.recovered / report.attainable)

--- a/tests/unit/test_published_benchmark_figures.py
+++ b/tests/unit/test_published_benchmark_figures.py
@@ -214,3 +214,30 @@ def test_a_perturbed_artifact_is_caught() -> None:
 
     mismatches = _mismatches(perturbed)
     assert len(mismatches) >= 2, f"a perturbed artifact still matched the page: {mismatches}"
+
+
+def test_every_published_share_is_reproducible_from_published_counts() -> None:
+    """A ratio in the artifact must be checkable against counts in the same artifact.
+
+    ``attainable_recall`` is ``recovered_attainable / attainable``, and those are
+    not the same blocks as ``recovered``: a block the output recovered that the
+    PDF's own text layer does not reproduce counts in ``recovered`` and in
+    neither side of the share. While the numerator went unpublished, dividing the
+    two counts that *were* published gave a plausible wrong answer (92/110 reads
+    as 83.6% where the artifact says 82.7%), with nothing in the payload to
+    settle it. Skipped rather than failed on an artifact recorded before the
+    numerator shipped, so re-recording stays the fix and never the blocker.
+    """
+    recall = json.loads(_PMC.read_bytes())["article_recall"]
+    if "recovered_attainable" not in recall:
+        pytest.skip("artifact predates the published numerator -- re-record to enable this check")
+
+    subjects = [("overall", recall)] + [(kind, counts) for kind, counts in recall["by_kind"].items()]
+    for name, counts in subjects:
+        if not counts["attainable"]:
+            continue
+        expected = counts["recovered_attainable"] / counts["attainable"]
+        assert counts["attainable_recall"] == pytest.approx(expected), (
+            f"{name}: attainable_recall {counts['attainable_recall']} does not equal "
+            f"{counts['recovered_attainable']}/{counts['attainable']} = {expected}"
+        )


### PR DESCRIPTION
Found by making the mistake: reading the re-recorded artifact, I quoted tables as **83.6%** by dividing `recovered` (92) by `attainable` (110). The artifact says **82.7%**. Both are computed correctly — they are just different questions, and only one of them had its numerator published.

`attainable_recall` is `recovered_attainable / attainable`. A block the output recovered that the PDF's own text layer does *not* reproduce counts in `recovered` and in **neither** side of the share. So `recovered / attainable` is not the published ratio, and while the real numerator went unpublished there was nothing in the artifact to settle which number was right.

This matters beyond one slip: `docs/source/benchmarks.rst` publishes exactly that trio (Attainable / Recovered / Share of attainable) for every block kind, so any reader can do the same division and conclude the page contradicts itself. A published figure nobody can check against the artifact is the failure this lane exists to prevent.

## Change

- The recall payload emits `recovered_attainable`, overall and per kind.
- **Unit guard**: pins `attainable_recall == recovered_attainable / attainable` on a case built so the two candidate denominators genuinely differ (one block recovered but not in the layer, one in the layer but not recovered).
- **Artifact guard**: every published share must reproduce from published counts. It *skips* rather than fails on an artifact recorded before the numerator shipped, so re-recording is the fix and never the blocker — the committed reference is schema 6 and skips today; the next recording enables it.

## Not bumping the schema

The schema version records what the measurement underneath the figures *means* (schema 6 = the caption-aware oracle). Nothing measured changes here — the key is purely additive, and bumping would invalidate a correct artifact and force a re-record to say nothing new.

Follow-up once a re-recorded artifact carries the field: publish the numerator in the by-kind table on the fidelity page, so the reader can check the share without leaving the page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)