### PR TITLE
docs(comparison): record the 2026-08-23 sealed-holdout reading

### DIFF
--- a/benchmarks/comparison/README.md
+++ b/benchmarks/comparison/README.md
@@ -41,62 +41,105 @@ tools — and text survival alone structurally favors low-structure converters: 
 highest-recall converter imaginable dumps the raw text layer with no structure at all.
 Quote these numbers with that asymmetry attached.
 
-## Reading, 2026-08-19 (`results-2026-08-19.json`)
+## Reading, 2026-08-23 (`results-2026-08-23.json`)
 
 110 of 110 articles converted by every tool; zero conversion failures anywhere.
 
-| | all2md @ 99a0eb0 | pymupdf4llm 1.28.2 | docling 2.120.3 |
+| | all2md @ 073e4da | pymupdf4llm 1.28.2 | docling 2.120.3 |
 | --- | --- | --- | --- |
-| Recall of attainable | 93.5% | **98.3%** | 95.5% |
-| — titles | 93.4% | 99.3% | 95.4% |
-| — table text | 69.9% | 65.1% | **82.2%** |
-| **Novel (invented) share** | **0.84%** | 5.49% | 2.87% |
-| Duplication | 0.61% | 0.19% | 0.62% |
-| Tables emitted / expected | 228 / 166 | 208 / 166 | 201 / 166 |
-| Seconds per article (CPU) | ~10 | ~35 | ~92 |
+| Recall of attainable | 98.2% | **98.3%** | 95.5% |
+| — text blocks | **98.4%** | 98.4% | 95.9% |
+| — titles | 98.7% | **99.3%** | 95.4% |
+| — table text | 77.4% | 65.1% | **82.2%** |
+| **Novel (invented) share** | **0.62%** | 5.64% | 2.87% |
+| Duplication | 0.46% | 0.19% | 0.62% |
+| Tables emitted / expected | 238 / 166 | 212 / 166 | 201 / 166 |
+| Seconds per article (CPU) | **12.7** | 26.9 | 55.2 |
+| OCR firings over the corpus | **0** | 423 | sparse |
 
-(The all2md row is the re-parsed figure per rule 3; its direct payload figure on the
-same corpus is 93.8%. Docling's timing mean is inflated by model warmup and by the run
-being suspended mid-flight; treat all timings as rough.)
+**The control comes first, because it is what licenses the rest.** Both baselines were
+re-run unchanged, at the versions `baselines.txt` still pins. **docling reproduced every
+recorded figure to six decimal places.** pymupdf4llm reproduced its deterministic figures
+exactly and drifted only on OCR-dependent ones (novel share +0.0015, tables +4) — RapidOCR
+is not bit-deterministic across thread counts. Two unchanged tools reproducing is what makes
+all2md's movement attributable to all2md rather than to the instrument.
+
+### What moved, against 2026-08-19 (`99a0eb0` → `073e4da`)
+
+Same corpus pin, same platform, same baseline versions; the only variable is our own commit.
+
+| | then | now |
+| --- | --- | --- |
+| Recall of attainable | 93.5% | **98.2%** (+4.71) |
+| — text blocks | 94.3% | **98.4%** (+4.15) |
+| — titles | 93.4% | **98.7%** (+5.30) |
+| — table text | 69.9% | **77.4%** (+7.53) |
+| Novel share | 0.84% | **0.62%** (−0.22) |
+| Duplication | 0.61% | **0.46%** (−0.15) |
+| `reparse_word_ratio` | 0.957 | 0.983 |
+
+Recall rose 4.7 points while invented text *fell*. That is the combination worth having:
+the highest-recall converter imaginable dumps the text layer with no structure, and
+pymupdf4llm shows what buying recall with OCR costs — it reaches the same 98.3% with 423
+OCR firings on a corpus where **no page needs OCR at all** (0 of 1,184 pages carry a text
+layer under 20 characters), and pays 5.64% novel share for it. all2md fired zero times.
+
+On this corpus all2md now leads docling overall, leads both on text blocks, and trails only
+pymupdf4llm on titles (98.7% vs 99.3%) and docling on table text.
+
+### The lost-block diff
+
+`lost_blocks.py` names every truth block a baseline recovers that all2md loses. Against
+pymupdf4llm it went **528 → 108** (title 49, text block 47, table 12); against docling, 113.
+
+The residue is almost entirely *shredded* rather than absent — 79 of the 108 sit at
+containment 0.4–0.8, only 2 below 0.05 — and it is concentrated: 45 of 108 fall in two
+articles (`PMC7250022.1`, `PMC7250011.1`). Its mechanism has not been diagnosed yet and is
+not assumed here.
+
+**#414 is answered by this diff.** Its exemplar, `PMC11000022.1`, now loses **zero** blocks
+against either baseline. The issue's own stated trigger was the class rising in a holdout
+block-diff; it has not risen.
+
+**Table misses became #438.** Of 146 attainable tables we recover 113, and of the 33 we miss,
+**none are absent** — word containment across all 33 is mean 0.998, median 1.000. Every miss
+is adjacency: wrapped cell text becomes extra table rows, so the words are all present and
+non-contiguous. docling recovers 20 of the 33 (twelve at containment 1.000), so they are
+reachable; its lead is merging wrapped cells, not reading text we cannot reach.
 
 The honest positioning, with each tool's structural advantage named:
 
-- **pymupdf4llm wins raw text survival and loses trustworthiness.** Its 5.5% novel
-  share — 6.5× ours — is not a scoring artifact: pymupdf4llm 1.28+ bundles
-  `pymupdf-layout` and auto-fires RapidOCR on born-digital pages, and OCR of pages that
-  already have a text layer mints text the document never contained. This is the same
-  misfire class the PMC lane measured and gated out of all2md with the
-  largest-single-image threshold.
-- **Docling has the best table cell preservation** (82.2% vs our 69.9%) at ~9× our
-  runtime. Its table extraction keeps cell text ours drops — a study target, not a
-  mystery to live with.
-- **all2md wins invented text decisively** (0.84%) and is the fastest of the three.
+- **pymupdf4llm wins raw text survival by 0.03 points and loses trustworthiness by 9×.**
+  Its 5.6% novel share is not a scoring artifact: pymupdf4llm 1.28+ bundles `pymupdf-layout`
+  and auto-fires RapidOCR on born-digital pages, and OCR of pages that already have a text
+  layer mints text the document never contained. Measured this run: 423 firings, zero needed.
+- **Docling has the best table cell preservation** (82.2% vs our 77.4%, a gap down from 12.3
+  points to 4.8) at ~4× our runtime. It is not OCR doing that — its OCR is sparse and
+  region-scoped. It is TableFormer merging wrapped cells. See #438.
+- **all2md wins invented text decisively** (0.62%) and is the fastest of the three.
 
-## What the reading produced
+## Earlier readings
 
-The point of the lane is the diff, not the leaderboard. `lost_blocks.py` names every
-truth block a baseline recovers that all2md loses; the 2026-08-19 run (528 blocks
-against pymupdf4llm) became:
-
-- **#405** — side-by-side regions interleaved line-by-line (~405 of 528 blocks at
-  partial containment 0.4–0.8): two-column reference lists with tight gutters, and boxed
-  sidebars beside body columns. Words survive; adjacency is destroyed.
-- **#406** — figure captions absent entirely (66 caption blocks at share ~0: the words
-  appear nowhere in the output, so this is not a binding failure).
-- Docling table-extraction study — what does it preserve that our cell extraction drops?
+- **2026-08-19** (`results-2026-08-19.json`, all2md `99a0eb0`). all2md 93.5% recall / 0.84%
+  novel; pymupdf4llm 98.3% / 5.49%; docling 95.5% / 2.87%. Its lost-block diff ran to 528
+  blocks against pymupdf4llm and became **#405** (side-by-side regions interleaved
+  line-by-line, ~405 blocks at partial containment 0.4-0.8) and **#406** (figure captions
+  absent entirely, 66 blocks at share ~0). Both are fixed; the diff is now 108.
 
 ## Caveats that bound the numbers
 
-- **The recording machine had no Tesseract binary**, so all2md's would-be OCR firings
-  fall back silently. Do not quote OCR misfire counts from this lane; the PMC lane on
-  Linux is the instrument for that.
+- **Tesseract is installed on the recording machine but not on PATH.** For this corpus that
+  is moot and was measured rather than assumed: 0 of its 1,184 pages carry a text layer under
+  20 characters, so all2md's auto-OCR has nothing to fire on, and it fired 0 times. The
+  2026-08-19 reading carried this as an unbounded caveat; it is now bounded. Still do not
+  quote all2md OCR *misfire* counts from this lane -- a corpus with no scans cannot measure
+  them. The PMC lane on Linux is the instrument for that.
 - **These results never go on the docs fidelity page.** `docs/source/benchmarks.rst` is
   verbatim-gated against committed artifacts of *this repo's* lanes; third-party numbers
   age with every baseline release and belong here, dated, instead.
 - Article-level text survival favors low-structure output (the asymmetry under
-  "deliberately narrow" above). A tool
-  "beating" all2md on attainable recall while inventing 6× more text is not ahead; the
-  two columns must travel together.
+  "deliberately narrow" above). A tool "beating" all2md on attainable recall by 0.03 points
+  while inventing 9× more text is not ahead; the two columns must travel together.
 
 ## Running it
 

