### PR TITLE
fix(benchmarks): re-pin PMC9500042.1 and re-record the artifact against the new pin

### DIFF
--- a/benchmarks/pmc/manifest.json
+++ b/benchmarks/pmc/manifest.json
@@ -525,7 +525,7 @@
       "paragraphs": 59,
       "pdf_sha256": "071fe35726fa3905ea532c02955079f00ab840174750dc8c1a6b7edde54e58ef",
       "pdf_size_bytes": 5406076,
-      "xml_sha256": "222882cd6e552b557140b15faa31874da855ed59d038221d8bd8647d7c376e90",
+      "xml_sha256": "367751ba574e76d0c8948d320b1917efb26e21eed035b78d63279c2fb590c06c",
       "xml_size_bytes": 117973
     }
   },

--- a/benchmarks/pmc/reference.json
+++ b/benchmarks/pmc/reference.json
@@ -1,13 +1,13 @@
 {
   "schema_version": 6,
   "provenance": {
-    "corpus_pin": "2710aef0f1a7133550a358b58a46aa89037c0f855cf9d22a719d82e100e91eb9",
+    "corpus_pin": "ffad81e6f9a6499a5889fdedaa001f8b251fac49faced83bed9dc15866e0dd00",
     "bucket": "pmc-oa-opendata",
     "complete_corpus": true,
     "oracle_schema_version": 2,
-    "all2md_commit": "dbf18363a5aa33219eff2222876ac174cd7415bc",
+    "all2md_commit": "c35f6b454615629c6011a76b4e8fb83af2e1a7c3",
     "worktree_dirty": false,
-    "created_at": "2026-08-22T04:08:55.143064+00:00",
+    "created_at": "2026-08-22T15:57:45.006514+00:00",
     "python": "3.12.3 (main, Jun 19 2026, 12:46:00) [GCC 13.3.0]",
     "platform": "linux",
     "parser_runtime": {
@@ -74,23 +74,27 @@
     "too_short": 2598,
     "ceiling": 0.624480628860191,
     "attainable": 5561,
+    "recovered_attainable": 5481,
     "attainable_recall": 0.9856140981837799,
     "by_kind": {
       "table": {
         "recovered": 92,
         "attainable": 110,
+        "recovered_attainable": 91,
         "scored": 123,
         "attainable_recall": 0.8272727272727273
       },
       "text_block": {
         "recovered": 3155,
         "attainable": 3160,
+        "recovered_attainable": 3125,
         "scored": 6356,
         "attainable_recall": 0.9889240506329114
       },
       "title": {
         "recovered": 2287,
         "attainable": 2291,
+        "recovered_attainable": 2265,
         "scored": 2426,
         "attainable_recall": 0.988651243998254
       }
@@ -100,18 +104,18 @@
     "discrimination": 0.6178551375631667
   },
   "article_precision": {
-    "precision": 0.9495318391919717,
-    "supported": 423796,
-    "emitted": 446321,
-    "resequenced": 18708,
-    "novel": 3817,
-    "novel_share": 0.008552140723828814,
-    "duplication": 0.007485203300648296,
-    "excess": 3555,
-    "occurrences": 474937,
-    "control_precision": 0.007035295224737352,
-    "control_emitted": 446321,
-    "discrimination": 0.9424965439672344
+    "precision": 0.9498668913528678,
+    "supported": 423880,
+    "emitted": 446252,
+    "resequenced": 18550,
+    "novel": 3822,
+    "novel_share": 0.008564667497288528,
+    "duplication": 0.0075020318441565,
+    "excess": 3563,
+    "occurrences": 474938,
+    "control_precision": 0.007036383030216111,
+    "control_emitted": 446252,
+    "discrimination": 0.9428305083226517
   },
   "figure_binding": {
     "binding_rate": 0.6697674418604651,
@@ -131,35 +135,35 @@
   "dimensions": {
     "block_structure_similarity": {
       "count": 706.0,
-      "mean": 0.5480422694597025,
+      "mean": 0.5484813685328609,
       "median": 0.5714285714285714,
       "minimum": 0.023255813953488413,
       "maximum": 1.0,
-      "stdev": 0.2087060377636029,
+      "stdev": 0.21058232887528835,
       "direction": "higher",
-      "control_mean": 0.4443440525120394,
-      "discrimination": 0.10369821694766307,
+      "control_mean": 0.4441323844565242,
+      "discrimination": 0.10434898407633669,
       "mutation_drop": {
-        "reversed": 0.014170808424083711,
-        "shuffled": 0.03105127188848035,
-        "halved": 0.0625283634989346
+        "reversed": 0.015782263093977338,
+        "shuffled": 0.03254869887397674,
+        "halved": 0.06241696982757137
       },
       "ungateable": "compares kind sequences without inspecting the text under a block, so content-free output scores 1.0 (issue #256); eleven text categories collapse to `text_block`, so fully reversed output scores exactly 1.0 on 153 of the 981 pinned pages; and on the born-digital lane it separates own-page from wrong-page output by only ~0.06 while *rising* when half the emitted content is deleted, which rewards dropping blocks"
     },
     "reading_order_similarity": {
       "count": 706.0,
-      "mean": 0.8148196176210619,
-      "median": 0.9,
+      "mean": 0.8281317303215293,
+      "median": 0.9090909090909091,
       "minimum": 0.0,
       "maximum": 1.0,
-      "stdev": 0.2235681649860168,
+      "stdev": 0.20974930316180884,
       "direction": "higher",
-      "control_mean": 0.290101336624721,
-      "discrimination": 0.5247182809963409,
+      "control_mean": 0.29215575823349715,
+      "discrimination": 0.5359759720880322,
       "mutation_drop": {
-        "reversed": 0.5010109644458876,
-        "shuffled": 0.24130959823794626,
-        "halved": 0.3378600923783364
+        "reversed": 0.5303437329469437,
+        "shuffled": 0.24328767375956228,
+        "halved": 0.3255185131028114
       }
     },
     "table_content_similarity": {
@@ -196,18 +200,18 @@
     },
     "text_content_similarity": {
       "count": 706.0,
-      "mean": 0.6666341152025155,
-      "median": 0.6866240142184139,
+      "mean": 0.6762563749831473,
+      "median": 0.6993291888523847,
       "minimum": 0.010652463382157085,
       "maximum": 0.9930305215092525,
-      "stdev": 0.2287185508163264,
+      "stdev": 0.22360381359462717,
       "direction": "higher",
-      "control_mean": 0.2338503391986872,
-      "discrimination": 0.4327837760038283,
+      "control_mean": 0.2341678713390695,
+      "discrimination": 0.4420885036440778,
       "mutation_drop": {
-        "reversed": 0.2666231737248577,
-        "shuffled": 0.19463664295320596,
-        "halved": 0.3018014821717125
+        "reversed": 0.2914274690677305,
+        "shuffled": 0.20251057893083302,
+        "halved": 0.29247980461231066
       }
     }
   },

--- a/docs/source/benchmarks.rst
+++ b/docs/source/benchmarks.rst
@@ -170,24 +170,24 @@ Unsupported output is therefore split in two:
      - **0.9%**
      - at least one word appears nowhere — the number worth reading
    * - Duplication
-     - 0.7%
+     - 0.8%
      - supported text emitted more than once
    * - Control: the *wrong* article
      - 0.7%
      - wants to be ~0%
 
-Over 446,321 emitted n-grams, 3,817 are novel. Reporting the raw unsupported figure instead
+Over 446,252 emitted n-grams, 3,822 are novel. Reporting the raw unsupported figure instead
 would have made the result roughly six times worse than the parser deserves.
 
 Duplication is counted apart from both, because it is invisible to either. Text emitted
 twice is an unchanged *set* and a doubled *multiset* — no set-based score can see it at all.
 
-Duplication is now 0.7%, and the path it took there is the point. It read 0.5% while the
-oracle was blind to captions, jumped to 2.0% when the corrected oracle could finally see
-that multi-panel figures re-bound one printed caption to every panel, and fell to 0.7%
-when that defect was fixed (issue #410). The middle figure was the honest one: the defect
-predated the re-record, and what changed first was only that a measurement became able to
-report it.
+Duplication is under a point, and the path it took there is the point. It read 0.5% while
+the oracle was blind to captions, jumped to 2.0% when the corrected oracle could finally
+see that multi-panel figures re-bound one printed caption to every panel, and fell by two
+thirds when that defect was fixed (issue #410). The middle figure was the honest one: the
+defect predated the re-record, and what changed first was only that a measurement became
+able to report it.
 
 Tables
 ~~~~~~


### PR DESCRIPTION
The PMC lane dispatched on `fix/figure-printed-position` failed corpus verification before scoring anything:

```
error: JATS PMC9500042.1 does not match the manifest:
  expected 222882cd... (117973 bytes), got 367751ba... (117973 bytes)
```

Same byte count, different digest. The pin did its job — something upstream changed — so the only question is *what*.

## What changed upstream

Eleven bytes, all inside one element:

```
old  <event event-type="pmc-last-change"><date iso-8601-date="2025-02-21 22:25:32.090">
new  <event event-type="pmc-last-change"><date iso-8601-date="2026-08-22 03:25:18.490">
```

Strip that event from both files and they are byte-identical — both hash to `c7c979e1b773b488`. Every body block, table, caption and reference the oracle reads is unchanged. PMC recorded when it last touched its own copy, at 03:25 UTC on the morning of the dispatch.

## Why the re-record rides along

A pin change makes the committed reference stale by construction, and the figure gate caught it rather than letting it drift:

```
benchmarks/pmc/reference.json was recorded against corpus pin 2710aef0f1a71335,
but the committed manifest hashes to ffad81e6f9a6499a -- re-record the reference
```

So the second commit re-records from the Linux runner (Python 3.12.3, PyMuPDF 1.28.0, 66 articles / 706 pages, no conversion failures) — the same configuration as the artifact it replaces.

## A clean A/B of #429 falls out of it

Both artifacts come from the same runner image and resolver, so this is like-for-like:

| Measure | Before | After |
|---|---|---|
| `reading_order_similarity` | 0.8148 | **0.8281** |
| `text_content_similarity` | 0.6666 | **0.6763** |
| attainable recall | 98.561% | 98.561% |
| figure binding | 66.98% | 66.98% |
| tables | 82.73% | 82.73% |
| precision | 94.953% | 94.987% |
| `novel_share` | 0.855% | 0.856% |

**This corrects a claim in #429's description.** That PR reported `novel_share` falling to 0.773%; it does not reproduce. The A/B there compared a local Windows / Python 3.13 run against the committed Linux artifact, and that pair differs by ~370 novel n-grams on its own. The improvement was the platform, and the mechanism narrated around it is unsupported. Corrected in a comment on #430. The reading-order and text-content gains — #429's actual result — reproduce exactly.

Also confirmed since: the **OmniDocBench gate passes** on #429 with all three dimensions byte-identical to 17 significant figures across 981 pages, which is the `_keeps_engine_order` guard doing exactly what it was written to do.

## Published figures

Two move. Emitted n-grams 446,321 → 446,252 with 3,817 → 3,822 novel, and the duplication row from 0.7% to 0.8% — a rounding boundary (0.7485% → 0.7503%, a rise of 0.002 points), not a regression. The narrative now describes the post-#410 fall as "by two thirds" instead of naming a figure that flips across the boundary at one decimal place and would misdate itself at the next re-record.

## Not fixed here

The pin covers PMC's bookkeeping as well as the article, so a timestamp PMC rewrites without changing content fails a run that takes over an hour, before the first article is scored. This one drifted after ~18 months; across 66 articles that is a handful of hard failures a year, each needing a human to do what this PR does.

A loader that keeps the raw digest as the primary check, and on mismatch compares the content digest with `pmc-last-change` normalized out — continuing and recording `corpus.digest_drift` as evidence when they match, failing as it does today when they do not — would keep the audit property (anyone can still `sha256sum` the file) without losing an hour to housekeeping. Proposed rather than done, because it changes what the published "pinned by per-file SHA-256, revalidated on every load" claim means.

🤖 Generated with [Claude Code](https://claude.com/claude-code)