### PR TITLE
fix(benchmarks): project text a node holds without a Paragraph wrapper (#443)

### DIFF
--- a/benchmarks/omnidocbench/benchmark.py
+++ b/benchmarks/omnidocbench/benchmark.py
@@ -31,6 +31,15 @@ SCHEMA_VERSION = 3
 #: figure vanished from measurement while an unbound one counted -- recall fell as
 #: binding improved (#406). The annotation side always counted captions as text blocks,
 #: so this removes an asymmetry rather than adding a credit.
+#:
+#: Still 6 after #443 widened ``_semantic_blocks`` to admit any container of inline text.
+#: This gate ratchets against a recorded ``baseline.json``, and the version must equal the
+#: one that baseline carries or the lane reports identity drift instead of a fidelity
+#: result -- so the number may only move together with a re-recorded baseline, which costs
+#: a 981-page OCR run. It is held back because the widening provably cannot reach this
+#: lane: it projects the PDF parser's AST, which emits no definition lists and wraps every
+#: list item in a ``Paragraph``, and 8 of 8 sampled corpus PDFs project byte-identically
+#: across the change. Bump to 7 with the next baseline re-record, whatever prompts it.
 ORACLE_SCHEMA_VERSION = 6
 
 

--- a/benchmarks/omnidocbench/oracles.py
+++ b/benchmarks/omnidocbench/oracles.py
@@ -13,6 +13,8 @@ from typing import Any, Callable, Iterable, Literal, Mapping, TypeVar
 from all2md.ast.nodes import (
     Code,
     CodeBlock,
+    Comment,
+    CommentInline,
     Document,
     Heading,
     MathBlock,
@@ -200,6 +202,39 @@ def _attached_captions(block: Node) -> Iterable[Paragraph]:
             yield _caption_paragraph(caption)
 
 
+# The block-level node types the projection recognises by name.
+_BLOCK_TYPES = (Heading, Paragraph, CodeBlock, Table, MathBlock)
+
+# Markup that never prints. A comment's text is not document text, and admitting it
+# would inflate two baselines with markers no reader ever sees: docling writes 976
+# ``<!-- image -->`` comments across 106 of the 110 held-out articles and pymupdf4llm
+# 359 ``<!-- Start of picture text -->`` across 83. Excluding them is what separates
+# "text this projection cannot see" from "text this projection should not see".
+_NON_PRINTING = (Comment, CommentInline)
+
+
+def _carries_only_inline_text(node: Node) -> bool:
+    """Whether ``node`` holds document text with no block-level node anywhere inside it.
+
+    ``_semantic_blocks`` recurses through every type it does not recognise, so a
+    container holding *inline* content directly -- with no ``Paragraph`` wrapper --
+    falls straight through the walk and contributes nothing (#443). ``DefinitionTerm``
+    is the shape that exposed it: the term vanished while its sibling
+    ``DefinitionDescription`` survived, and survived only because it happens to wrap
+    its own content in a ``Paragraph``.
+
+    Recognising the *shape* rather than adding two more type names is deliberate: an
+    instrument that silently cannot see part of its input is a bad instrument, and the
+    next node type built to the same shape would otherwise reproduce the bug in
+    silence.
+    """
+    if isinstance(node, _NON_PRINTING):
+        return False
+    if any(isinstance(descendant, _BLOCK_TYPES) for descendant in _all_nodes(node)):
+        return False
+    return bool(_node_text(node).strip())
+
+
 def _semantic_blocks(node: Node) -> Iterable[Node]:
     # A caption is document text the AST carries as a string *attribute* --
     # ``Figure.caption``, ``Table.caption``, ``Image.caption`` -- not as a child node, so a
@@ -210,12 +245,21 @@ def _semantic_blocks(node: Node) -> Iterable[Node]:
     # corpus were sitting in the output the whole time. Captions are projected as
     # synthesized paragraphs because that is exactly how the annotation side reads them:
     # ``project_annotation`` collapses figure_caption/table_caption to ``text_block``.
-    if isinstance(node, (Heading, Paragraph, CodeBlock, Table, MathBlock)):
+    if isinstance(node, _BLOCK_TYPES):
         yield node
         yield from _attached_captions(node)
         return
     for child in get_node_children(node):
-        yield from _semantic_blocks(child)
+        # Tested on the child rather than on ``node`` so the text is yielded at the
+        # coarsest node that owns all of it: asking here admits a whole
+        # ``DefinitionTerm`` as one block, where asking at the top would either
+        # collapse a document into a single block or shred a term into its
+        # ``Strong``/``Text`` pieces and count each as a block of its own.
+        if _carries_only_inline_text(child):
+            yield child
+            yield from _attached_captions(child)
+        else:
+            yield from _semantic_blocks(child)
     caption = getattr(node, "caption", None)
     if isinstance(caption, str) and caption.strip():
         # Containers (Figure) carry their caption after their content, matching where a
@@ -251,9 +295,6 @@ def project_ast(document: Document) -> PageProjection:
         if isinstance(block, Heading):
             block_kinds.append("title")
             text_blocks.append(_node_text(block))
-        elif isinstance(block, (Paragraph, CodeBlock)):
-            block_kinds.append("text_block")
-            text_blocks.append(_node_text(block))
         elif isinstance(block, Table):
             block_kinds.append("table")
             tables.append(_ast_table(block))
@@ -265,6 +306,13 @@ def project_ast(document: Document) -> PageProjection:
             block_kinds.append("equation_isolated")
             content, _ = block.get_preferred_representation("latex")
             formulas.append(FormulaProjection("block", content))
+        else:
+            # Paragraph, CodeBlock, and any inline-only container the walk admits (#443).
+            # A catch-all rather than a type list because the annotation side collapses
+            # every text-bearing category to ``text_block``: a block that reaches here
+            # carrying text belongs in the text stream whatever its node type is.
+            block_kinds.append("text_block")
+            text_blocks.append(_node_text(block))
 
         if not isinstance(block, MathBlock):
             formulas.extend(

--- a/benchmarks/pmc/benchmark.py
+++ b/benchmarks/pmc/benchmark.py
@@ -71,9 +71,15 @@ from benchmarks.pmc.pages import ASSIGNMENTS, assign_pages, index_pages
 #: the 103 "lost" captions on the held-out corpus were in the output the whole time (#406).
 #: No payload key changes shape; the measurement underneath every recall figure does.
 SCHEMA_VERSION = 6
+#: 3 = the shared projection admits any container of inline text, by shape rather than by
+#: type name, so a node holding inline content with no ``Paragraph`` wrapper is no longer
+#: invisible to measurement (#443). ``SCHEMA_VERSION`` deliberately does *not* move with
+#: it: this lane projects the PDF parser's AST, which emits no definition lists and wraps
+#: every list item in a ``Paragraph``, so no figure in the payload can change. The oracle
+#: version tracks the oracle; the lane version tracks what the lane measures.
 #: 2 = the shared projection reads caption attributes (see schema 6 above and
 #: ``benchmarks.omnidocbench.oracles._semantic_blocks``).
-ORACLE_SCHEMA_VERSION = 2
+ORACLE_SCHEMA_VERSION = 3
 
 #: Fixed seed: a control that scrambles differently every run cannot be compared across
 #: runs, and a resolution change would be indistinguishable from a parser change.

--- a/changelog.d/443-oracle-inline-only-blindness.fixed.md
+++ b/changelog.d/443-oracle-inline-only-blindness.fixed.md
@@ -1,0 +1,13 @@
+- **Benchmark oracle: a container of inline text counts as text again** (#443). The shared
+  AST projection recognised block types by name and recursed through everything else, so a
+  node holding inline content *directly* — with no `Paragraph` wrapper — fell through the
+  walk and contributed nothing. `DefinitionTerm` is the shape that exposed it: the term
+  vanished while its sibling `DefinitionDescription` survived, and survived only because it
+  happens to wrap its own content in a `Paragraph`. The projection now admits any container
+  of inline text by that *shape* rather than by a list of type names, so the next node built
+  the same way cannot reproduce the bug in silence — while comments, which carry text but
+  never print, stay excluded. On the held-out 110-article corpus this recovers 130 words
+  across 3 all2md files and 1 word of docling's, and **5 of the 113 blocks the 2026-08-23
+  lost-block census attributed to conversion defects turn out to have been emitted
+  correctly all along** — 3 of them titles. Both PDF lanes are unaffected: the PDF parser
+  emits no definition lists and wraps every list item in a `Paragraph`.

--- a/tests/unit/test_omnidocbench_oracles.py
+++ b/tests/unit/test_omnidocbench_oracles.py
@@ -8,10 +8,16 @@ from hypothesis import strategies as st
 
 from all2md.ast.nodes import (
     CodeBlock,
+    Comment,
+    DefinitionDescription,
+    DefinitionList,
+    DefinitionTerm,
     Document,
+    Emphasis,
     Figure,
     Heading,
     Image,
+    ListItem,
     MathBlock,
     MathInline,
     Paragraph,
@@ -212,6 +218,93 @@ def test_a_caption_free_ast_projects_exactly_as_before() -> None:
 
     assert projection.text_blocks == ("Title", "Panel text", "")
     assert projection.block_kinds == ("title", "text_block", "text_block")
+
+
+def test_a_definition_terms_text_survives_projection() -> None:
+    """A definition term is page text, and used to vanish from measurement (#443).
+
+    ``DefinitionTerm`` holds inline content *directly*, with no ``Paragraph`` wrapper, so
+    a walk that recognises only block types descended straight past it into
+    ``Text``/``Emphasis`` and yielded nothing. Its sibling ``DefinitionDescription``
+    survived only because it happens to wrap its content in a ``Paragraph`` -- so half of
+    every definition list was scored as if it had never been emitted. On the held-out
+    110-article corpus that hid 130 words across 3 all2md files and 1 word of docling's.
+    """
+    document = Document(
+        children=[
+            DefinitionList(
+                items=[
+                    (
+                        DefinitionTerm(
+                            content=[
+                                Text(content="Bastin GN, Sparrow AD (1999)."),
+                                Emphasis(content=[Text(content="Rangeland Information System")]),
+                            ]
+                        ),
+                        [DefinitionDescription(content=[Paragraph(content=[Text(content="preparing for change.")])])],
+                    )
+                ]
+            )
+        ]
+    )
+
+    projection = project_ast(document)
+
+    # Two blocks, term before description: the term is admitted whole rather than shredded
+    # into its Text and Emphasis pieces, which would have counted one term as two blocks
+    # and moved the block-structure dimension for a change that adds no content.
+    assert projection.text_blocks == (
+        "Bastin GN, Sparrow AD (1999). Rangeland Information System",
+        "preparing for change.",
+    )
+    assert projection.block_kinds == ("text_block", "text_block")
+
+
+def test_any_container_of_inline_text_is_projected_whatever_its_type() -> None:
+    """The admission tests the *shape*, not a list of type names (#443).
+
+    ``DefinitionTerm`` is only the node that happened to expose this. Any container that
+    holds inline content with no block-level node inside it has the same blindness, so the
+    projection admits it by that property -- otherwise the next node type built to the same
+    shape reproduces the bug in silence, and an instrument that cannot see part of its
+    input is a bad instrument at any magnitude.
+    """
+    document = Document(
+        children=[
+            ListItem(children=[Text(content="An item that skipped its paragraph wrapper.")]),
+            ListItem(children=[Paragraph(content=[Text(content="An item that did not.")])]),
+        ]
+    )
+
+    projection = project_ast(document)
+
+    assert projection.text_blocks == (
+        "An item that skipped its paragraph wrapper.",
+        "An item that did not.",
+    )
+    assert projection.block_kinds == ("text_block", "text_block")
+
+
+def test_a_comment_is_never_page_text() -> None:
+    """Markup that never prints must stay invisible, or two baselines inflate (#443).
+
+    This is the boundary the shape rule has to respect: a comment carries text and holds no
+    block-level node, so admitting "anything with inline text" would sweep it in. On the
+    held-out corpus that would newly credit docling with 976 ``<!-- image -->`` markers
+    across 106 of 110 articles and pymupdf4llm with 359 -- text no reader ever sees,
+    counted against ground truth that never contains it.
+    """
+    document = Document(
+        children=[
+            Comment(content="image"),
+            Paragraph(content=[Text(content="Real page text.")]),
+        ]
+    )
+
+    projection = project_ast(document)
+
+    assert projection.text_blocks == ("Real page text.",)
+    assert projection.block_kinds == ("text_block",)
 
 
 def test_page_scores_have_exact_independent_dimension_semantics() -> None:


### PR DESCRIPTION
Fixes #443.

`project_ast` recognised block types **by name** and recursed through everything else, so a
node holding inline content *directly* — with no `Paragraph` wrapper — fell through the walk
and contributed nothing. `DefinitionTerm` is the shape that exposed it: the term vanished
while its sibling `DefinitionDescription` survived, and survived only because it happens to
wrap its own content in a `Paragraph`. Half of every definition list was scored as if it had
never been emitted.

## The fix admits a shape, not two more type names

`_carries_only_inline_text(node)` is true when a node carries text and has no block-level
node anywhere inside it. `_semantic_blocks` tests it **on each child** rather than on itself:
asking at the top would either collapse a whole document into one block or shred a term into
its `Strong`/`Text` pieces and count each as a block of its own. `project_ast`'s dispatch
becomes a catch-all `else`, because the annotation side already collapses every text-bearing
category to `text_block`.

Naming the two types would have been smaller, but the issue's own argument applies to the
fix as much as to the bug: an instrument that silently cannot see part of its input is a bad
instrument, and the next node built to the same shape would reproduce it in silence.

## Comments are the boundary the shape rule has to respect

A census of *all* invisible text — not just `DefinitionTerm` — across the 110-article
held-out corpus, all three tools:

| owner | nodes | files | words |
| --- | --- | --- | --- |
| docling `Comment` | 976 | 106 | 976 |
| pymupdf4llm `Comment` | 359 | 83 | 1436 |
| all2md `DefinitionTerm` | 5 | 3 | 130 |
| docling `DefinitionTerm` | 1 | 1 | 1 |

Comments carry text and hold no block-level node, so "admit anything with inline text" —
the fix shape the issue proposed — would have swept in 976 `<!-- image -->` markers from
docling and 359 from pymupdf4llm. That is text no reader ever sees, counted against ground
truth that never contains it, **inflating two baselines we do not control**. `_NON_PRINTING`
excludes them, and the A/B confirms both baselines are untouched apart from docling's single
real term.

## Measured, not assumed

A/B of the old and new projection over every file in `benchmarks/comparison/out/`,
asserting per file that no table moved, no formula moved, and no text was lost:

| tool | files changed | blocks | words |
| --- | --- | --- | --- |
| all2md | 3 / 110 | +5 | +130 |
| docling | 1 / 110 | +1 | +1 |
| pymupdf4llm | 0 / 110 | 0 | 0 |

Reproduces the issue's table exactly.

## 5 of the 113 "lost" blocks were never lost

The finding the issue did not predict. Replaying `lost_blocks.json` — the census behind the
2026-08-23 reading — through both projections at the instruments' own `RECALL_MIN`:

| article | share before → after | kind |
| --- | --- | --- |
| PMC2253516.1 | 0.020 → 1.000 | text_block |
| PMC2253516.1 | 0.000 → 1.000 | text_block |
| PMC9750022.1 | 0.250 → 1.000 | title |
| PMC9750033.1 | 0.250 → 1.000 | title |
| PMC9750033.1 | 0.643 → 1.000 | title |

Five blocks attributed to conversion defects were emitted correctly all along. **Three are
titles**, which revises a standing reading: "all 49 title losses are reference
`<article-title>`s, a reference-list layout problem" is now 3 blocks smaller and partly a
measurement artifact. The committed artifacts are left untouched — a dated reading is never
edited in place (ground rule 4) — so this lands in the issue and here, and the next reading
will show the smaller residue.

## No published figure moves — checked, not assumed

The issue claimed this; verifying it is the point of the change. The PDF parser emits no
`DefinitionList` (only markdown/html/asciidoc/org/rst do) and wraps every list item in a
`Paragraph` (`parsers/pdf.py:4926`), so neither PDF lane can reach the path. Confirmed
empirically: **8 of 8 corpus PDFs project byte-identically** across the change.

## Schema versions

- **PMC `ORACLE_SCHEMA_VERSION` 2 → 3.** The oracle changed, so the oracle's version moves.
  `SCHEMA_VERSION` deliberately does not: this lane's figures cannot change. The lane is
  ungated and publishes evidence, so nothing goes red; `reference.json` refreshes at oracle 3
  with the re-record already pending from #441/#445.
- **OmniDocBench `ORACLE_SCHEMA_VERSION` stays 6**, with the reason recorded in the constant's
  comment. That gate ratchets against a recorded `baseline.json` and demands exact equality,
  so the number may only move together with a re-recorded baseline — a 981-page OCR run — to
  buy a field change that cannot alter a score. It bumps to 7 with the next re-record,
  whatever prompts it.

## Tests

Three regression tests in `tests/unit/test_omnidocbench_oracles.py`: a definition term's text
survives projection **as one block**; any container of inline text is admitted whatever its
type (a `ListItem` that skipped its paragraph wrapper); and a comment is never page text.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