--- a/benchmarks/comparison/results-2026-08-23.json
+++ b/benchmarks/comparison/results-2026-08-23.json
@@ -1,0 +1,1772 @@
+{
+  "provenance": {
+    "recorded": "2026-08-23",
+    "corpus": "benchmarks/pmc/manifest-holdout.json (110 held-out articles)",
+    "corpus_pin": "93fb2c78ec99af5c84620155eef10c8dd616c5fdf0c69c58338e1aafbe4918cb",
+    "all2md_commit": "073e4da",
+    "platform": "Windows 11, CPU only, 8 threads pinned to logical cores 0-7",
+    "note": "all2md ran the PMC lane parser policy; baselines ran their defaults, at the versions baselines.txt pins -- unchanged from the 2026-08-19 reading. Every tool's markdown was re-parsed through all2md's markdown parser before scoring, so all three share one normalization path. Tesseract is installed on this box but not on PATH; that is moot here, because 0 of the corpus's 1,184 pages carry a text layer under 20 characters, so all2md's auto-OCR has nothing to fire on. It fired 0 times; pymupdf4llm fired 423.",
+    "control": "Both baselines were re-run unchanged. docling reproduced every recorded figure to six decimal places; pymupdf4llm reproduced its deterministic figures exactly and drifted only on OCR-dependent ones (novel_share +0.0015, tables_emitted +4), RapidOCR not being bit-deterministic across thread counts. An unchanged tool reproducing is what licenses attributing all2md's movement to all2md."
+  },
+  "tools": {
+    "all2md": {
+      "versions": {
+        "all2md": "1.13.0"
+      },
+      "articles_scored": 110,
+      "articles_missing": 0,
+      "parse_failures": {},
+      "conversion_failures": [],
+      "attainable_recall": 0.9823287077189939,
+      "recall_raw": 0.6126708902967656,
+      "ceiling": 0.61513837945982,
+      "by_kind": {
+        "table": {
+          "attainable_recall": 0.773972602739726,
+          "attainable": 146
+        },
+        "text_block": {
+          "attainable_recall": 0.9843285062487601,
+          "attainable": 5041
+        },
+        "title": {
+          "attainable_recall": 0.9873668565766658,
+          "attainable": 4037
+        }
+      },
+      "control_recall": 0.003667889296432144,
+      "novel_share": 0.006172993534506659,
+      "precision_raw": 0.937624069822892,
+      "duplication": 0.004568556385741096,
+      "tables_emitted": 238,
+      "tables_expected": 166,
+      "seconds_per_article_mean": 12.719747015451802,
+      "reparse_word_ratio": 0.9827710658510064,
+      "per_article": {
+        "PMC10250014.1": {
+          "attainable_recall": 0.9387755102040817,
+          "tables_emitted": 1,
+          "tables_expected": 1
+        },
+        "PMC10250036.1": {
+          "attainable_recall": 1.0,
+          "tables_emitted": 0,
+          "tables_expected": 0
+        },
+        "PMC10250047.1": {
+          "attainable_recall": 1.0,
+          "tables_emitted": 0,
+          "tables_expected": 0
+        },
+        "PMC10250057.1": {
+          "attainable_recall": 1.0,
+          "tables_emitted": 1,
+          "tables_expected": 1
+        },
+        "PMC10250068.1": {
+          "attainable_recall": 1.0,
+          "tables_emitted": 0,
+          "tables_expected": 0
+        },
+        "PMC10750000.1": {
+          "attainable_recall": 0.9912280701754386,
+          "tables_emitted": 1,
+          "tables_expected": 1
+        },
+        "PMC10750011.1": {
+          "attainable_recall": 0.9915966386554622,
+          "tables_emitted": 1,
+          "tables_expected": 1
+        },
+        "PMC10750022.1": {
+          "attainable_recall": 0.9438202247191011,
+          "tables_emitted": 13,
+          "tables_expected": 5
+        },
+        "PMC10750033.1": {
+          "attainable_recall": 0.948051948051948,
+          "tables_emitted": 5,
+          "tables_expected": 5
+        },
+        "PMC10750044.1": {
+          "attainable_recall": 1.0,
+          "tables_emitted": 6,
+          "tables_expected": 6
+        },
+        "PMC11250000.1": {
+          "attainable_recall": 1.0,
+          "tables_emitted": 2,
+          "tables_expected": 2
+        },
+        "PMC11250011.1": {
+          "attainable_recall": 0.9841269841269841,
+          "tables_emitted": 6,
+          "tables_expected": 1
+        },
+        "PMC11250022.1": {
+          "attainable_recall": 1.0,
+          "tables_emitted": 0,
+          "tables_expected": 0
+        },
+        "PMC11250033.1": {
+          "attainable_recall": 0.978021978021978,
+          "tables_emitted": 3,
+          "tables_expected": 3
+        },
+        "PMC11250047.1": {
+          "attainable_recall": 1.0,
+          "tables_emitted": 1,
+          "tables_expected": 1
+        },
+        "PMC11750000.1": {
+          "attainable_recall": 0.9384615384615385,
+          "tables_emitted": 5,
+          "tables_expected": 7
+        },
+        "PMC11750013.1": {
+          "attainable_recall": 0.9813084112149533,
+          "tables_emitted": 1,
+          "tables_expected": 0
+        },
+        "PMC11750023.1": {
+          "attainable_recall": 0.9583333333333334,
+          "tables_emitted": 5,
+          "tables_expected": 4
+        },
+        "PMC11750034.1": {
+          "attainable_recall": 0.9655172413793104,
+          "tables_emitted": 1,
+          "tables_expected": 0
+        },
+        "PMC11750046.1": {
+          "attainable_recall": 1.0,
+          "tables_emitted": 0,
+          "tables_expected": 0
+        },
+        "PMC12250000.1": {
+          "attainable_recall": 0.9961904761904762,
+          "tables_emitted": 1,
+          "tables_expected": 1
+        },
+        "PMC12250011.1": {
+          "attainable_recall": 0.9907407407407407,
+          "tables_emitted": 0,
+          "tables_expected": 0
+        },
+        "PMC12250022.1": {
+          "attainable_recall": 0.9934640522875817,
+          "tables_emitted": 0,
+          "tables_expected": 0
+        },
+        "PMC12250033.1": {
+          "attainable_recall": 0.9801324503311258,
+          "tables_emitted": 4,
+          "tables_expected": 4
+        },
+        "PMC12250044.1": {
+          "attainable_recall": 0.9888888888888889,
+          "tables_emitted": 6,
+          "tables_expected": 3
+        },
+        "PMC1750924.1": {
+          "attainable_recall": 1.0,
+          "tables_emitted": 0,
+          "tables_expected": 0
+        },
+        "PMC1750935.1": {
+          "attainable_recall": 1.0,
+          "tables_emitted": 0,
+          "tables_expected": 0
+        },
+        "PMC1750972.1": {
+          "attainable_recall": 1.0,
+          "tables_emitted": 1,
+          "tables_expected": 1
+        },
+        "PMC1750983.1": {
+          "attainable_recall": 1.0,
+          "tables_emitted": 1,
+          "tables_expected": 1
+        },
+        "PMC1750994.1": {
+          "attainable_recall": 1.0,
+          "tables_emitted": 0,
+          "tables_expected": 0
+        },
+        "PMC2250455.1": {
+          "attainable_recall": 0.2,
+          "tables_emitted": 1,
+          "tables_expected": 0
+        },
+        "PMC2250466.1": {
+          "attainable_recall": 0.75,
+          "tables_emitted": 0,
+          "tables_expected": 0
+        },
+        "PMC2253494.1": {
+          "attainable_recall": 0.9787234042553191,
+          "tables_emitted": 0,
+          "tables_expected": 0
+        },
+        "PMC2253505.1": {
+          "attainable_recall": 0.974025974025974,
+          "tables_emitted": 3,
+          "tables_expected": 3
+        },
+        "PMC2253516.1": {
+          "attainable_recall": 0.9387755102040817,
+          "tables_emitted": 5,
+          "tables_expected": 0
+        },
+        "PMC2750101.1": {
+          "attainable_recall": 1.0,
+          "tables_emitted": 1,
+          "tables_expected": 1
+        },
+        "PMC2750112.1": {
+          "attainable_recall": 0.9929577464788732,
+          "tables_emitted": 7,
+          "tables_expected": 6
+        },
+        "PMC2750123.1": {
+          "attainable_recall": 1.0,
+          "tables_emitted": 0,
+          "tables_expected": 0
+        },
+        "PMC2750134.1": {
+          "attainable_recall": 1.0,
+          "tables_emitted": 1,
+          "tables_expected": 1
+        },
+        "PMC2750145.1": {
+          "attainable_recall": 1.0,
+          "tables_emitted": 0,
+          "tables_expected": 0
+        },
+        "PMC3250000.1": {
+          "attainable_recall": 1.0,
+          "tables_emitted": 1,
+          "tables_expected": 0
+        },
+        "PMC3250011.1": {
+          "attainable_recall": 1.0,
+          "tables_emitted": 2,
+          "tables_expected": 0
+        },
+        "PMC3250022.1": {
+          "attainable_recall": 1.0,
+          "tables_emitted": 1,
+          "tables_expected": 0
+        },
+        "PMC3250033.1": {
+          "attainable_recall": 1.0,
+          "tables_emitted": 10,
+          "tables_expected": 0
+        },
+        "PMC3250055.1": {
+          "attainable_recall": 0.8674698795180723,
+          "tables_emitted": 4,
+          "tables_expected": 4
+        },
+        "PMC3750000.1": {
+          "attainable_recall": 0.9682539682539683,
+          "tables_emitted": 5,
+          "tables_expected": 5
+        },
+        "PMC3750011.1": {
+          "attainable_recall": 0.9878048780487805,
+          "tables_emitted": 0,
+          "tables_expected": 0
+        },
+        "PMC3750022.1": {
+          "attainable_recall": 1.0,
+          "tables_emitted": 0,
+          "tables_expected": 0
+        },
+        "PMC3750033.1": {
+          "attainable_recall": 0.9863013698630136,
+          "tables_emitted": 1,
+          "tables_expected": 2
+        },
+        "PMC3750044.1": {
+          "attainable_recall": 0.9893617021276596,
+          "tables_emitted": 1,
+          "tables_expected": 1
+        },
+        "PMC4250000.1": {
+          "attainable_recall": 0.9696969696969697,
+          "tables_emitted": 1,
+          "tables_expected": 1
+        },
+        "PMC4250011.1": {
+          "attainable_recall": 1.0,
+          "tables_emitted": 0,
+          "tables_expected": 0
+        },
+        "PMC4250022.1": {
+          "attainable_recall": 1.0,
+          "tables_emitted": 1,
+          "tables_expected": 1
+        },
+        "PMC4250033.1": {
+          "attainable_recall": 1.0,
+          "tables_emitted": 3,
+          "tables_expected": 1
+        },
+        "PMC4250054.1": {
+          "attainable_recall": 1.0,
+          "tables_emitted": 0,
+          "tables_expected": 4
+        },
+        "PMC4750000.1": {
+          "attainable_recall": 1.0,
+          "tables_emitted": 0,
+          "tables_expected": 0
+        },
+        "PMC4750011.1": {
+          "attainable_recall": 1.0,
+          "tables_emitted": 0,
+          "tables_expected": 0
+        },
+        "PMC4750022.1": {
+          "attainable_recall": 0.9871794871794872,
+          "tables_emitted": 1,
+          "tables_expected": 6
+        },
+        "PMC4750033.1": {
+          "attainable_recall": 1.0,
+          "tables_emitted": 1,
+          "tables_expected": 1
+        },
+        "PMC4750044.1": {
+          "attainable_recall": 1.0,
+          "tables_emitted": 0,
+          "tables_expected": 0
+        },
+        "PMC5250590.1": {
+          "attainable_recall": 1.0,
+          "tables_emitted": 6,
+          "tables_expected": 2
+        },
+        "PMC5250601.1": {
+          "attainable_recall": 0.9625,
+          "tables_emitted": 1,
+          "tables_expected": 1
+        },
+        "PMC5250623.1": {
+          "attainable_recall": 1.0,
+          "tables_emitted": 0,
+          "tables_expected": 0
+        },
+        "PMC5250635.1": {
+          "attainable_recall": 0.971830985915493,
+          "tables_emitted": 3,
+          "tables_expected": 2
+        },
+        "PMC5250647.1": {
+          "attainable_recall": 0.9923076923076923,
+          "tables_emitted": 4,
+          "tables_expected": 5
+        },
+        "PMC5750000.1": {
+          "attainable_recall": 1.0,
+          "tables_emitted": 0,
+          "tables_expected": 0
+        },
+        "PMC5750011.1": {
+          "attainable_recall": 0.9857142857142858,
+          "tables_emitted": 5,
+          "tables_expected": 1
+        },
+        "PMC5750022.1": {
+          "attainable_recall": 1.0,
+          "tables_emitted": 0,
+          "tables_expected": 0
+        },
+        "PMC5750033.1": {
+          "attainable_recall": 0.987012987012987,
+          "tables_emitted": 0,
+          "tables_expected": 3
+        },
+        "PMC5750208.1": {
+          "attainable_recall": 1.0,
+          "tables_emitted": 0,
+          "tables_expected": 0
+        },
+        "PMC6250000.1": {
+          "attainable_recall": 0.9726027397260274,
+          "tables_emitted": 5,
+          "tables_expected": 4
+        },
+        "PMC6250011.1": {
+          "attainable_recall": 0.9747899159663865,
+          "tables_emitted": 4,
+          "tables_expected": 2
+        },
+        "PMC6250022.1": {
+          "attainable_recall": 0.9882352941176471,
+          "tables_emitted": 0,
+          "tables_expected": 0
+        },
+        "PMC6250033.1": {
+          "attainable_recall": 1.0,
+          "tables_emitted": 0,
+          "tables_expected": 0
+        },
+        "PMC6250044.1": {
+          "attainable_recall": 0.9914529914529915,
+          "tables_emitted": 2,
+          "tables_expected": 2
+        },
+        "PMC6750044.1": {
+          "attainable_recall": 1.0,
+          "tables_emitted": 1,
+          "tables_expected": 0
+        },
+        "PMC6750072.1": {
+          "attainable_recall": 1.0,
+          "tables_emitted": 2,
+          "tables_expected": 1
+        },
+        "PMC6750083.1": {
+          "attainable_recall": 0.9506172839506173,
+          "tables_emitted": 0,
+          "tables_expected": 0
+        },
+        "PMC6750094.1": {
+          "attainable_recall": 1.0,
+          "tables_emitted": 0,
+          "tables_expected": 0
+        },
+        "PMC6750105.1": {
+          "attainable_recall": 1.0,
+          "tables_emitted": 0,
+          "tables_expected": 0
+        },
+        "PMC7250000.1": {
+          "attainable_recall": 1.0,
+          "tables_emitted": 4,
+          "tables_expected": 3
+        },
+        "PMC7250011.1": {
+          "attainable_recall": 0.7849462365591398,
+          "tables_emitted": 2,
+          "tables_expected": 2
+        },
+        "PMC7250022.1": {
+          "attainable_recall": 0.8169014084507042,
+          "tables_emitted": 2,
+          "tables_expected": 1
+        },
+        "PMC7250033.1": {
+          "attainable_recall": 0.9862385321100917,
+          "tables_emitted": 0,
+          "tables_expected": 0
+        },
+        "PMC7250055.2": {
+          "attainable_recall": 0.9919354838709677,
+          "tables_emitted": 2,
+          "tables_expected": 0
+        },
+        "PMC7750000.1": {
+          "attainable_recall": 1.0,
+          "tables_emitted": 0,
+          "tables_expected": 0
+        },
+        "PMC7750009.1": {
+          "attainable_recall": 0.9882352941176471,
+          "tables_emitted": 1,
+          "tables_expected": 5
+        },
+        "PMC7750019.1": {
+          "attainable_recall": 0.9761904761904762,
+          "tables_emitted": 4,
+          "tables_expected": 1
+        },
+        "PMC7750040.1": {
+          "attainable_recall": 0.9642857142857143,
+          "tables_emitted": 3,
+          "tables_expected": 2
+        },
+        "PMC7750051.1": {
+          "attainable_recall": 0.9848484848484849,
+          "tables_emitted": 3,
+          "tables_expected": 3
+        },
+        "PMC8250041.1": {
+          "attainable_recall": 0.9655172413793104,
+          "tables_emitted": 9,
+          "tables_expected": 5
+        },
+        "PMC8250095.2": {
+          "attainable_recall": 1.0,
+          "tables_emitted": 5,
+          "tables_expected": 5
+        },
+        "PMC8250106.1": {
+          "attainable_recall": 1.0,
+          "tables_emitted": 0,
+          "tables_expected": 0
+        },
+        "PMC8250133.1": {
+          "attainable_recall": 1.0,
+          "tables_emitted": 0,
+          "tables_expected": 0
+        },
+        "PMC8250144.1": {
+          "attainable_recall": 0.9873417721518988,
+          "tables_emitted": 1,
+          "tables_expected": 0
+        },
+        "PMC8750000.1": {
+          "attainable_recall": 0.9873417721518988,
+          "tables_emitted": 0,
+          "tables_expected": 0
+        },
+        "PMC8750011.1": {
+          "attainable_recall": 1.0,
+          "tables_emitted": 7,
+          "tables_expected": 7
+        },
+        "PMC8750022.1": {
+          "attainable_recall": 0.984,
+          "tables_emitted": 4,
+          "tables_expected": 4
+        },
+        "PMC8750036.1": {
+          "attainable_recall": 1.0,
+          "tables_emitted": 3,
+          "tables_expected": 3
+        },
+        "PMC8750048.1": {
+          "attainable_recall": 0.993006993006993,
+          "tables_emitted": 0,
+          "tables_expected": 0
+        },
+        "PMC9250000.1": {
+          "attainable_recall": 1.0,
+          "tables_emitted": 0,
+          "tables_expected": 0
+        },
+        "PMC9250014.1": {
+          "attainable_recall": 0.9928057553956835,
+          "tables_emitted": 10,
+          "tables_expected": 1
+        },
+        "PMC9250025.1": {
+          "attainable_recall": 1.0,
+          "tables_emitted": 13,
+          "tables_expected": 1
+        },
+        "PMC9250036.1": {
+          "attainable_recall": 1.0,
+          "tables_emitted": 2,
+          "tables_expected": 3
+        },
+        "PMC9250060.1": {
+          "attainable_recall": 1.0,
+          "tables_emitted": 2,
+          "tables_expected": 2
+        },
+        "PMC9750000.1": {
+          "attainable_recall": 1.0,
+          "tables_emitted": 3,
+          "tables_expected": 3
+        },
+        "PMC9750011.1": {
+          "attainable_recall": 1.0,
+          "tables_emitted": 3,
+          "tables_expected": 2
+        },
+        "PMC9750022.1": {
+          "attainable_recall": 0.9905660377358491,
+          "tables_emitted": 5,
+          "tables_expected": 3
+        },
+        "PMC9750033.1": {
+          "attainable_recall": 0.9775280898876404,
+          "tables_emitted": 2,
+          "tables_expected": 2
+        },
+        "PMC9750044.1": {
+          "attainable_recall": 0.9876543209876543,
+          "tables_emitted": 0,
+          "tables_expected": 0
+        }
+      }
+    },
+    "docling": {
+      "versions": {
+        "docling": "2.120.3"
+      },
+      "articles_scored": 110,
+      "articles_missing": 0,
+      "parse_failures": {},
+      "conversion_failures": [],
+      "attainable_recall": 0.9550086730268864,
+      "recall_raw": 0.6076025341780593,
+      "ceiling": 0.61513837945982,
+      "by_kind": {
+        "table": {
+          "attainable_recall": 0.821917808219178,
+          "attainable": 146
+        },
+        "text_block": {
+          "attainable_recall": 0.9593334655822258,
+          "attainable": 5041
+        },
+        "title": {
+          "attainable_recall": 0.9544216001981669,
+          "attainable": 4037
+        }
+      },
+      "control_recall": 0.0038012670890296765,
+      "novel_share": 0.028657929252586214,
+      "precision_raw": 0.9105295560430023,
+      "duplication": 0.006164097959466427,
+      "tables_emitted": 201,
+      "tables_expected": 166,
+      "seconds_per_article_mean": 55.16511307455049,
+      "reparse_word_ratio": 0.9564599307954796,
+      "per_article": {
+        "PMC10250014.1": {
+          "attainable_recall": 0.9183673469387755,
+          "tables_emitted": 1,
+          "tables_expected": 1
+        },
+        "PMC10250036.1": {
+          "attainable_recall": 0.875,
+          "tables_emitted": 2,
+          "tables_expected": 0
+        },
+        "PMC10250047.1": {
+          "attainable_recall": 0.875,
+          "tables_emitted": 1,
+          "tables_expected": 0
+        },
+        "PMC10250057.1": {
+          "attainable_recall": 1.0,
+          "tables_emitted": 2,
+          "tables_expected": 1
+        },
+        "PMC10250068.1": {
+          "attainable_recall": 1.0,
+          "tables_emitted": 0,
+          "tables_expected": 0
+        },
+        "PMC10750000.1": {
+          "attainable_recall": 0.9210526315789473,
+          "tables_emitted": 1,
+          "tables_expected": 1
+        },
+        "PMC10750011.1": {
+          "attainable_recall": 0.9411764705882353,
+          "tables_emitted": 1,
+          "tables_expected": 1
+        },
+        "PMC10750022.1": {
+          "attainable_recall": 0.9325842696629213,
+          "tables_emitted": 7,
+          "tables_expected": 5
+        },
+        "PMC10750033.1": {
+          "attainable_recall": 0.935064935064935,
+          "tables_emitted": 5,
+          "tables_expected": 5
+        },
+        "PMC10750044.1": {
+          "attainable_recall": 0.9904761904761905,
+          "tables_emitted": 6,
+          "tables_expected": 6
+        },
+        "PMC11250000.1": {
+          "attainable_recall": 1.0,
+          "tables_emitted": 2,
+          "tables_expected": 2
+        },
+        "PMC11250011.1": {
+          "attainable_recall": 1.0,
+          "tables_emitted": 5,
+          "tables_expected": 1
+        },
+        "PMC11250022.1": {
+          "attainable_recall": 0.9897959183673469,
+          "tables_emitted": 0,
+          "tables_expected": 0
+        },
+        "PMC11250033.1": {
+          "attainable_recall": 0.978021978021978,
+          "tables_emitted": 3,
+          "tables_expected": 3
+        },
+        "PMC11250047.1": {
+          "attainable_recall": 1.0,
+          "tables_emitted": 1,
+          "tables_expected": 1
+        },
+        "PMC11750000.1": {
+          "attainable_recall": 1.0,
+          "tables_emitted": 7,
+          "tables_expected": 7
+        },
+        "PMC11750013.1": {
+          "attainable_recall": 1.0,
+          "tables_emitted": 0,
+          "tables_expected": 0
+        },
+        "PMC11750023.1": {
+          "attainable_recall": 0.9583333333333334,
+          "tables_emitted": 4,
+          "tables_expected": 4
+        },
+        "PMC11750034.1": {
+          "attainable_recall": 1.0,
+          "tables_emitted": 0,
+          "tables_expected": 0
+        },
+        "PMC11750046.1": {
+          "attainable_recall": 0.9512195121951219,
+          "tables_emitted": 0,
+          "tables_expected": 0
+        },
+        "PMC12250000.1": {
+          "attainable_recall": 0.9866666666666667,
+          "tables_emitted": 3,
+          "tables_expected": 1
+        },
+        "PMC12250011.1": {
+          "attainable_recall": 0.9907407407407407,
+          "tables_emitted": 0,
+          "tables_expected": 0
+        },
+        "PMC12250022.1": {
+          "attainable_recall": 0.9803921568627451,
+          "tables_emitted": 1,
+          "tables_expected": 0
+        },
+        "PMC12250033.1": {
+          "attainable_recall": 0.9933774834437086,
+          "tables_emitted": 4,
+          "tables_expected": 4
+        },
+        "PMC12250044.1": {
+          "attainable_recall": 0.9925925925925926,
+          "tables_emitted": 6,
+          "tables_expected": 3
+        },
+        "PMC1750924.1": {
+          "attainable_recall": 1.0,
+          "tables_emitted": 0,
+          "tables_expected": 0
+        },
+        "PMC1750935.1": {
+          "attainable_recall": 1.0,
+          "tables_emitted": 0,
+          "tables_expected": 0
+        },
+        "PMC1750972.1": {
+          "attainable_recall": 1.0,
+          "tables_emitted": 1,
+          "tables_expected": 1
+        },
+        "PMC1750983.1": {
+          "attainable_recall": 1.0,
+          "tables_emitted": 1,
+          "tables_expected": 1
+        },
+        "PMC1750994.1": {
+          "attainable_recall": 1.0,
+          "tables_emitted": 0,
+          "tables_expected": 0
+        },
+        "PMC2250455.1": {
+          "attainable_recall": 1.0,
+          "tables_emitted": 0,
+          "tables_expected": 0
+        },
+        "PMC2250466.1": {
+          "attainable_recall": 1.0,
+          "tables_emitted": 0,
+          "tables_expected": 0
+        },
+        "PMC2253494.1": {
+          "attainable_recall": 0.9787234042553191,
+          "tables_emitted": 0,
+          "tables_expected": 0
+        },
+        "PMC2253505.1": {
+          "attainable_recall": 0.974025974025974,
+          "tables_emitted": 3,
+          "tables_expected": 3
+        },
+        "PMC2253516.1": {
+          "attainable_recall": 0.9591836734693877,
+          "tables_emitted": 0,
+          "tables_expected": 0
+        },
+        "PMC2750101.1": {
+          "attainable_recall": 1.0,
+          "tables_emitted": 1,
+          "tables_expected": 1
+        },
+        "PMC2750112.1": {
+          "attainable_recall": 0.9929577464788732,
+          "tables_emitted": 7,
+          "tables_expected": 6
+        },
+        "PMC2750123.1": {
+          "attainable_recall": 1.0,
+          "tables_emitted": 0,
+          "tables_expected": 0
+        },
+        "PMC2750134.1": {
+          "attainable_recall": 1.0,
+          "tables_emitted": 1,
+          "tables_expected": 1
+        },
+        "PMC2750145.1": {
+          "attainable_recall": 1.0,
+          "tables_emitted": 0,
+          "tables_expected": 0
+        },
+        "PMC3250000.1": {
+          "attainable_recall": 1.0,
+          "tables_emitted": 0,
+          "tables_expected": 0
+        },
+        "PMC3250011.1": {
+          "attainable_recall": 1.0,
+          "tables_emitted": 0,
+          "tables_expected": 0
+        },
+        "PMC3250022.1": {
+          "attainable_recall": 1.0,
+          "tables_emitted": 1,
+          "tables_expected": 0
+        },
+        "PMC3250033.1": {
+          "attainable_recall": 1.0,
+          "tables_emitted": 7,
+          "tables_expected": 0
+        },
+        "PMC3250055.1": {
+          "attainable_recall": 0.9397590361445783,
+          "tables_emitted": 4,
+          "tables_expected": 4
+        },
+        "PMC3750000.1": {
+          "attainable_recall": 0.9682539682539683,
+          "tables_emitted": 7,
+          "tables_expected": 5
+        },
+        "PMC3750011.1": {
+          "attainable_recall": 0.9878048780487805,
+          "tables_emitted": 0,
+          "tables_expected": 0
+        },
+        "PMC3750022.1": {
+          "attainable_recall": 1.0,
+          "tables_emitted": 0,
+          "tables_expected": 0
+        },
+        "PMC3750033.1": {
+          "attainable_recall": 0.9863013698630136,
+          "tables_emitted": 2,
+          "tables_expected": 2
+        },
+        "PMC3750044.1": {
+          "attainable_recall": 0.9680851063829787,
+          "tables_emitted": 1,
+          "tables_expected": 1
+        },
+        "PMC4250000.1": {
+          "attainable_recall": 0.9696969696969697,
+          "tables_emitted": 1,
+          "tables_expected": 1
+        },
+        "PMC4250011.1": {
+          "attainable_recall": 1.0,
+          "tables_emitted": 0,
+          "tables_expected": 0
+        },
+        "PMC4250022.1": {
+          "attainable_recall": 0.9672131147540983,
+          "tables_emitted": 1,
+          "tables_expected": 1
+        },
+        "PMC4250033.1": {
+          "attainable_recall": 1.0,
+          "tables_emitted": 1,
+          "tables_expected": 1
+        },
+        "PMC4250054.1": {
+          "attainable_recall": 1.0,
+          "tables_emitted": 4,
+          "tables_expected": 4
+        },
+        "PMC4750000.1": {
+          "attainable_recall": 0.9,
+          "tables_emitted": 0,
+          "tables_expected": 0
+        },
+        "PMC4750011.1": {
+          "attainable_recall": 1.0,
+          "tables_emitted": 0,
+          "tables_expected": 0
+        },
+        "PMC4750022.1": {
+          "attainable_recall": 0.7692307692307693,
+          "tables_emitted": 6,
+          "tables_expected": 6
+        },
+        "PMC4750033.1": {
+          "attainable_recall": 0.984375,
+          "tables_emitted": 1,
+          "tables_expected": 1
+        },
+        "PMC4750044.1": {
+          "attainable_recall": 0.9887640449438202,
+          "tables_emitted": 0,
+          "tables_expected": 0
+        },
+        "PMC5250590.1": {
+          "attainable_recall": 0.9886363636363636,
+          "tables_emitted": 2,
+          "tables_expected": 2
+        },
+        "PMC5250601.1": {
+          "attainable_recall": 1.0,
+          "tables_emitted": 1,
+          "tables_expected": 1
+        },
+        "PMC5250623.1": {
+          "attainable_recall": 0.75,
+          "tables_emitted": 0,
+          "tables_expected": 0
+        },
+        "PMC5250635.1": {
+          "attainable_recall": 0.9577464788732394,
+          "tables_emitted": 2,
+          "tables_expected": 2
+        },
+        "PMC5250647.1": {
+          "attainable_recall": 0.9846153846153847,
+          "tables_emitted": 4,
+          "tables_expected": 5
+        },
+        "PMC5750000.1": {
+          "attainable_recall": 1.0,
+          "tables_emitted": 0,
+          "tables_expected": 0
+        },
+        "PMC5750011.1": {
+          "attainable_recall": 0.9857142857142858,
+          "tables_emitted": 1,
+          "tables_expected": 1
+        },
+        "PMC5750022.1": {
+          "attainable_recall": 1.0,
+          "tables_emitted": 0,
+          "tables_expected": 0
+        },
+        "PMC5750033.1": {
+          "attainable_recall": 0.987012987012987,
+          "tables_emitted": 3,
+          "tables_expected": 3
+        },
+        "PMC5750208.1": {
+          "attainable_recall": 0.8444444444444444,
+          "tables_emitted": 0,
+          "tables_expected": 0
+        },
+        "PMC6250000.1": {
+          "attainable_recall": 0.958904109589041,
+          "tables_emitted": 5,
+          "tables_expected": 4
+        },
+        "PMC6250011.1": {
+          "attainable_recall": 0.6554621848739496,
+          "tables_emitted": 2,
+          "tables_expected": 2
+        },
+        "PMC6250022.1": {
+          "attainable_recall": 0.7764705882352941,
+          "tables_emitted": 0,
+          "tables_expected": 0
+        },
+        "PMC6250033.1": {
+          "attainable_recall": 1.0,
+          "tables_emitted": 0,
+          "tables_expected": 0
+        },
+        "PMC6250044.1": {
+          "attainable_recall": 0.5555555555555556,
+          "tables_emitted": 3,
+          "tables_expected": 2
+        },
+        "PMC6750044.1": {
+          "attainable_recall": 0.98,
+          "tables_emitted": 0,
+          "tables_expected": 0
+        },
+        "PMC6750072.1": {
+          "attainable_recall": 0.9736842105263158,
+          "tables_emitted": 1,
+          "tables_expected": 1
+        },
+        "PMC6750083.1": {
+          "attainable_recall": 0.9753086419753086,
+          "tables_emitted": 0,
+          "tables_expected": 0
+        },
+        "PMC6750094.1": {
+          "attainable_recall": 0.9550561797752809,
+          "tables_emitted": 0,
+          "tables_expected": 0
+        },
+        "PMC6750105.1": {
+          "attainable_recall": 0.9701492537313433,
+          "tables_emitted": 0,
+          "tables_expected": 0
+        },
+        "PMC7250000.1": {
+          "attainable_recall": 0.9847328244274809,
+          "tables_emitted": 4,
+          "tables_expected": 3
+        },
+        "PMC7250011.1": {
+          "attainable_recall": 0.956989247311828,
+          "tables_emitted": 2,
+          "tables_expected": 2
+        },
+        "PMC7250022.1": {
+          "attainable_recall": 0.9366197183098591,
+          "tables_emitted": 4,
+          "tables_expected": 1
+        },
+        "PMC7250033.1": {
+          "attainable_recall": 0.963302752293578,
+          "tables_emitted": 0,
+          "tables_expected": 0
+        },
+        "PMC7250055.2": {
+          "attainable_recall": 0.9919354838709677,
+          "tables_emitted": 0,
+          "tables_expected": 0
+        },
+        "PMC7750000.1": {
+          "attainable_recall": 0.8571428571428571,
+          "tables_emitted": 0,
+          "tables_expected": 0
+        },
+        "PMC7750009.1": {
+          "attainable_recall": 0.9764705882352941,
+          "tables_emitted": 1,
+          "tables_expected": 5
+        },
+        "PMC7750019.1": {
+          "attainable_recall": 1.0,
+          "tables_emitted": 1,
+          "tables_expected": 1
+        },
+        "PMC7750040.1": {
+          "attainable_recall": 0.7857142857142857,
+          "tables_emitted": 2,
+          "tables_expected": 2
+        },
+        "PMC7750051.1": {
+          "attainable_recall": 0.9393939393939394,
+          "tables_emitted": 3,
+          "tables_expected": 3
+        },
+        "PMC8250041.1": {
+          "attainable_recall": 0.8793103448275862,
+          "tables_emitted": 5,
+          "tables_expected": 5
+        },
+        "PMC8250095.2": {
+          "attainable_recall": 0.9625,
+          "tables_emitted": 5,
+          "tables_expected": 5
+        },
+        "PMC8250106.1": {
+          "attainable_recall": 0.9473684210526315,
+          "tables_emitted": 0,
+          "tables_expected": 0
+        },
+        "PMC8250133.1": {
+          "attainable_recall": 0.875,
+          "tables_emitted": 0,
+          "tables_expected": 0
+        },
+        "PMC8250144.1": {
+          "attainable_recall": 0.8607594936708861,
+          "tables_emitted": 0,
+          "tables_expected": 0
+        },
+        "PMC8750000.1": {
+          "attainable_recall": 0.9936708860759493,
+          "tables_emitted": 0,
+          "tables_expected": 0
+        },
+        "PMC8750011.1": {
+          "attainable_recall": 0.9939024390243902,
+          "tables_emitted": 7,
+          "tables_expected": 7
+        },
+        "PMC8750022.1": {
+          "attainable_recall": 0.952,
+          "tables_emitted": 4,
+          "tables_expected": 4
+        },
+        "PMC8750036.1": {
+          "attainable_recall": 0.98989898989899,
+          "tables_emitted": 3,
+          "tables_expected": 3
+        },
+        "PMC8750048.1": {
+          "attainable_recall": 0.993006993006993,
+          "tables_emitted": 0,
+          "tables_expected": 0
+        },
+        "PMC9250000.1": {
+          "attainable_recall": 0.9444444444444444,
+          "tables_emitted": 0,
+          "tables_expected": 0
+        },
+        "PMC9250014.1": {
+          "attainable_recall": 1.0,
+          "tables_emitted": 3,
+          "tables_expected": 1
+        },
+        "PMC9250025.1": {
+          "attainable_recall": 0.9836065573770492,
+          "tables_emitted": 4,
+          "tables_expected": 1
+        },
+        "PMC9250036.1": {
+          "attainable_recall": 0.9857142857142858,
+          "tables_emitted": 4,
+          "tables_expected": 3
+        },
+        "PMC9250060.1": {
+          "attainable_recall": 1.0,
+          "tables_emitted": 2,
+          "tables_expected": 2
+        },
+        "PMC9750000.1": {
+          "attainable_recall": 0.9878048780487805,
+          "tables_emitted": 3,
+          "tables_expected": 3
+        },
+        "PMC9750011.1": {
+          "attainable_recall": 0.989010989010989,
+          "tables_emitted": 3,
+          "tables_expected": 2
+        },
+        "PMC9750022.1": {
+          "attainable_recall": 0.9811320754716981,
+          "tables_emitted": 3,
+          "tables_expected": 3
+        },
+        "PMC9750033.1": {
+          "attainable_recall": 0.9662921348314607,
+          "tables_emitted": 2,
+          "tables_expected": 2
+        },
+        "PMC9750044.1": {
+          "attainable_recall": 1.0,
+          "tables_emitted": 0,
+          "tables_expected": 0
+        }
+      }
+    },
+    "pymupdf4llm": {
+      "versions": {
+        "pymupdf4llm": "1.28.2",
+        "pymupdf": "PyMuPDF 1.28.2: Python bindings for the MuPDF 1.28.2 library.\nPython 3.13 running on win32 (64-bit).\n"
+      },
+      "articles_scored": 110,
+      "articles_missing": 0,
+      "parse_failures": {},
+      "conversion_failures": [],
+      "attainable_recall": 0.9826539462272333,
+      "recall_raw": 0.6144714904968323,
+      "ceiling": 0.61513837945982,
+      "by_kind": {
+        "table": {
+          "attainable_recall": 0.6506849315068494,
+          "attainable": 146
+        },
+        "text_block": {
+          "attainable_recall": 0.9841301329101368,
+          "attainable": 5041
+        },
+        "title": {
+          "attainable_recall": 0.9928164478573198,
+          "attainable": 4037
+        }
+      },
+      "control_recall": 0.0038679559853284427,
+      "novel_share": 0.056401530471061535,
+      "precision_raw": 0.8821680963834905,
+      "duplication": 0.0018876686916127676,
+      "tables_emitted": 212,
+      "tables_expected": 166,
+      "seconds_per_article_mean": 26.872143609092614,
+      "reparse_word_ratio": 1.037088309036216,
+      "per_article": {
+        "PMC10250014.1": {
+          "attainable_recall": 0.9387755102040817,
+          "tables_emitted": 1,
+          "tables_expected": 1
+        },
+        "PMC10250036.1": {
+          "attainable_recall": 1.0,
+          "tables_emitted": 2,
+          "tables_expected": 0
+        },
+        "PMC10250047.1": {
+          "attainable_recall": 1.0,
+          "tables_emitted": 0,
+          "tables_expected": 0
+        },
+        "PMC10250057.1": {
+          "attainable_recall": 1.0,
+          "tables_emitted": 3,
+          "tables_expected": 1
+        },
+        "PMC10250068.1": {
+          "attainable_recall": 0.6,
+          "tables_emitted": 0,
+          "tables_expected": 0
+        },
+        "PMC10750000.1": {
+          "attainable_recall": 1.0,
+          "tables_emitted": 1,
+          "tables_expected": 1
+        },
+        "PMC10750011.1": {
+          "attainable_recall": 0.9915966386554622,
+          "tables_emitted": 1,
+          "tables_expected": 1
+        },
+        "PMC10750022.1": {
+          "attainable_recall": 0.9662921348314607,
+          "tables_emitted": 7,
+          "tables_expected": 5
+        },
+        "PMC10750033.1": {
+          "attainable_recall": 0.948051948051948,
+          "tables_emitted": 5,
+          "tables_expected": 5
+        },
+        "PMC10750044.1": {
+          "attainable_recall": 0.9809523809523809,
+          "tables_emitted": 6,
+          "tables_expected": 6
+        },
+        "PMC11250000.1": {
+          "attainable_recall": 1.0,
+          "tables_emitted": 2,
+          "tables_expected": 2
+        },
+        "PMC11250011.1": {
+          "attainable_recall": 1.0,
+          "tables_emitted": 5,
+          "tables_expected": 1
+        },
+        "PMC11250022.1": {
+          "attainable_recall": 1.0,
+          "tables_emitted": 0,
+          "tables_expected": 0
+        },
+        "PMC11250033.1": {
+          "attainable_recall": 0.978021978021978,
+          "tables_emitted": 4,
+          "tables_expected": 3
+        },
+        "PMC11250047.1": {
+          "attainable_recall": 1.0,
+          "tables_emitted": 2,
+          "tables_expected": 1
+        },
+        "PMC11750000.1": {
+          "attainable_recall": 0.9538461538461539,
+          "tables_emitted": 8,
+          "tables_expected": 7
+        },
+        "PMC11750013.1": {
+          "attainable_recall": 0.9813084112149533,
+          "tables_emitted": 1,
+          "tables_expected": 0
+        },
+        "PMC11750023.1": {
+          "attainable_recall": 0.8958333333333334,
+          "tables_emitted": 5,
+          "tables_expected": 4
+        },
+        "PMC11750034.1": {
+          "attainable_recall": 0.9655172413793104,
+          "tables_emitted": 0,
+          "tables_expected": 0
+        },
+        "PMC11750046.1": {
+          "attainable_recall": 1.0,
+          "tables_emitted": 0,
+          "tables_expected": 0
+        },
+        "PMC12250000.1": {
+          "attainable_recall": 0.9961904761904762,
+          "tables_emitted": 2,
+          "tables_expected": 1
+        },
+        "PMC12250011.1": {
+          "attainable_recall": 1.0,
+          "tables_emitted": 0,
+          "tables_expected": 0
+        },
+        "PMC12250022.1": {
+          "attainable_recall": 0.9934640522875817,
+          "tables_emitted": 0,
+          "tables_expected": 0
+        },
+        "PMC12250033.1": {
+          "attainable_recall": 0.9735099337748344,
+          "tables_emitted": 4,
+          "tables_expected": 4
+        },
+        "PMC12250044.1": {
+          "attainable_recall": 0.9888888888888889,
+          "tables_emitted": 5,
+          "tables_expected": 3
+        },
+        "PMC1750924.1": {
+          "attainable_recall": 1.0,
+          "tables_emitted": 0,
+          "tables_expected": 0
+        },
+        "PMC1750935.1": {
+          "attainable_recall": 1.0,
+          "tables_emitted": 0,
+          "tables_expected": 0
+        },
+        "PMC1750972.1": {
+          "attainable_recall": 1.0,
+          "tables_emitted": 1,
+          "tables_expected": 1
+        },
+        "PMC1750983.1": {
+          "attainable_recall": 1.0,
+          "tables_emitted": 1,
+          "tables_expected": 1
+        },
+        "PMC1750994.1": {
+          "attainable_recall": 1.0,
+          "tables_emitted": 0,
+          "tables_expected": 0
+        },
+        "PMC2250455.1": {
+          "attainable_recall": 1.0,
+          "tables_emitted": 0,
+          "tables_expected": 0
+        },
+        "PMC2250466.1": {
+          "attainable_recall": 0.5,
+          "tables_emitted": 0,
+          "tables_expected": 0
+        },
+        "PMC2253494.1": {
+          "attainable_recall": 0.9574468085106383,
+          "tables_emitted": 0,
+          "tables_expected": 0
+        },
+        "PMC2253505.1": {
+          "attainable_recall": 1.0,
+          "tables_emitted": 3,
+          "tables_expected": 3
+        },
+        "PMC2253516.1": {
+          "attainable_recall": 1.0,
+          "tables_emitted": 0,
+          "tables_expected": 0
+        },
+        "PMC2750101.1": {
+          "attainable_recall": 1.0,
+          "tables_emitted": 1,
+          "tables_expected": 1
+        },
+        "PMC2750112.1": {
+          "attainable_recall": 0.9929577464788732,
+          "tables_emitted": 7,
+          "tables_expected": 6
+        },
+        "PMC2750123.1": {
+          "attainable_recall": 1.0,
+          "tables_emitted": 0,
+          "tables_expected": 0
+        },
+        "PMC2750134.1": {
+          "attainable_recall": 1.0,
+          "tables_emitted": 1,
+          "tables_expected": 1
+        },
+        "PMC2750145.1": {
+          "attainable_recall": 1.0,
+          "tables_emitted": 0,
+          "tables_expected": 0
+        },
+        "PMC3250000.1": {
+          "attainable_recall": 1.0,
+          "tables_emitted": 0,
+          "tables_expected": 0
+        },
+        "PMC3250011.1": {
+          "attainable_recall": 1.0,
+          "tables_emitted": 1,
+          "tables_expected": 0
+        },
+        "PMC3250022.1": {
+          "attainable_recall": 1.0,
+          "tables_emitted": 1,
+          "tables_expected": 0
+        },
+        "PMC3250033.1": {
+          "attainable_recall": 1.0,
+          "tables_emitted": 7,
+          "tables_expected": 0
+        },
+        "PMC3250055.1": {
+          "attainable_recall": 0.7590361445783133,
+          "tables_emitted": 5,
+          "tables_expected": 4
+        },
+        "PMC3750000.1": {
+          "attainable_recall": 0.9682539682539683,
+          "tables_emitted": 5,
+          "tables_expected": 5
+        },
+        "PMC3750011.1": {
+          "attainable_recall": 0.9878048780487805,
+          "tables_emitted": 0,
+          "tables_expected": 0
+        },
+        "PMC3750022.1": {
+          "attainable_recall": 1.0,
+          "tables_emitted": 0,
+          "tables_expected": 0
+        },
+        "PMC3750033.1": {
+          "attainable_recall": 0.9863013698630136,
+          "tables_emitted": 2,
+          "tables_expected": 2
+        },
+        "PMC3750044.1": {
+          "attainable_recall": 0.9893617021276596,
+          "tables_emitted": 1,
+          "tables_expected": 1
+        },
+        "PMC4250000.1": {
+          "attainable_recall": 1.0,
+          "tables_emitted": 2,
+          "tables_expected": 1
+        },
+        "PMC4250011.1": {
+          "attainable_recall": 1.0,
+          "tables_emitted": 0,
+          "tables_expected": 0
+        },
+        "PMC4250022.1": {
+          "attainable_recall": 1.0,
+          "tables_emitted": 1,
+          "tables_expected": 1
+        },
+        "PMC4250033.1": {
+          "attainable_recall": 0.9166666666666666,
+          "tables_emitted": 2,
+          "tables_expected": 1
+        },
+        "PMC4250054.1": {
+          "attainable_recall": 1.0,
+          "tables_emitted": 4,
+          "tables_expected": 4
+        },
+        "PMC4750000.1": {
+          "attainable_recall": 1.0,
+          "tables_emitted": 0,
+          "tables_expected": 0
+        },
+        "PMC4750011.1": {
+          "attainable_recall": 1.0,
+          "tables_emitted": 0,
+          "tables_expected": 0
+        },
+        "PMC4750022.1": {
+          "attainable_recall": 0.9743589743589743,
+          "tables_emitted": 6,
+          "tables_expected": 6
+        },
+        "PMC4750033.1": {
+          "attainable_recall": 1.0,
+          "tables_emitted": 1,
+          "tables_expected": 1
+        },
+        "PMC4750044.1": {
+          "attainable_recall": 0.9887640449438202,
+          "tables_emitted": 0,
+          "tables_expected": 0
+        },
+        "PMC5250590.1": {
+          "attainable_recall": 1.0,
+          "tables_emitted": 2,
+          "tables_expected": 2
+        },
+        "PMC5250601.1": {
+          "attainable_recall": 1.0,
+          "tables_emitted": 2,
+          "tables_expected": 1
+        },
+        "PMC5250623.1": {
+          "attainable_recall": 1.0,
+          "tables_emitted": 0,
+          "tables_expected": 0
+        },
+        "PMC5250635.1": {
+          "attainable_recall": 0.9014084507042254,
+          "tables_emitted": 3,
+          "tables_expected": 2
+        },
+        "PMC5250647.1": {
+          "attainable_recall": 0.9923076923076923,
+          "tables_emitted": 4,
+          "tables_expected": 5
+        },
+        "PMC5750000.1": {
+          "attainable_recall": 0.8461538461538461,
+          "tables_emitted": 2,
+          "tables_expected": 0
+        },
+        "PMC5750011.1": {
+          "attainable_recall": 0.9571428571428572,
+          "tables_emitted": 1,
+          "tables_expected": 1
+        },
+        "PMC5750022.1": {
+          "attainable_recall": 1.0,
+          "tables_emitted": 0,
+          "tables_expected": 0
+        },
+        "PMC5750033.1": {
+          "attainable_recall": 0.8831168831168831,
+          "tables_emitted": 5,
+          "tables_expected": 3
+        },
+        "PMC5750208.1": {
+          "attainable_recall": 1.0,
+          "tables_emitted": 0,
+          "tables_expected": 0
+        },
+        "PMC6250000.1": {
+          "attainable_recall": 0.9726027397260274,
+          "tables_emitted": 5,
+          "tables_expected": 4
+        },
+        "PMC6250011.1": {
+          "attainable_recall": 1.0,
+          "tables_emitted": 2,
+          "tables_expected": 2
+        },
+        "PMC6250022.1": {
+          "attainable_recall": 1.0,
+          "tables_emitted": 0,
+          "tables_expected": 0
+        },
+        "PMC6250033.1": {
+          "attainable_recall": 1.0,
+          "tables_emitted": 0,
+          "tables_expected": 0
+        },
+        "PMC6250044.1": {
+          "attainable_recall": 0.9914529914529915,
+          "tables_emitted": 2,
+          "tables_expected": 2
+        },
+        "PMC6750044.1": {
+          "attainable_recall": 1.0,
+          "tables_emitted": 0,
+          "tables_expected": 0
+        },
+        "PMC6750072.1": {
+          "attainable_recall": 0.9868421052631579,
+          "tables_emitted": 1,
+          "tables_expected": 1
+        },
+        "PMC6750083.1": {
+          "attainable_recall": 0.9876543209876543,
+          "tables_emitted": 0,
+          "tables_expected": 0
+        },
+        "PMC6750094.1": {
+          "attainable_recall": 0.9887640449438202,
+          "tables_emitted": 0,
+          "tables_expected": 0
+        },
+        "PMC6750105.1": {
+          "attainable_recall": 1.0,
+          "tables_emitted": 0,
+          "tables_expected": 0
+        },
+        "PMC7250000.1": {
+          "attainable_recall": 1.0,
+          "tables_emitted": 4,
+          "tables_expected": 3
+        },
+        "PMC7250011.1": {
+          "attainable_recall": 0.978494623655914,
+          "tables_emitted": 2,
+          "tables_expected": 2
+        },
+        "PMC7250022.1": {
+          "attainable_recall": 0.9647887323943662,
+          "tables_emitted": 3,
+          "tables_expected": 1
+        },
+        "PMC7250033.1": {
+          "attainable_recall": 0.9908256880733946,
+          "tables_emitted": 0,
+          "tables_expected": 0
+        },
+        "PMC7250055.2": {
+          "attainable_recall": 0.9879032258064516,
+          "tables_emitted": 0,
+          "tables_expected": 0
+        },
+        "PMC7750000.1": {
+          "attainable_recall": 0.9880952380952381,
+          "tables_emitted": 0,
+          "tables_expected": 0
+        },
+        "PMC7750009.1": {
+          "attainable_recall": 0.9647058823529412,
+          "tables_emitted": 5,
+          "tables_expected": 5
+        },
+        "PMC7750019.1": {
+          "attainable_recall": 0.9880952380952381,
+          "tables_emitted": 1,
+          "tables_expected": 1
+        },
+        "PMC7750040.1": {
+          "attainable_recall": 0.9880952380952381,
+          "tables_emitted": 2,
+          "tables_expected": 2
+        },
+        "PMC7750051.1": {
+          "attainable_recall": 0.9848484848484849,
+          "tables_emitted": 3,
+          "tables_expected": 3
+        },
+        "PMC8250041.1": {
+          "attainable_recall": 0.896551724137931,
+          "tables_emitted": 5,
+          "tables_expected": 5
+        },
+        "PMC8250095.2": {
+          "attainable_recall": 0.95,
+          "tables_emitted": 5,
+          "tables_expected": 5
+        },
+        "PMC8250106.1": {
+          "attainable_recall": 0.7894736842105263,
+          "tables_emitted": 0,
+          "tables_expected": 0
+        },
+        "PMC8250133.1": {
+          "attainable_recall": 1.0,
+          "tables_emitted": 0,
+          "tables_expected": 0
+        },
+        "PMC8250144.1": {
+          "attainable_recall": 1.0,
+          "tables_emitted": 0,
+          "tables_expected": 0
+        },
+        "PMC8750000.1": {
+          "attainable_recall": 0.9873417721518988,
+          "tables_emitted": 0,
+          "tables_expected": 0
+        },
+        "PMC8750011.1": {
+          "attainable_recall": 0.9939024390243902,
+          "tables_emitted": 7,
+          "tables_expected": 7
+        },
+        "PMC8750022.1": {
+          "attainable_recall": 0.976,
+          "tables_emitted": 4,
+          "tables_expected": 4
+        },
+        "PMC8750036.1": {
+          "attainable_recall": 0.98989898989899,
+          "tables_emitted": 3,
+          "tables_expected": 3
+        },
+        "PMC8750048.1": {
+          "attainable_recall": 1.0,
+          "tables_emitted": 0,
+          "tables_expected": 0
+        },
+        "PMC9250000.1": {
+          "attainable_recall": 1.0,
+          "tables_emitted": 0,
+          "tables_expected": 0
+        },
+        "PMC9250014.1": {
+          "attainable_recall": 1.0,
+          "tables_emitted": 3,
+          "tables_expected": 1
+        },
+        "PMC9250025.1": {
+          "attainable_recall": 1.0,
+          "tables_emitted": 4,
+          "tables_expected": 1
+        },
+        "PMC9250036.1": {
+          "attainable_recall": 0.9857142857142858,
+          "tables_emitted": 3,
+          "tables_expected": 3
+        },
+        "PMC9250060.1": {
+          "attainable_recall": 1.0,
+          "tables_emitted": 2,
+          "tables_expected": 2
+        },
+        "PMC9750000.1": {
+          "attainable_recall": 0.9878048780487805,
+          "tables_emitted": 3,
+          "tables_expected": 3
+        },
+        "PMC9750011.1": {
+          "attainable_recall": 0.989010989010989,
+          "tables_emitted": 3,
+          "tables_expected": 2
+        },
+        "PMC9750022.1": {
+          "attainable_recall": 0.9811320754716981,
+          "tables_emitted": 3,
+          "tables_expected": 3
+        },
+        "PMC9750033.1": {
+          "attainable_recall": 1.0,
+          "tables_emitted": 2,
+          "tables_expected": 2
+        },
+        "PMC9750044.1": {
+          "attainable_recall": 1.0,
+          "tables_emitted": 0,
+          "tables_expected": 0
+        }
+      }
+    }
+  }
+}

