### PR TITLE
feat(benchmarks): measure what the table surplus is, instead of asserting it

### DIFF
--- a/benchmarks/pmc/benchmark.py
+++ b/benchmarks/pmc/benchmark.py
@@ -35,7 +35,7 @@ from typing import Any, Callable, Mapping, Sequence
 
 from benchmarks.omnidocbench.dimensions import UNGATEABLE as SHARED_UNGATEABLE
 from benchmarks.omnidocbench.oracles import PageProjection, project_ast, score_page
-from benchmarks.pmc.alignment import TOKEN_PLACEMENT_MIN
+from benchmarks.pmc.alignment import MIN_NGRAMS, TOKEN_PLACEMENT_MIN, ngrams, normalize
 from benchmarks.pmc.article import (
     RECALL_MIN,
     BindingReport,
@@ -154,6 +154,11 @@ class ArticleEvaluation:
     ground_truth_blocks: int
     #: ``<table-wrap>`` elements the publisher deposited as a graphic rather than as markup.
     image_tables: int = 0
+    #: What the tables on over-emitting pages are, by `SURPLUS_VERDICTS`.
+    surplus_verdicts: Mapping[str, int] = field(default_factory=dict)
+    surplus_examined: int = 0
+    surplus_in_text_layer: int = 0
+    surplus_words_in_text_layer: int = 0
     emitted_text: str = ""
     #: The PDF's own text layer, which bounds what any parser could recover.
     pdf_text: str = ""
@@ -260,6 +265,7 @@ def evaluate_article(article: Any, *, options: Any = None) -> ArticleEvaluation:
 
     emitted = [project_ast(page) for page in converted.pages]
     evaluations: list[PageEvaluation] = []
+    scored_pages: list[tuple[Any, Any]] = []
     for index, placed in enumerate(assignment.pages):
         truth = to_projection(tuple(item.block for item in placed))
         if not truth.text_blocks:
@@ -267,6 +273,7 @@ def evaluate_article(article: Any, *, options: Any = None) -> ArticleEvaluation:
             # verdict. Counted in the payload's page accounting instead.
             continue
         actual = emitted[index]
+        scored_pages.append((truth, actual))
         # The next page of the same article: a harder control than a different article,
         # because it shares the running head, the vocabulary, and a continuing sentence.
         control = emitted[(index + 1) % len(emitted)] if len(emitted) > 1 else PageProjection((), (), (), ())
@@ -284,6 +291,10 @@ def evaluate_article(article: Any, *, options: Any = None) -> ArticleEvaluation:
             )
         )
 
