### PR TITLE
fix(pdf): stop folding a table's section heading onto the row above (#448)

### DIFF
--- a/changelog.d/438-wrapped-cell-rows.fixed.md
+++ b/changelog.d/438-wrapped-cell-rows.fixed.md
@@ -1,16 +1,11 @@
-- **PDF tables: a wrapped cell stays one cell** (#438). Row grouping separates wrapped lines
-  from row boundaries by the jump in inter-line gaps, but a vertically centred multi-line
-  cell prints *three* gap populations, not two: lines from different columns interlace and
-  go negative, a tall cell's own successive lines merely abut, and real rows are separated
-  by padding. Taking the first jump on faith put a cell's own wrap lines on the
-  row-boundary side, so the top and bottom lines of a tall header cell stood as rows of
-  their own and displaced the header labels down into the first body row. Worse, the jump
-  candidates are *distinct* gap values, so a single stray gap could sit below the whole
-  population and take the threshold with it — on the held-out corpus's largest table one
-  −7.95pt gap below a cluster of 52 at −3.21pt turned 97 printed lines into 89 rows with
-  nothing merged at all. Jumps are now tried in order and the first whose grouping is not
-  mostly half-empty rows wins, and a fragment that adds no columns of its own folds into
-  whichever neighbour it abuts — including *downward*, which is how a table's first printed
-  line can now join the header it belongs to. Measured over every table on the 110-article
-  held-out corpus: 14 tables improve, 154 spurious rows and 166 half-empty rows disappear,
-  and **no table gets worse**. The worst table on the corpus goes from 96 rows to 49.
+- **PDF tables: a stray gap no longer defines what counts as a row** (#438). Row grouping
+  separates wrapped lines from row boundaries by the jump in inter-line gaps, but a
+  vertically centred multi-line cell prints *three* gap populations, not two: lines from
+  different columns interlace and go negative, a tall cell's own successive lines merely
+  abut, and real rows are separated by padding. Worse, the jump candidates are *distinct*
+  gap values, so a single stray gap could sit below the whole population and take the
+  threshold with it — on the held-out corpus's largest table one −7.95pt gap below a
+  cluster of 52 at −3.21pt turned 97 printed lines into 89 rows with nothing merged at
+  all. Jumps are now tried in order and the first whose grouping is not mostly half-empty
+  rows wins: the grouping is judged by what it produces rather than by the gap statistics
+  that proposed it.

--- a/changelog.d/448-table-section-headings.fixed.md
+++ b/changelog.d/448-table-section-headings.fixed.md
@@ -1,0 +1,12 @@
+- **PDF tables: a section heading is no longer folded onto the row above it** (#448). The
+  first cut of #438 also folded any half-empty line group into a neighbour it abutted. A
+  heading row *inside* a table — "Gender", with the indented "Male"/"Female" rows beneath
+  it — fills one column and leaves the rest empty, which is exactly the shape of a wrapped
+  fragment, so it was swallowed: its label fused onto the previous row's data and every
+  value below it came out under the wrong heading. Silently mislabelled data is worse than
+  the shredding the fold was meant to repair, and geometry cannot separate the two cases —
+  one affected table prints a single body gap value, 1.56pt, for headings and data rows
+  alike. The fold is removed; the gap-jump selection it shipped alongside is kept. Measured
+  against JATS ground truth, removing it restores table content exactly on the born-digital
+  corpus (7 pages that regressed recover, none lose) and improves the held-out corpus the
+  fold was tuned on, where it had cost 5 table pages against 3 gained.

--- a/src/all2md/parsers/_pdf_tables.py
+++ b/src/all2md/parsers/_pdf_tables.py
@@ -192,6 +192,19 @@ ROW_GAP_JUMP_MIN_RATIO = 1.8
 # printed lines became 89 rows, 77 of them half-empty, nothing merged at all. Distinct gap
 # values are the candidates, so without this a gap occurring once weighs exactly as much
 # as one occurring fifty times.
+#
+# This bar is a *share*, and deliberately only that. Nothing here folds a half-empty group
+# into its neighbour, because a half-empty row is not always a wrap: a section-heading row
+# inside a table -- "Gender", then indented "Male"/"Female" beneath it -- fills exactly one
+# column and is a real row. #438 shipped such a fold and it silently relabelled data: on
+# PMC4500011.1 "Gender" fused onto the Age row's numbers and "Height (cm)" onto Female's,
+# so every value sat under the wrong label. Folding is not separable from that by geometry
+# -- those headings abut their neighbours as tightly as any wrapped fragment, so no gap
+# tolerance divides them -- and measured against JATS ground truth on both corpora the fold
+# lost: 7 table pages worse against 1 better on the born-digital corpus, and on the held-out
+# corpus it was designed against, 5 worse against 3 better. It looked like a win only under
+# a half-empty-row count, which *rewards* folding a real heading away. Judge groupings by
+# ground truth, and treat a proxy that cannot see its own worst outcome as no evidence.
 ROW_GROUP_MAX_SPARSE_SHARE = 0.5
 # A cell is "mostly numeric" when digits dominate its alphanumerics. Two adjacent
 # lines that each hold two or more such cells are two data rows, not a wrapped cell:
@@ -208,22 +221,6 @@ ROW_FUSE_MIN_NUMERIC_CELLS = 2
 # they imply survives the numeric-fusion guard above.
 ROW_ANCHOR_MIN_FILL = 0.2
 ROW_ANCHOR_TRUSTED_FILL = 0.6
-# A gap-derived group is a wrapped fragment of its neighbour, not a row of its own,
-# only when it fills at most this share of the columns that neighbour fills. A wrapped
-# continuation continues *one* cell while every other column stays empty; a line filling
-# half its neighbour's columns or more is carrying independent content. Measured on the
-# header that motivated #438 ("Maximum bite / force / (mean+-standard / deviation)"): the
-# two escaping fragments fill 1 of the 4 columns their row fills, while the data row the
-# same rule must not swallow fills 3 of 4 -- the separation is 0.25 against 0.75.
-ROW_FRAGMENT_MAX_COLUMN_SHARE = 0.5
-# How far above or below its row a wrapped fragment may sit, as a share of line height.
-# Successive lines of one wrapped cell nearly touch, but a spanning header tier prints with
-# its own leading, so this is deliberately looser than the jump floor it started out
-# reusing. Bounded by one leading rather than by the corpus: the held-out numbers keep
-# improving past 1.0 with no measured regression, but a fragment a full line height from
-# its row is separated by a blank line's worth of space and is a row, not a wrap -- the
-# continuation-row count cannot see that difference and would happily trade it away.
-ROW_FRAGMENT_MAX_GAP_HEIGHT_SHARE = 0.75
 # A column may hold at most this many separate filled runs inside one merged row.
 # A cell fills contiguous lines, so two runs is a hole (tolerated: one stray gap in a
 # ragged prose cell), while three or more is a stack of distinct cells -- the group is
@@ -1430,12 +1427,11 @@ def _gap_row_groups(line_rows: list[list[str]], line_extents: list[tuple[float, 
         if _groups_stack_column_cells(line_rows, groups):
             return None
 
-        folded = _fold_wrapped_fragments(line_rows, groups, gaps, median_height)
-        if _sparse_row_share(line_rows, folded) > ROW_GROUP_MAX_SPARSE_SHARE:
+        if _sparse_row_share(line_rows, groups) > ROW_GROUP_MAX_SPARSE_SHARE:
             # This jump cut below the row population instead of between it and the
             # wraps. Try the next one up before handing the table to the fill rules.
             continue
-        return folded
+        return groups
     return None
 
 
@@ -1458,67 +1454,6 @@ def _sparse_row_share(line_rows: list[list[str]], groups: list[list[int]]) -> fl
 
 def _filled_columns(line_rows: list[list[str]], group: list[int]) -> set[int]:
     return {column for index in group for column, cell in enumerate(line_rows[index]) if cell}
-
-
-def _fold_wrapped_fragments(
-    line_rows: list[list[str]],
-    groups: list[list[int]],
-    gaps: list[float],
-    median_height: float,
-) -> list[list[int]]:
-    """Fold a group that is one cell's wrap into the row it continues (#438).
-
-    The gap jump separates two populations, but a vertically centered multi-line cell
-    prints three: lines from different columns interlace and go *negative*, a tall cell's
-    own successive lines merely abut a fraction of a point apart, and real rows are
-    separated by padding. The jump lands between the first and the rest, so the top and
-    bottom lines of a tall header cell -- the ones with no interlacing neighbour to
-    overlap -- are left standing as rows of their own. Measured on PMC5250635.1, that
-    splits "Maximum bite force (mean+-standard deviation)" into three rows and displaces
-    the header labels down into the first body row.
-
-    A fragment is folded into whichever neighbour it abuts more closely, so the first
-    printed line of a table folds *downward* -- the case the anchor rule structurally
-    cannot reach, because it only ever continues a row that already started.
-
-    Three guards, in the order that makes a wrong fold impossible rather than unlikely:
-    the fragment's filled columns must be a proper subset of its neighbour's, so it adds
-    no content of its own; it must fill no more than ``ROW_FRAGMENT_MAX_COLUMN_SHARE`` of
-    them, which is what separates a wrapped cell from a data row that merely shares its
-    columns; and the merged grouping must still survive the numeric-fusion and
-    column-stack guards that police every other grouping here.
-    """
-    fragment_gap = ROW_FRAGMENT_MAX_GAP_HEIGHT_SHARE * median_height
-    changed = True
-    while changed and len(groups) > 1:
-        changed = False
-        for position, group in enumerate(groups):
-            columns = _filled_columns(line_rows, group)
-            if not columns:
-                continue
-            # Above and below, each with the gap that separates it from this group.
-            neighbours = []
-            if position > 0:
-                neighbours.append((gaps[groups[position - 1][-1]], position - 1))
-            if position + 1 < len(groups):
-                neighbours.append((gaps[group[-1]], position + 1))
-            for gap, target in sorted(neighbours):
-                if gap > fragment_gap:
-                    continue
-                host = _filled_columns(line_rows, groups[target])
-                if not columns < host or len(columns) > ROW_FRAGMENT_MAX_COLUMN_SHARE * len(host):
-                    continue
-                candidate = [list(existing) for existing in groups]
-                candidate[target] = sorted(candidate[target] + group)
-                del candidate[position]
-                if _groups_fuse_numeric_rows(line_rows, candidate) or _groups_stack_column_cells(line_rows, candidate):
-                    continue
-                groups = candidate
-                changed = True
-                break
-            if changed:
-                break
-    return groups
 
 
 def _rows_from_groups(line_rows: list[list[str]], groups: list[list[int]]) -> list[list[str]]:

--- a/tests/unit/formats/pdf/test_pdf_wrapped_cell_rows.py
+++ b/tests/unit/formats/pdf/test_pdf_wrapped_cell_rows.py
@@ -10,9 +10,14 @@ lines merely abut, and real rows are separated by padding. Taking the first jump
 puts a cell's own wrap lines on the row-boundary side, and a single outlier gap can put the
 threshold below every real gap at once (#438).
 
-Geometry here is taken from the held-out corpus rather than invented: the header is
-PMC5250635.1's, whose "Maximum bite force (mean+-standard deviation)" cell shredded into
-three rows and pushed the real header labels down into the first body row.
+Geometry here is taken from the corpora rather than invented: the gap populations are
+PMC5250635.1's, and the section-heading table is PMC4500011.1's.
+
+The other half of #438 -- folding a half-empty group into a neighbour it abuts -- was
+removed after it was measured against ground truth rather than against a half-empty-row
+count. A section-heading row is legitimately half-empty, and no gap tolerance separates
+the two: PMC4500011.1 prints *one* body gap value, 1.56pt, for headings and data rows
+alike. See ``ROW_GROUP_MAX_SPARSE_SHARE``.
 """
 
 from __future__ import annotations
@@ -24,8 +29,8 @@ from all2md.parsers._pdf_tables import merge_continuation_lines
 pytestmark = [pytest.mark.unit, pytest.mark.pdf, pytest.mark.table]
 
 
-class TestWrappedCellsFoldIntoTheirRow:
-    """A cell that wraps stays one cell."""
+class TestGapGroupsSeparateRowsFromWraps:
+    """A gap jump is believed only when the grouping it produces looks like rows."""
 
     # PMC5250635.1's Table 2, verbatim: 15 printed lines, 4 columns, 7 logical rows.
     LINES = [
@@ -62,34 +67,6 @@ class TestWrappedCellsFoldIntoTheirRow:
         (625.1, 636.1),
         (633.0, 644.0),
     ]
-
-    def test_a_wrapped_header_cell_keeps_its_labels_on_the_header_row(self) -> None:
-        """The header's own wrap lines fold into it instead of displacing it downward.
-
-        "Maximum bite" has no interlacing neighbour to overlap, so it abuts the line below
-        by 0.49pt where every within-row gap is -3pt or lower -- the jump calls it a row of
-        its own. It is the *first* printed line, which is the case the anchor rule
-        structurally cannot reach: that rule only ever continues a row that has already
-        started, so the fragment stood as row one and pushed the labels into row two.
-        """
-        rows = merge_continuation_lines([list(r) for r in self.LINES], self.EXTENTS)
-
-        assert rows[0] == [
-            "Measurement",
-            "Gender",
-            "Number\nof patients",
-            "Maximum bite\nforce\n(mean±standard\ndeviation)",
-        ]
-        # And the six data rows are untouched -- three of them carry a wrapped row label
-        # ("Before surgery"), which is the merge working as it already did.
-        assert rows[1:] == [
-            ["", "Males", "14", "606.28±266.28"],
-            ["Before\nsurgery", "Females", "10", "342.68±126.07"],
-            ["", "Total", "24", "496.45±252.82"],
-            ["", "Males", "14", "611.75±260.28"],
-            ["Eight weeks\nafter surgery", "Females", "10", "277.68±90.42"],
-            ["", "Total", "24", "472.55±264.19"],
-        ]
 
     def test_a_lone_outlier_gap_cannot_define_the_row_population(self) -> None:
         """A gap occurring once must not outweigh one occurring many times.
@@ -159,3 +136,65 @@ class TestWrappedCellsFoldIntoTheirRow:
             ["", "12", "3", "0.25"],
             ["", "15", "4", "0.27"],
         ]
+
+
+class TestSectionHeadingRowsSurvive:
+    """A row that fills one column may be a heading, not a wrapped fragment."""
+
+    # PMC4500011.1's Table 1, verbatim: 33 printed lines, 3 columns. Five of its rows are
+    # section headings ("Gender", "Height (cm)", ...) whose data columns are empty by
+    # design, each followed by the indented rows it governs.
+    LINES = [
+        ["", "The", "Blind"],
+        ["Variable", "", ""],
+        ["", "Text reading group", "Braille reading group"],
+        ["Age (yrs)", "16.0 ± 0.8", "13.6 ± 0.8"],
+        ["Gender", "", ""],
+        ["Male (%)", "9 (64.3)", "5 (35.7)"],
+        ["Female (%)", "5 (35.7)", "9 (64.3)"],
+        ["Height (cm)", "", ""],
+        ["Male", "160.6 ± 4.9", "163.9 ± 2.2"],
+        ["Female", "153.1 ± 3.6", "148.4 ± 3.6"],
+        ["Gender total", "158.0 ± 3.4", "154.0 ± 3.1"],
+    ]
+    # y-extents as printed: the header tier interlaces (-4.80pt), and every body gap that
+    # follows is +1.56pt -- one value, shared by the headings and the data rows they head.
+    EXTENTS = [
+        (107.87, 119.04),
+        (114.23, 125.40),
+        (120.60, 131.77),
+        (133.46, 144.63),
+        (146.19, 157.36),
+        (158.93, 170.09),
+        (171.66, 182.83),
+        (184.39, 195.56),
+        (197.12, 208.29),
+        (209.86, 221.03),
+        (222.59, 233.76),
+    ]
+
+    def test_a_section_heading_is_not_folded_onto_the_row_above_it(self) -> None:
+        """A heading must not join the row above it, or values land under the wrong label.
+
+        This is the regression #438 shipped: the heading fills one of the three columns its
+        neighbour fills, which is exactly the shape of a wrapped fragment, so a fold rule
+        keyed on that shape swallowed it. The printed page offers nothing to tell them
+        apart -- the gap above "Gender" is 1.56pt, the same as the gap above "Male (%)"
+        and above every other row in the table.
+        """
+        rows = merge_continuation_lines([list(r) for r in self.LINES], self.EXTENTS)
+
+        assert ["Gender", "", ""] in rows, rows
+        assert ["Height (cm)", "", ""] in rows, rows
+        # The heading kept its own row, so the Age row still owns its own numbers.
+        age = [row for row in rows if row[0].startswith("Age")]
+        assert age == [["Age (yrs)", "16.0 ± 0.8", "13.6 ± 0.8"]], rows
+
+    def test_every_data_row_keeps_the_label_it_was_printed_with(self) -> None:
+        """No row may carry two labels: that is what mislabelling looks like structurally."""
+        rows = merge_continuation_lines([list(r) for r in self.LINES], self.EXTENTS)
+
+        for row in rows:
+            assert (
+                "\n" not in row[0] or not row[1]
+            ), f"row label {row[0]!r} fused two printed labels onto data {row[1]!r}"


### PR DESCRIPTION
Fixes #448.

`2bbb9eb` (#438, PR #447) shipped two changes to `_gap_row_groups`. The gap-jump selection
— try jumps in order, reject a grouping that comes out mostly half-empty — is sound and is
kept. `_fold_wrapped_fragments` is removed.

## What the fold did

`PMC4500011.1` Table 1 has section-heading rows: the heading fills the label column, leaves
the data columns empty, and the rows it governs are indented beneath it.

Before (correct, 31 rows) → after #438 (23 rows):

```
Age (yrs)      | 16.0 ± 0.8 | 13.6 ± 0.8        Age (yrs) Gender       | 16.0 ± 0.8 | 13.6 ± 0.8
Gender         |            |                   Male (%)               | 9 (64.3)   | 5 (35.7)
  Male (%)     | 9 (64.3)   | 5 (35.7)          Female (%) Height (cm) | 5 (35.7)   | 9 (64.3)
  Female (%)   | 5 (35.7)   | 9 (64.3)
Height (cm)    |            |
  Male         | 160.6 ± 4.9| 163.9 ± 2.2
```

`Gender` fused onto the *Age* row's numbers, `Height (cm)` onto *Female's*. Every value
below a heading is attributed to the wrong heading. Mislabelled data reads as correct,
which makes it worse than the shredding the fold was meant to repair.

## Why it can't be tuned

A section heading and a wrapped fragment are the same shape — one filled column, a proper
subset of the neighbour's. The only other guard is a gap bar, and it cannot separate them:
this table prints **one** body gap value, `1.56pt` (0.14 of line height), for headings and
data rows alike.

| gap share | born-digital table pages worse than pre-#438 | better |
| --- | --- | --- |
| 0.75 (shipped) | 7 | 1 |
| 0.5 / 0.35 / 0.25 / 0.15 | 2 | 1 |
| 0.05 | **0** | 0 |

The only value that clears the regressions is one low enough that the fold never fires.

## Measured against ground truth

`table_content_similarity` / `table_structure_similarity` vs JATS, fold on vs off, same
platform both sides:

| corpus | content | structure |
| --- | --- | --- |
| born-digital (66 articles, 124 table pages) | 7 worse, 1 better | 7 worse, 2 better |
| held-out (110 articles, 39 touched pages) — **the corpus #438 was tuned on** | 5 worse, 3 better | 5 worse, 4 better |

Means fall on both. The fold helps `PMC5250635.1`, the table its own tests were built from
(+0.033 content), but `PMC7750051.1` loses 0.244 and `PMC9750022.1` drops a perfect 1.000
structure to 0.800. `PMC7750019.1` — the table #438 was filed about — does not move at all.

Removing the fold restores born-digital table content **exactly** to the pre-#438 values
(0 worse, 0 better) and leaves structure strictly better than either side; the remaining
gain is the jump-selection half alone (`PMC2000230.1` page 6, structure 0.492 → 0.889).

## Why #447 didn't catch it

#438 was measured by counting half-empty rows. Folding a genuine section heading away
*reduces* that count, so the proxy scored this corruption as an improvement — which is how
that PR reported "0 tables worse" while shipping seven regressions. The proxy is
anti-correlated with correctness in exactly the failure mode that matters.

#438's changelog entry is unreleased and makes that claim, so it is **corrected here rather
than contradicted by a second entry**.

## Tests

Two regression tests built from `PMC4500011.1`'s printed geometry, verified to fail on
`2bbb9eb`:

```
AssertionError: row label 'Age (yrs)\nGender' fused two printed labels onto data '16.0 ± 0.8'
```

Full local unit suite green; ruff and mypy clean.

## Follow-up

The born-digital `reference.json` is still unrecorded and **must not** be recorded from run
32793761384 — that run contains this regression. It needs a fresh PMC run once this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