--- a/benchmarks/pmc/reference.json
+++ b/benchmarks/pmc/reference.json
@@ -5,9 +5,9 @@
     "bucket": "pmc-oa-opendata",
     "complete_corpus": true,
     "oracle_schema_version": 2,
-    "all2md_commit": "5ad13f0997f12df48606e4e9c8fd36b9708ee9db",
+    "all2md_commit": "1226777d23973e2447a562a081b4f59b1c971d4f",
     "worktree_dirty": false,
-    "created_at": "2026-08-23T01:06:43.389010+00:00",
+    "created_at": "2026-08-23T21:00:44.428227+00:00",
     "python": "3.12.3 (main, Jun 19 2026, 12:46:00) [GCC 13.3.0]",
     "platform": "linux",
     "parser_runtime": {
@@ -115,18 +115,18 @@
     "discrimination": 0.6178551375631667
   },
   "article_precision": {
-    "precision": 0.9498668913528678,
+    "precision": 0.9506444457900769,
     "supported": 423880,
-    "emitted": 446252,
-    "resequenced": 18550,
-    "novel": 3822,
-    "novel_share": 0.008564667497288528,
-    "duplication": 0.0075020318441565,
-    "excess": 3563,
-    "occurrences": 474938,
-    "control_precision": 0.007036383030216111,
-    "control_emitted": 446252,
-    "discrimination": 0.9428305083226517
+    "emitted": 445887,
+    "resequenced": 18393,
+    "novel": 3614,
+    "novel_share": 0.008105192571211988,
+    "duplication": 0.004493983009108454,
+    "excess": 2126,
+    "occurrences": 473077,
+    "control_precision": 0.007042142964473062,
+    "control_emitted": 445887,
+    "discrimination": 0.9436023028256039
   },
   "figure_binding": {
     "binding_rate": 0.6697674418604651,
@@ -138,7 +138,7 @@
     "caption_recall": 0.9441860465116279,
     "present": 203,
     "images_emitted": 429,
-    "captioned_emitted": 190,
+    "captioned_emitted": 189,
     "control_binding_rate": 0.0,
     "control_scored": 215,
     "discrimination": 0.6697674418604651
@@ -146,18 +146,18 @@
   "dimensions": {
     "block_structure_similarity": {
       "count": 706.0,
-      "mean": 0.5484813685328609,
+      "mean": 0.5485028296024805,
       "median": 0.5714285714285714,
       "minimum": 0.023255813953488413,
       "maximum": 1.0,
-      "stdev": 0.21058232887528835,
+      "stdev": 0.21055959591452936,
       "direction": "higher",
-      "control_mean": 0.4441323844565242,
-      "discrimination": 0.10434898407633669,
+      "control_mean": 0.44415691139323243,
+      "discrimination": 0.1043459182092481,
       "mutation_drop": {
         "reversed": 0.015782263093977338,
         "shuffled": 0.03254869887397674,
-        "halved": 0.06241696982757137
+        "halved": 0.062309664479472816
       },
       "ungateable": "compares kind sequences without inspecting the text under a block, so content-free output scores 1.0 (issue #256); eleven text categories collapse to `text_block`, so fully reversed output scores exactly 1.0 on 153 of the 981 pinned pages; and on the born-digital lane it separates own-page from wrong-page output by only ~0.06 while *rising* when half the emitted content is deleted, which rewards dropping blocks"
     },
@@ -169,12 +169,12 @@
       "maximum": 1.0,
       "stdev": 0.20974930316180884,
       "direction": "higher",
-      "control_mean": 0.29215575823349715,
-      "discrimination": 0.5359759720880322,
+      "control_mean": 0.29069717196612904,
+      "discrimination": 0.5374345583554003,
       "mutation_drop": {
         "reversed": 0.5303437329469437,
-        "shuffled": 0.24328767375956228,
-        "halved": 0.3255185131028114
+        "shuffled": 0.24338884737348376,
+        "halved": 0.32697035446258477
       }
     },
     "table_content_similarity": {
@@ -211,18 +211,18 @@
     },
     "text_content_similarity": {
       "count": 706.0,
-      "mean": 0.6762563749831473,
-      "median": 0.6993291888523847,
+      "mean": 0.6813156888254379,
+      "median": 0.7082209683552323,
       "minimum": 0.010652463382157085,
       "maximum": 0.9930305215092525,
-      "stdev": 0.22360381359462717,
+      "stdev": 0.22329983041306012,
       "direction": "higher",
-      "control_mean": 0.2341678713390695,
-      "discrimination": 0.4420885036440778,
+      "control_mean": 0.2334461851782221,
+      "discrimination": 0.4478695036472158,
       "mutation_drop": {
-        "reversed": 0.2914274690677305,
-        "shuffled": 0.20251057893083302,
-        "halved": 0.29247980461231066
+        "reversed": 0.292270299536416,
+        "shuffled": 0.20376197639542715,
+        "halved": 0.29620063786003653
       }
     }
   },

