### PR TITLE
fix(pdf): let a list item keep the lines it wraps onto (#442)

### DIFF
--- a/changelog.d/442-list-continuation.fixed.md
+++ b/changelog.d/442-list-continuation.fixed.md
@@ -1,0 +1,12 @@
+- **PDF: a list item keeps the lines it wraps onto** (#442). Paragraph assembly refused any
+  merge touching a list item. That is right for two *items*, but it also stranded every line
+  a long item wraps onto — and a numbered bibliography is a list of long items, so a
+  reference's title and journal arrived as separate blocks from its authors, and the
+  hyphenation repair that runs at a merged seam never got the chance to run. Measured over
+  8,183 merge decisions on twelve dev-corpus articles, 151 of the 325 blocks that end
+  mid-sentence are stranded this way, and 98% of them sit 0.5–3.8pt below the item — the
+  same geometry as the wraps already merged (median 1.98pt, 95th percentile 3.67pt). A
+  continuation now joins its item on that geometry; a new list item never merges, and
+  neither does a block starting *above* its predecessor, which under a list item is a page
+  or column break rather than a wrap. Across those twelve articles: blocks 1,262 → 1,066,
+  blocks ending mid-sentence 412 → 257 (32.6% → 24.1%), median words per block 15 → 23.

--- a/src/all2md/parsers/pdf.py
+++ b/src/all2md/parsers/pdf.py
@@ -4389,21 +4389,42 @@ class PdfToAstConverter(BaseParser):
         current_is_list = (current_metadata and current_metadata.get("is_list_item", False)) or is_list_item
         last_is_list = (last_metadata and last_metadata.get("is_list_item", False)) or last_was_list_item
 
-        # Don't merge list items with anything
-        if current_is_list or last_is_list:
+        # A list item never merges into what came before it: two items are two items,
+        # and an item opening under a paragraph starts its own block.
+        if current_is_list:
             return False
 
-        # If bbox information is missing, don't merge to be safe
+        # If bbox information is missing, don't merge to be safe -- and a continuation
+        # of a list item is admitted on its geometry alone, so without geometry it stays
+        # where the unconditional rule used to put it.
         if not current_bbox or last_bbox_bottom is None:
-            return not accumulated_content
+            return not accumulated_content and not last_is_list
 
         # Must have accumulated content and valid bbox info
         if not accumulated_content:
-            return True
+            return not last_is_list
 
         # Calculate vertical gap
         current_bbox_top = current_bbox[1]
         vertical_gap = current_bbox_top - last_bbox_bottom
+
+        # A list item's own wrapped lines are not new paragraphs (#442). The rule here
+        # used to refuse any merge touching a list item, which strands every line a long
+        # item wraps onto -- and a numbered bibliography is a list of long items, so a
+        # reference's title and journal arrive as separate blocks from its authors.
+        #
+        # Measured over 8,183 merge decisions on twelve dev-corpus articles, 151 of the
+        # 325 blocks that end mid-sentence are stranded this way, and 98% of them sit
+        # 0.5-3.8pt below the item -- the same geometry as the wraps this method already
+        # merges (median 1.98pt, 95th percentile 3.67pt). They are indistinguishable from
+        # an ordinary wrap except for the list item above them.
+        #
+        # What is NOT admitted is a negative gap. For ordinary prose a continuation above
+        # its predecessor is the foot of one column meeting the head of the next, and
+        # joining them is usually right; under a list item it is 8 cases of a page or
+        # column break -- one of them 287pt -- where "just below" means nothing.
+        if last_is_list:
+            return 0.0 <= vertical_gap < merge_threshold
 
         # Only merge if gap is small
         return vertical_gap < merge_threshold

--- a/tests/unit/formats/pdf/test_pdf_list_continuation.py
+++ b/tests/unit/formats/pdf/test_pdf_list_continuation.py
@@ -1,0 +1,130 @@
+#  Copyright (c) 2025 Tom Villani, Ph.D.
+"""A list item's wrapped lines are not new paragraphs (#442).
+
+``_should_merge_with_accumulated`` used to refuse any merge touching a list item.
+That is right for two *items* -- two items are two items -- but it also strands
+every line a long item wraps onto. A numbered bibliography is a list of long
+items, so a reference's title and journal arrived as separate blocks from its
+authors, and the hyphenation repair that runs at a merged seam never got to run.
+
+Measured over 8,183 merge decisions on twelve dev-corpus articles: 151 of the 325
+blocks that end mid-sentence are stranded this way, and 98% of them sit 0.5-3.8pt
+below the item -- the same geometry as the wraps this method already merges
+(median 1.98pt, 95th percentile 3.67pt).
+
+A negative gap is the one shape refused. Under ordinary prose a block starting
+*above* its predecessor is the foot of one column meeting the head of the next;
+under a list item, across the sample, it was 8 page or column breaks -- one of
+them 287pt -- where "just below" means nothing.
+"""
+
+import pytest
+
+from all2md.ast.nodes import Paragraph, SourceLocation, Text
+from all2md.parsers.pdf import PdfToAstConverter
+
+pytestmark = [pytest.mark.unit, pytest.mark.pdf]
+
+
+def _para(text: str, top: float, bottom: float, *, is_list_item: bool = False) -> Paragraph:
+    """A paragraph as the PDF parser produces one, at a given vertical position."""
+    metadata: dict = {"bbox": [50.0, top, 280.0, bottom]}
+    if is_list_item:
+        metadata["is_list_item"] = True
+    return Paragraph(
+        content=[Text(content=text)],
+        source_location=SourceLocation(format="pdf", page=1, metadata=metadata),
+    )
+
+
+def _merge(nodes: list[Paragraph]) -> list[str]:
+    merged = PdfToAstConverter()._merge_adjacent_paragraphs(nodes)
+    return ["".join(t.content for t in node.content if isinstance(t, Text)) for node in merged]
+
+
+class TestAListItemKeepsItsWrappedLines:
+    def test_a_continuation_just_below_joins_its_item(self) -> None:
+        """The regression: 2.74pt below is a wrap, not a new paragraph."""
+        nodes = [
+            _para("1. Smith AB, Jones CD, Karlin K. D. & Hoffman B. M.", 100.0, 110.0, is_list_item=True),
+            _para("Opportunities and challenges for a sustainable", 112.74, 122.74),
+        ]
+
+        assert _merge(nodes) == [
+            "1. Smith AB, Jones CD, Karlin K. D. & Hoffman B. M. Opportunities and challenges for a sustainable"
+        ]
+
+    def test_a_second_continuation_joins_too(self) -> None:
+        """A reference wraps onto three lines as readily as two."""
+        nodes = [
+            _para("42. Andreassen KH, Dahl C and Andersen JT", 100.0, 110.0, is_list_item=True),
+            _para("Mineral extraction from seawater with", 112.7, 122.7),
+            _para("selective separation. J Chem 2019;4:1-9.", 125.4, 135.4),
+        ]
+
+        assert len(_merge(nodes)) == 1
+
+    def test_a_hyphen_is_repaired_across_the_seam(self) -> None:
+        """The seam repair only runs where a merge happens, so it never ran here.
+
+        This is the sub-case #442 folded in: a word broken at a block boundary is
+        out of ``dehyphenate_blocks``'s reach by construction, because that works
+        within a block.
+        """
+        nodes = [
+            _para("7. Effects of electro-chemical transcrip-", 100.0, 110.0, is_list_item=True),
+            _para("tion factor binding", 112.7, 122.7),
+        ]
+
+        assert "transcription factor" in _merge(nodes)[0]
+
+
+class TestWhatStillWillNotMerge:
+    def test_a_new_list_item_stays_its_own_block(self) -> None:
+        """Two items are two items, however tightly they are set."""
+        nodes = [
+            _para("1. The first reference of the list", 100.0, 110.0, is_list_item=True),
+            _para("2. The second reference of the list", 112.7, 122.7, is_list_item=True),
+        ]
+
+        assert len(_merge(nodes)) == 2
+
+    def test_a_list_item_under_prose_stays_its_own_block(self) -> None:
+        """A list opening under a paragraph starts a block even at a tight gap."""
+        nodes = [
+            _para("The study considered three factors.", 100.0, 110.0),
+            _para("1. The first of the three factors", 112.7, 122.7, is_list_item=True),
+        ]
+
+        assert len(_merge(nodes)) == 2
+
+    def test_a_block_above_the_item_does_not_join_it(self) -> None:
+        """A negative gap is a column or page break, not a wrap.
+
+        Across the sample every one of these was exactly that -- the largest 287pt
+        -- so under a list item "just below" is required, not merely "close".
+        """
+        nodes = [
+            _para("9. The last reference at the foot of a column", 700.0, 710.0, is_list_item=True),
+            _para("Introduction text at the head of the next", 90.0, 100.0),
+        ]
+
+        assert len(_merge(nodes)) == 2
+
+    def test_a_paragraph_a_clear_gap_below_stays_separate(self) -> None:
+        """The wrap test is still a gap test: 20pt below the item is a new block."""
+        nodes = [
+            _para("3. A reference that ends here.", 100.0, 110.0, is_list_item=True),
+            _para("A following paragraph of body prose", 130.0, 140.0),
+        ]
+
+        assert len(_merge(nodes)) == 2
+
+    def test_a_continuation_without_geometry_stays_separate(self) -> None:
+        """Admission rests on the geometry, so no geometry means no admission."""
+        nodes = [
+            _para("5. A reference with a bbox", 100.0, 110.0, is_list_item=True),
+            Paragraph(content=[Text(content="a continuation with none")], source_location=None),
+        ]
+
+        assert len(_merge(nodes)) == 2


### PR DESCRIPTION
Takes the largest single cause of #442's over-segmentation. The issue stays open for the rest.

## Diagnosed, not guessed

#442 measured *that* prose is over-segmented and said explicitly that the cause was unknown — *"That has not been diagnosed — the numbers above say that it happens and at what rate, not why."* So every merge decision was recorded: **8,183** of them across twelve dev-corpus articles. Of the 325 that split a block ending mid-sentence:

| count | cause |
|---|---|
| **151** | **a continuation stranded after a list item** |
| 115 | gap 5–25pt |
| 28 | gap ≥ 25pt — a column, page or section break (correct) |
| 21 | a list item opening under prose (correct) |
| 7 | no bbox |
| 3 | two real list items (correct) |

`_should_merge_with_accumulated` refused **any** merge touching a list item. That is right for two *items*, but it also strands every line a long item wraps onto — and a numbered bibliography is a list of long items, so a reference's title and journal arrived as separate blocks from its authors, and the hyphenation repair that only runs at a merged seam never got to run.

**They are not borderline.** 98% sit **0.5–3.8pt** below the item, against merges this method already makes at a median of 1.98pt and a 95th percentile of 3.67pt. Geometrically indistinguishable from an ordinary wrap; only the list item above them stopped it.

## A text test was tried and rejected

Requiring the block to end mid-sentence looked like the obvious guard. The data killed it: it misses a reference wrapping after author initials (`Karlin, K. D. & Hoffman, B. M.` reads as a sentence end and is not one) and misses a line ending in its own hyphen — **57 of the 204 admissions**. The geometry carries it alone.

What is still refused is a **negative** gap. Under ordinary prose a block starting *above* its predecessor is the foot of one column meeting the head of the next, and joining them is usually right; under a list item it was 8 page or column breaks, one of them 287pt, where "just below" means nothing.

## Output quality, measured

Across the twelve articles:

| | before | after |
|---|---|---|
| blocks | 1,262 | **1,066** |
| ending mid-sentence | 412 (32.6%) | **257 (24.1%)** |
| median words/block | 15 | **23** |
| mean words/block | 49.0 | 57.9 |
| hyphens stranded at a seam | 2 | **1** |

## Recall does not move — which is the whole point

Scored on an 11-article subset, both sides from this same commit (the old rule restored by monkeypatch, so neither side depends on the working tree):

| | before | after |
|---|---|---|
| recall of attainable | 0.99084 | 0.99084 |
| — text blocks / titles / tables | 0.99628 / 0.99357 / 0.83333 | *identical* |
| precision, resequenced, novel, duplication | — | *identical* |
| emitted / supported / novel n-grams | 71,442 / 67,674 / 231 | *identical* |
| **`block_structure_similarity`** | 0.57298 | **0.57855** |

Every content figure is unchanged **to the token** — no text is gained or lost, it is only grouped differently. The single dimension that moves is `block_structure_similarity`, which is precisely the one #442 names as the only instrument able to see this defect. (It is declared ungateable in both lanes, so nothing ratchets on it.)

## Scope

The **115 splits in the 5–25pt band** are untouched and are the remaining half of #442, so the issue stays open after this.

## Tests

8 tests. The 3 that assert the new merge fail on `main`; the 5 that pin what must *still* not merge — a new list item, a list item under prose, a negative gap, a clear gap, a continuation with no geometry — pass on both sides, which is what makes them guards rather than restatements. Full PDF suite green, ruff and mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)