### PR TITLE
fix(pdf): measure page furniture by height, not by distance (#440)

### DIFF
--- a/changelog.d/440-column-furniture-height.fixed.md
+++ b/changelog.d/440-column-furniture-height.fixed.md
@@ -1,0 +1,11 @@
+- **PDF: a footer printed close to the body no longer vetoes the column split** (#440). The
+  trim that stopped page furniture erasing a tight-gutter column channel banded the page at
+  24pt of clear space. Ten held-out pages set their footer 8.6–11.5pt below the last line of
+  text — tighter than the gap above many a table row — so the trim could not see them and the
+  page was read line-by-line in y, interleaving both columns. No measure of clear space can
+  separate the two cases; height can. Furniture prints a line or two, the body prints the
+  page, so a trim is now admitted by the share of the page's printed text it discards, and
+  it must cut at a band boundary rather than between arbitrary blocks. Measured against JATS
+  ground truth on the 110-article held-out corpus: 10 pages split that did not, 14 lost
+  blocks come back (13 of them reference titles), no block's share falls, and 36 of the 43
+  re-converted articles project byte-identically.

--- a/src/all2md/constants.py
+++ b/src/all2md/constants.py
@@ -792,11 +792,17 @@ PDF_COLUMN_SINGLE_COLUMN_WIDTH_RATIO = 0.6  # Width ratio threshold for single c
 PDF_COLUMN_CHANNEL_MIN_WIDTH = 8.0  # Points; measured gutters bottom out at 14.9
 PDF_COLUMN_CHANNEL_MIN_BLOCKS_PER_SIDE = 3  # Sides with fewer blocks cannot interleave much
 PDF_COLUMN_CHANNEL_MIN_Y_OVERLAP_RATIO = 0.3  # Of the smaller side's y-span
-# Points of clear vertical space that separate page furniture from the body (#440).
-# Body blocks tile with sub-point gaps; the six held-out corpus pages where a footer
-# erased a real channel separate at 40-312pt, and the page count this admits is flat
-# across 18-60pt, so the exact value is not load-bearing.
-PDF_COLUMN_CHANNEL_BAND_GAP = 24.0
+# How much of a page's printed text height a furniture trim may discard (#440).
+# When a footer crosses the gutter the channel search retries on the body alone, and
+# the question is what counts as body. A clear-space threshold cannot answer it: the
+# six pages #445 was measured on separate their footer from the body by 40-312pt, but
+# ten more separate it by 8.6-11.5pt -- tighter than the gap above many a table row --
+# so no distance tells furniture from text. Height does. Furniture prints a line or
+# two; the body prints the page. Across the 110-article held-out corpus every trim
+# that unlocks a real channel discards 1.4-2.3% of the page's text height and every
+# trim that would discard body discards 14.8% or more, so this bar sits about 2.5x
+# clear of each side of a 6x gap.
+PDF_COLUMN_CHANNEL_MAX_TRIM_HEIGHT_SHARE = 0.06
 
 # Line-level resegmentation of gutter-merged blocks (#405). On 64 of 455 dev-corpus
 # pages PyMuPDF fuses both columns of a tight-gutter page into a single block, so no

--- a/src/all2md/parsers/_pdf_columns.py
+++ b/src/all2md/parsers/_pdf_columns.py
@@ -15,7 +15,7 @@ from collections import defaultdict
 
 from all2md.constants import (
     DEFAULT_COLUMN_GAP_THRESHOLD,
-    PDF_COLUMN_CHANNEL_BAND_GAP,
+    PDF_COLUMN_CHANNEL_MAX_TRIM_HEIGHT_SHARE,
     PDF_COLUMN_CHANNEL_MIN_BLOCKS_PER_SIDE,
     PDF_COLUMN_CHANNEL_MIN_WIDTH,
     PDF_COLUMN_CHANNEL_MIN_Y_OVERLAP_RATIO,
@@ -274,20 +274,10 @@ def _detect_columns_by_whitespace(
     return whitespace_columns if len(whitespace_columns) > 1 else None
 
 
-def _dominant_y_band(boxes: list[tuple[float, float, float, float]]) -> list[tuple[float, float, float, float]]:
-    """Return the boxes in the page's densest horizontal band of text.
-
-    Running heads, page numbers and copyright lines sit in their own band,
-    separated from the body by far more vertical space than any two body blocks
-    are ever separated by. Sweeping the boxes in y and cutting wherever that
-    space exceeds ``PDF_COLUMN_CHANNEL_BAND_GAP`` therefore isolates the body
-    without needing the page rectangle, a margin ratio, or knowledge of what the
-    furniture says.
-
-    The band holding the most boxes wins, but only if everything it leaves behind
-    is too small to be a column of anything. A page whose body a figure has split
-    into two real bands is returned whole instead: choosing the larger half there
-    would be a guess about which half to read, not a trim.
+def _clean_bands(
+    boxes: list[tuple[float, float, float, float]],
+) -> list[list[tuple[float, float, float, float]]]:
+    """Split ``boxes`` wherever a horizontal line crosses the page touching nothing.
 
     Parameters
     ----------
@@ -296,36 +286,78 @@ def _dominant_y_band(boxes: list[tuple[float, float, float, float]]) -> list[tup
 
     Returns
     -------
-    list of tuple
-        The boxes of the most populous band, or ``boxes`` unchanged when what
-        that would discard is too substantial to be page furniture. A caller
-        that gets its input back has learned there is no furniture to strip.
+    list of list of tuple
+        The bands, top to bottom. Two blocks land in different bands only when no
+        block anywhere on the page bridges the y-interval between them, so a band
+        boundary is a place the page can be cut without dividing anything printed.
 
     """
-    if not boxes:
-        return []
     bands: list[list[tuple[float, float, float, float]]] = []
     reach = float("-inf")
     for box in sorted(boxes, key=lambda b: b[1]):
-        if not bands or box[1] > reach + PDF_COLUMN_CHANNEL_BAND_GAP:
+        if not bands or box[1] > reach:
             bands.append([])
-            reach = box[3]
-        else:
-            reach = max(reach, box[3])
+        reach = max(reach, box[3])
         bands[-1].append(box)
+    return bands
 
-    body = max(bands, key=len)
-    # Only furniture may be discarded. A band holding as many blocks as a column
-    # needs is not a running head; it is the other half of a body that a figure
-    # or a table split in two, and dropping it is a guess about which half to
-    # read. Measured on the 110-article held-out corpus: the six pages where a
-    # footer erases a real channel discard exactly two blocks each, while every
-    # page this rejects would have discarded 6, 17, 27 or 39 -- the separation is
-    # not close, so the bar is the detector's own idea of how few blocks cannot
-    # make a column.
-    if any(len(band) >= PDF_COLUMN_CHANNEL_MIN_BLOCKS_PER_SIDE for band in bands if band is not body):
-        return list(boxes)
-    return body
+
+def _furniture_trims(
+    boxes: list[tuple[float, float, float, float]], max_share: float
+) -> list[tuple[list[tuple[float, float, float, float]], set[tuple[float, float, float, float]]]]:
+    """Ways to set page furniture aside, least discarded first.
+
+    Running heads, page numbers, copyright lines and DOI stamps sit in their own
+    bands at the top and bottom of the page. Trimming whole bands from the ends is
+    therefore enough to reach every one of them, and reaches nothing else: a body
+    block is never alone at an end of the page with clear space between it and the
+    text it belongs to.
+
+    What bounds the trim is height, not distance and not block count. Furniture
+    prints a line or two; the body prints the page (#440).
+
+    Parameters
+    ----------
+    boxes : list of tuple
+        (x0, y0, x1, y1) for each block carrying interleaving evidence.
+    max_share : float
+        Largest share of the page's printed text height a trim may discard.
+
+    Returns
+    -------
+    list of tuple
+        ``(body, furniture)`` for each admissible trim, smallest discard first.
+        Empty when the page has no band structure to trim.
+
+    """
+    bands = _clean_bands(boxes)
+    if len(bands) < 2:
+        return []
+    heights = [sum(box[3] - box[1] for box in band) for band in bands]
+    total = sum(heights)
+    if total <= 0:
+        return []
+
+    trims: list[tuple[float, list[tuple[float, float, float, float]], set[tuple[float, float, float, float]]]] = []
+    for head in range(len(bands)):
+        # Bands are trimmed in whole, so the share of a longer trim only grows:
+        # once the head alone is over the bar no tail can bring it back under.
+        if sum(heights[:head]) > max_share * total:
+            break
+        for tail in range(len(bands) - head):
+            if head + tail == 0:
+                continue
+            share = (sum(heights[:head]) + sum(heights[len(bands) - tail :])) / total
+            if share > max_share:
+                break
+            body = [box for band in bands[head : len(bands) - tail] for box in band]
+            if not body:
+                continue
+            gone = {box for band in bands[:head] for box in band}
+            gone |= {box for band in bands[len(bands) - tail :] for box in band}
+            trims.append((share, body, gone))
+    trims.sort(key=lambda trim: trim[0])
+    return [(body, gone) for _, body, gone in trims]
 
 
 def _channel_boundaries(kept: list[tuple[float, float, float, float]]) -> list[float]:
@@ -408,12 +440,15 @@ def _detect_columns_by_channel(
     produce the channel in the first place.
 
     Page furniture is held to the same standard but cannot meet it, so when the
-    whole page yields no channel the search is retried on the body band alone
-    (#440). A footer with two elements on one baseline -- a copyright line
-    crossing the gutter and a page number -- survives the isolation prune by
-    mutual vouching, and the copyright line then merges the two x-runs into one,
-    erasing a channel that twenty blocks a side support. Nothing above or below
-    the body can be interleaved with it by a y-sort, so nothing there gets a vote.
+    whole page yields no channel the search is retried with the furniture bands
+    trimmed off the ends (#440). A footer with two elements on one baseline -- a
+    copyright line crossing the gutter and a page number -- survives the isolation
+    prune by mutual vouching, and the copyright line then merges the two x-runs
+    into one, erasing a channel that twenty blocks a side support. Nothing above
+    or below the body can be interleaved with it by a y-sort, so nothing there
+    gets a vote. What bounds that trim is the height it discards, not the clear
+    space it crosses: journal footers print anywhere from 8.6 to 312pt below the
+    last line of text, so no distance separates them from the body.
 
     Parameters
     ----------
@@ -464,17 +499,19 @@ def _detect_columns_by_channel(
         # cannot be interleaved with the body by a y-sort whatever it overlaps,
         # so it carries no evidence and does not get to veto.
         #
+        # Every trim is tried, least discarded first, rather than one guess at
+        # where the body starts: what makes a trim right is that it reveals a
+        # channel, and the height bar is what keeps it from reaching the body.
+        #
         # Restricted to a retry rather than applied outright: a page that
         # already splits keeps splitting on exactly the evidence it always used.
-        body = _dominant_y_band(kept)
-        if len(body) == len(kept):
+        for body, trimmed in _furniture_trims(kept, PDF_COLUMN_CHANNEL_MAX_TRIM_HEIGHT_SHARE):
+            candidates = _channel_boundaries(body)
+            if len(candidates) == 1:
+                boundaries, furniture, kept = candidates, trimmed, body
+                break
+        else:
             return None
-
-        boundaries = _channel_boundaries(body)
-        if len(boundaries) != 1:
-            return None
-        furniture = {tuple(bbox) for bbox in kept} - {tuple(bbox) for bbox in body}
-        kept = body
 
     content_top = min(bbox[1] for bbox in kept)
     content_bottom = max(bbox[3] for bbox in kept)

--- a/tests/unit/formats/pdf/test_pdf_column_channel_footer.py
+++ b/tests/unit/formats/pdf/test_pdf_column_channel_footer.py
@@ -14,9 +14,14 @@ a copyright line crossing the gutter and a page number -- so each vouches for
 the other, both survive, and the copyright line erases a channel that twenty
 blocks a side support.
 
+What makes that footer discardable is not how far below the body it sits. The
+pages #445 was measured on separate the two by 40-312pt; ten more separate them
+by 8.6-11.5pt, tighter than the gap above many a table row. Height is the
+discriminator instead: furniture prints a line or two, the body prints the page.
+
 The geometry in these tests is the real thing, taken from page 13 of
-PMC7250011.1 in the held-out corpus: 260pt columns at x 28-288 and x 309-569, a
-20.7pt gutter, and a footer 312pt below the last line of text.
+PMC7250011.1 in the held-out corpus: 260pt columns at x 28-288 and x 309-569 and
+a 20.7pt gutter, with the footer printed at both distances.
 """
 
 import pytest
@@ -112,3 +117,62 @@ class TestOnlyFurnitureIsDiscarded:
         """Removing furniture must not manufacture a channel out of nothing."""
         body = [{"bbox": [28.3, 50.0 + i * 30.0, 520.0, 78.0 + i * 30.0]} for i in range(12)]
         assert len(detect_columns(body + _footer())) == 1
+
+
+def _tight_footer(rows: int = 13) -> list[dict]:
+    """The same footer, printed a single line below the last line of text.
+
+    PMC7250011.1 p6 and nine pages like it in the held-out corpus set their
+    footer 8.6-11.5pt below the body -- tighter than the gap above many a table
+    row, so no measure of clear space can tell the two apart.
+    """
+    body_bottom = 50.0 + (rows - 1) * 36.0 + 35.5
+    return [
+        {"bbox": [211.5, body_bottom + 11.5, 383.7, body_bottom + 23.0]},
+        {"bbox": [550.2, body_bottom + 10.1, 566.9, body_bottom + 24.1]},
+    ]
+
+
+class TestFurnitureIsMeasuredByHeightNotDistance:
+    """What makes a band furniture is that it prints a line, not that it sits far off."""
+
+    def test_a_footer_one_line_below_the_body_still_splits(self) -> None:
+        """The regression: a footer too close to the body to clear a gap threshold.
+
+        The trim that #445 shipped banded the page at 24pt of clear space, which
+        these pages never reach. Ten of them read line-by-line in y as a result,
+        seven in the two articles that between them own 44 of the reading's lost
+        blocks.
+        """
+        assert len(detect_columns(_two_columns() + _tight_footer())) == 2
+
+    def test_the_tight_footer_still_reads_after_both_columns(self) -> None:
+        """Trimming furniture from the evidence must not move it in the output."""
+        body, footer = _two_columns(), _tight_footer()
+        columns = detect_columns(body + footer)
+        assert len([block for column in columns for block in column]) == len(body) + len(footer)
+        for block in footer:
+            assert _column_of(columns, block) == len(columns) - 1
+
+    def test_a_tall_end_band_is_not_furniture(self) -> None:
+        """A band that prints paragraphs is body, however few blocks it holds.
+
+        PMC8250041.1 p0 prints a correspondence sidebar beside an abstract whose
+        narrower lines cross the gutter. An end trim does unlock a channel there,
+        but only by discarding 19.4% of the page's printed text; every trim on
+        the corpus that unlocks a *real* channel discards 1.4-2.3%. Counting
+        blocks cannot see the difference -- the band here holds two, fewer than
+        a column needs -- so the bar is height.
+        """
+        tight_left, tight_right = 290.0, 306.0  # a 16pt gutter: only the channel can admit it
+        intro = [
+            {"bbox": [44.8, 50.0, 188.4, 300.0]},  # the sidebar
+            {"bbox": [207.1, 50.0, 464.9, 300.0]},  # the abstract, crossing the gutter
+        ]
+        body = []
+        for i in range(4):
+            top = 400.0 + i * 36.0
+            body.append({"bbox": [28.3, top, tight_left, top + 35.5]})
+            body.append({"bbox": [tight_right, top, PAGE_RIGHT, top + 35.5]})
+        assert len(detect_columns(body)) == 2, "control: the body alone is a channel"
+        assert len(detect_columns(intro + body)) == 1


### PR DESCRIPTION
Part of #440. `_detect_columns_by_channel` admits a tight-gutter two-column page on structural evidence, and any single block crossing the channel merges the two x-runs into one and erases it — the page is then read line-by-line in y and both columns interleave. #445 stopped page furniture being that block by retrying the search on the body band alone, banding the page wherever **24pt of clear space** separated two blocks.

**That threshold cannot see the case it was built for.** The six pages #445 was measured on separate their footer from the body by 40–312pt. Ten more in the same held-out corpus separate it by **8.6–11.5pt** — tighter than the gap above many a table row — so no measure of clear space tells furniture from text.

Height does. Furniture prints a line or two; the body prints the page.

## The change

The trim is now bounded by the **share of the page's printed text height** it discards, and it must **cut at a band boundary** — everything discarded lies wholly above or wholly below everything kept — rather than between two arbitrary blocks in y order. Every admissible trim is tried, least discarded first: what makes a trim right is that it reveals a channel, and the height bar is what keeps it from reaching the body.

Both halves are load-bearing, and each was measured by replaying the recorded block geometry of all **1,184 held-out pages**:

| | admitted | rejected |
|---|---|---|
| share of page text height discarded | 1.4–2.3% | 14.8% and up |

The **block count** it replaces cannot see that difference: the band that would be wrongly discarded (`PMC8250041.1` p0, a correspondence sidebar beside a gutter-crossing abstract) holds two blocks, fewer than a column needs.

The **band-cut requirement** is what rejects a page whose top block is a table header (`PMC9250036.1` p7) and a page whose bottom block is a reference entry (`PMC3250055.1` p8), with no tuning at all: neither can be cut off without dividing something printed. Both were false positives before it was added.

## Measured, main vs this branch, same platform

Ground truth is the JATS text of the blocks the 2026-08-23 sealed-holdout reading lost.

- **10 pages split that did not**; 4 more fall from 3 or 4 columns to their true 2 (a page whose maths fragments faked a third column, and a figure page)
- **14 lost blocks recovered**, 13 of them reference titles
- **0 blocks whose n-gram share falls**
- **36 of 43** re-converted articles project byte-identically

The reading's residue falls **72 → 58** blocks, and its title losses **23 → 10**.

## Still open

#440 stays open. Rotated spine text (`PMC2250455.1` p0 — 148 corpus pages carry rotated text whose sliver bbox can fake a column), a 4-band reference layout (`PMC3250055.1` p8), and a two-column page with one block per column (`PMC5250647.1` p12) still fail the same all-or-nothing veto. Between them the first two own 12 of the 58 remaining blocks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)