--- a/docs/source/benchmarks.rst
+++ b/docs/source/benchmarks.rst
@@ -167,33 +167,39 @@ Unsupported output is therefore split in two:
      - Share
      - Meaning
    * - Supported
-     - **95.0%**
+     - **95.1%**
      - the n-gram appears in the document's text layer
    * - Resequenced
-     - 4.2%
+     - 4.1%
      - every word is in the document, in a new adjacency
    * - **Novel**
-     - **0.9%**
+     - **0.8%**
      - at least one word appears nowhere — the number worth reading
    * - Duplication
-     - 0.8%
+     - 0.4%
      - supported text emitted more than once
    * - Control: the *wrong* article
      - 0.7%
      - wants to be ~0%
 
-Over 446,252 emitted n-grams, 3,822 are novel. Reporting the raw unsupported figure instead
+Over 445,887 emitted n-grams, 3,614 are novel. Reporting the raw unsupported figure instead
 would have made the result roughly six times worse than the parser deserves.
 
 Duplication is counted apart from both, because it is invisible to either. Text emitted
 twice is an unchanged *set* and a doubled *multiset* — no set-based score can see it at all.
 
-Duplication is under a point, and the path it took there is the point. It read 0.5% while
-the oracle was blind to captions, jumped to 2.0% when the corrected oracle could finally
-see that multi-panel figures re-bound one printed caption to every panel, and fell by two
-thirds when that defect was fixed (issue #410). The middle figure was the honest one: the
-defect predated the re-record, and what changed first was only that a measurement became
+Duplication is under half a point, and the path it took there is the point. It read 0.5%
+while the oracle was blind to captions, jumped to 2.0% when the corrected oracle could
+finally see that multi-panel figures re-bound one printed caption to every panel, and fell
+by two thirds when that defect was fixed (issue #410). The middle figure was the honest one:
+the defect predated the re-record, and what changed first was only that a measurement became
 able to report it.
+
+It fell by two fifths again, 0.8% to 0.4%, on #435. That defect mostly *doubled* captions
+rather than inventing them — the clipped-away typesetting is the same words as the printed
+one — so duplication is where the bulk of it landed. Novel share moved by less than a
+twentieth of a point, 0.86% to 0.81%, which is enough to cross a rounding boundary in the
+table above and not much more.
 
 Tables
 ~~~~~~
@@ -270,12 +276,12 @@ pages:
      - Gap
    * - ``reading_order_similarity``
      - 0.828
-     - 0.292
-     - **0.536**
+     - 0.291
+     - **0.537**
    * - ``text_content_similarity``
-     - 0.676
-     - 0.234
-     - **0.442**
+     - 0.681
+     - 0.233
+     - **0.448**
    * - ``table_content_similarity``
      - 0.606
      - 0.039
@@ -285,7 +291,7 @@ pages:
      - 0.095
      - **0.519**
    * - ``block_structure_similarity``
-     - 0.548
+     - 0.549
      - 0.444
      - 0.104 — **not gated**
 
@@ -306,6 +312,16 @@ the position they occupy in the column (#429) took reading order from 0.815 to 0
 content from 0.667 to 0.676, with recall, figure binding and the table counts unchanged — and
 left all three scanned-lane dimensions byte-identical across 981 pages, because the guard
 that keeps OCR pages in engine order held.
+
+Text content moved again, to 0.681, when the parser stopped reading text that clipping paths
+erase from the page (#435). Five of the 66 articles are journal proofs that keep a superseded,
+wider typesetting of each page inside a clipped form XObject: it renders as blank paper, but
+the one PyMuPDF call the parser used to read a region's text collected it anyway, cut mid-word
+at the region's edges. Reading order's own value did not move at all — the ghost was extra
+text, not misplaced text — and recall did not move either, for the same reason. What it
+changes is precision, below. One figure lost its caption, because the only thing that had
+ever captioned it was the ghost; ``caption_recall`` against the JATS captions is unchanged
+to every recorded digit, which is how we know no real one went with it.
 
 The two lanes' values are not comparable to each other as quality scores: born-digital pages
 carry a text layer and scanned pages do not, and the ground truths are differently strict.


### PR DESCRIPTION
The sealed-holdout comparison, run against `073e4da`. 110 held-out articles, three tools,
**zero conversion failures anywhere**.

## The control, first

Same corpus pin, same platform, and `baselines.txt` unchanged — so the only variable is our
own commit. Both baselines were re-run untouched:

- **docling reproduced every recorded figure to six decimal places.** Recall, novel share,
  duplication, precision, reparse ratio, tables emitted, all three by-kind figures — zero drift.
- **pymupdf4llm reproduced its deterministic figures exactly** and drifted only on
  OCR-dependent ones (novel share +0.0015, tables +4), because RapidOCR is not
  bit-deterministic across thread counts.

Two unchanged tools reproducing is what licenses attributing all2md's movement to all2md
rather than to the instrument. Without it this is just a table of numbers that moved.

## The reading

| | all2md @ 073e4da | pymupdf4llm 1.28.2 | docling 2.120.3 |
| --- | --- | --- | --- |
| Recall of attainable | 98.2% | **98.3%** | 95.5% |
| — text blocks | **98.4%** | 98.4% | 95.9% |
| — titles | 98.7% | **99.3%** | 95.4% |
| — table text | 77.4% | 65.1% | **82.2%** |
| **Novel (invented) share** | **0.62%** | 5.64% | 2.87% |
| Tables emitted / expected | 238 / 166 | 212 / 166 | 201 / 166 |
| Seconds per article | **12.7** | 26.9 | 55.2 |
| OCR firings | **0** | 423 | sparse |

## Against 2026-08-19

| | then | now |
| --- | --- | --- |
| Recall of attainable | 93.5% | **98.2%** (+4.71) |
| — text blocks | 94.3% | **98.4%** (+4.15) |
| — titles | 93.4% | **98.7%** (+5.30) |
| — table text | 69.9% | **77.4%** (+7.53) |
| Novel share | 0.84% | **0.62%** (−0.22) |
| Duplication | 0.61% | **0.46%** (−0.15) |

**Recall rose 4.7 points while invented text fell.** That combination is the point. Text
survival alone favours low-structure output, and pymupdf4llm shows the price of buying recall
the easy way: it reaches the same figure to within 0.03 points by firing OCR **423 times on a
corpus where no page needs it** — 0 of 1,184 pages carry a text layer under 20 characters —
and pays 5.64% novel share. We fired zero times.

## The lost-block diff: 528 → 108

Two findings recorded rather than assumed:

**#414 is answered.** Its exemplar `PMC11000022.1` now loses **zero** blocks against either
baseline. The issue's own stated trigger was the class rising in a holdout block-diff. It has
not risen, so the XY-cut work stays unbuilt on evidence rather than on a guess.

**Table misses became #438.** Of 146 attainable tables we recover 113. Of the 33 we miss,
**none are absent** — word containment across all 33 is mean 0.998, median 1.000, thirty of
them exactly 1.000. Every miss is adjacency: wrapped cell text becomes extra table rows, so
every word is present and none are contiguous. docling recovers 20 of the 33, twelve at
containment 1.000 — so they are reachable, and its table lead is *merging wrapped cells*, not
reading text we cannot reach.

The remaining 108 are 79 shredded (0.4–0.8), 2 absent, and concentrated — 45 of them in two
articles. **I have not diagnosed that mechanism and the README does not guess at it.**

## Housekeeping

The 2026-08-19 Tesseract caveat was open-ended; it is now bounded. The binary is installed on
this box but off PATH, and that is moot for a corpus with no scanned pages — measured, not
assumed. Earlier readings keep their own section so the provenance of #405 and #406 survives.

Working artifacts (`out/`, `articles.json`, `comparison.json`) are gitignored; only the dated
results file and the README are committed, per the lane's own rule that a new reading is a new
dated file and never an edit to an old one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
