### PR TITLE
fix(pdf): stop a footer vetoing the column channel it cannot interleave (#440)

### DIFF
--- a/src/all2md/constants.py
+++ b/src/all2md/constants.py
@@ -792,6 +792,11 @@ PDF_COLUMN_SINGLE_COLUMN_WIDTH_RATIO = 0.6  # Width ratio threshold for single c
 PDF_COLUMN_CHANNEL_MIN_WIDTH = 8.0  # Points; measured gutters bottom out at 14.9
 PDF_COLUMN_CHANNEL_MIN_BLOCKS_PER_SIDE = 3  # Sides with fewer blocks cannot interleave much
 PDF_COLUMN_CHANNEL_MIN_Y_OVERLAP_RATIO = 0.3  # Of the smaller side's y-span
+# Points of clear vertical space that separate page furniture from the body (#440).
+# Body blocks tile with sub-point gaps; the six held-out corpus pages where a footer
+# erased a real channel separate at 40-312pt, and the page count this admits is flat
+# across 18-60pt, so the exact value is not load-bearing.
+PDF_COLUMN_CHANNEL_BAND_GAP = 24.0
 
 # Line-level resegmentation of gutter-merged blocks (#405). On 64 of 455 dev-corpus
 # pages PyMuPDF fuses both columns of a tight-gutter page into a single block, so no

--- a/src/all2md/parsers/_pdf_columns.py
+++ b/src/all2md/parsers/_pdf_columns.py
@@ -15,6 +15,7 @@ from collections import defaultdict
 
 from all2md.constants import (
     DEFAULT_COLUMN_GAP_THRESHOLD,
+    PDF_COLUMN_CHANNEL_BAND_GAP,
     PDF_COLUMN_CHANNEL_MIN_BLOCKS_PER_SIDE,
     PDF_COLUMN_CHANNEL_MIN_WIDTH,
     PDF_COLUMN_CHANNEL_MIN_Y_OVERLAP_RATIO,
@@ -273,6 +274,116 @@ def _detect_columns_by_whitespace(
     return whitespace_columns if len(whitespace_columns) > 1 else None
 
 
+def _dominant_y_band(boxes: list[tuple[float, float, float, float]]) -> list[tuple[float, float, float, float]]:
+    """Return the boxes in the page's densest horizontal band of text.
+
+    Running heads, page numbers and copyright lines sit in their own band,
+    separated from the body by far more vertical space than any two body blocks
+    are ever separated by. Sweeping the boxes in y and cutting wherever that
+    space exceeds ``PDF_COLUMN_CHANNEL_BAND_GAP`` therefore isolates the body
+    without needing the page rectangle, a margin ratio, or knowledge of what the
+    furniture says.
+
+    The band holding the most boxes wins, but only if everything it leaves behind
+    is too small to be a column of anything. A page whose body a figure has split
+    into two real bands is returned whole instead: choosing the larger half there
+    would be a guess about which half to read, not a trim.
+
+    Parameters
+    ----------
+    boxes : list of tuple
+        (x0, y0, x1, y1) for each block under consideration.
+
+    Returns
+    -------
+    list of tuple
+        The boxes of the most populous band, or ``boxes`` unchanged when what
+        that would discard is too substantial to be page furniture. A caller
+        that gets its input back has learned there is no furniture to strip.
+
+    """
+    if not boxes:
+        return []
+    bands: list[list[tuple[float, float, float, float]]] = []
+    reach = float("-inf")
+    for box in sorted(boxes, key=lambda b: b[1]):
+        if not bands or box[1] > reach + PDF_COLUMN_CHANNEL_BAND_GAP:
+            bands.append([])
+            reach = box[3]
+        else:
+            reach = max(reach, box[3])
+        bands[-1].append(box)
+
+    body = max(bands, key=len)
+    # Only furniture may be discarded. A band holding as many blocks as a column
+    # needs is not a running head; it is the other half of a body that a figure
+    # or a table split in two, and dropping it is a guess about which half to
+    # read. Measured on the 110-article held-out corpus: the six pages where a
+    # footer erases a real channel discard exactly two blocks each, while every
+    # page this rejects would have discarded 6, 17, 27 or 39 -- the separation is
+    # not close, so the bar is the detector's own idea of how few blocks cannot
+    # make a column.
+    if any(len(band) >= PDF_COLUMN_CHANNEL_MIN_BLOCKS_PER_SIDE for band in bands if band is not body):
+        return list(boxes)
+    return body
+
+
+def _channel_boundaries(kept: list[tuple[float, float, float, float]]) -> list[float]:
+    """Find x-positions no block in ``kept`` touches, with columns on both sides.
+
+    Parameters
+    ----------
+    kept : list of tuple
+        (x0, y0, x1, y1) for the blocks carrying interleaving evidence.
+
+    Returns
+    -------
+    list of float
+        Midpoints of every channel that passes the per-side guards. A page is
+        admitted as two-column only when this holds exactly one.
+
+    """
+    intervals = sorted((bbox[0], bbox[2]) for bbox in kept)
+    if len(intervals) < 2 * PDF_COLUMN_CHANNEL_MIN_BLOCKS_PER_SIDE:
+        return []
+
+    # Merge the x-intervals; the complement between merged runs is the channel space.
+    merged: list[tuple[float, float]] = [intervals[0]]
+    for x0, x1 in intervals[1:]:
+        last_x0, last_x1 = merged[-1]
+        if x0 <= last_x1 + PDF_COLUMN_CHANNEL_MIN_WIDTH:
+            merged[-1] = (last_x0, max(last_x1, x1))
+        else:
+            merged.append((x0, x1))
+    if len(merged) < 2:
+        return []
+
+    # y-extent of the evidence blocks on each side of each candidate channel.
+    def side_stats(lo: float, hi: float) -> tuple[int, float, float]:
+        count = 0
+        y0 = float("inf")
+        y1 = float("-inf")
+        for bbox in kept:
+            if bbox[0] >= lo and bbox[2] <= hi:
+                count += 1
+                y0 = min(y0, bbox[1])
+                y1 = max(y1, bbox[3])
+        return count, y0, y1
+
+    boundaries: list[float] = []
+    for (_, left_end), (right_start, _) in zip(merged, merged[1:], strict=False):
+        left_count, left_y0, left_y1 = side_stats(float("-inf"), left_end)
+        right_count, right_y0, right_y1 = side_stats(right_start, float("inf"))
+        if left_count < PDF_COLUMN_CHANNEL_MIN_BLOCKS_PER_SIDE or right_count < PDF_COLUMN_CHANNEL_MIN_BLOCKS_PER_SIDE:
+            continue
+        overlap = min(left_y1, right_y1) - max(left_y0, right_y0)
+        smaller_span = min(left_y1 - left_y0, right_y1 - right_y0)
+        if smaller_span <= 0 or overlap < PDF_COLUMN_CHANNEL_MIN_Y_OVERLAP_RATIO * smaller_span:
+            continue
+        boundaries.append((left_end + right_start) / 2)
+    return boundaries
+
+
 def _detect_columns_by_channel(
     blocks: list,
     block_ranges: list[tuple[float, float]],
@@ -295,6 +406,14 @@ def _detect_columns_by_channel(
     mutual y-overlap between the sides that a y-sort would provably interleave
     them. An indented quotation overlaps its body text in x, so it can never
     produce the channel in the first place.
+
+    Page furniture is held to the same standard but cannot meet it, so when the
+    whole page yields no channel the search is retried on the body band alone
+    (#440). A footer with two elements on one baseline -- a copyright line
+    crossing the gutter and a page number -- survives the isolation prune by
+    mutual vouching, and the copyright line then merges the two x-runs into one,
+    erasing a channel that twenty blocks a side support. Nothing above or below
+    the body can be interleaved with it by a y-sort, so nothing there gets a vote.
 
     Parameters
     ----------
@@ -327,51 +446,35 @@ def _detect_columns_by_channel(
     # y-overlaps no other block cannot be interleaved with anything by a y-sort, so it
     # carries no evidence either way; it is still assigned to a column by center below.
     kept = [a for a in narrow if any(min(a[3], b[3]) > max(a[1], b[1]) for b in narrow if b is not a)]
-    intervals = sorted((bbox[0], bbox[2]) for bbox in kept)
-    if len(intervals) < 2 * PDF_COLUMN_CHANNEL_MIN_BLOCKS_PER_SIDE:
-        return None
-
-    # Merge the x-intervals; the complement between merged runs is the channel space.
-    merged: list[tuple[float, float]] = [intervals[0]]
-    for x0, x1 in intervals[1:]:
-        last_x0, last_x1 = merged[-1]
-        if x0 <= last_x1 + PDF_COLUMN_CHANNEL_MIN_WIDTH:
-            merged[-1] = (last_x0, max(last_x1, x1))
-        else:
-            merged.append((x0, x1))
-    if len(merged) < 2:
-        return None
-
-    # y-extent of the evidence blocks on each side of each candidate channel.
-    def side_stats(lo: float, hi: float) -> tuple[int, float, float]:
-        count = 0
-        y0 = float("inf")
-        y1 = float("-inf")
-        for bbox in kept:
-            if bbox[0] >= lo and bbox[2] <= hi:
-                count += 1
-                y0 = min(y0, bbox[1])
-                y1 = max(y1, bbox[3])
-        return count, y0, y1
-
-    boundaries: list[float] = []
-    for (_, left_end), (right_start, _) in zip(merged, merged[1:], strict=False):
-        left_count, left_y0, left_y1 = side_stats(float("-inf"), left_end)
-        right_count, right_y0, right_y1 = side_stats(right_start, float("inf"))
-        if left_count < PDF_COLUMN_CHANNEL_MIN_BLOCKS_PER_SIDE or right_count < PDF_COLUMN_CHANNEL_MIN_BLOCKS_PER_SIDE:
-            continue
-        overlap = min(left_y1, right_y1) - max(left_y0, right_y0)
-        smaller_span = min(left_y1 - left_y0, right_y1 - right_y0)
-        if smaller_span <= 0 or overlap < PDF_COLUMN_CHANNEL_MIN_Y_OVERLAP_RATIO * smaller_span:
-            continue
-        boundaries.append((left_end + right_start) / 2)
 
     # Exactly one admitted gutter -- a two-column page. Every measured tight-gutter
     # page is two-column; layouts with more columns have wider gutters relative to
     # their column width and clear the ordinary threshold path. Several qualifying
     # channels on one page is the signature of an undetected table, not a layout.
+    boundaries = _channel_boundaries(kept)
+    furniture: set[tuple[float, float, float, float]] = set()
+
     if len(boundaries) != 1:
-        return None
+        # Retry on the body alone (#440). The prune above drops a block that
+        # y-overlaps *nothing*, which is enough for a lone stray page number but
+        # not for a footer with two elements on one baseline: a copyright line
+        # crossing the gutter and a page number vouch for each other, both
+        # survive, and the copyright line then merges the two x-runs into one
+        # and erases a channel that twenty blocks a side support. Furniture
+        # cannot be interleaved with the body by a y-sort whatever it overlaps,
+        # so it carries no evidence and does not get to veto.
+        #
+        # Restricted to a retry rather than applied outright: a page that
+        # already splits keeps splitting on exactly the evidence it always used.
+        body = _dominant_y_band(kept)
+        if len(body) == len(kept):
+            return None
+
+        boundaries = _channel_boundaries(body)
+        if len(boundaries) != 1:
+            return None
+        furniture = {tuple(bbox) for bbox in kept} - {tuple(bbox) for bbox in body}
+        kept = body
 
     content_top = min(bbox[1] for bbox in kept)
     content_bottom = max(bbox[3] for bbox in kept)
@@ -382,7 +485,15 @@ def _detect_columns_by_channel(
             columns[0].append(block)
             continue
         bbox = block["bbox"]
-        if (bbox[2] - bbox[0]) > spanning_width:
+        # The blocks the band trim identified as furniture are routed like a
+        # spanning block: in page order, not column order. Without this the
+        # copyright line, being narrow and centred a hair left of the boundary,
+        # lands at the end of the *left* column -- spliced between the two
+        # columns of the very page it was just stopped from vetoing (#440).
+        # Only those blocks: widening this to everything on a trimmed page also
+        # catches body blocks the isolation prune dropped, and re-interleaves
+        # the reference list it was supposed to repair.
+        if tuple(bbox) in furniture or (bbox[2] - bbox[0]) > spanning_width:
             # A spanning block reads in page order, not column order. Assigning it by
             # center drops it *between* the columns at emission time: an untrimmed
             # running header whose center fell a hair right of the boundary lands at

--- a/tests/unit/formats/pdf/test_pdf_column_channel_footer.py
+++ b/tests/unit/formats/pdf/test_pdf_column_channel_footer.py
@@ -1,0 +1,114 @@
+"""A footer must not veto a column channel it cannot interleave (#440).
+
+``_detect_columns_by_channel`` admits a tight-gutter two-column page on
+structural evidence: an x-interval no non-spanning block touches, with enough
+blocks and enough mutual y-overlap on each side that a y-sort would provably
+interleave them. Any single block crossing that interval merges the two x-runs
+into one and the channel disappears, so the page is read line-by-line in y and
+both columns interleave -- every word survives, every adjacency dies.
+
+The prune that guarded against this dropped blocks that y-overlap *nothing*,
+which is enough for a lone stray page number but not for a real journal footer.
+On the mycology reference pages the footer has two elements on one baseline --
+a copyright line crossing the gutter and a page number -- so each vouches for
+the other, both survive, and the copyright line erases a channel that twenty
+blocks a side support.
+
+The geometry in these tests is the real thing, taken from page 13 of
+PMC7250011.1 in the held-out corpus: 260pt columns at x 28-288 and x 309-569, a
+20.7pt gutter, and a footer 312pt below the last line of text.
+"""
+
+import pytest
+
+from all2md.parsers._pdf_columns import detect_columns
+
+pytestmark = [pytest.mark.unit, pytest.mark.pdf]
+
+GUTTER_LEFT, GUTTER_RIGHT = 288.3, 309.0
+PAGE_RIGHT = 569.0
+
+
+def _two_columns(rows: int = 13) -> list[dict]:
+    """Build a reference page: ``rows`` stacked blocks in each of two columns."""
+    blocks = []
+    for i in range(rows):
+        top = 50.0 + i * 36.0
+        blocks.append({"bbox": [28.3, top, GUTTER_LEFT, top + 35.5]})
+        blocks.append({"bbox": [GUTTER_RIGHT, top, PAGE_RIGHT, top + 35.5]})
+    return blocks
+
+
+def _footer() -> list[dict]:
+    """The copyright line, which crosses the gutter, and the page number."""
+    return [
+        {"bbox": [211.5, 808.0, 383.7, 819.5]},
+        {"bbox": [550.2, 806.6, 566.9, 820.6]},
+    ]
+
+
+def _column_of(columns: list[list[dict]], block: dict) -> int:
+    for i, column in enumerate(columns):
+        if block in column:
+            return i
+    raise AssertionError("block was assigned to no column")
+
+
+class TestFooterDoesNotVetoTheChannel:
+    def test_clean_page_splits(self) -> None:
+        """The control: without furniture the channel has always been found."""
+        assert len(detect_columns(_two_columns())) == 2
+
+    def test_gutter_crossing_footer_pair_still_splits(self) -> None:
+        """The regression: two footer elements on one baseline vouched for each other."""
+        assert len(detect_columns(_two_columns() + _footer())) == 2
+
+    def test_lone_gutter_crossing_footer_still_splits(self) -> None:
+        """The case the original prune already handled stays handled."""
+        assert len(detect_columns(_two_columns() + _footer()[:1])) == 2
+
+    def test_footer_reads_after_both_columns(self) -> None:
+        """Furniture below the body belongs after it, not spliced into a column.
+
+        Excluding the footer from the *evidence* must not exclude it from the
+        *output*: it is still assigned a column, and being below all body text
+        it goes to the last one so a reader reaches it after both columns.
+        """
+        body, footer = _two_columns(), _footer()
+        columns = detect_columns(body + footer)
+        emitted = [block for column in columns for block in column]
+        assert len(emitted) == len(body) + len(footer)
+        for block in footer:
+            assert _column_of(columns, block) == len(columns) - 1
+
+    def test_columns_are_not_interleaved(self) -> None:
+        """The point of the whole exercise: each side stays contiguous."""
+        columns = detect_columns(_two_columns() + _footer())
+        left, right = columns[0], columns[1]
+        assert all(block["bbox"][2] <= GUTTER_LEFT for block in left)
+        assert all(block["bbox"][0] >= GUTTER_RIGHT for block in right[: len(right) - 2])
+
+
+class TestOnlyFurnitureIsDiscarded:
+    """A band big enough to be a column is body, and body never gets dropped."""
+
+    def test_a_figure_split_body_is_left_alone(self) -> None:
+        """Two substantial bands with a bridging block: no guess about which half.
+
+        Dropping the smaller band here would admit a channel on half a page's
+        evidence. Measured on the held-out corpus, every page this rejects would
+        have discarded 6, 17, 27 or 39 blocks, against exactly 2 for every page
+        it accepts.
+        """
+        upper = [{"bbox": [28.3, 50.0 + i * 30.0, GUTTER_LEFT, 78.0 + i * 30.0]} for i in range(4)]
+        upper += [{"bbox": [GUTTER_RIGHT, 50.0 + i * 30.0, PAGE_RIGHT, 78.0 + i * 30.0]} for i in range(4)]
+        lower = [{"bbox": [28.3, 400.0 + i * 30.0, GUTTER_LEFT, 428.0 + i * 30.0]} for i in range(4)]
+        lower += [{"bbox": [GUTTER_RIGHT, 400.0 + i * 30.0, PAGE_RIGHT, 428.0 + i * 30.0]} for i in range(4)]
+        bridge = [{"bbox": [211.5, 404.0, 383.7, 415.0]}]
+
+        assert len(detect_columns(upper + lower + bridge)) == 1
+
+    def test_a_single_column_page_is_not_split_by_stripping_its_footer(self) -> None:
+        """Removing furniture must not manufacture a channel out of nothing."""
+        body = [{"bbox": [28.3, 50.0 + i * 30.0, 520.0, 78.0 + i * 30.0]} for i in range(12)]
+        assert len(detect_columns(body + _footer())) == 1


### PR DESCRIPTION
Fixes #440. Stacked on nothing — branches off `main`, independent of #444.

## The defect

`_detect_columns_by_channel` admits a tight-gutter two-column page on structural evidence: an x-interval no non-spanning block touches, with enough blocks and enough mutual y-overlap on each side that a y-sort would provably interleave them. **Any single block crossing that interval** merges the two x-runs into one, the channel disappears, and the page is read line-by-line in y — every word survives, every adjacency dies.

The prune that guarded against this dropped blocks that y-overlap *nothing*. That is enough for a lone stray page number but not for a real journal footer: on the mycology reference pages the footer has two elements on one baseline — a copyright line crossing the gutter and a page number — so **each vouches for the other**, both survive, and the copyright line erases a channel that twenty blocks a side support.

Reproduced exactly on page 13 of `PMC7250011.1`. 260pt columns at x 28–288 and x 309–569, a 20.7pt gutter, 26 body blocks, and a footer 312pt below the last line:

```
merged runs = [(28.3, 569.0)]     <- one run; the copyright line bridges 288.3 -> 309.0
```

## The fix

**Retry on the body band.** When the whole page yields no channel, blocks are swept in y and cut wherever the clear space exceeds `PDF_COLUMN_CHANNEL_BAND_GAP`, isolating the body without needing the page rectangle or a margin ratio. A retry rather than an outright change, so a page that already splits keeps splitting on exactly the evidence it always used.

**Only furniture may be discarded.** A band holding as many blocks as a column needs is not a running head — it is the other half of a body that a figure split, and choosing between halves is a guess, not a trim. The separation is not close:

| | discarded blocks |
|---|---|
| pages this accepts | **2, 2, 2, 2, 2, 2** |
| pages this rejects | 6, 17, 27, 39 |

So the bar is the detector's own `PDF_COLUMN_CHANNEL_MIN_BLOCKS_PER_SIDE`, not a new tuning knob. The band gap itself is not load-bearing either — the page count is flat across 18–60pt.

**Furniture is routed in page order**, like a spanning block. Without it the copyright line, narrow and centred a hair left of the boundary, lands at the end of the *left* column — spliced between the two columns of the page it was just stopped from vetoing. Scoped to exactly those blocks: an earlier draft applied it to everything on a trimmed page, which also caught body blocks the isolation prune had dropped and **re-interleaved the very reference list it was meant to repair** (caught by re-measuring, one recovered block short).

## Measurement

Replaying the real block geometry handed to `detect_columns` for all 110 held-out articles — **1,184 pages**:

```
pages whose column count changed: 6
    PMC11250033.1 p3, p9    PMC7250011.1 p1, p8, p12    PMC7250022.1 p17
regressions (fewer columns): []
```

Re-converting the 39 articles carrying a lost block:

```
lost blocks recovered: 27 of 113
blocks whose share fell: 0
projection byte-identical on 36 of 39 articles
```

Mostly reference `<article-title>`s, which matches the issue's finding that all 49 title losses are reference titles. A representative one:

```
before:  Swofford DL (2003). *PAUP\*. Phylogenetic Analysis Using Parsimony (\**
         notes on Canadian species of *Elaphomyces*... **67**: 909-914.
         *and other methods).* Version 4. Sinauer, USA.
after:   Swofford DL (2003). *PAUP\*. Phylogenetic Analysis Using Parsimony (\**
         *and other methods).* Version 4. Sinauer, USA.
```

## On the issue's numbers

The issue quotes a page-geometry simulation predicting **17 pages / 43 blocks**, flagged there as unverified. It does not reproduce. It did not model the furniture guard, and the extra pages it flipped are body splits this deliberately declines — `PMC6250011.1` p8 would have thrown away 39 of 82 blocks. The honest figure is 6 pages and 27 blocks, each verified against the actual lost-block text rather than inferred from geometry.

That leaves the rest of #440's bucket — the full-width spanning line, the 4-band reference layout, the rotated spine text, the PyMuPDF-fused wide blocks — untouched and still open.

## Tests

7 new tests built on the exemplar's real geometry: the control, the two-element footer, the lone crossing block, furniture reading after both columns, columns staying contiguous, and two rejection cases (a figure-split body, and a single-column page that must not be split by stripping its footer).

Full suite green — unit, golden, integration, e2e. ruff and mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)