### PR TITLE
docs(benchmarks): re-record the born-digital lane after the clipped-text fix (#435)

### DIFF
--- a/benchmarks/pmc/reference.json
+++ b/benchmarks/pmc/reference.json
@@ -5,9 +5,9 @@
     "bucket": "pmc-oa-opendata",
     "complete_corpus": true,
     "oracle_schema_version": 2,
-    "all2md_commit": "5ad13f0997f12df48606e4e9c8fd36b9708ee9db",
+    "all2md_commit": "1226777d23973e2447a562a081b4f59b1c971d4f",
     "worktree_dirty": false,
-    "created_at": "2026-08-23T01:06:43.389010+00:00",
+    "created_at": "2026-08-23T21:00:44.428227+00:00",
     "python": "3.12.3 (main, Jun 19 2026, 12:46:00) [GCC 13.3.0]",
     "platform": "linux",
     "parser_runtime": {
@@ -115,18 +115,18 @@
     "discrimination": 0.6178551375631667
   },
   "article_precision": {
-    "precision": 0.9498668913528678,
+    "precision": 0.9506444457900769,
     "supported": 423880,
-    "emitted": 446252,
-    "resequenced": 18550,
-    "novel": 3822,
-    "novel_share": 0.008564667497288528,
-    "duplication": 0.0075020318441565,
-    "excess": 3563,
-    "occurrences": 474938,
-    "control_precision": 0.007036383030216111,
-    "control_emitted": 446252,
-    "discrimination": 0.9428305083226517
+    "emitted": 445887,
+    "resequenced": 18393,
+    "novel": 3614,
+    "novel_share": 0.008105192571211988,
+    "duplication": 0.004493983009108454,
+    "excess": 2126,
+    "occurrences": 473077,
+    "control_precision": 0.007042142964473062,
+    "control_emitted": 445887,
+    "discrimination": 0.9436023028256039
   },
   "figure_binding": {
     "binding_rate": 0.6697674418604651,
@@ -138,7 +138,7 @@
     "caption_recall": 0.9441860465116279,
     "present": 203,
     "images_emitted": 429,
-    "captioned_emitted": 190,
+    "captioned_emitted": 189,
     "control_binding_rate": 0.0,
     "control_scored": 215,
     "discrimination": 0.6697674418604651
@@ -146,18 +146,18 @@
   "dimensions": {
     "block_structure_similarity": {
       "count": 706.0,
-      "mean": 0.5484813685328609,
+      "mean": 0.5485028296024805,
       "median": 0.5714285714285714,
       "minimum": 0.023255813953488413,
       "maximum": 1.0,
-      "stdev": 0.21058232887528835,
+      "stdev": 0.21055959591452936,
       "direction": "higher",
-      "control_mean": 0.4441323844565242,
-      "discrimination": 0.10434898407633669,
+      "control_mean": 0.44415691139323243,
+      "discrimination": 0.1043459182092481,
       "mutation_drop": {
         "reversed": 0.015782263093977338,
         "shuffled": 0.03254869887397674,
-        "halved": 0.06241696982757137
+        "halved": 0.062309664479472816
       },
       "ungateable": "compares kind sequences without inspecting the text under a block, so content-free output scores 1.0 (issue #256); eleven text categories collapse to `text_block`, so fully reversed output scores exactly 1.0 on 153 of the 981 pinned pages; and on the born-digital lane it separates own-page from wrong-page output by only ~0.06 while *rising* when half the emitted content is deleted, which rewards dropping blocks"
     },
@@ -169,12 +169,12 @@
       "maximum": 1.0,
       "stdev": 0.20974930316180884,
       "direction": "higher",
-      "control_mean": 0.29215575823349715,
-      "discrimination": 0.5359759720880322,
+      "control_mean": 0.29069717196612904,
+      "discrimination": 0.5374345583554003,
       "mutation_drop": {
         "reversed": 0.5303437329469437,
-        "shuffled": 0.24328767375956228,
-        "halved": 0.3255185131028114
+        "shuffled": 0.24338884737348376,
+        "halved": 0.32697035446258477
       }
     },
     "table_content_similarity": {
@@ -211,18 +211,18 @@
     },
     "text_content_similarity": {
       "count": 706.0,
-      "mean": 0.6762563749831473,
-      "median": 0.6993291888523847,
+      "mean": 0.6813156888254379,
+      "median": 0.7082209683552323,
       "minimum": 0.010652463382157085,
       "maximum": 0.9930305215092525,
-      "stdev": 0.22360381359462717,
+      "stdev": 0.22329983041306012,
       "direction": "higher",
-      "control_mean": 0.2341678713390695,
-      "discrimination": 0.4420885036440778,
+      "control_mean": 0.2334461851782221,
+      "discrimination": 0.4478695036472158,
       "mutation_drop": {
-        "reversed": 0.2914274690677305,
-        "shuffled": 0.20251057893083302,
-        "halved": 0.29247980461231066
+        "reversed": 0.292270299536416,
+        "shuffled": 0.20376197639542715,
+        "halved": 0.29620063786003653
       }
     }
   },

--- a/docs/source/benchmarks.rst
+++ b/docs/source/benchmarks.rst
@@ -167,33 +167,39 @@ Unsupported output is therefore split in two:
      - Share
      - Meaning
    * - Supported
-     - **95.0%**
+     - **95.1%**
      - the n-gram appears in the document's text layer
    * - Resequenced
-     - 4.2%
+     - 4.1%
      - every word is in the document, in a new adjacency
    * - **Novel**
-     - **0.9%**
+     - **0.8%**
      - at least one word appears nowhere — the number worth reading
    * - Duplication
-     - 0.8%
+     - 0.4%
      - supported text emitted more than once
    * - Control: the *wrong* article
      - 0.7%
      - wants to be ~0%
 
-Over 446,252 emitted n-grams, 3,822 are novel. Reporting the raw unsupported figure instead
+Over 445,887 emitted n-grams, 3,614 are novel. Reporting the raw unsupported figure instead
 would have made the result roughly six times worse than the parser deserves.
 
 Duplication is counted apart from both, because it is invisible to either. Text emitted
 twice is an unchanged *set* and a doubled *multiset* — no set-based score can see it at all.
 
-Duplication is under a point, and the path it took there is the point. It read 0.5% while
-the oracle was blind to captions, jumped to 2.0% when the corrected oracle could finally
-see that multi-panel figures re-bound one printed caption to every panel, and fell by two
-thirds when that defect was fixed (issue #410). The middle figure was the honest one: the
-defect predated the re-record, and what changed first was only that a measurement became
+Duplication is under half a point, and the path it took there is the point. It read 0.5%
+while the oracle was blind to captions, jumped to 2.0% when the corrected oracle could
+finally see that multi-panel figures re-bound one printed caption to every panel, and fell
+by two thirds when that defect was fixed (issue #410). The middle figure was the honest one:
+the defect predated the re-record, and what changed first was only that a measurement became
 able to report it.
+
+It fell by two fifths again, 0.8% to 0.4%, on #435. That defect mostly *doubled* captions
+rather than inventing them — the clipped-away typesetting is the same words as the printed
+one — so duplication is where the bulk of it landed. Novel share moved by less than a
+twentieth of a point, 0.86% to 0.81%, which is enough to cross a rounding boundary in the
+table above and not much more.
 
 Tables
 ~~~~~~
@@ -270,12 +276,12 @@ pages:
      - Gap
    * - ``reading_order_similarity``
      - 0.828
-     - 0.292
-     - **0.536**
+     - 0.291
+     - **0.537**
    * - ``text_content_similarity``
-     - 0.676
-     - 0.234
-     - **0.442**
+     - 0.681
+     - 0.233
+     - **0.448**
    * - ``table_content_similarity``
      - 0.606
      - 0.039
@@ -285,7 +291,7 @@ pages:
      - 0.095
      - **0.519**
    * - ``block_structure_similarity``
-     - 0.548
+     - 0.549
      - 0.444
      - 0.104 — **not gated**
 
@@ -306,6 +312,16 @@ the position they occupy in the column (#429) took reading order from 0.815 to 0
 content from 0.667 to 0.676, with recall, figure binding and the table counts unchanged — and
 left all three scanned-lane dimensions byte-identical across 981 pages, because the guard
 that keeps OCR pages in engine order held.
+
+Text content moved again, to 0.681, when the parser stopped reading text that clipping paths
+erase from the page (#435). Five of the 66 articles are journal proofs that keep a superseded,
+wider typesetting of each page inside a clipped form XObject: it renders as blank paper, but
+the one PyMuPDF call the parser used to read a region's text collected it anyway, cut mid-word
+at the region's edges. Reading order's own value did not move at all — the ghost was extra
+text, not misplaced text — and recall did not move either, for the same reason. What it
+changes is precision, below. One figure lost its caption, because the only thing that had
+ever captioned it was the ghost; ``caption_recall`` against the JATS captions is unchanged
+to every recorded digit, which is how we know no real one went with it.
 
 The two lanes' values are not comparable to each other as quality scores: born-digital pages
 carry a text layer and scanned pages do not, and the ground truths are differently strict.


### PR DESCRIPTION
Follow-up to #436, which merged before this landed on it. The parser fix is on `main`; this
is the artifact that measures it, plus the published figures it moves.

`main` is self-consistent in the meantime — the old artifact and the old figures agree with
each other, so the verbatim gate passes there. What it is not, until this lands, is *current*:
the published numbers describe a parser that no longer exists.

## The recording

Run [32664947467](https://github.com/thomas-villani/all2md/actions/runs/32664947467) on the
Linux runner at `1226777` (the tree that merged as `d2e59fd`), lockfile-resolved, worktree
clean, same corpus pin and oracle schema 2.

**The payload differs from the previous reference at 29 leaves and nowhere else.**

### What does *not* move

Recall is byte-identical — `attainable_recall` and every by-kind count (3,160/3,125 text
blocks, 2,291/2,265 titles, 110/91 tables), the table counts, and the whole surplus census.
`reading_order_similarity`'s own value stays 0.828.

That is the acceptance test, not a footnote. The ghost text was **extra**, not missing and
not misplaced, so a recording that moved recall would mean the fix did something other than
what it claims.

### What does

| | before | after |
|---|---|---|
| Duplication | 0.8% | **0.4%** |
| Novel share | 0.86% | **0.81%** |
| Supported | 95.0% | **95.1%** |
| Resequenced | 4.2% | **4.1%** |
| emitted n-grams | 446,252 | 445,887 |
| novel n-grams | 3,822 | **3,614** |
| `text_content_similarity` | 0.676 | **0.681** |
| `block_structure_similarity` | 0.548 | 0.549 |

Duplication falls by two fifths while novel share falls by less than a twentieth of a point —
exactly the split a defect that *doubled* captions rather than inventing them should produce,
since a clipped-away typesetting is the same words as the printed one.
`reading_order_similarity`'s gap widens to 0.537 on its control moving, not its value.

### The one drop

`figure_binding.captioned_emitted` goes 190 → 189: one figure's only caption was the ghost.
`caption_recall` against the JATS captions is unchanged to every recorded digit, so no real
caption went with it. The prose says so on the page, because a bare count going down reads as
a regression otherwise.

Figure gate green, full unit suite green (7,936 passed), `sphinx -W` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
