### PR TITLE
docs(benchmarks): re-record the born-digital lane at 1a80814

### DIFF
--- a/benchmarks/pmc/reference.json
+++ b/benchmarks/pmc/reference.json
@@ -4,10 +4,10 @@
     "corpus_pin": "ffad81e6f9a6499a5889fdedaa001f8b251fac49faced83bed9dc15866e0dd00",
     "bucket": "pmc-oa-opendata",
     "complete_corpus": true,
-    "oracle_schema_version": 2,
-    "all2md_commit": "1226777d23973e2447a562a081b4f59b1c971d4f",
+    "oracle_schema_version": 3,
+    "all2md_commit": "1a808145f12b305f7a496cf657e840f83a98962f",
     "worktree_dirty": false,
-    "created_at": "2026-08-23T21:00:44.428227+00:00",
+    "created_at": "2026-08-26T14:14:54.865188+00:00",
     "python": "3.12.3 (main, Jun 19 2026, 12:46:00) [GCC 13.3.0]",
     "platform": "linux",
     "parser_runtime": {
@@ -79,14 +79,14 @@
     "unsplit_spans": 42
   },
   "article_recall": {
-    "recall": 0.6214486243683324,
-    "recovered": 5534,
+    "recall": 0.6232453677709152,
+    "recovered": 5550,
     "scored": 8905,
     "too_short": 2598,
     "ceiling": 0.624480628860191,
     "attainable": 5561,
-    "recovered_attainable": 5481,
-    "attainable_recall": 0.9856140981837799,
+    "recovered_attainable": 5496,
+    "attainable_recall": 0.9883114547743211,
     "by_kind": {
       "table": {
         "recovered": 92,
@@ -96,37 +96,37 @@
         "attainable_recall": 0.8272727272727273
       },
       "text_block": {
-        "recovered": 3155,
+        "recovered": 3170,
         "attainable": 3160,
-        "recovered_attainable": 3125,
+        "recovered_attainable": 3139,
         "scored": 6356,
-        "attainable_recall": 0.9889240506329114
+        "attainable_recall": 0.9933544303797468
       },
       "title": {
-        "recovered": 2287,
+        "recovered": 2288,
         "attainable": 2291,
-        "recovered_attainable": 2265,
+        "recovered_attainable": 2266,
         "scored": 2426,
-        "attainable_recall": 0.988651243998254
+        "attainable_recall": 0.9890877346137058
       }
     },
     "control_recall": 0.003593486805165637,
     "control_scored": 8905,
-    "discrimination": 0.6178551375631667
+    "discrimination": 0.6196518809657495
   },
   "article_precision": {
-    "precision": 0.9506444457900769,
-    "supported": 423880,
-    "emitted": 445887,
-    "resequenced": 18393,
-    "novel": 3614,
-    "novel_share": 0.008105192571211988,
-    "duplication": 0.004493983009108454,
-    "excess": 2126,
-    "occurrences": 473077,
-    "control_precision": 0.007042142964473062,
-    "control_emitted": 445887,
-    "discrimination": 0.9436023028256039
+    "precision": 0.9544781078265867,
+    "supported": 425178,
+    "emitted": 445456,
+    "resequenced": 18352,
+    "novel": 1926,
+    "novel_share": 0.004323659351316404,
+    "duplication": 0.004473458677642229,
+    "excess": 2114,
+    "occurrences": 472565,
+    "control_precision": 0.007073650371753888,
+    "control_emitted": 445456,
+    "discrimination": 0.9474044574548328
   },
   "figure_binding": {
     "binding_rate": 0.6697674418604651,
@@ -146,35 +146,35 @@
   "dimensions": {
     "block_structure_similarity": {
       "count": 706.0,
-      "mean": 0.5485028296024805,
+      "mean": 0.5486112218466038,
       "median": 0.5714285714285714,
       "minimum": 0.023255813953488413,
       "maximum": 1.0,
-      "stdev": 0.21055959591452936,
+      "stdev": 0.21046855066332154,
       "direction": "higher",
-      "control_mean": 0.44415691139323243,
-      "discrimination": 0.1043459182092481,
+      "control_mean": 0.44430427296133546,
+      "discrimination": 0.10430694888526837,
       "mutation_drop": {
         "reversed": 0.015782263093977338,
-        "shuffled": 0.03254869887397674,
-        "halved": 0.062309664479472816
+        "shuffled": 0.03245427016765002,
+        "halved": 0.06223410469828426
       },
       "ungateable": "compares kind sequences without inspecting the text under a block, so content-free output scores 1.0 (issue #256); eleven text categories collapse to `text_block`, so fully reversed output scores exactly 1.0 on 153 of the 981 pinned pages; and on the born-digital lane it separates own-page from wrong-page output by only ~0.06 while *rising* when half the emitted content is deleted, which rewards dropping blocks"
     },
     "reading_order_similarity": {
       "count": 706.0,
-      "mean": 0.8281317303215293,
+      "mean": 0.828274133182863,
       "median": 0.9090909090909091,
       "minimum": 0.0,
       "maximum": 1.0,
-      "stdev": 0.20974930316180884,
+      "stdev": 0.2098343721755957,
       "direction": "higher",
-      "control_mean": 0.29069717196612904,
-      "discrimination": 0.5374345583554003,
+      "control_mean": 0.2912792743177823,
+      "discrimination": 0.5369948588650808,
       "mutation_drop": {
-        "reversed": 0.5303437329469437,
-        "shuffled": 0.24338884737348376,
-        "halved": 0.32697035446258477
+        "reversed": 0.5317684007098304,
+        "shuffled": 0.24442783042379826,
+        "halved": 0.32781082501145536
       }
     },
     "table_content_similarity": {
@@ -195,34 +195,34 @@
     },
     "table_structure_similarity": {
       "count": 124.0,
-      "mean": 0.6133126964680959,
-      "median": 0.8333333333333333,
+      "mean": 0.616512901281204,
+      "median": 0.8432934712346478,
       "minimum": 0.0,
       "maximum": 1.0,
-      "stdev": 0.4139273643367654,
+      "stdev": 0.41451590031159846,
       "direction": "higher",
-      "control_mean": 0.09460228054599214,
-      "discrimination": 0.5187104159221038,
+      "control_mean": 0.09342488651145524,
+      "discrimination": 0.5230880147697488,
       "mutation_drop": {
         "reversed": 0.0,
         "shuffled": 0.0,
-        "halved": 0.6074885964352613
+        "halved": 0.6114175607602652
       }
     },
     "text_content_similarity": {
       "count": 706.0,
-      "mean": 0.6813156888254379,
+      "mean": 0.681726436373371,
       "median": 0.7082209683552323,
       "minimum": 0.010652463382157085,
-      "maximum": 0.9930305215092525,
-      "stdev": 0.22329983041306012,
+      "maximum": 0.993987493987494,
+      "stdev": 0.2233971546943521,
       "direction": "higher",
-      "control_mean": 0.2334461851782221,
-      "discrimination": 0.4478695036472158,
+      "control_mean": 0.23348201181941364,
+      "discrimination": 0.4482444245539574,
       "mutation_drop": {
-        "reversed": 0.292270299536416,
-        "shuffled": 0.20376197639542715,
-        "halved": 0.29620063786003653
+        "reversed": 0.29251892492466225,
+        "shuffled": 0.20380052809431592,
+        "halved": 0.2966849381111877
       }
     }
   },

--- a/changelog.d/pmc-rerecord-post-450.changed.md
+++ b/changelog.d/pmc-rerecord-post-450.changed.md
@@ -1,0 +1,10 @@
+- **Born-digital lane re-recorded, and the fidelity page with it.**
+  `benchmarks/pmc/reference.json` now holds the CI reading taken at `1a80814`, replacing
+  the one taken at `1226777` (#435). Same corpus pin, same runner, same PyMuPDF, complete
+  corpus, so every movement is ours: recall of attainable 98.6% → **98.8%** (text blocks
+  98.9% → **99.3%**), supported share 95.1% → **95.4%**, and novel share 0.81% → **0.43%**
+  on the entity fix in #441 — emitted n-grams fell by 431 while *supported* ones rose by
+  1,298, which is the arithmetic of text corrected rather than text dropped. Table recall
+  is unchanged at 82.7%: the intermediate reading dipped to 80.9% on the row-fold defect
+  in #448, and #449 returned it to the recorded figure exactly. Every published figure on
+  `docs/source/benchmarks.rst` is updated against the new artifact.

--- a/docs/source/benchmarks.rst
+++ b/docs/source/benchmarks.rst
@@ -74,13 +74,13 @@ Did the text survive?
      - Value
      -
    * - Raw recall
-     - 62.1%
+     - 62.3%
      - of 8,905 ground-truth blocks
    * - Attainable ceiling
      - 62.4%
      - what the PDF's own text layer reproduces
    * - **Recall of what is attainable**
-     - **98.6%**
+     - **98.8%**
      - the number worth reading
    * - Control: the *wrong* article
      - 0.4%
@@ -98,11 +98,11 @@ The movement after that correction is the opposite kind: a parser fix (#405).
 Side-by-side regions with tight gutters — two-column reference lists above all — were
 read as one column and interleaved line-by-line, so every word survived while every
 adjacency died. Admitting those gutters on structural evidence and joining words
-hyphenated at block seams raised attainable recall from 95.4% to 98.3% (98.6% after
-the table repairs below), and the held-out corpus moved the same way it was never
-tuned against.
+hyphenated at block seams raised attainable recall from 95.4% to 98.3% (98.8% after
+the table repairs below and the furniture-trimmed column channel that followed), and
+the held-out corpus moved the same way it was never tuned against.
 
-Raw recall is 62.1%, and that figure is close to meaningless on its own. A large share of
+Raw recall is 62.3%, and that figure is close to meaningless on its own. A large share of
 any JATS article cannot be recovered by *any* parser, because the markup records words in an
 order the page never prints — author affiliation blocks, structured metadata, citation
 fields. Charging a PDF parser for failing to reproduce text the PDF does not contain
@@ -124,11 +124,11 @@ By block kind:
      - Share of attainable
    * - Text blocks
      - 3,160 of 6,356
-     - 3,125
-     - **98.9%**
+     - 3,139
+     - **99.3%**
    * - Titles
      - 2,291 of 2,426
-     - 2,265
+     - 2,266
      - **98.9%**
    * - Tables
      - 110 of 123
@@ -136,7 +136,7 @@ By block kind:
      - **82.7%**
 
 The middle column counts only blocks inside the ceiling, so each row's share is its own
-two counts divided. A few more blocks are recovered than that: 3,155 text blocks, 2,287
+two counts divided. A few more blocks are recovered than that: 3,170 text blocks, 2,288
 titles and 92 tables come out matching the ground truth, including some the PDF's own text
 layer does not reproduce. Those count as recovered and on neither side of the share, which
 is why the larger count is not the one printed here.
@@ -167,13 +167,13 @@ Unsupported output is therefore split in two:
      - Share
      - Meaning
    * - Supported
-     - **95.1%**
+     - **95.4%**
      - the n-gram appears in the document's text layer
    * - Resequenced
      - 4.1%
      - every word is in the document, in a new adjacency
    * - **Novel**
-     - **0.8%**
+     - **0.4%**
      - at least one word appears nowhere — the number worth reading
    * - Duplication
      - 0.4%
@@ -182,8 +182,8 @@ Unsupported output is therefore split in two:
      - 0.7%
      - wants to be ~0%
 
-Over 445,887 emitted n-grams, 3,614 are novel. Reporting the raw unsupported figure instead
-would have made the result roughly six times worse than the parser deserves.
+Over 445,456 emitted n-grams, 1,926 are novel. Reporting the raw unsupported figure instead
+would have made the result roughly ten times worse than the parser deserves.
 
 Duplication is counted apart from both, because it is invisible to either. Text emitted
 twice is an unchanged *set* and a doubled *multiset* — no set-based score can see it at all.
@@ -198,8 +198,15 @@ able to report it.
 It fell by two fifths again, 0.8% to 0.4%, on #435. That defect mostly *doubled* captions
 rather than inventing them — the clipped-away typesetting is the same words as the printed
 one — so duplication is where the bulk of it landed. Novel share moved by less than a
-twentieth of a point, 0.86% to 0.81%, which is enough to cross a rounding boundary in the
-table above and not much more.
+twentieth of a point, 0.86% to 0.81%, which was enough to cross a rounding boundary in the
+table as it then stood and not much more.
+
+It then very nearly halved, 0.81% to 0.43%, on #441 — the largest single movement this
+figure has recorded. The parser wrote ``&lt;`` and ``&gt;`` into the AST where the page
+prints ``<`` and ``>``, so every affected n-gram matched nothing in the text layer and
+counted as invented. The arithmetic is what identifies a correction rather than a deletion,
+and it is worth reusing: emitted n-grams fell by 431 while *supported* ones rose by 1,298.
+Text that is merely dropped cannot raise the supported count.
 
 Tables
 ~~~~~~
@@ -279,7 +286,7 @@ pages:
      - 0.291
      - **0.537**
    * - ``text_content_similarity``
-     - 0.681
+     - 0.682
      - 0.233
      - **0.448**
    * - ``table_content_similarity``
@@ -287,9 +294,9 @@ pages:
      - 0.039
      - **0.567**
    * - ``table_structure_similarity``
-     - 0.613
-     - 0.095
-     - **0.519**
+     - 0.617
+     - 0.093
+     - **0.523**
    * - ``block_structure_similarity``
      - 0.549
      - 0.444


### PR DESCRIPTION
Records CI run [32976243824](https://github.com/thomas-villani/all2md/actions/runs/32976243824) as `benchmarks/pmc/reference.json`, replacing the reading taken at `1226777` (#435), and updates every figure the fidelity page publishes from it.

## Why this run is comparable

Same corpus pin `ffad81e6f9a6499a`, same runner image, same PyMuPDF 1.28.0, `complete_corpus: true`, `worktree_dirty: false`, recorded at the merge commit `1a80814`. Every denominator in the payload is byte-identical — 66 articles, 706 pages, 11,503 ground-truth blocks, 8,905 scored, ceiling 62.4478%, and the whole table population (121 expected, 164 emitted, 19 image-deposited, 247 rejected, 124 scored). Nothing moved except what we changed.

## The reading

| | reference (`1226777`) | this run (`1a80814`) |
|---|---|---|
| recall of attainable | 98.56% | **98.83%** |
| — text blocks | 98.89% | **99.34%** |
| — titles | 98.87% | 98.91% |
| — tables | 82.73% | 82.73% |
| supported share | 95.06% | **95.45%** |
| novel share | 0.81% | **0.43%** |

Spanning #441, #443, #438/#447, #448/#449 and both halves of #440 (#445, #450).

**Novel share is the headline, and the arithmetic is what identifies it.** Emitted n-grams fell by 431 while *supported* ones **rose by 1,298**. Text that is merely dropped cannot raise the supported count, so this is #441's entity fix correcting tokens rather than deleting them. That test is worth reusing on any future movement in this figure, and it is now written into the page.

**Table recall wanted the care.** The intermediate run [32793761384](https://github.com/thomas-villani/all2md/actions/runs/32793761384) at `2bbb9eb` read 80.91% on the row-fold defect that #438 shipped — which is why it was deliberately never recorded. #449 removed the fold and the figure returns to **82.73% exactly**. The table dimensions bracket that from both sides: `table_content_similarity` is byte-identical to the old reference (0.606192, to six decimals) and `table_structure_similarity` *rises* 0.613 → 0.617. A restored measurement, not a coincidence landing on the old number.

`oracle_schema_version` moves 2 → 3 with #443. This lane is ungated, so the bump travels with the re-record rather than needing a change of its own. (The OmniDocBench 6 → 7 bump stays parked until that lane's next baseline re-record, for the reason recorded in its constant.)

## Docs

`test_published_figures_match_their_artifacts` names each stale snippet, and all eleven are updated. Two figures the inventory does **not** gate were stale alongside them and are fixed here:

- the unsupported-to-novel ratio — halving novel share moves it from "roughly six times" to roughly ten;
- a #435 paragraph that pointed at "the table above" for a novel-share value no longer printed there. It now carries the #441 movement instead.

Sphinx builds clean; the figures test and the 289-test benchmark unit batch pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)