### PR TITLE
fix(pdf): keep a wrapped table cell in one row (#438)

### DIFF
--- a/changelog.d/438-wrapped-cell-rows.fixed.md
+++ b/changelog.d/438-wrapped-cell-rows.fixed.md
@@ -1,0 +1,16 @@
+- **PDF tables: a wrapped cell stays one cell** (#438). Row grouping separates wrapped lines
+  from row boundaries by the jump in inter-line gaps, but a vertically centred multi-line
+  cell prints *three* gap populations, not two: lines from different columns interlace and
+  go negative, a tall cell's own successive lines merely abut, and real rows are separated
+  by padding. Taking the first jump on faith put a cell's own wrap lines on the
+  row-boundary side, so the top and bottom lines of a tall header cell stood as rows of
+  their own and displaced the header labels down into the first body row. Worse, the jump
+  candidates are *distinct* gap values, so a single stray gap could sit below the whole
+  population and take the threshold with it — on the held-out corpus's largest table one
+  −7.95pt gap below a cluster of 52 at −3.21pt turned 97 printed lines into 89 rows with
+  nothing merged at all. Jumps are now tried in order and the first whose grouping is not
+  mostly half-empty rows wins, and a fragment that adds no columns of its own folds into
+  whichever neighbour it abuts — including *downward*, which is how a table's first printed
+  line can now join the header it belongs to. Measured over every table on the 110-article
+  held-out corpus: 14 tables improve, 154 spurious rows and 166 half-empty rows disappear,
+  and **no table gets worse**. The worst table on the corpus goes from 96 rows to 49.

--- a/src/all2md/parsers/_pdf_tables.py
+++ b/src/all2md/parsers/_pdf_tables.py
@@ -183,6 +183,16 @@ MIN_ROTATED_WORD_ASPECT = 1.2
 # leading with jitter does not manufacture rows).
 ROW_GAP_JUMP_MIN_HEIGHT_SHARE = 0.10
 ROW_GAP_JUMP_MIN_RATIO = 1.8
+# A grouping whose rows are mostly half-empty has mistaken wrapping for rows: a real row
+# fills its columns, while a line left standing by a threshold set too low fills one. So
+# the first gap jump is no longer taken on faith -- jumps are tried in order and the first
+# whose grouping clears this bar wins. Measured on PMC7750019.1, the worst table on the
+# held-out corpus: a single -7.95pt gap sat below a cluster of 52 at -3.21pt, the first
+# jump peeled that outlier off, and the threshold landed beneath every real gap -- 97
+# printed lines became 89 rows, 77 of them half-empty, nothing merged at all. Distinct gap
+# values are the candidates, so without this a gap occurring once weighs exactly as much
+# as one occurring fifty times.
+ROW_GROUP_MAX_SPARSE_SHARE = 0.5
 # A cell is "mostly numeric" when digits dominate its alphanumerics. Two adjacent
 # lines that each hold two or more such cells are two data rows, not a wrapped cell:
 # no publisher wraps a numeric row. Any grouping that would fuse such a pair is
@@ -198,6 +208,22 @@ ROW_FUSE_MIN_NUMERIC_CELLS = 2
 # they imply survives the numeric-fusion guard above.
 ROW_ANCHOR_MIN_FILL = 0.2
 ROW_ANCHOR_TRUSTED_FILL = 0.6
+# A gap-derived group is a wrapped fragment of its neighbour, not a row of its own,
+# only when it fills at most this share of the columns that neighbour fills. A wrapped
+# continuation continues *one* cell while every other column stays empty; a line filling
+# half its neighbour's columns or more is carrying independent content. Measured on the
+# header that motivated #438 ("Maximum bite / force / (mean+-standard / deviation)"): the
+# two escaping fragments fill 1 of the 4 columns their row fills, while the data row the
+# same rule must not swallow fills 3 of 4 -- the separation is 0.25 against 0.75.
+ROW_FRAGMENT_MAX_COLUMN_SHARE = 0.5
+# How far above or below its row a wrapped fragment may sit, as a share of line height.
+# Successive lines of one wrapped cell nearly touch, but a spanning header tier prints with
+# its own leading, so this is deliberately looser than the jump floor it started out
+# reusing. Bounded by one leading rather than by the corpus: the held-out numbers keep
+# improving past 1.0 with no measured regression, but a fragment a full line height from
+# its row is separated by a blank line's worth of space and is a row, not a wrap -- the
+# continuation-row count cannot see that difference and would happily trade it away.
+ROW_FRAGMENT_MAX_GAP_HEIGHT_SHARE = 0.75
 # A column may hold at most this many separate filled runs inside one merged row.
 # A cell fills contiguous lines, so two runs is a hole (tolerated: one stray gap in a
 # ragged prose cell), while three or more is a stack of distinct cells -- the group is
@@ -1383,30 +1409,115 @@ def _gap_row_groups(line_rows: list[list[str]], line_extents: list[tuple[float, 
     if len(unique_gaps) < 2:
         return None
 
-    threshold: float | None = None
     for lower, upper in zip(unique_gaps, unique_gaps[1:], strict=False):
         if upper - lower < ROW_GAP_JUMP_MIN_HEIGHT_SHARE * median_height:
             continue
         if lower > 0 and upper / lower < ROW_GAP_JUMP_MIN_RATIO:
             continue
         threshold = (lower + upper) / 2
-        break
-    if threshold is None:
-        return None
 
-    groups: list[list[int]] = []
-    current = [0]
-    for index, gap in enumerate(gaps, start=1):
-        if gap > threshold:
-            groups.append(current)
-            current = [index]
-        else:
-            current.append(index)
-    groups.append(current)
-    if len(groups) < 2 or _groups_fuse_numeric_rows(line_rows, groups):
-        return None
-    if _groups_stack_column_cells(line_rows, groups):
-        return None
+        groups: list[list[int]] = []
+        current = [0]
+        for index, gap in enumerate(gaps, start=1):
+            if gap > threshold:
+                groups.append(current)
+                current = [index]
+            else:
+                current.append(index)
+        groups.append(current)
+        if len(groups) < 2 or _groups_fuse_numeric_rows(line_rows, groups):
+            return None
+        if _groups_stack_column_cells(line_rows, groups):
+            return None
+
+        folded = _fold_wrapped_fragments(line_rows, groups, gaps, median_height)
+        if _sparse_row_share(line_rows, folded) > ROW_GROUP_MAX_SPARSE_SHARE:
+            # This jump cut below the row population instead of between it and the
+            # wraps. Try the next one up before handing the table to the fill rules.
+            continue
+        return folded
+    return None
+
+
+def _sparse_row_share(line_rows: list[list[str]], groups: list[list[int]]) -> float:
+    """Share of grouped rows that fill at most half their columns.
+
+    The fingerprint of a threshold set below the row population: every wrapped line is
+    left standing as a row of its own, so the grid fills with half-empty rows holding one
+    cell's continuation each. all2md prints them on 33.2% of the articles where it loses a
+    table, against docling's 12.0% (#438).
+    """
+    if not groups:
+        return 0.0
+    width = max((len(line_rows[index]) for group in groups for index in group), default=0)
+    if width == 0:
+        return 0.0
+    sparse = sum(1 for group in groups if 0 < len(_filled_columns(line_rows, group)) * 2 <= width)
+    return sparse / len(groups)
+
+
+def _filled_columns(line_rows: list[list[str]], group: list[int]) -> set[int]:
+    return {column for index in group for column, cell in enumerate(line_rows[index]) if cell}
+
+
+def _fold_wrapped_fragments(
+    line_rows: list[list[str]],
+    groups: list[list[int]],
+    gaps: list[float],
+    median_height: float,
+) -> list[list[int]]:
+    """Fold a group that is one cell's wrap into the row it continues (#438).
+
+    The gap jump separates two populations, but a vertically centered multi-line cell
+    prints three: lines from different columns interlace and go *negative*, a tall cell's
+    own successive lines merely abut a fraction of a point apart, and real rows are
+    separated by padding. The jump lands between the first and the rest, so the top and
+    bottom lines of a tall header cell -- the ones with no interlacing neighbour to
+    overlap -- are left standing as rows of their own. Measured on PMC5250635.1, that
+    splits "Maximum bite force (mean+-standard deviation)" into three rows and displaces
+    the header labels down into the first body row.
+
+    A fragment is folded into whichever neighbour it abuts more closely, so the first
+    printed line of a table folds *downward* -- the case the anchor rule structurally
+    cannot reach, because it only ever continues a row that already started.
+
+    Three guards, in the order that makes a wrong fold impossible rather than unlikely:
+    the fragment's filled columns must be a proper subset of its neighbour's, so it adds
+    no content of its own; it must fill no more than ``ROW_FRAGMENT_MAX_COLUMN_SHARE`` of
+    them, which is what separates a wrapped cell from a data row that merely shares its
+    columns; and the merged grouping must still survive the numeric-fusion and
+    column-stack guards that police every other grouping here.
+    """
+    fragment_gap = ROW_FRAGMENT_MAX_GAP_HEIGHT_SHARE * median_height
+    changed = True
+    while changed and len(groups) > 1:
+        changed = False
+        for position, group in enumerate(groups):
+            columns = _filled_columns(line_rows, group)
+            if not columns:
+                continue
+            # Above and below, each with the gap that separates it from this group.
+            neighbours = []
+            if position > 0:
+                neighbours.append((gaps[groups[position - 1][-1]], position - 1))
+            if position + 1 < len(groups):
+                neighbours.append((gaps[group[-1]], position + 1))
+            for gap, target in sorted(neighbours):
+                if gap > fragment_gap:
+                    continue
+                host = _filled_columns(line_rows, groups[target])
+                if not columns < host or len(columns) > ROW_FRAGMENT_MAX_COLUMN_SHARE * len(host):
+                    continue
+                candidate = [list(existing) for existing in groups]
+                candidate[target] = sorted(candidate[target] + group)
+                del candidate[position]
+                if _groups_fuse_numeric_rows(line_rows, candidate) or _groups_stack_column_cells(line_rows, candidate):
+                    continue
+                groups = candidate
+                changed = True
+                break
+            if changed:
+                break
     return groups
 
 

--- a/tests/unit/formats/pdf/test_pdf_wrapped_cell_rows.py
+++ b/tests/unit/formats/pdf/test_pdf_wrapped_cell_rows.py
@@ -1,0 +1,161 @@
+#  Copyright (c) 2025 Tom Villani, Ph.D.
+#
+# tests/unit/formats/pdf/test_pdf_wrapped_cell_rows.py
+"""One printed line is not one table row, and the gap between lines is not the whole story.
+
+``_gap_row_groups`` separates wrapped lines from row boundaries by the jump in their
+inter-line gaps. A vertically centered multi-line cell prints *three* gap populations, not
+two: lines from different columns interlace and go negative, a tall cell's own successive
+lines merely abut, and real rows are separated by padding. Taking the first jump on faith
+puts a cell's own wrap lines on the row-boundary side, and a single outlier gap can put the
+threshold below every real gap at once (#438).
+
+Geometry here is taken from the held-out corpus rather than invented: the header is
+PMC5250635.1's, whose "Maximum bite force (mean+-standard deviation)" cell shredded into
+three rows and pushed the real header labels down into the first body row.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from all2md.parsers._pdf_tables import merge_continuation_lines
+
+pytestmark = [pytest.mark.unit, pytest.mark.pdf, pytest.mark.table]
+
+
+class TestWrappedCellsFoldIntoTheirRow:
+    """A cell that wraps stays one cell."""
+
+    # PMC5250635.1's Table 2, verbatim: 15 printed lines, 4 columns, 7 logical rows.
+    LINES = [
+        ["", "", "", "Maximum bite"],
+        ["", "", "Number", "force"],
+        ["Measurement", "Gender", "", ""],
+        ["", "", "of patients", "(mean±standard"],
+        ["", "", "", "deviation)"],
+        ["", "Males", "14", "606.28±266.28"],
+        ["Before", "", "", ""],
+        ["", "Females", "10", "342.68±126.07"],
+        ["surgery", "", "", ""],
+        ["", "Total", "24", "496.45±252.82"],
+        ["", "Males", "14", "611.75±260.28"],
+        ["Eight weeks", "", "", ""],
+        ["", "Females", "10", "277.68±90.42"],
+        ["after surgery", "", "", ""],
+        ["", "Total", "24", "472.55±264.19"],
+    ]
+    EXTENTS = [
+        (507.3, 518.3),
+        (518.8, 529.9),
+        (524.6, 535.6),
+        (530.4, 541.4),
+        (541.9, 552.9),
+        (555.9, 566.9),
+        (564.0, 575.0),
+        (570.6, 581.6),
+        (577.2, 588.2),
+        (585.1, 596.1),
+        (603.8, 614.8),
+        (611.7, 622.7),
+        (618.3, 629.4),
+        (625.1, 636.1),
+        (633.0, 644.0),
+    ]
+
+    def test_a_wrapped_header_cell_keeps_its_labels_on_the_header_row(self) -> None:
+        """The header's own wrap lines fold into it instead of displacing it downward.
+
+        "Maximum bite" has no interlacing neighbour to overlap, so it abuts the line below
+        by 0.49pt where every within-row gap is -3pt or lower -- the jump calls it a row of
+        its own. It is the *first* printed line, which is the case the anchor rule
+        structurally cannot reach: that rule only ever continues a row that has already
+        started, so the fragment stood as row one and pushed the labels into row two.
+        """
+        rows = merge_continuation_lines([list(r) for r in self.LINES], self.EXTENTS)
+
+        assert rows[0] == [
+            "Measurement",
+            "Gender",
+            "Number\nof patients",
+            "Maximum bite\nforce\n(mean±standard\ndeviation)",
+        ]
+        # And the six data rows are untouched -- three of them carry a wrapped row label
+        # ("Before surgery"), which is the merge working as it already did.
+        assert rows[1:] == [
+            ["", "Males", "14", "606.28±266.28"],
+            ["Before\nsurgery", "Females", "10", "342.68±126.07"],
+            ["", "Total", "24", "496.45±252.82"],
+            ["", "Males", "14", "611.75±260.28"],
+            ["Eight weeks\nafter surgery", "Females", "10", "277.68±90.42"],
+            ["", "Total", "24", "472.55±264.19"],
+        ]
+
+    def test_a_lone_outlier_gap_cannot_define_the_row_population(self) -> None:
+        """A gap occurring once must not outweigh one occurring many times.
+
+        The jump candidates are *distinct* gap values, so a single stray gap below the real
+        population used to be peeled off as the jump -- putting the threshold beneath every
+        genuine gap, so nothing merged. Measured on PMC7750019.1, the worst table on the
+        held-out corpus: one -7.95pt gap below a cluster of 52 at -3.21pt turned 97 printed
+        lines into 89 rows, 77 of them half-empty. The give-away is the *result*, so a
+        grouping that leaves most rows half-empty is rejected and the next jump tried.
+        """
+        lines = [
+            ["Smith", "Kenya", "Cost-effective"],
+            ["2019", "", ""],
+            ["", "", "analysis"],
+            ["", "2015", ""],
+            ["Jones", "Ghana", "Cost-benefit"],
+            ["2020", "", ""],
+            ["", "", "study"],
+            ["Lee", "Peru", "Cost-utility"],
+            ["2021", "", ""],
+            ["", "", "model"],
+        ]
+        # One -8pt outlier, a -3pt within-row population, and +2pt row boundaries.
+        extents = [
+            (0.0, 8.0),
+            (0.0, 8.0),
+            (5.0, 13.0),
+            (10.0, 18.0),
+            (20.0, 28.0),
+            (25.0, 33.0),
+            (30.0, 38.0),
+            (40.0, 48.0),
+            (45.0, 53.0),
+            (50.0, 58.0),
+        ]
+
+        rows = merge_continuation_lines([list(r) for r in lines], extents)
+
+        assert rows == [
+            ["Smith\n2019", "Kenya\n2015", "Cost-effective\nanalysis"],
+            ["Jones\n2020", "Ghana", "Cost-benefit\nstudy"],
+            ["Lee\n2021", "Peru", "Cost-utility\nmodel"],
+        ]
+
+    def test_a_data_row_is_not_folded_into_the_row_above_it(self) -> None:
+        """Sharing your neighbour's columns is not the same as continuing its cell.
+
+        The fold's tempting case: a data row whose leading label cell is empty fills a
+        strict subset of the columns the row above fills, and sits close enough to it. What
+        separates them is how *much* of the row they fill -- a wrapped fragment continues
+        one cell while every other column stays empty, so a line filling half its
+        neighbour's columns or more is carrying content of its own.
+        """
+        lines = [
+            ["Region", "Cases", "Deaths", "Rate"],
+            ["South", "", "", ""],
+            ["", "12", "3", "0.25"],
+            ["", "15", "4", "0.27"],
+        ]
+        extents = [(0.0, 8.0), (5.0, 13.0), (15.0, 23.0), (25.0, 33.0)]
+
+        rows = merge_continuation_lines([list(r) for r in lines], extents)
+
+        assert rows == [
+            ["Region\nSouth", "Cases", "Deaths", "Rate"],
+            ["", "12", "3", "0.25"],
+            ["", "15", "4", "0.27"],
+        ]


### PR DESCRIPTION
Fixes #438.

The issue's diagnosis was right about the symptom and slightly off about the cause. The
existing `merge_continuation_lines` already does most of the work — on the issue's own
exemplar it correctly fuses `Number`/`of patients`, `force`/`(mean±standard` and the wrapped
row labels `Before`/`surgery`. The defect is upstream of all of that, in how row groups are
chosen from inter-line gaps.

## Three gap populations, not two

A vertically centred multi-line cell prints three:

| gap | what it is |
| --- | --- |
| −3 to −5.3pt | lines from different columns, interlaced *within* one row |
| **+0.49pt** | **one tall cell's own successive wrap lines — also one row** |
| +3.0, +7.7pt | genuine row boundaries |

`_gap_row_groups` takes the first jump, which separates population 1 from 2+3 — so a cell's
own wrap lines land on the row-boundary side. The top and bottom lines of a tall header cell
are exactly the ones with no interlacing neighbour to overlap, which is why the header
shredded and the labels moved down a row.

## And a single outlier could take the threshold with it

The jump candidates come from `set(gaps)`, so a gap occurring **once** weighed as much as one
occurring **fifty times**. On PMC7750019.1 — the worst table on the corpus, the one the issue
sizes at containment 0.057 against docling's 0.887 — a lone −7.95pt gap sat below a cluster of
52 at −3.21pt. The first jump peeled off that outlier, the threshold landed beneath every real
gap, and 97 printed lines became 89 rows with nothing merged at all.

## Two changes, both keyed to evidence the grouping already produces

**Jumps are tried in order, and the first whose grouping is not mostly half-empty rows wins.**
The give-away is the *result*, not the gap statistics: a grouping that leaves most of its rows
filling a single column has mistaken wrapping for rows. This is what makes the outlier
unusable without needing to characterise outliers.

**A group that adds no columns of its own folds into whichever neighbour it abuts more
closely.** Folding by proximity rather than always upward is what lets a table's *first*
printed line fold **downward** into the header it belongs to — the case the issue flagged as
needing an extra step, and the one the anchor rule structurally cannot reach, since it only
ever continues a row that has already started.

Guarded by how much of a row the fragment fills: a wrapped continuation carries one cell while
every other column stays empty, so a line filling half its neighbour's columns or more is
content of its own and is left alone.

## Measured by replay, not by re-conversion

`merge_continuation_lines` is a pure function of `(line_rows, line_extents, kwargs)`, so
recording its inputs once across the 110 held-out articles (110/110, zero failures) lets any
candidate be scored in milliseconds — the method that settled #440.

| | value |
| --- | --- |
| tables replayed | 220 |
| tables changed | **14** across 12 articles |
| rows | 3265 → 3111 (**−154**) |
| half-empty rows | 674 → 508 (**−166**, −25%) |
| **tables that get worse** | **0** |

Half-empty rows are the issue's own fingerprint for this defect — all2md prints them on 33.2%
of the articles where it loses a table against docling's 12.0%.

Every touched table improves; the largest:

| article | rows | half-empty rows |
| --- | --- | --- |
| PMC7750019.1 | 96 → 49 | 84 → 25 |
| PMC7750019.1 (2nd table) | 30 → 5 | 27 → 2 |
| PMC5250590.1 | 50 → 33 | 24 → 7 |
| PMC10250014.1 | 33 → 18 | 20 → 5 |
| PMC7750051.1 | 25 → 11 | 19 → 5 |

## Two things worth knowing before merging

**The constants were swept, not guessed** — the replay makes each value cost milliseconds. The
sparse-row bar sits at the only value with zero regressions (0.34–0.40 costs a table; 0.5 is
clean). The fragment reach is the one place I stopped *short* of the corpus optimum: the
numbers keep improving past one line height with no measured regression, but a fragment a full
line height from its row is separated by a blank line's worth of space and is a row, not a
wrap. The continuation-row count cannot see that difference and would happily trade it away.

**This is a structural measurement, not a recall one.** Half-empty rows are a faithful proxy —
they are the defect's fingerprint and the issue's own metric — but the number the issue sizes
(table text 77.4% → ~91%) needs a ground-truth re-score, which belongs to the PMC lane on the
Linux runner. I have not claimed that figure moved; I have shown the structure it depends on
did, in the right direction, on every table it touched.

## Tests

Three in `tests/unit/formats/pdf/test_pdf_wrapped_cell_rows.py`, with the header geometry taken
verbatim from PMC5250635.1 rather than invented: a wrapped header cell keeps its labels on the
header row; a lone outlier gap cannot define the row population; and a data row sharing its
neighbour's columns is not folded into it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
