### PR TITLE
docs(benchmarks): print the by-kind share's own numerator

### DIFF
--- a/docs/source/benchmarks.rst
+++ b/docs/source/benchmarks.rst
@@ -120,20 +120,26 @@ By block kind:
 
    * - Kind
      - Attainable
-     - Recovered
+     - Recovered of those
      - Share of attainable
    * - Text blocks
      - 3,160 of 6,356
-     - 3,155
+     - 3,125
      - **98.9%**
    * - Titles
      - 2,291 of 2,426
-     - 2,287
+     - 2,265
      - **98.9%**
    * - Tables
      - 110 of 123
-     - 92
+     - 91
      - **82.7%**
+
+The middle column counts only blocks inside the ceiling, so each row's share is its own
+two counts divided. A few more blocks are recovered than that: 3,155 text blocks, 2,287
+titles and 92 tables come out matching the ground truth, including some the PDF's own text
+layer does not reproduce. Those count as recovered and on neither side of the share, which
+is why the larger count is not the one printed here.
 
 Table blocks are the outlier, and deliberately so — their text now routes through
 structured table extraction rather than flowing out as prose. What that buys and what it

--- a/tests/unit/test_published_benchmark_figures.py
+++ b/tests/unit/test_published_benchmark_figures.py
@@ -101,12 +101,26 @@ def _pmc_figures(pmc: dict[str, Any]) -> list[tuple[str, str]]:
         entry = kinds[kind]
         rows.append(
             (
+                # The middle cell is the share's own numerator, not ``recovered``.
+                # Printing ``recovered`` beside a share computed from
+                # ``recovered_attainable`` invited the reader to divide the two printed
+                # counts and land somewhere the artifact contradicts -- 92/110 reads as
+                # 83.6% where the row says 82.7%.
                 f"by-kind row: {label}",
                 f"     - {entry['attainable']:,} of {entry['scored']:,}\n"
-                f"     - {entry['recovered']:,}\n"
+                f"     - {entry['recovered_attainable']:,}\n"
                 f"     - **{_percent(entry['attainable_recall'])}**",
             )
         )
+    rows.append(
+        (
+            # Published so the counts the share leaves out are on the page rather than
+            # inferred from its absence.
+            "by-kind recovered counts",
+            f"{kinds['text_block']['recovered']:,} text blocks, {kinds['title']['recovered']:,}\n"
+            f"titles and {kinds['table']['recovered']} tables come out matching the ground truth",
+        )
+    )
     return rows
 
 
@@ -222,11 +236,13 @@ def test_every_published_share_is_reproducible_from_published_counts() -> None:
     ``attainable_recall`` is ``recovered_attainable / attainable``, and those are
     not the same blocks as ``recovered``: a block the output recovered that the
     PDF's own text layer does not reproduce counts in ``recovered`` and in
-    neither side of the share. While the numerator went unpublished, dividing the
-    two counts that *were* published gave a plausible wrong answer (92/110 reads
-    as 83.6% where the artifact says 82.7%), with nothing in the payload to
-    settle it. Skipped rather than failed on an artifact recorded before the
-    numerator shipped, so re-recording stays the fix and never the blocker.
+    neither side of the share. The fidelity page printed ``recovered`` beside a
+    share computed from ``recovered_attainable`` for several recordings, so
+    dividing the two counts a reader could see gave a plausible wrong answer
+    (92/110 reads as 83.6% where the artifact says 82.7%). Both the page and this
+    check now print the share's own numerator. Skipped rather than failed on an
+    artifact recorded before that numerator shipped, so re-recording stays the
+    fix and never the blocker.
     """
     recall = json.loads(_PMC.read_bytes())["article_recall"]
     if "recovered_attainable" not in recall:


### PR DESCRIPTION
The by-kind recall table on the fidelity page printed `recovered` in the middle
column next to a share computed from `recovered_attainable`. Both numbers are
correct in the artifact; the page published the wrong one of the two, so a
reader dividing the counts in front of them got an answer the artifact
contradicts:

| Kind | printed | share | printed ÷ ceiling |
| --- | --- | --- | --- |
| Text blocks | 3,155 | 98.9% | 99.8% |
| Titles | 2,287 | 98.9% | 99.8% |
| Tables | 92 | 82.7% | 83.6% |

`test_every_published_share_is_reproducible_from_published_counts` already named
this exact trap in its docstring — 92/110 reading as 83.6% — while the page went
on inviting it.

**Change.** The middle column now prints `recovered_attainable`, so each row's
two counts divide to the share beside it. The `recovered` counts the share
leaves out (blocks the output recovers that the PDF's own text layer does not
reproduce, which sit on neither side of the ratio) are stated in prose instead
of being inferred from their absence. The figure gate reads the same fields and
covers the new sentence, so both counts are now pinned to the artifact.

**No re-record.** Every field involved is already in the committed
`benchmarks/pmc/reference.json`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)