+    surplus_verdicts, surplus_examined, surplus_in_layer, surplus_layer_words = _classify_surplus_tables(
+        blocks, pdf_text, scored_pages
+    )
+
     return ArticleEvaluation(
         article_id=article.article_id,
         pages=tuple(evaluations),
@@ -296,6 +307,10 @@ def evaluate_article(article: Any, *, options: Any = None) -> ArticleEvaluation:
         duration_seconds=time.perf_counter() - started,
         ground_truth_blocks=len(blocks),
         image_tables=image_tables,
+        surplus_verdicts=dict(surplus_verdicts),
+        surplus_examined=surplus_examined,
+        surplus_in_text_layer=surplus_in_layer,
+        surplus_words_in_text_layer=surplus_layer_words,
         emitted_text=" ".join(block for page in emitted for block in page.text_blocks),
         pdf_text=pdf_text,
         truth_blocks=truth_pairs,
@@ -350,6 +365,96 @@ def _dimension(pages: Sequence[PageEvaluation], name: str) -> dict[str, Any] | N
     if name in UNGATEABLE:
         summary["ungateable"] = UNGATEABLE[name]
     return summary
+
+
+#: Where a surplus table's text sits in the ground truth, by 5-gram containment at
+#: `RECALL_MIN` -- the same rule and the same threshold the recall instrument places blocks
+#: with, so a verdict here and a verdict there differ only in where the text was looked for.
+#:
+#: Deliberately *not* extended with an unordered-token fallback, though the alignment module
+#: has one. That rule answers "which page of this article holds this block", discriminating
+#: among that article's own pages, and it is calibrated for that question. The question here
+#: is whether a grid holds table text or prose -- and an article's tables and its prose share
+#: a vocabulary by construction, so a bag of words cannot separate them at any threshold. An
+#: earlier draft borrowed `TOKEN_PLACEMENT_MIN` anyway and filed 21 of 58 surplus tables as
+#: resequenced prose, none of which were prose.
+SURPLUS_VERDICTS = ("jats_table", "jats_prose", "outside_jats")
+
+
+def _share(needle: set, haystack: set) -> float:
+    return len(needle & haystack) / len(needle) if needle else 0.0
+
+
+def _classify_surplus_tables(
+    blocks: Sequence[Any],
+    pdf_text: str,
+    pages: Sequence[tuple[Any, Any]],
+) -> tuple[Counter, int, int, int]:
+    """Ask what the tables on over-emitting pages actually are.
+
+    The lane publishes `tables_emitted` beside `tables_expected`, and the gap between them
+    reads as invention unless something says otherwise. This says otherwise, or fails to.
+
+    Every table emitted on a page carrying more tables than the ground truth expects is
+    put to two questions. First, and independently of JATS: does the PDF's own text layer
+    hold this table's words? Text in the layer was printed on the page, so a table that
+    fails here is the only kind that could have been invented. Second: where does the text
+    sit in the ground truth -- inside a ``<table>``, inside prose, or nowhere? Prose
+    committed to a grid is the defect this was built to find.
+
+    Only the first question has an unordered form, and only there does it mean anything.
+    A grid re-cuts the page's words into cells, so a real table can hold every word the
+    text layer holds while sharing few of its 5-grams -- which is why `words_in_text_layer`
+    is the invention test and `in_text_layer` is a statement about adjacency. Against JATS
+    the same fallback would be worthless: prose committed to a grid keeps its word order
+    *inside* the cells, so ordered containment is what detects it, while a bag of words
+    cannot tell an article's table vocabulary from its prose vocabulary at all.
+
+    Returns
+    -------
+    tuple[Counter, int, int, int]
+        Verdict counts, tables examined, how many the text layer holds by n-gram
+        containment, and how many by word containment. Both are reported because they
+        answer different questions: a grid re-cuts the page's words into cells, so a
+        real table can hold every word the layer holds while sharing few of its
+        5-grams. The word figure is the invention test; the n-gram figure is adjacency.
+
+    """
+    truth_table_grams: set = set()
+    truth_prose_grams: set = set()
+    for block in blocks:
+        if not block.text:
+            continue
+        tokens = normalize(block.text)
+        if block.kind == "table":
+            truth_table_grams |= ngrams(tokens)
+        else:
+            truth_prose_grams |= ngrams(tokens)
+    layer_tokens = normalize(pdf_text)
+    layer_grams, layer_words = ngrams(layer_tokens), set(layer_tokens)
+
+    verdicts: Counter = Counter()
+    examined = layer_supported = layer_words_supported = 0
+    for truth, actual in pages:
+        if len(actual.tables) <= len(truth.tables):
+            continue
+        for table in actual.tables:
+            tokens = normalize(table.text)
+            grams, words = ngrams(tokens), set(tokens)
+            if len(grams) < MIN_NGRAMS:
+                continue
+            examined += 1
+            if _share(grams, layer_grams) >= RECALL_MIN:
+                layer_supported += 1
+            if _share(words, layer_words) >= TOKEN_PLACEMENT_MIN:
+                layer_words_supported += 1
+            if _share(grams, truth_table_grams) >= RECALL_MIN:
+                verdicts["jats_table"] += 1
+            elif _share(grams, truth_prose_grams) >= RECALL_MIN:
+                verdicts["jats_prose"] += 1
+            else:
+                verdicts["outside_jats"] += 1
+    return verdicts, examined, layer_supported, layer_words_supported
 
 
 def normalize_results(
@@ -456,6 +561,18 @@ def normalize_results(
             # cell text, so it is absent from `tables_expected` while the table it prints is
             # extracted from the page and counted in `tables_emitted`.
             "tables_deposited_as_images": sum(result.image_tables for result in evaluations),
+            # What the surplus *is*. Without this the gap between the two counts above can
+            # only be read as invention or explained away in prose; here it is measured
+            # every run, against the document's own text layer and against JATS.
+            "table_surplus": {
+                "examined": sum(result.surplus_examined for result in evaluations),
+                "in_text_layer": sum(result.surplus_in_text_layer for result in evaluations),
+                "words_in_text_layer": sum(result.surplus_words_in_text_layer for result in evaluations),
+                "by_source": {
+                    verdict: sum(result.surplus_verdicts.get(verdict, 0) for result in evaluations)
+                    for verdict in SURPLUS_VERDICTS
+                },
+            },
             "pages_with_expected_table": sum(1 for page in pages if page.truth_tables),
             "pages_with_emitted_table": sum(1 for page in pages if page.emitted_tables),
         },

--- a/benchmarks/pmc/benchmark.py
+++ b/benchmarks/pmc/benchmark.py
@@ -152,6 +152,8 @@ class ArticleEvaluation:
     degraded: tuple[DegradedFact, ...]
     duration_seconds: float
     ground_truth_blocks: int
+    #: ``<table-wrap>`` elements the publisher deposited as a graphic rather than as markup.
+    image_tables: int = 0
     emitted_text: str = ""
     #: The PDF's own text layer, which bounds what any parser could recover.
     pdf_text: str = ""
@@ -234,6 +236,7 @@ def evaluate_article(article: Any, *, options: Any = None) -> ArticleEvaluation:
     indexed = index_pages(article.pdf_path)
     assignment = assign_pages(blocks, indexed)
     truth_pairs = tuple((block.kind, block.text) for block in blocks if block.text)
+    image_tables = sum(1 for block in blocks if block.image_table)
 
     try:
         converted = convert_article(article.pdf_path, page_count, options=options or pdf_options())
@@ -249,6 +252,7 @@ def evaluate_article(article: Any, *, options: Any = None) -> ArticleEvaluation:
             degraded=(),
             duration_seconds=time.perf_counter() - started,
             ground_truth_blocks=len(blocks),
+            image_tables=image_tables,
             truth_blocks=truth_pairs,
             truth_captions=truth_captions,
             error=f"{type(exc).__name__}: {exc}",
@@ -291,6 +295,7 @@ def evaluate_article(article: Any, *, options: Any = None) -> ArticleEvaluation:
         degraded=converted.degraded,
         duration_seconds=time.perf_counter() - started,
         ground_truth_blocks=len(blocks),
+        image_tables=image_tables,
         emitted_text=" ".join(block for page in emitted for block in page.text_blocks),
         pdf_text=pdf_text,
         truth_blocks=truth_pairs,
@@ -446,6 +451,11 @@ def normalize_results(
             # `table_rejected` events say it often finds a candidate and then rejects it.
             "tables_expected": sum(page.truth_tables for page in pages),
             "tables_emitted": sum(page.emitted_tables for page in pages),
+            # Reported beside them because it is a share of the gap between them that no
+            # parser change can close: a `<table-wrap>` deposited as a graphic carries no
+            # cell text, so it is absent from `tables_expected` while the table it prints is
+            # extracted from the page and counted in `tables_emitted`.
+            "tables_deposited_as_images": sum(result.image_tables for result in evaluations),
             "pages_with_expected_table": sum(1 for page in pages if page.truth_tables),
             "pages_with_emitted_table": sum(1 for page in pages if page.emitted_tables),
         },

--- a/benchmarks/pmc/oracles.py
+++ b/benchmarks/pmc/oracles.py
@@ -132,6 +132,11 @@ class JatsBlock:
         elsewhere.
     table : TableProjection or None
         Structure and content of a ``<table-wrap>``'s table, when it has one.
+    image_table : bool
+        True for a ``<table-wrap>`` the publisher deposited as a graphic rather than as
+        markup. The block is a caption-only ``text_block`` either way -- there is no cell
+        text to score -- but the count is reported, because the page still prints a table
+        the parser can and does extract, and nothing in the ground truth can match it.
 
     """
 
@@ -139,6 +144,7 @@ class JatsBlock:
     text: str
     caption: str = ""
     table: TableProjection | None = None
+    image_table: bool = False
 
 
 def _tag(element: Any) -> str:
@@ -266,8 +272,11 @@ def _table_wrap(element: Any) -> JatsBlock:
     if projection is None:
         # A table-wrap with no table renders as a graphic plus its caption: real page
         # content, but nothing a Table node could match. Scoring it as an empty table would
-        # punish a parser for the absence of something that was never there.
-        return JatsBlock(kind="text_block", text=caption, caption="")
+        # punish a parser for the absence of something that was never there. Flagged rather
+        # than merely absorbed, so the count can be reported beside the table totals: the
+        # page prints a table the parser extracts from the text layer, and it lands in
+        # `tables_emitted` with nothing on the expected side to answer it.
+        return JatsBlock(kind="text_block", text=caption, caption="", image_table=True)
     return JatsBlock(kind="table", text=projection.text, caption=caption, table=projection)
 
 

--- a/benchmarks/pmc/reference.json
+++ b/benchmarks/pmc/reference.json
@@ -5,9 +5,9 @@
     "bucket": "pmc-oa-opendata",
     "complete_corpus": true,
     "oracle_schema_version": 2,
-    "all2md_commit": "c35f6b454615629c6011a76b4e8fb83af2e1a7c3",
+    "all2md_commit": "5ad13f0997f12df48606e4e9c8fd36b9708ee9db",
     "worktree_dirty": false,
-    "created_at": "2026-08-22T15:57:45.006514+00:00",
+    "created_at": "2026-08-23T01:06:43.389010+00:00",
     "python": "3.12.3 (main, Jun 19 2026, 12:46:00) [GCC 13.3.0]",
     "platform": "linux",
     "parser_runtime": {
@@ -47,6 +47,17 @@
     },
     "tables_expected": 121,
     "tables_emitted": 164,
+    "tables_deposited_as_images": 19,
+    "table_surplus": {
+      "examined": 58,
+      "in_text_layer": 41,
+      "words_in_text_layer": 58,
+      "by_source": {
+        "jats_table": 16,
+        "jats_prose": 0,
+        "outside_jats": 42
+      }
+    },
     "pages_with_expected_table": 94,
     "pages_with_emitted_table": 120
   },

--- a/docs/source/benchmarks.rst
+++ b/docs/source/benchmarks.rst
@@ -199,10 +199,34 @@ behind measured guards, the artifact reads **164 emitted against 121
 expected**, with tables emitted on 120 pages
 against the 94 that carry one in the ground truth.
 
-The surplus is mostly an accounting gap rather than invention: a table that continues
-across pages is one JATS ``<table-wrap>`` but several printed tables, and the expected
-count does not yet credit continuations. The remaining deficit is a handful of table
-classes with no shared mechanism.
+The surplus is not invention, and that is now measured rather than asserted. Every table
+emitted on a page carrying more tables than the ground truth expects — **58** of them — is
+put to two questions. The first does not involve JATS at all: does the PDF's own text layer
+hold this table's words? Text in the layer was printed on the page, so a table failing here
+is the only kind that could have been invented. **58 of 58** pass. The second asks where
+that text sits in the ground truth, and the verdict that would matter is prose committed to
+a grid — a parser turning running text into a table it invented. That is **0 of 58**.
+
+Only 41 of the 58 also match the *order* of the text layer, and that gap is a grid doing its
+job rather than a fault: re-cutting a page's words into cells changes their adjacency, which
+is why the invention test is asked of the words and not of the 5-grams.
+
+What the surplus is instead is accounting, with two named causes. **16** of the 58 trace to a
+JATS ``<table>`` that the expected count assigns to another page — a table continuing across
+a page break is one ``<table-wrap>`` and several printed tables, and the expected count does
+not credit continuations. And **19** ``<table-wrap>`` elements across five articles carry no
+``<table>`` markup at all: those publishers deposited their tables as images, so the ground
+truth holds no cell text for them and the tables those pages print can never reach the
+expected side, however well they are extracted. Those five articles alone contribute 20 of
+the **42** tables the census files outside JATS.
+
+The other 22 are in the page's own text layer and match no JATS block in order. The
+instrument stops there rather than guessing: it does not distinguish text JATS never
+recorded from a table re-cut into cells in an order JATS does not declare. Unordered token
+containment would answer neither, because an article's tables and its prose share a
+vocabulary by construction, so no bag-of-words threshold can separate them.
+
+The remaining table *deficit* is a handful of classes with no shared mechanism.
 
 The cost sat one section up: table blocks are the one kind whose attainable-recall figure
 *fell* across those recordings, from 83.6% to 69.1%. The first explanation written here —

--- a/tests/unit/test_pmc_oracle.py
+++ b/tests/unit/test_pmc_oracle.py
@@ -97,6 +97,31 @@ def test_a_table_wrap_without_a_table_is_not_scored_as_an_empty_table() -> None:
     assert "Only an image" in blocks[0].text
 
 
+def test_a_table_deposited_as_a_graphic_is_counted_rather_than_only_absorbed() -> None:
+    """The page prints a table nothing in the ground truth can match; the count says so.
+
+    Five of the 66 pinned articles deposit every table as an image -- 19 ``<table-wrap>``
+    elements carrying no ``<table>`` markup at all. all2md extracts those tables from the
+    PDF's own text layer correctly, and each one lands in ``tables_emitted`` with nothing
+    on the expected side to answer it. Absorbing them silently made that gap read as
+    over-emission.
+    """
+    blocks, _ = oracles.project_jats(
+        _jats(
+            "<table-wrap><label>Table 2</label><caption><p>Only an image</p></caption>"
+            "<graphic href='tbl2.jpg'/></table-wrap>"
+        )
+    )
+    assert [block.image_table for block in blocks] == [True]
+
+
+def test_a_table_with_markup_is_not_counted_as_deposited_as_an_image() -> None:
+    blocks, _ = oracles.project_jats(
+        _jats("<table-wrap><caption><p>Real markup</p></caption><table><tr><td>1</td></tr></table></table-wrap>")
+    )
+    assert [(block.kind, block.image_table) for block in blocks] == [("table", False)]
+
+
 def test_element_text_is_joined_not_concatenated() -> None:
     """Concatenation fused ``<label>Table 2</label>`` onto its caption as one bogus token."""
     blocks, _ = oracles.project_jats(_jats("<p><italic>Table 2</italic>obtained results</p>"))

--- a/tests/unit/test_pmc_oracle.py
+++ b/tests/unit/test_pmc_oracle.py
@@ -122,6 +122,79 @@ def test_a_table_with_markup_is_not_counted_as_deposited_as_an_image() -> None:
     assert [(block.kind, block.image_table) for block in blocks] == [("table", False)]
 
 
+# ---------------------------------------------------------------------------
+# What the surplus tables are
+# ---------------------------------------------------------------------------
+
+
+def _table_page(*tables: str) -> Any:
+    from benchmarks.omnidocbench.oracles import PageProjection, TableProjection
+
+    return PageProjection(
+        text_blocks=("a page needs one text block to be scored",),
+        block_kinds=("text_block",),
+        tables=tuple(TableProjection(rows=2, columns=2, cell_slots=4, text=text) for text in tables),
+        formulas=(),
+    )
+
+
+_TABLE_TEXT = "Group Control Treated N 15 18 Mean age 41.2 39.8 Response rate 0.62 0.71 P value 0.03"
+_PROSE_TEXT = "The cohort was recruited over eleven months from three centres in the same region."
+
+
+def _blocks() -> list[Any]:
+    return [
+        oracles.JatsBlock(kind="table", text=_TABLE_TEXT),
+        oracles.JatsBlock(kind="text_block", text=_PROSE_TEXT),
+    ]
+
+
+def test_a_surplus_table_holding_jats_table_text_is_traced_to_it() -> None:
+    verdicts, examined, _, _ = benchmark._classify_surplus_tables(
+        _blocks(), f"{_TABLE_TEXT} {_PROSE_TEXT}", [(_table_page(), _table_page(_TABLE_TEXT))]
+    )
+    assert examined == 1
+    assert verdicts["jats_table"] == 1
+
+
+def test_prose_committed_to_a_grid_is_the_defect_this_finds() -> None:
+    """The one verdict that would mean the parser invented a table out of running text."""
+    verdicts, _, _, _ = benchmark._classify_surplus_tables(
+        _blocks(), f"{_TABLE_TEXT} {_PROSE_TEXT}", [(_table_page(), _table_page(_PROSE_TEXT))]
+    )
+    assert verdicts["jats_prose"] == 1
+
+
+def test_a_table_the_text_layer_does_not_hold_is_the_only_kind_that_could_be_invented() -> None:
+    """The invention test asks the PDF, not JATS: text in the layer was printed on the page."""
+    invented = "Wholly absent phrasing that no page of this document ever printed anywhere"
+    _, examined, in_layer, words_in_layer = benchmark._classify_surplus_tables(
+        _blocks(), f"{_TABLE_TEXT} {_PROSE_TEXT}", [(_table_page(), _table_page(invented))]
+    )
+    assert (examined, in_layer, words_in_layer) == (1, 0, 0)
+
+    _, _, in_layer, words_in_layer = benchmark._classify_surplus_tables(
+        _blocks(), f"{_TABLE_TEXT} {_PROSE_TEXT}", [(_table_page(), _table_page(_TABLE_TEXT))]
+    )
+    assert (in_layer, words_in_layer) == (1, 1)
+
+
+def test_only_pages_carrying_more_tables_than_expected_are_examined() -> None:
+    """A page that emits what the ground truth expects is not in surplus and is not asked about."""
+    matched = (_table_page(_TABLE_TEXT), _table_page(_TABLE_TEXT))
+    _, examined, _, _ = benchmark._classify_surplus_tables(_blocks(), _TABLE_TEXT, [matched])
+    assert examined == 0
+
+
+def test_the_verdicts_reported_are_exactly_the_ones_the_payload_publishes() -> None:
+    """A verdict the payload never reads would vanish from the evidence without failing."""
+    verdicts, _, _, _ = benchmark._classify_surplus_tables(
+        _blocks(), f"{_TABLE_TEXT} {_PROSE_TEXT}", [(_table_page(), _table_page(_TABLE_TEXT, _PROSE_TEXT))]
+    )
+    assert set(verdicts) <= set(benchmark.SURPLUS_VERDICTS)
+    assert sum(verdicts.values()) == 2
+
+
 def test_element_text_is_joined_not_concatenated() -> None:
     """Concatenation fused ``<label>Table 2</label>`` onto its caption as one bogus token."""
     blocks, _ = oracles.project_jats(_jats("<p><italic>Table 2</italic>obtained results</p>"))

--- a/tests/unit/test_published_benchmark_figures.py
+++ b/tests/unit/test_published_benchmark_figures.py
@@ -97,6 +97,42 @@ def _pmc_figures(pmc: dict[str, Any]) -> list[tuple[str, str]]:
             f"against the {corpus['pages_with_expected_table']} that carry one in the ground truth.",
         ),
     ]
+    surplus = corpus["table_surplus"]
+    rows.extend(
+        [
+            # The claim these support -- that the surplus is accounting rather than
+            # invention -- was prose on this page for three recordings before anything
+            # measured it. Gated now, so it cannot quietly stop being true.
+            (
+                "surplus tables examined",
+                f"expects — **{surplus['examined']}** of them — is",
+            ),
+            (
+                "surplus invention test",
+                f"**{surplus['words_in_text_layer']} of {surplus['examined']}** pass.",
+            ),
+            (
+                "surplus prose committed to a grid",
+                f"That is **{surplus['by_source']['jats_prose']} of {surplus['examined']}**.",
+            ),
+            (
+                "surplus matching the layer's order",
+                f"Only {surplus['in_text_layer']} of the {surplus['examined']} also match the *order*",
+            ),
+            (
+                "surplus traced to a JATS table",
+                f"**{surplus['by_source']['jats_table']}** of the {surplus['examined']} trace to a",
+            ),
+            (
+                "surplus outside JATS",
+                f"the **{surplus['by_source']['outside_jats']}** tables the census files outside JATS.",
+            ),
+            (
+                "tables deposited as images",
+                f"And **{corpus['tables_deposited_as_images']}** ``<table-wrap>`` elements across five articles",
+            ),
+        ]
+    )
     for label, kind in (("text blocks", "text_block"), ("titles", "title"), ("tables", "table")):
         entry = kinds[kind]
         rows.append(


### PR DESCRIPTION
The docs rewrite this exists for needs numbers from a CI-recorded artifact, and that artifact needs the code in this PR. Opened early for CI signal on the new tests. I'll mark it ready once the artifact and the rewritten section are in.

## Why

The fidelity page says the gap between `tables_emitted` (164) and `tables_expected` (121) is *"mostly an accounting gap rather than invention"*. That sentence has no artifact behind it. A claim about invention is exactly the kind this lane is built to measure and publish beside a control, so it should not be sitting on the page as prose.

## What lands

**`corpus.tables_deposited_as_images`** — five of the 66 pinned articles deposit every table as a `<graphic>`. 19 `<table-wrap>` elements corpus-wide carry no `<table>` markup at all, against 123 that do — and 123 is exactly the attainable-table denominator the page already publishes, so the two are commensurable. The oracle always handled these correctly (a caption-only text block, never an empty table, because punishing a parser for the absence of something that was never there measures the ground truth). But it absorbed them silently, and that silence is what turns them into apparent over-emission: the page prints a table, all2md extracts it from the text layer, it lands in `tables_emitted`, and nothing on the expected side can answer it.

**`corpus.table_surplus`** — every table emitted on a page carrying more tables than the ground truth expects, put to two questions:

- `words_in_text_layer` / `in_text_layer` — does the PDF's own text layer hold this table's words? This does not depend on JATS at all; text in the layer was printed on the page, so a table failing here is the only kind that could have been invented. Both forms are published because a grid re-cuts the page's words into cells: a real table can hold every word the layer holds while sharing few of its 5-grams. The word figure is the invention test, the n-gram figure is a statement about adjacency.
- `by_source` — `jats_table` / `jats_prose` / `outside_jats`. Prose committed to a grid is the defect worth finding.

## Two rules I got wrong first, recorded so they stay fixed

**No unordered-token fallback.** A draft added one on the grounds that `alignment.py` already has it — and filed **21 of 58** surplus tables as resequenced prose, none of which are prose. `TOKEN_PLACEMENT_MIN = 0.65` is calibrated for *"which page of this article holds this block"*, discriminating among that article's own pages. Whether a grid holds table text or prose is a different question, and an article's tables and its prose share a vocabulary by construction, so a bag of words cannot separate them at any threshold. Prose forced into cells keeps its word order *inside* the cells, which is what ordered containment sees.

**This replaces a scratchpad probe whose numbers were void.** It read `PageEvaluation.page` — a zero-based index — as one-based, so every table it classified came from the page *before* the surplus page. Every over-emission figure derived from it is withdrawn, including the "0 prose committed to a grid, measured" conclusion recorded earlier. Measuring inside the lane, against the same `project_ast` projection the scores use and with `(truth, actual)` paired in the scoring loop itself, is what makes that class of error impossible rather than merely unlikely.

Purely additive to the payload: no measurement changes, so `SCHEMA_VERSION` stays 6, as for the `recovered_attainable` numerator (#428).

## Tests

Five, driving the classifier directly: a surplus table traced to JATS table text; prose committed to a grid detected as `jats_prose`; a table the layer does not hold scoring 0 on both invention counters while a real one scores 1; a page emitting exactly what is expected not examined at all; and the verdicts emitted being exactly the set the payload publishes, so a verdict the payload never reads cannot vanish from the evidence without failing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)