### PR TITLE
fix(pdf): stop reading text that clipping paths erase from the page (#435)

### DIFF
--- a/src/all2md/parsers/_pdf_images.py
+++ b/src/all2md/parsers/_pdf_images.py
@@ -20,6 +20,7 @@ from all2md.constants import (
     PDF_CAPTION_SEARCH_GAP,
 )
 from all2md.options.pdf import PdfOptions
+from all2md.parsers._pdf_text import clipped_textbox
 from all2md.utils.attachments import generate_attachment_filename, process_attachment
 
 if TYPE_CHECKING:
@@ -74,7 +75,7 @@ def _region_text(page: "pymupdf.Page", rect: Any) -> str:
     the body copy kept the full text, so the copies could never match and the
     caption printed twice (#410).
     """
-    return " ".join(page.get_textbox(rect).split())
+    return " ".join(clipped_textbox(page, rect).split())
 
 
 def _caption_from_layout(

--- a/src/all2md/parsers/_pdf_text.py
+++ b/src/all2md/parsers/_pdf_text.py
@@ -11,7 +11,7 @@ including handling rotated text and resolving hyperlinks.
 from __future__ import annotations
 
 import re
-from typing import TYPE_CHECKING, Iterable
+from typing import TYPE_CHECKING, Any, Iterable
 
 from all2md.ast import Code, Emphasis, Link, Node, Strong, Text
 from all2md.constants import DEFAULT_OVERLAP_THRESHOLD_PERCENT
@@ -23,6 +23,7 @@ if TYPE_CHECKING:
 
 __all__ = [
     "classify_line_rotation",
+    "clipped_textbox",
     "collapse_whitespace_runs",
     "extract_rotated_text",
     "format_rotation_note",
@@ -30,6 +31,48 @@ __all__ = [
     "inline_has_text",
     "resolve_links",
 ]
+
+
+def clipped_textbox(page: Any, rect: Any) -> str:
+    """Return the text inside ``rect``, honouring the page's clipping paths.
+
+    ``Page.get_textbox(rect)`` builds its own text page, and the flags it uses omit
+    ``TEXT_CLIP`` -- the same bit PyMuPDF also exports as ``TEXT_MEDIABOX_CLIP``, and one
+    that PyMuPDF's ``TEXTFLAGS_TEXT`` default turns on. With it off, glyphs that a clipping
+    path or a form XObject's ``/BBox`` removes from the rendered page are still collected.
+    So this one call answered from a different page than every other extraction here: text
+    that is on no printed page, and that ``get_text()`` correctly refuses to return.
+
+    Journal proofs make that concrete. PMC9000022 carries a superseded typesetting of each
+    page inside a clipped XObject, set to a wider measure; rendering the strip it occupies
+    gives blank paper. Reading a caption region through the unclipped call returned it
+    anyway -- cut at the region's edges, mid-word, and ahead of the real caption because it
+    sits higher: ``"...enrichment analysis o roups was pe..."`` in place of the caption
+    printed under the figure. Elsewhere the ghost merely doubles the caption, which is
+    worse to spot and just as wrong. Across the five corpus articles that carry one, this
+    put 1,808 words into the output that are printed nowhere.
+
+    Passing an explicit text page fixes it without changing what ``get_textbox`` means: the
+    clip is still per glyph, so a rect through the middle of a word still returns half of it
+    and table cells read exactly as before. Measured over a 160-call grid it is also about
+    twice as fast as the bare call, so no caller needs to cache anything.
+
+    Parameters
+    ----------
+    page : PyMuPDF Page
+        The page to read.
+    rect : PyMuPDF Rect
+        Region to clip to.
+
+    Returns
+    -------
+    str
+        Text inside the region, carrying its printed line breaks.
+
+    """
+    import pymupdf
+
+    return str(page.get_textbox(rect, textpage=page.get_textpage(flags=pymupdf.TEXTFLAGS_TEXT)))
 
 
 # Run of two or more horizontal-whitespace characters (no newlines, so we don't

--- a/src/all2md/parsers/pdf.py
+++ b/src/all2md/parsers/pdf.py
@@ -124,6 +124,7 @@ from all2md.parsers._pdf_tables import (
 )
 from all2md.parsers._pdf_text import (
     classify_line_rotation,
+    clipped_textbox,
     collapse_whitespace_runs,
     extract_rotated_text,
     format_rotation_note,
@@ -332,7 +333,7 @@ def _caption_comparison_key(text: str) -> str:
     """Reduce text to the glyphs both extraction routes agree on, for caption dedup.
 
     A bound caption and its body copy are the same printed glyphs read back through
-    different routes -- ``get_textbox`` for the caption, span text (or a rescued
+    different routes -- ``clipped_textbox`` for the caption, span text (or a rescued
     region, which dehyphenates) for the copy. The routes disagree on what they
     insert or keep *between* glyphs: ligature expansion ("ﬁrst" vs "first"),
     spacing split mid-word ("enrich ment"), and wrap hyphens kept by one route and
@@ -2379,7 +2380,7 @@ class PdfToAstConverter(BaseParser):
         bound_captions = [" ".join(item["caption"].split()) for item in figure_plan if item["caption"]]
 
         # The caption's printed region suppresses geometrically what the textual rule
-        # cannot: ``get_textbox`` and the block spans read the same glyphs through
+        # cannot: ``clipped_textbox`` and the block spans read the same glyphs through
         # different heuristics (wrap hyphens kept vs dehyphenated, spacing split mid-word,
         # occasionally a dropped character), so the two strings can disagree while the
         # geometry stays exact (#410). A region qualifies only when its entire text sits
@@ -2390,7 +2391,7 @@ class PdfToAstConverter(BaseParser):
             region_bound_keys = [_caption_comparison_key(c) for c in bound_captions]
             for pred in layout.get_predictions_by_label("caption"):
                 rect = pymupdf.Rect(pred.bbox)
-                region_key = _caption_comparison_key(page.get_textbox(rect))
+                region_key = _caption_comparison_key(clipped_textbox(page, rect))
                 if region_key and any(region_key in bound for bound in region_bound_keys):
                     bound_caption_rects.append(rect + PDF_CAPTION_REGION_SUPPRESS_MARGIN)
 
@@ -3697,7 +3698,7 @@ class PdfToAstConverter(BaseParser):
 
             for _col_idx, (x0, x1) in enumerate(col_x_coords):
                 cell_rect = pymupdf.Rect(x0, y0, x1, y1)
-                cell_text = page.get_textbox(cell_rect).strip()
+                cell_text = clipped_textbox(page, cell_rect).strip()
 
                 if cell_text:
                     unique_texts.add(cell_text)
@@ -4011,11 +4012,11 @@ class PdfToAstConverter(BaseParser):
             The region's text as a paragraph, or ``None`` if the region holds no text.
 
         """
-        text = page.get_textbox(region)
+        text = clipped_textbox(page, region)
         if not text or not text.strip():
             return None
 
-        # get_textbox is raw extraction: it returns the glyphs with their printed line
+        # clipped_textbox is raw extraction: it returns the glyphs with their printed line
         # breaks, and this is the only path into the AST that does not pass through
         # dehyphenate_blocks(). Without this a word broken across a line survives as two
         # fragments and the whole word is absent from the output -- "Coroman-" + "del" meant

--- a/tests/unit/formats/pdf/test_pdf_find_tables_repair.py
+++ b/tests/unit/formats/pdf/test_pdf_find_tables_repair.py
@@ -60,7 +60,14 @@ class _FakePage:
         assert kind == "words"
         return list(self._words)
 
-    def get_textbox(self, rect):
+    def get_textpage(self, flags=None):
+        """Real pages hand one to ``get_textbox`` so clipped-away glyphs stay out.
+
+        This fake has no clipping paths, so the token it returns is never read.
+        """
+        return None
+
+    def get_textbox(self, rect, textpage=None):
         return " ".join(word[4] for word in self._words)
 
 

--- a/tests/unit/formats/pdf/test_pdf_layout_region_tables.py
+++ b/tests/unit/formats/pdf/test_pdf_layout_region_tables.py
@@ -57,7 +57,14 @@ class _FakePage:
         self._by_strategy = by_strategy or {}
         self.strategies_tried: list[str] = []
 
-    def get_textbox(self, rect) -> str:
+    def get_textpage(self, flags=None):
+        """Real pages hand one to ``get_textbox`` so clipped-away glyphs stay out.
+
+        This fake has no clipping paths, so the token it returns is never read.
+        """
+        return None
+
+    def get_textbox(self, rect, textpage=None) -> str:
         return self._text
 
     def get_text(self, kind: str, **kwargs):

--- a/tests/unit/formats/pdf/test_pdf_rejected_region_text.py
+++ b/tests/unit/formats/pdf/test_pdf_rejected_region_text.py
@@ -4,7 +4,7 @@
 """Text rescued from a rejected table region is prose, and has to be treated as prose.
 
 When a detected table's grid turns out to be degenerate, the region is emitted as a
-paragraph instead. Its text is recovered with ``page.get_textbox()``, which is raw
+paragraph instead. Its text is recovered with ``clipped_textbox()``, which is raw
 extraction: the glyphs come back with their printed line breaks intact. Every other route
 into the AST passes through ``dehyphenate_blocks()`` first, and this one did not, so a word
 broken across a line stayed broken -- "Coroman-" and "del" never became "Coromandel", and

--- a/tests/unit/formats/pdf/test_pdf_ruling_table_guards.py
+++ b/tests/unit/formats/pdf/test_pdf_ruling_table_guards.py
@@ -58,7 +58,14 @@ class _RuledRegion:
     def rect(self):
         return pymupdf.Rect(self.xs[0], self.ys[0], self.xs[-1], self.ys[-1])
 
-    def get_textbox(self, rect) -> str:
+    def get_textpage(self, flags=None):
+        """Real pages hand one to ``get_textbox`` so clipped-away glyphs stay out.
+
+        This fake has no clipping paths, so the token it returns is never read.
+        """
+        return None
+
+    def get_textbox(self, rect, textpage=None) -> str:
         for row, (y0, y1) in enumerate(zip(self.ys, self.ys[1:], strict=False)):
             for col, (x0, x1) in enumerate(zip(self.xs, self.xs[1:], strict=False)):
                 if (rect.x0, rect.y0, rect.x1, rect.y1) == (x0, y0, x1, y1):

--- a/tests/unit/formats/pdf/test_pdf_table_guards.py
+++ b/tests/unit/formats/pdf/test_pdf_table_guards.py
@@ -46,7 +46,14 @@ class _FakePage:
         self._text = text
         self.asked_for: list[tuple] = []
 
-    def get_textbox(self, rect) -> str:
+    def get_textpage(self, flags=None):
+        """Real pages hand one to ``get_textbox`` so clipped-away glyphs stay out.
+
+        This fake has no clipping paths, so the token it returns is never read.
+        """
+        return None
+
+    def get_textbox(self, rect, textpage=None) -> str:
         self.asked_for.append(tuple(rect))
         return self._text
 

--- a/tests/unit/parsers/test_pdf_clipped_text.py
+++ b/tests/unit/parsers/test_pdf_clipped_text.py
@@ -1,0 +1,127 @@
+"""Text that a clipping path removes from the page must not reach the output.
+
+``Page.get_textbox()`` builds its text page without ``TEXT_CLIP``, so it collects glyphs
+that a clipping path or a form XObject ``/BBox`` erases from the rendering -- text that is
+printed on no page and that ``get_text()`` will not return. Four extractions in the PDF
+parser go through that call: figure captions, the caption-suppression key, table cell text,
+and the paragraph a rejected table region falls back to.
+
+The corpus case is a journal proof (PMC9000022) that keeps a superseded, wider typesetting
+of each page inside a clipped XObject. Rendering the strip it occupies gives blank paper;
+reading a caption region through the unclipped call returned it anyway, cut mid-word at the
+region's edges and ahead of the real caption -- ``"...enrichment analysis o roups was
+pe..."``. Where the two typesettings line up it doubles the caption instead, which is
+harder to notice and no less wrong.
+
+These tests build the same structure the proof does, with `show_pdf_page` clipped to a
+strip: the ghost glyphs are in the content stream but outside the XObject's bbox.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from all2md.parsers._pdf_images import detect_image_caption
+from all2md.parsers._pdf_text import clipped_textbox
+
+pytestmark = [pytest.mark.unit, pytest.mark.pdf]
+
+PRINTED = "Figure 1. Growth of the assay over twelve weeks."
+#: Same opening as PRINTED, so the failure is a doubled caption rather than a foreign one.
+GHOST = "Figure 1. Growth of the assay over many more twelve weeks superseded"
+CAPTION_REGION = (60.0, 240.0, 560.0, 300.0)
+IMAGE_RECT = (72.0, 120.0, 400.0, 236.0)
+
+
+@pytest.fixture
+def clipped_page(tmp_path: Path):
+    """A page whose only printed caption is PRINTED, with GHOST clipped out of sight."""
+    pymupdf = pytest.importorskip("pymupdf")
+
+    source = pymupdf.open()
+    source_page = source.new_page()
+    # Below the printed caption, so the blank-paper check below samples a band the
+    # printed caption does not reach into -- its ascenders would otherwise paint it.
+    source_page.insert_text((72, 285), GHOST, fontsize=9)
+    source_page.insert_text((72, 700), "visible strip", fontsize=9)
+
+    document = pymupdf.open()
+    page = document.new_page()
+    page.insert_text((72, 258), PRINTED, fontsize=9)
+    # The whole source page is drawn into an XObject whose bbox is this strip, so GHOST --
+    # at y=285 in source space -- is in the stream and outside the bbox. This is the shape
+    # the journal proof has, not an approximation of it.
+    strip = pymupdf.Rect(0, 690, 595, 710)
+    page.show_pdf_page(strip, source, 0, clip=strip)
+    path = tmp_path / "clipped.pdf"
+    document.save(path)
+    document.close()
+    source.close()
+
+    opened = pymupdf.open(path)
+    try:
+        yield opened[0]
+    finally:
+        opened.close()
+
+
+def test_the_ghost_is_not_printed_anywhere(clipped_page) -> None:
+    """The premise: it is invisible, so returning it is not a judgement call.
+
+    Without this the other tests only show that two extractions disagree, not which
+    one is right.
+    """
+    pymupdf = pytest.importorskip("pymupdf")
+
+    assert "superseded" not in clipped_page.get_text("text")
+    pixmap = clipped_page.get_pixmap(clip=pymupdf.Rect(0, 272, 595, 292), dpi=72)
+    painted = {pixmap.pixel(x, y) for x in range(pixmap.width) for y in range(pixmap.height)}
+    assert painted == {(255, 255, 255)}, "the ghost's band renders as blank paper"
+
+
+def test_bare_get_textbox_returns_the_ghost(clipped_page) -> None:
+    """Pins the PyMuPDF behaviour this helper exists to correct.
+
+    If a release ever makes ``get_textbox`` honour clips on its own, this fails and the
+    helper can go -- which is the only signal that would tell us so.
+    """
+    pymupdf = pytest.importorskip("pymupdf")
+
+    assert "superseded" in clipped_page.get_textbox(pymupdf.Rect(*CAPTION_REGION))
+
+
+def test_clipped_textbox_returns_only_printed_text(clipped_page) -> None:
+    pymupdf = pytest.importorskip("pymupdf")
+
+    text = clipped_textbox(clipped_page, pymupdf.Rect(*CAPTION_REGION))
+    assert text.strip() == PRINTED
+
+
+def test_a_bound_caption_is_not_doubled_by_the_ghost(clipped_page) -> None:
+    """The end of the path: what the figure actually carries."""
+    pymupdf = pytest.importorskip("pymupdf")
+
+    class FakeRegion:
+        bbox = CAPTION_REGION
+
+    caption = detect_image_caption(clipped_page, pymupdf.Rect(*IMAGE_RECT), [FakeRegion()])
+    assert caption == PRINTED
+    assert caption.count("Figure 1.") == 1
+
+
+def test_clipping_still_cuts_a_word_the_rect_crosses(clipped_page) -> None:
+    """The helper changes which glyphs exist, not how the rect selects among them.
+
+    Table cells depend on the per-glyph clip: a cell rect is a cell's contents, not the
+    whole line it sits on. Switching to a line-preserving extraction would have fixed the
+    ghost and broken every grid, so the distinction is load-bearing.
+    """
+    pymupdf = pytest.importorskip("pymupdf")
+
+    whole = clipped_textbox(clipped_page, pymupdf.Rect(*CAPTION_REGION))
+    half = clipped_textbox(clipped_page, pymupdf.Rect(150.0, 240.0, 560.0, 300.0))
+    assert whole.startswith("Figure 1. Growth")
+    assert not half.startswith("Figure 1. Growth")
+    assert half and half in whole

--- a/tests/unit/parsers/test_pdf_figure_plan.py
+++ b/tests/unit/parsers/test_pdf_figure_plan.py
@@ -46,7 +46,14 @@ class _FakePage:
     def __init__(self, texts: dict[tuple[float, float, float, float], str]) -> None:
         self._texts = texts
 
-    def get_textbox(self, rect: "pymupdf.Rect") -> str:
+    def get_textpage(self, flags=None):
+        """Real pages hand one to ``get_textbox`` so clipped-away glyphs stay out.
+
+        This fake has no clipping paths, so the token it returns is never read.
+        """
+        return None
+
+    def get_textbox(self, rect: "pymupdf.Rect", textpage=None) -> str:
         return self._texts.get((rect.x0, rect.y0, rect.x1, rect.y1), "")
 
 

--- a/tests/unit/parsers/test_pdf_parser.py
+++ b/tests/unit/parsers/test_pdf_parser.py
@@ -733,7 +733,7 @@ class TestDetectedCaptionsReachTheFigureNode:
     def test_a_ligature_in_the_body_copy_still_matches_the_bound_caption(self) -> None:
         """NFKC applies to both sides of the containment test (#410).
 
-        The bound caption comes through ``get_textbox``, which expands ligatures;
+        The bound caption comes through ``clipped_textbox``, which expands ligatures;
         the body block's spans preserve them. "ﬁrst" against "first" made the same
         printed text fail the substring test and the caption printed twice.
         """
@@ -745,7 +745,7 @@ class TestDetectedCaptionsReachTheFigureNode:
         assert PdfToAstConverter._is_bound_caption_block(block, [caption])
 
     def test_a_dehyphenated_body_copy_still_matches_the_caption_keeping_the_wrap_hyphen(self) -> None:
-        """The rescued-region route dehyphenates; ``get_textbox`` keeps the wrap hyphen.
+        """The rescued-region route dehyphenates; ``clipped_textbox`` keeps the wrap hyphen.
 
         "knock- down" in the bound caption against "knockdown" in the body copy is
         the same printed word read through two policies; the comparison key drops
@@ -759,7 +759,7 @@ class TestDetectedCaptionsReachTheFigureNode:
         assert PdfToAstConverter._is_bound_caption_block(block, [caption])
 
     def test_a_body_copy_with_spacing_artifacts_still_matches_the_caption(self) -> None:
-        """``get_textbox`` can split a word ("enrich ment"); the block keeps it whole (#410)."""
+        """``clipped_textbox`` can split a word ("enrich ment"); the block keeps it whole (#410)."""
         from all2md.parsers.pdf import PdfToAstConverter
 
         caption = "Figure 5. Pathway enrich ment analysis of the knockdown cells."


### PR DESCRIPTION
Closes #435.

`page.get_textbox()` builds its own `TextPage` with flags that omit `TEXT_CLIP` — the bit
PyMuPDF also exports as `TEXT_MEDIABOX_CLIP`, and one that is **on** in the
`TEXTFLAGS_TEXT` default every other extraction in this parser uses. With it off, glyphs
that a clipping path or a form XObject's `/BBox` removes from the rendered page are still
collected. Four extractions went through that call — figure captions, the
caption-suppression key, table cell text, and the rejected-region fallback paragraph — so
they answered from a different page than the rest of the parser.

## What it was returning

Five of the 66 PMC born-digital articles are journal proofs that keep a superseded, wider
typesetting of each page inside a clipped XObject. **Rendering the strip it occupies gives
blank paper**, so returning that text is not a judgement call — it is on no printed page,
and `get_text()` correctly refuses to return it.

It came back anyway, cut at the region's edges mid-word and *ahead of* the real caption
because it sits higher. PMC9000022 page 8 handed its figure:

```
...cells. (A) Pathway enrichment analysis o roups was pe...
```

against a caption printed underneath that reads "…enrichment analysis of up-regulated
proteins in CCT3 knockdown groups was performed with…". Where the two typesettings line up
it doubles the caption instead — harder to spot, no less wrong.

## Measured

109 of 736 pages carry clipped-away text, concentrated in five articles. Converting those
five before and after, same process, same options:

| | before | after |
|---|---|---|
| words emitted | 49,952 | **48,144** |
| caption words printed nowhere in the PDF | 67 | **0** |
| captions changed | — | 45 of 89 figures (26 doubled) |

**1,808 words** removed, all of them glyphs no reader can see. Figure counts are unchanged
on every article, so this is text quality rather than a detection change.

## Why an explicit text page and not a different extraction

Passing a text page does not change what `get_textbox` means: the clip stays **per glyph**,
so a rect through the middle of a word still returns half of it and table cells read
exactly as before. `get_text("text", clip=rect)` would also have killed the ghost, by
returning whole lines — and broken every grid, because a cell rect is a cell's contents and
not the line it sits on. `test_clipping_still_cuts_a_word_the_rect_crosses` pins that
distinction.

Incidentally ~2× faster than the bare call over a 160-call grid, since the bare call builds
a text page per invocation regardless.

## Tests

`tests/unit/parsers/test_pdf_clipped_text.py` builds the same structure the proof does —
`show_pdf_page` clipped to a strip, so the ghost glyphs are in the content stream and
outside the XObject's bbox. It asserts the premise first (the ghost renders as blank
paper), then that the parser no longer emits it.

One of them pins PyMuPDF's own behaviour: if a release ever makes `get_textbox` honour
clips by itself, `test_bare_get_textbox_returns_the_ghost` fails and the helper can be
deleted. That is the only signal that would tell us.

Full unit suite green: 7,936 passed.

## Recording

This moves parser output, so the born-digital artifact needs re-recording on the Linux
runner before any published figure moves. Dispatching the PMC lane against this branch
next; docs figures follow in the same PR once the artifact lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
