### PR TITLE
fix(pdf): emit figures where they are printed, not at the page tail (#429)

### DIFF
--- a/src/all2md/parsers/pdf.py
+++ b/src/all2md/parsers/pdf.py
@@ -1750,18 +1750,22 @@ class PdfToAstConverter(BaseParser):
             logger.warning(f"OCR processing failed: {e}. Falling back to standard text extraction.")
             return all_blocks, False
 
-    def _assign_tables_to_columns(self, table_info: list[dict], columns: list[list[dict]]) -> None:
-        """Assign each table to a column based on x-coordinate.
+    def _assign_to_columns(self, items: list[dict], columns: list[list[dict]]) -> None:
+        """Assign each item to a column based on x-coordinate.
+
+        Used for tables and for figures: both are placed by the column their own
+        bbox falls in, and both fall back to the first column when their centre
+        lands in none of them.
 
         Parameters
         ----------
-        table_info : list of dict
-            Table information with bbox
+        items : list of dict
+            Tables or figure plan items, each with a ``bbox`` rect
         columns : list of list of dict
             Column blocks
 
         """
-        for table in table_info:
+        for table in items:
             table_center_x = (table["bbox"].x0 + table["bbox"].x1) / 2
             table["column"] = 0  # Default to first column
 
@@ -1828,9 +1832,18 @@ class PdfToAstConverter(BaseParser):
         # as one, the y sort interleaves left and right into nonsense. Trust the engine's
         # order instead. Scoped to engine-segmented pages with no tables to interleave;
         # native blocks keep the existing behaviour exactly.
-        if col_tables or not items or not all(item[2].get("_engine_segmented") for item in items):
+        if not self._keeps_engine_order(items, col_tables):
             items = self._sort_items_into_reading_order(items, column)
         return items
+
+    @staticmethod
+    def _keeps_engine_order(items: list[tuple[str, float, Any]], col_tables: list[dict]) -> bool:
+        """Whether this column keeps the OCR engine's block order instead of sorting by y.
+
+        Callers that read position out of the item stream need to know: when this is
+        true, an item's ``y`` says nothing about where it sits in the stream.
+        """
+        return bool(items) and not col_tables and all(item[2].get("_engine_segmented") for item in items)
 
     def _sort_items_into_reading_order(
         self, items: list[tuple[str, float, Any]], column: list[dict]
@@ -1982,12 +1995,38 @@ class PdfToAstConverter(BaseParser):
         average_line_height = self._calculate_average_line_height(columns)
         links = self._get_page_links(page)
 
+        # A figure is printed at a place on the page, and the text around it reads as
+        # though it is there: the paragraph above introduces it, the one below refers
+        # back to it. Emitting every figure at the page tail moved all of that text
+        # one step out of reading order (#429). Place each figure in the column its
+        # own bbox falls in, at the y it is printed at, the way tables already are.
+        if figure_plan and columns:
+            self._assign_to_columns(figure_plan, columns)
+        placed: set[int] = set()
+
         # Process each column
         for col_idx, column in enumerate(columns):
             col_tables = [t for t in table_info if t["column"] == col_idx]
             items = self._build_sorted_column_items(column, col_tables)
+            # Placement reads position out of the item stream's y order. On a page an
+            # OCR engine segmented, that stream is in the engine's order instead (#411),
+            # where y says nothing about position -- those pages keep the tail emission.
+            col_figures = (
+                []
+                if self._keeps_engine_order(items, col_tables)
+                else sorted(
+                    (item for item in figure_plan if item.get("column") == col_idx),
+                    key=lambda item: (item["bbox"].y0, item["bbox"].x0),
+                )
+            )
+            pending = 0
 
-            for item_type, _y, item_data in items:
+            for item_type, item_y, item_data in items:
+                # Everything printed above this item's top belongs before it.
+                while pending < len(col_figures) and col_figures[pending]["bbox"].y0 <= item_y:
+                    nodes.extend(self._figure_nodes(col_figures[pending], page_num))
+                    placed.add(id(col_figures[pending]))
+                    pending += 1
                 if item_type == "block":
                     block_nodes = self._process_single_block_to_ast(item_data, links, page_num, average_line_height)
                     nodes.extend(block_nodes)
@@ -1995,6 +2034,9 @@ class PdfToAstConverter(BaseParser):
                     table_node = self._process_table_item(item_data, page, page_num)
                     if table_node:
                         nodes.append(table_node)
+            for item in col_figures[pending:]:
+                nodes.extend(self._figure_nodes(item, page_num))
+                placed.add(id(item))
 
         # A caption's body copy can reach the node list around the block-level
         # suppression entirely: find_tables() can fire on a caption's aligned lines,
@@ -2023,22 +2065,29 @@ class PdfToAstConverter(BaseParser):
         nodes = self._merge_adjacent_paragraphs(nodes)
         nodes = self._convert_paragraphs_to_lists(nodes)
 
-        # Emit the page's figures: a captioned group becomes a Figure container
-        # (caption on the container, so it renders once), an uncaptioned image
-        # stays the bare paragraph it always was, and a vector-drawn figure --
-        # images empty -- is a caption-only container (#338).
-        if figure_plan:
-            source = SourceLocation(format="pdf", page=page_num + 1)
-            for item in figure_plan:
-                panels: list[Node] = [
-                    node for info in item["images"] if (node := self._create_image_node(info, page_num))
-                ]
-                if item["caption"] is None:
-                    nodes.extend(panels)
-                elif panels or not item["images"]:
-                    nodes.append(AstFigure(children=panels, caption=item["caption"], source_location=source))
+        # Figures the column pass could not place -- a page with no text columns at
+        # all, so there was no stream to interleave them into -- keep the tail
+        # emission they have always had.
+        for item in figure_plan:
+            if id(item) not in placed:
+                nodes.extend(self._figure_nodes(item, page_num))
 
         return nodes
+
+    def _figure_nodes(self, item: dict, page_num: int) -> list[Node]:
+        """Render one figure plan item.
+
+        A captioned group becomes a ``Figure`` container (caption on the container, so
+        it renders once), an uncaptioned image stays the bare paragraph it always was,
+        and a vector-drawn figure -- images empty -- is a caption-only container (#338).
+        """
+        source = SourceLocation(format="pdf", page=page_num + 1)
+        panels: list[Node] = [node for info in item["images"] if (node := self._create_image_node(info, page_num))]
+        if item["caption"] is None:
+            return panels
+        if panels or not item["images"]:
+            return [AstFigure(children=panels, caption=item["caption"], source_location=source)]
+        return []
 
     def _plan_page_figures(
         self,
@@ -2070,6 +2119,13 @@ class PdfToAstConverter(BaseParser):
         picture_rects = (
             [pymupdf.Rect(pred.bbox) for pred in layout.get_predictions_by_label("picture")] if layout else []
         )
+
+        def union(members: list[dict]) -> Any:
+            """Return the extent of a figure's panels, used to place it back on the page."""
+            box = pymupdf.Rect(members[0]["bbox"])
+            for member in members[1:]:
+                box |= member["bbox"]
+            return box
 
         def region_index(bbox: Any) -> int | None:
             center = pymupdf.Point((bbox.x0 + bbox.x1) / 2, (bbox.y0 + bbox.y1) / 2)
@@ -2105,18 +2161,28 @@ class PdfToAstConverter(BaseParser):
                 continue
             used_captions.add(caption)
             members = sorted(members, key=lambda member: (member["bbox"].y0, member["bbox"].x0))
-            plan.append((min(member["bbox"].y0 for member in members), {"images": members, "caption": caption}))
+            plan.append(
+                (
+                    min(member["bbox"].y0 for member in members),
+                    {"images": members, "caption": caption, "bbox": union(members)},
+                )
+            )
 
         by_caption: dict[str, list[dict]] = {}
         for info in loose:
             if info.get("caption"):
                 by_caption.setdefault(info["caption"], []).append(info)
             else:
-                plan.append((info["bbox"].y0, {"images": [info], "caption": None}))
+                plan.append((info["bbox"].y0, {"images": [info], "caption": None, "bbox": union([info])}))
         for caption, members in by_caption.items():
             used_captions.add(caption)
             members = sorted(members, key=lambda member: (member["bbox"].y0, member["bbox"].x0))
-            plan.append((min(member["bbox"].y0 for member in members), {"images": members, "caption": caption}))
+            plan.append(
+                (
+                    min(member["bbox"].y0 for member in members),
+                    {"images": members, "caption": caption, "bbox": union(members)},
+                )
+            )
 
         for idx, rect in enumerate(picture_rects):
             if idx in by_region:
@@ -2130,7 +2196,7 @@ class PdfToAstConverter(BaseParser):
             if not caption or caption in used_captions:
                 continue
             used_captions.add(caption)
-            plan.append((rect.y0, {"images": [], "caption": caption}))
+            plan.append((rect.y0, {"images": [], "caption": caption, "bbox": pymupdf.Rect(rect)}))
 
         # One printed caption is one figure. The region loop emits one item per
         # ``picture`` region, so a multi-panel figure whose panels the layout model
@@ -2153,6 +2219,7 @@ class PdfToAstConverter(BaseParser):
                 ordered.append(item)
             else:
                 existing["images"].extend(item["images"])
+                existing["bbox"] |= item["bbox"]
         for item in by_caption_final.values():
             item["images"].sort(key=lambda member: (member["bbox"].y0, member["bbox"].x0))
         return ordered
@@ -2388,7 +2455,7 @@ class PdfToAstConverter(BaseParser):
             columns = [text_blocks]
 
         # Assign tables to columns
-        self._assign_tables_to_columns(table_info, columns)
+        self._assign_to_columns(table_info, columns)
 
         # Process columns and tables (the figure plan is already empty when OCR
         # replaced page content or placement markers are off)

--- a/tests/unit/parsers/test_pdf_figure_plan.py
+++ b/tests/unit/parsers/test_pdf_figure_plan.py
@@ -173,7 +173,10 @@ class TestVectorFigures:
             texts={_CAPTION_REGION.bbox: _CAPTION},
         )
 
-        assert plan == [{"images": [], "caption": _CAPTION}]
+        assert [(item["images"], item["caption"]) for item in plan] == [([], _CAPTION)]
+        # The region's own extent is where the figure prints, so a caption-only
+        # figure can still be placed back into the text stream (#429).
+        assert plan[0]["bbox"] == pymupdf.Rect(_PICTURE.bbox)
 
     def test_a_region_the_table_detector_claimed_stays_a_table(self) -> None:
         table = {"bbox": pymupdf.Rect(72, 100, 400, 300)}

--- a/tests/unit/parsers/test_pdf_ocr.py
+++ b/tests/unit/parsers/test_pdf_ocr.py
@@ -887,3 +887,42 @@ class TestOCRBlocksKeepEngineOrder:
     def test_born_digital_blocks_still_get_the_column_sort(self) -> None:
         ordered = self._convert(ocr_applied=False)
         assert ordered and ordered[0].startswith("LEFT"), ordered
+
+    def _place_figure(self, engine_segmented: bool) -> list[str]:
+        """Emit two stacked blocks and one figure printed between them; report the order."""
+        import pymupdf
+
+        from all2md.ast import Figure as AstFigure
+
+        top = self._block("TOP BLOCK", (40.0, 50.0, 280.0, 70.0), engine_segmented=engine_segmented)
+        bottom = self._block("BOTTOM BLOCK", (40.0, 400.0, 280.0, 420.0), engine_segmented=engine_segmented)
+        figure = {"images": [], "caption": "Figure 1. Printed between them.", "bbox": pymupdf.Rect(40, 200, 280, 300)}
+
+        page = Mock()
+        page.get_links = Mock(return_value=[])
+        converter = PdfToAstConverter(PdfOptions(attachment_mode="skip"))
+        nodes = converter._process_columns_and_tables([[top, bottom]], [], page, 0, figure_plan=[figure])
+
+        labels = []
+        for node in nodes:
+            if isinstance(node, AstFigure):
+                labels.append("FIGURE")
+            else:
+                text = "".join(
+                    child.content for child in getattr(node, "content", []) or [] if isinstance(child.content, str)
+                )
+                if "BLOCK" in text:
+                    labels.append(text.strip())
+        return labels
+
+    def test_a_figure_is_placed_where_it_prints_on_a_born_digital_page(self) -> None:
+        """The stream is y-ordered there, so the figure's own y locates it in it (#429)."""
+        assert self._place_figure(engine_segmented=False) == ["TOP BLOCK", "FIGURE", "BOTTOM BLOCK"]
+
+    def test_an_engine_ordered_page_keeps_the_tail_emission(self) -> None:
+        """A figure's position cannot be read out of a stream y did not order.
+
+        With the engine's order in the stream, a block's y no longer says where it
+        sits in it, so placing by y would be placing by noise (#411).
+        """
+        assert self._place_figure(engine_segmented=True) == ["TOP BLOCK", "BOTTOM BLOCK", "FIGURE"]

--- a/tests/unit/parsers/test_pdf_parser.py
+++ b/tests/unit/parsers/test_pdf_parser.py
@@ -637,8 +637,12 @@ startxref
 _FIGURE_CAPTION = "Figure 1. Growth of the assay over twelve weeks."
 
 
-def _pdf_with_image(tmp_path, caption_text=None, body_text=None):
-    """A one-page PDF holding one raster image, optionally with a caption below it."""
+def _pdf_with_image(tmp_path, caption_text=None, body_text=None, lead_text=None):
+    """A one-page PDF holding one raster image, optionally with a caption below it.
+
+    ``lead_text`` prints above the image and ``body_text`` below it, so a test can
+    check the figure lands between them rather than after both.
+    """
     pymupdf = pytest.importorskip("pymupdf")
     source = pymupdf.open()
     source_page = source.new_page()
@@ -648,6 +652,8 @@ def _pdf_with_image(tmp_path, caption_text=None, body_text=None):
 
     document = pymupdf.open()
     page = document.new_page()
+    if lead_text:
+        page.insert_text((72, 100.0), lead_text, fontsize=9)
     # keep_proportion=False so the placement rect equals the requested rect;
     # fitted placement would leave the caption outside the detector's band.
     page.insert_image(pymupdf.Rect(72.0, 120.0, 400.0, 240.0), pixmap=pixmap, keep_proportion=False)
@@ -835,3 +841,44 @@ class TestDefaultModeEmitsCaptionedFigures:
         # The figure extent markers are what make the container round-trippable.
         assert "all2md:figure" in markdown
         assert "all2md:figure-caption" in markdown
+
+
+@pytest.mark.unit
+@pytest.mark.pdf
+@pytest.mark.image
+class TestFiguresPrintWhereTheyAre:
+    """A figure is emitted at the position it is printed at, not at the page tail (#429).
+
+    Every figure used to be appended after the page's text, so the paragraph that
+    introduces a figure and the one that refers back to it were separated by
+    nothing, and everything printed below the figure read one step out of order.
+    """
+
+    _LEAD = "The cohort design is summarized below."
+    _BODY = "The assay was repeated in triplicate across all cohorts."
+
+    def test_a_captioned_figure_lands_between_the_text_above_and_below_it(self, tmp_path) -> None:
+        from all2md.api import to_markdown
+
+        path = _pdf_with_image(tmp_path, caption_text=_FIGURE_CAPTION, lead_text=self._LEAD, body_text=self._BODY)
+        markdown = to_markdown(path, attachment_mode="base64")
+
+        assert markdown.index(self._LEAD) < markdown.index(_FIGURE_CAPTION) < markdown.index(self._BODY)
+
+    def test_an_uncaptioned_image_lands_in_position_too(self, tmp_path) -> None:
+        """The bare image paragraph takes the same route as the ``Figure`` container."""
+        from all2md.api import to_markdown
+
+        path = _pdf_with_image(tmp_path, lead_text=self._LEAD, body_text=self._BODY)
+        markdown = to_markdown(path, attachment_mode="base64")
+
+        assert markdown.index(self._LEAD) < markdown.index("![") < markdown.index(self._BODY)
+
+    def test_the_text_around_a_figure_is_not_fused_across_it(self, tmp_path) -> None:
+        """Placing a figure mid-stream must not let the paragraphs it separates merge."""
+        from all2md.api import to_markdown
+
+        path = _pdf_with_image(tmp_path, caption_text=_FIGURE_CAPTION, lead_text=self._LEAD, body_text=self._BODY)
+        markdown = to_markdown(path, attachment_mode="base64")
+
+        assert f"{self._LEAD} {self._BODY}" not in markdown


### PR DESCRIPTION
Closes #429.

## What

Figures were appended after all of a page's text. Tables were already placed by geometry — `_assign_to_columns` puts each in the column its centre x falls in, and `_build_sorted_column_items` interleaves it with that column's blocks by y — and figures carry the same geometry, so they now take the same route. Each plan item carries the bbox of its panels (or the picture region, for a vector figure), unioned when two items fold together on a shared caption.

One coupling is made explicit rather than left implicit. On a page an OCR engine segmented, the item stream is deliberately in the engine's order rather than y order (#411), so a block's y says nothing about where it sits in that stream — placing a figure by y there would be placing it by noise. `_keeps_engine_order` is extracted so the sort and the placement read the same predicate, and those pages keep the tail emission. So does a page with no text columns at all, which has no stream to interleave into.

## Measured — 66-article dev corpus

| Measure | Before | After | Δ |
|---|---|---|---|
| `reading_order_similarity` | 0.8148 | **0.8281** | **+0.0133** |
| `text_content_similarity` | 0.6666 | **0.6763** | +0.0096 |
| `novel_share` | 0.855% | **0.773%** | −0.082pp |
| precision | 94.95% | 95.09% | +0.13pp |
| attainable recall | 98.561% | 98.561% | flat |
| figure binding | 66.98% | 66.98% | flat |
| tables | 82.73% | 82.73% | flat |
| duplication | 0.749% | 0.751% | +0.002pp |

The order gain is about twice what #425's caption dedup had unmasked.

The **novel drop is the same defect seen from the other side**: novel n-grams fell 3,817 → 3,448 while total emitted fell only 529. A figure parked at the page tail butts its caption against whatever text ended the page, and that seam mints n-grams in an adjacency the text layer never had. This recovers more than the 0.80 → 0.86 `novel_share` uptick that #425 left behind, so part of that uptick was this rather than mis-drawn caption regions.

## The one thing that moved wrong, traced

Duplication rose by 8 excess occurrences in 474k. Forcing figures back to the tail in-process and diffing the doubled n-grams per article puts all of them at seams:

- **Running footers** — `...not for citation purposes | BMC Urology`. Pages that used to end with a figure now end the way every other page does, so a repeated boilerplate adjacency recurs on more pages than the text layer's own extraction order holds it.
- **PMC6500022** — the caption *"Fig 2. An overview of the process of collecting and analysing data in this study."* and the body sentence *"Figure 2 illustrates an overview of the process of collecting and analysing data in this study."* now both abut the following heading *"Analysing the stroke rehabilitation plan case"*. The caption is still emitted exactly once; the shared wording is the journal's.

Four articles moved the other way, the largest by −13.

## Tests

Five new. A captioned figure and a bare image each land between the text printed above and below them; the paragraphs a figure separates do not fuse across it; a born-digital page places by y and an engine-ordered page keeps the tail emission. Two of them fail on `main`, verified by stashing the source change.

Round-trip gate: 39 passed, 1 skipped.

## Pending in this PR

Re-recorded `benchmarks/pmc/reference.json` and the `docs/source/benchmarks.rst` figures, from the CI runs dispatched on this branch (the artifact must come from the Linux runner with lockfile-resolved deps, not from my machine). The OmniDocBench gate is running as a check that the raster lane is unmoved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)