### PR TITLE
docs(benchmarks): publish the born-digital lane's own dimensions

### DIFF
--- a/docs/source/benchmarks.rst
+++ b/docs/source/benchmarks.rst
@@ -221,6 +221,66 @@ dissolving those boundaries on structural evidence and healing the cut values in
 recovered *as a table* is what downstream consumers need — but it is a trade, and the
 artifact says so rather than netting the two effects into one flattering number.
 
+Did it come out in the right order?
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Recall counts whether a block's words came out. It says nothing about whether they came out
+in the order the page prints them, and a converter can score well on every measure above
+while emitting a page as a shuffled bag of correct paragraphs. So the born-digital lane also
+runs the *same* dimensions as the scanned lane below, through the same oracle, over its 706
+pages:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 40 14 20 26
+
+   * - Dimension
+     - Value
+     - Wrong page
+     - Gap
+   * - ``reading_order_similarity``
+     - 0.828
+     - 0.292
+     - **0.536**
+   * - ``text_content_similarity``
+     - 0.676
+     - 0.234
+     - **0.442**
+   * - ``table_content_similarity``
+     - 0.606
+     - 0.039
+     - **0.567**
+   * - ``table_structure_similarity``
+     - 0.613
+     - 0.095
+     - **0.519**
+   * - ``block_structure_similarity``
+     - 0.548
+     - 0.444
+     - 0.104 — **not gated**
+
+The two table dimensions score only the 124 pages that carry a table on either side; the
+other three score all 706.
+
+The middle column is each dimension scored against the *wrong* page of the same article, and
+the gap is what is left. A measure with no gap is not measuring the output. That is the case
+against ``block_structure_similarity``, which is recorded here and excluded from the verdict
+in both lanes, for the reasons set out in the scanned-pages section below: on this corpus it
+separates own-page from wrong-page output by 0.10, and it *rises* when half the emitted
+content is deleted.
+
+These are the numbers the figure-placement work moves. Figures and their captions used to be
+flushed at the end of whichever page they appeared on, no matter where on the page they were
+printed, so every block after them on the page was reported out of order. Emitting them at
+the position they occupy in the column (#429) took reading order from 0.815 to 0.828 and text
+content from 0.667 to 0.676, with recall, figure binding and the table counts unchanged — and
+left all three scanned-lane dimensions byte-identical across 981 pages, because the guard
+that keeps OCR pages in engine order held.
+
+The two lanes' values are not comparable to each other as quality scores: born-digital pages
+carry a text layer and scanned pages do not, and the ground truths are differently strict.
+What the shared dimensions buy is that a change can be watched in both places at once.
+
 Scanned pages
 -------------
 

--- a/tests/unit/test_published_benchmark_figures.py
+++ b/tests/unit/test_published_benchmark_figures.py
@@ -181,6 +181,8 @@ def _pmc_figures(pmc: dict[str, Any]) -> list[tuple[str, str]]:
             f"score only the {int(pmc['dimensions']['table_content_similarity']['count'])} pages that carry a table "
             f"on either side; the\n"
             f"other three score all {int(pmc['dimensions']['reading_order_similarity']['count'])}.",
+        )
+    )
     rows.append(
         (
             # Published so the counts the share leaves out are on the page rather than

--- a/tests/unit/test_published_benchmark_figures.py
+++ b/tests/unit/test_published_benchmark_figures.py
@@ -107,6 +107,41 @@ def _pmc_figures(pmc: dict[str, Any]) -> list[tuple[str, str]]:
                 f"     - **{_percent(entry['attainable_recall'])}**",
             )
         )
+    # The born-digital lane records the same dimensions as the scanned lane and
+    # published none of them, so the whole of #429's movement -- figures emitted where
+    # they are printed -- was invisible on this page. Value, wrong-page control and the
+    # gap between them are pinned together: a dimension is only worth reading next to
+    # its gap, and a control that quietly rose would flatter every row above it.
+    for name, summary in pmc["dimensions"].items():
+        gap = f"{summary['discrimination']:.3f}"
+        # The one ungateable dimension carries its exclusion in the same cell.
+        gap_cell = f"{gap} \u2014 **not gated**" if "ungateable" in summary else f"**{gap}**"
+        rows.append(
+            (
+                f"pmc dimension: {name}",
+                f"   * - ``{name}``\n"
+                f"     - {summary['mean']:.3f}\n"
+                f"     - {summary['control_mean']:.3f}\n"
+                f"     - {gap_cell}",
+            )
+        )
+    rows.append(
+        (
+            "pmc dimension page count",
+            "runs the *same* dimensions as the scanned lane below, through the same oracle, over its "
+            f"{int(pmc['dimensions']['reading_order_similarity']['count'])}",
+        )
+    )
+    rows.append(
+        (
+            # The table dimensions score a different, much smaller population than the
+            # other three, which is the kind of thing a reader assumes away unless told.
+            "pmc table dimension page count",
+            f"score only the {int(pmc['dimensions']['table_content_similarity']['count'])} pages that carry a table "
+            f"on either side; the\n"
+            f"other three score all {int(pmc['dimensions']['reading_order_similarity']['count'])}.",
+        )
+    )
     return rows
 
 


### PR DESCRIPTION
The born-digital lane records the same five dimensions as the scanned lane,
through the same oracle — and published none of them. The whole of #429's
movement was therefore invisible on the evidence page: emitting figures at the
position they are printed, rather than flushing them to the end of the page,
took reading order **0.815 → 0.828** and text content **0.667 → 0.676**, and a
reader of `benchmarks.rst` had no way to see it.

**Change.** A new *Did it come out in the right order?* subsection under
Born-digital PDFs, carrying all five dimensions next to their wrong-page control
and the gap between them:

| Dimension | Value | Wrong page | Gap |
| --- | --- | --- | --- |
| `reading_order_similarity` | 0.828 | 0.292 | **0.536** |
| `text_content_similarity` | 0.676 | 0.234 | **0.442** |
| `table_content_similarity` | 0.606 | 0.039 | **0.567** |
| `table_structure_similarity` | 0.613 | 0.095 | **0.519** |
| `block_structure_similarity` | 0.548 | 0.444 | 0.104 — **not gated** |

The control is published with each value because a dimension without one cannot
be read. `block_structure_similarity` separating own-page from wrong-page output
by 0.10 *is* the case against it (#256), so the row carries its own exclusion in
the same cell rather than relying on a paragraph further down. The two table
dimensions score 124 pages against the other three's 706; the page says so
instead of letting the reader assume 706.

**Gate.** Every value, every control and every gap is pinned to
`benchmarks/pmc/reference.json`. Verified it can fail: a 0.001 drift in the
published reading-order value takes the gate red and names the row.

**No re-record.** Every field is already in the committed artifact. Sphinx
builds clean under `-W`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)