### PR TITLE
fix(pdf): stop emphasising a display equation one glyph at a time (#456)

### DIFF
--- a/changelog.d/456-display-equation-emphasis.fixed.md
+++ b/changelog.d/456-display-equation-emphasis.fixed.md
@@ -1,0 +1,19 @@
+- **PDF: a display equation's variables are no longer emphasised one glyph at a time**
+  (#456). An equation is typeset glyph by glyph — each variable, operator and bracket piece
+  its own span in its own font — and an italic variable is italic *because it is a
+  variable*. Wrapping each one separately produced ``*e* *c* *e* *S* *m* *R*``: markup
+  asserting that a dozen single letters are each stressed, which is neither what the page
+  means nor anything a reader or a model can use. A line is now recognised as part of a
+  display equation when two things hold together — it carries math evidence (30%+ of its
+  spans in a symbol or TeX math font, or a Private Use codepoint anywhere in it) and it is
+  at most six words. Either test alone claims real prose: 36 corpus lines of 11–24 words
+  carry a symbol span while being sentences merely *about* mathematics, and a page is full
+  of short italic lines. Because the evidence is not spread evenly down an equation — one
+  line carries the operators in a symbol font, the next only the variables in the ordinary
+  text italic — a block whose lines are half equation lines carries the rest with it.
+  Measured over 9,417 lines of three equation-heavy articles and two without: 99% of
+  evidence-bearing lines hold two words or fewer, the first prose line to carry evidence
+  holds ten, and every word cap between 3 and 8 admits the same lines and no prose at all.
+  Across the three articles this removes 1,154 emphasis markers; both control articles are
+  byte-identical, and prose that names its variables in italics — ``mass (*m*), velocity
+  (*v*), charge (*e*)`` — keeps them.

--- a/src/all2md/parsers/_pdf_math.py
+++ b/src/all2md/parsers/_pdf_math.py
@@ -1,0 +1,133 @@
+#  Copyright (c) 2025 Tom Villani, Ph.D.
+#
+# src/all2md/parsers/_pdf_math.py
+"""Recognising a display equation in a PDF's spans.
+
+A display equation is typeset glyph by glyph: each variable, operator and bracket
+piece is its own span, in its own font, positioned absolutely. PyMuPDF hands that
+back as it finds it, so one equation arrives as dozens of one-word blocks -- and
+because nothing marks them as mathematical, every rule downstream treats them as
+prose. They are wrapped in emphasis one glyph at a time (an italic variable is
+italic because it is a variable, not because it is stressed), and they interleave
+with the paragraphs around them.
+
+This module answers only the narrow question the rest of the parser needs: *is
+this line part of a display equation?* It does not attempt to read the equation.
+Reconstructing sub/superscripts and stacked constructs is a separate problem, and
+until it is solved the honest thing is to keep the glyphs together and stop them
+corrupting the text beside them.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+
+__all__ = [
+    "MATH_BLOCK_MAX_WORDS",
+    "MATH_BLOCK_MIN_LINE_SHARE",
+    "MATH_LINE_MAX_WORDS",
+    "MATH_LINE_MIN_FONT_SHARE",
+    "is_equation_block",
+    "is_equation_line",
+]
+
+# The font families a typesetter reaches for when it needs a glyph the text font
+# does not carry: Adobe Symbol, TeX's math families, MathType's extras.
+_MATH_FONT = re.compile(r"symbol|math|cmmi|cmsy|cmex|mtextra|msam|msbm", re.I)
+
+# Enough of the line's spans in a math font that the line is being *set* as math,
+# rather than a sentence reaching for one Greek letter.
+MATH_LINE_MIN_FONT_SHARE = 0.30
+
+# An equation line is a handful of glyphs, not a sentence. Measured over 9,417
+# lines of three equation-heavy articles and two without: of the lines carrying
+# math evidence, 99% hold two words or fewer, and the first prose line to carry
+# it holds ten. Every cap between 3 and 8 admits the same 2,850-2,880 lines and
+# no prose line at all, so this sits mid-plateau rather than on an edge.
+MATH_LINE_MAX_WORDS = 6
+
+
+def _private_use(text: str) -> bool:
+    """Report whether the text carries a Private Use Area codepoint.
+
+    A symbol font addresses its glyphs through the PUA, so ``0xF0B6`` reaches us
+    where the page prints an operator. The character is unreadable as it stands --
+    mapping it back through the font's encoding is its own problem -- but its
+    presence is decisive evidence that the line is not ordinary prose.
+    """
+    return any(0xE000 <= ord(char) <= 0xF8FF for char in text)
+
+
+def is_equation_line(spans: "Sequence[dict]") -> bool:
+    """Decide whether these spans are a fragment of a display equation.
+
+    Two things must hold together, because either alone claims real prose. The
+    line must carry math evidence -- a substantial share of its spans set in a
+    math font, or a Private Use codepoint anywhere in it -- and it must be short.
+    Prose reaches for a Greek letter often enough ("in terms of electronic
+    density ρ, momentum p") that evidence alone would strip the emphasis from,
+    and refuse to join, sentences that are only *about* mathematics; on the
+    corpus that is 36 lines of 11 to 24 words. Shortness alone is worse still,
+    since a page is full of short lines.
+
+    Neither test fires on an article without display equations: across 1,436
+    control lines, this returned ``True`` for none of them.
+    """
+    if not spans:
+        return False
+    text = "".join(span.get("text", "") for span in spans)
+    if len(text.split()) > MATH_LINE_MAX_WORDS:
+        return False
+    return _has_math_evidence(spans)
+
+
+def _has_math_evidence(spans: "Sequence[dict]") -> bool:
+    """Report whether these spans are set as mathematics, ignoring how long they are."""
+    if not spans:
+        return False
+    if _private_use("".join(span.get("text", "") for span in spans)):
+        return True
+    in_math_font = sum(1 for span in spans if _MATH_FONT.search(span.get("font", "")))
+    return in_math_font >= MATH_LINE_MIN_FONT_SHARE * len(spans)
+
+
+# A display equation is a few lines of glyphs, not a section of prose. This bounds the
+# block the share test below may claim, so a long paragraph that happens to quote one
+# formula keeps its own typography.
+MATH_BLOCK_MAX_WORDS = 24
+
+# Half the block's lines carrying evidence is enough to call the block math, and with it
+# the lines that carry none.
+MATH_BLOCK_MIN_LINE_SHARE = 0.5
+
+
+def is_equation_block(block: dict) -> bool:
+    """Decide whether a whole block is a display equation.
+
+    A line test alone is not enough, and the reason is worth stating. An equation is set
+    glyph by glyph across several lines, and the evidence is not spread evenly over them:
+    one line carries the operators and brackets in a symbol font, the next carries only
+    the variables, set in the ordinary text italic. That second line is indistinguishable
+    from prose *by itself* -- it is short, italic and says nothing else -- so a per-line
+    test leaves it emphasised one letter at a time in the middle of an equation it plainly
+    belongs to.
+
+    What identifies it is its neighbours. When half a block's lines carry math evidence
+    and the block is short enough not to be prose, the block is an equation and every line
+    in it is part of it.
+    """
+    lines = [line for line in (block.get("lines") or []) if line.get("spans")]
+    if not lines:
+        return False
+    text = "".join(span.get("text", "") for line in lines for span in line["spans"])
+    if len(text.split()) > MATH_BLOCK_MAX_WORDS:
+        return False
+    # Counted on the full line test, not on the evidence alone: a paragraph that names
+    # one Greek letter carries evidence on a line 22 words long, and letting that line
+    # vote lets a sentence claim the block it sits in.
+    equation_lines = sum(1 for line in lines if is_equation_line(line["spans"]))
+    return equation_lines >= MATH_BLOCK_MIN_LINE_SHARE * len(lines)

--- a/src/all2md/parsers/pdf.py
+++ b/src/all2md/parsers/pdf.py
@@ -85,6 +85,7 @@ from all2md.parsers._pdf_layout import (
     native_find_tables,
     predict_page_layout,
 )
+from all2md.parsers._pdf_math import is_equation_block, is_equation_line
 from all2md.parsers._pdf_numbering import parse_numbering_prefix
 from all2md.parsers._pdf_ocr import (
     dehyphenate_blocks,
@@ -2482,7 +2483,12 @@ class PdfToAstConverter(BaseParser):
         return None
 
     def _process_text_spans_to_inline(
-        self, spans: list[dict], links: list[dict], page_num: int, average_line_height: float | None = None
+        self,
+        spans: list[dict],
+        links: list[dict],
+        page_num: int,
+        average_line_height: float | None = None,
+        in_equation_block: bool = False,
     ) -> list[Node]:
         """Process text spans to inline AST nodes.
 
@@ -2496,6 +2502,10 @@ class PdfToAstConverter(BaseParser):
             Page number for source tracking
         average_line_height : float or None, optional
             Average line height for the page, used for link threshold auto-calibration
+        in_equation_block : bool, optional
+            Whether the block these spans came from is a display equation, in which
+            case its variables are italic because they are variables and must not be
+            emphasised one glyph at a time.
 
         Returns
         -------
@@ -2508,6 +2518,12 @@ class PdfToAstConverter(BaseParser):
         # with whitespace, so we can avoid creating multi-space runs at span
         # boundaries when collapse_excess_whitespace is enabled.
         prev_text_ends_ws = False
+        # A display equation is set glyph by glyph, and its variables are italic
+        # because they are variables (#456). Emphasising each one separately turns
+        # an equation into "*e* *c* *e* *S* *m* *R*" -- markup that says a dozen
+        # single letters are each stressed, which is not what the page means and
+        # not something a reader or a model can use.
+        in_equation = in_equation_block or is_equation_line(spans)
 
         for span in spans:
             span_text = span["text"]
@@ -2566,7 +2582,7 @@ class PdfToAstConverter(BaseParser):
                 # for whitespace-only spans, since "**  **" or "* *" carries
                 # no meaning and tends to confuse the inline-formatting
                 # consolidator into emitting redundant marker pairs.
-                if span_text.strip():
+                if span_text.strip() and not in_equation:
                     if bold:
                         inline_node = Strong(content=[inline_node])
                     if italic:
@@ -3045,13 +3061,16 @@ class PdfToAstConverter(BaseParser):
         state: _BlockProcessingState,
         page_num: int,
         average_line_height: float | None,
+        in_equation_block: bool = False,
     ) -> None:
         """Accumulate regular text line into paragraph state."""
         # Converted before the split test below rather than after it, because the conversion
         # is what turns a symbol-font bullet into a recognisable marker -- see
         # _leading_inline_text. The flush still has to happen before the empty-content
         # return, so that a line which converts to nothing keeps ending a paragraph on gap.
-        inline_content = self._process_text_spans_to_inline(spans, links, page_num, average_line_height)
+        inline_content = self._process_text_spans_to_inline(
+            spans, links, page_num, average_line_height, in_equation_block
+        )
 
         # A list item runs on across the vertical gaps that separate paragraphs -- the space
         # between two bullets is the same space that ends a paragraph -- so the gap rule is
@@ -3126,6 +3145,10 @@ class PdfToAstConverter(BaseParser):
         layout_label = block.get("_layout_label")
         state = _BlockProcessingState()
         paragraph_break_threshold = self._calculate_paragraph_break_threshold(block)
+        # Decided once for the whole block: an equation's variable-only lines carry no
+        # evidence of their own and are told apart from prose only by their neighbours
+        # (#456).
+        in_equation_block = is_equation_block(block)
 
         # Layout hint: if model says list-item, pre-set list state
         if layout_label == "list-item":
@@ -3167,7 +3190,15 @@ class PdfToAstConverter(BaseParser):
 
             # Regular paragraph text
             self._accumulate_paragraph_line(
-                line, spans, links, vertical_gap, paragraph_break_threshold, state, page_num, average_line_height
+                line,
+                spans,
+                links,
+                vertical_gap,
+                paragraph_break_threshold,
+                state,
+                page_num,
+                average_line_height,
+                in_equation_block,
             )
 
         # Finalize remaining content

--- a/tests/unit/formats/pdf/test_pdf_display_equations.py
+++ b/tests/unit/formats/pdf/test_pdf_display_equations.py
@@ -1,0 +1,126 @@
+#  Copyright (c) 2025 Tom Villani, Ph.D.
+"""A display equation's variables are not emphasised text (#456).
+
+An equation is typeset glyph by glyph: each variable, operator and bracket piece
+is its own span in its own font. An italic variable is italic *because it is a
+variable*, so wrapping each one separately turns an equation into
+``*e* *c* *e* *S* *m* *R*`` -- markup asserting that a dozen single letters are
+each stressed, which is neither what the page means nor anything a reader or a
+model can use.
+
+Two tests decide, and both must hold, because either alone claims real prose.
+The line must carry math evidence -- a substantial share of its spans in a math
+font, or a Private Use codepoint anywhere in it -- and it must be short. Prose
+reaches for a Greek letter often enough ("in terms of electronic density rho,
+momentum p") that evidence alone would strip 36 sentences on the corpus that are
+merely *about* mathematics.
+
+Evidence is not spread evenly down an equation, which is why the block test
+exists: one line carries the operators in a symbol font, the next carries only
+the variables in the ordinary text italic and is indistinguishable from prose by
+itself. Its neighbours are what identify it.
+
+The font names and codepoints here are the real ones, from PMC3000079.1 and
+PMC5000011.1 in the dev corpus.
+"""
+
+import pytest
+
+from all2md.parsers._pdf_math import is_equation_block, is_equation_line
+
+pytestmark = [pytest.mark.unit, pytest.mark.pdf]
+
+ITALIC = 2  # PyMuPDF's italic flag
+
+
+def _span(text: str, font: str = "TimesNewRoman", *, italic: bool = False) -> dict:
+    return {"text": text, "font": font, "flags": ITALIC if italic else 0}
+
+
+def _line(*spans: dict) -> dict:
+    return {"spans": list(spans)}
+
+
+class TestALineOfAnEquation:
+    def test_symbol_font_operators_are_an_equation(self) -> None:
+        """``\uf0b6`` is Symbol's partial-derivative sign, addressed through the PUA."""
+        spans = [_span("\uf0b6", "Symbol"), _span("\uf02b", "Symbol"), _span("\uf03d", "Symbol")]
+
+        assert is_equation_line(spans)
+
+    def test_a_math_font_without_private_use_is_an_equation(self) -> None:
+        """TeX's math italic carries ordinary codepoints; the font name is the evidence."""
+        spans = [_span("x", "CMMI10", italic=True), _span("=", "CMSY10"), _span("y", "CMMI10", italic=True)]
+
+        assert is_equation_line(spans)
+
+    def test_prose_naming_a_greek_letter_is_not_an_equation(self) -> None:
+        """The measured false positive: 36 corpus lines of 11-24 words carry a symbol span.
+
+        "in terms of electronic density rho, momentum p, total energy E" is a
+        sentence about mathematics, and its one Greek letter must not cost it its
+        typography.
+        """
+        spans = [
+            _span("in terms of electronic density "),
+            _span("\uf072", "Symbol"),
+            _span(", momentum p, total energy E and the chemical field"),
+        ]
+
+        assert not is_equation_line(spans)
+
+    def test_a_short_italic_line_without_math_evidence_is_not_an_equation(self) -> None:
+        """Shortness alone is worthless -- a page is full of short italic lines."""
+        spans = [_span("Int. J. Mol. Sci.", "TimesNewRoman-Italic", italic=True)]
+
+        assert not is_equation_line(spans)
+
+    def test_no_spans_is_not_an_equation(self) -> None:
+        assert not is_equation_line([])
+
+
+class TestABlockOfAnEquation:
+    def test_variables_inherit_evidence_from_their_neighbours(self) -> None:
+        """The line the per-line test cannot reach.
+
+        The second line here is variables in the text italic and nothing else --
+        prose by every signal it carries alone. The operators above it say what
+        it is.
+        """
+        block = {
+            "lines": [
+                _line(_span("\uf0e6", "Symbol"), _span("\uf0b6", "Symbol"), _span("\uf03d", "Symbol")),
+                _line(_span("x", italic=True), _span("t", italic=True), _span("S", italic=True)),
+            ]
+        }
+
+        assert is_equation_block(block)
+
+    def test_a_paragraph_quoting_one_formula_is_not_an_equation_block(self) -> None:
+        """A block long enough to be prose keeps its typography, whatever it quotes."""
+        prose = "The bondon mass is recovered from the relation above and compared against "
+        block = {
+            "lines": [
+                _line(_span(prose), _span("\uf0b6", "Symbol")),
+                _line(_span("the experimental values reported for the same series of compounds")),
+            ]
+        }
+
+        assert not is_equation_block(block)
+
+    def test_one_evidence_line_among_many_does_not_carry_the_block(self) -> None:
+        """Half the lines must agree, so a single symbol span cannot claim the rest."""
+        block = {
+            "lines": [
+                _line(_span("\uf0b6", "Symbol")),
+                _line(_span("first", italic=True)),
+                _line(_span("second", italic=True)),
+                _line(_span("third", italic=True)),
+            ]
+        }
+
+        assert not is_equation_block(block)
+
+    def test_an_empty_block_is_not_an_equation(self) -> None:
+        assert not is_equation_block({"lines": []})
+        assert not is_equation_block({})


### PR DESCRIPTION
Step 2 of #456, plus the block-level half of step 1. The issue stays open for the rest.

## The defect

An equation is typeset glyph by glyph — each variable, operator and bracket piece its own span in its own font — and an italic variable is italic **because it is a variable**. Wrapping each one separately produced:

```
2 2 2 2 *e* *c* *e* *S* *m* *R* *R* *m* *c* *e* *R* *S* *R* *t* *t*
```

Markup asserting that a dozen single letters are each stressed. Neither what the page means nor anything a reader or a model can use.

## Two tests, because either alone claims real prose

A line is part of a display equation when it carries **math evidence** — 30%+ of its spans in a symbol or TeX math font, or a Private Use codepoint anywhere in it — **and** is at most six words.

| dropping | what breaks |
|---|---|
| the length test | 36 corpus lines of 11–24 words carry a symbol span while being sentences merely *about* mathematics — `in terms of electronic density ρ, momentum p, total energy E` |
| the evidence test | a page is full of short italic lines — running heads, labels, captions |

Evidence is **not spread evenly down an equation**: one line carries the operators in a symbol font, the next carries only the variables in the ordinary text italic and is indistinguishable from prose by itself. So a block whose lines are half equation lines carries the rest with it.

That share is counted on the *full line test*, not on the evidence alone — otherwise a 22-word paragraph quoting one Greek letter claims the block it sits in. A unit test caught exactly that, and the tightening cost 10 markers.

## Thresholds sit on a plateau

Measured over **9,417 lines** of three equation-heavy articles and two without:

- 99% of evidence-bearing lines hold **two words or fewer**
- the first prose line to carry evidence holds **ten**
- every word cap between **3 and 8** admits the same 2,850–2,880 lines and **no prose line at all**

## Results

| article | emphasis markers |
|---|---|
| `PMC3000079.1` | 3,789 → 3,473 |
| `PMC5000011.1` | 1,888 → **1,312** (−31%) |
| `PMC9000011.1` | 2,112 → 1,850 |
| `PMC7000039.1` (control) | 27 → **27** |
| `PMC10000015.1` (control) | 134 → **134** |

Prose keeps its own typography — `mass (*m*), velocity (*v*), charge (*e*)` and the running head `*Int. J. Mol. Sci.*` all survive.

**Recall is untouched**, scored on the born-digital lane: attainable recall, text blocks, titles, novel share and duplication identical to five decimals. Precision rises a hair (supported 10,732 → 10,737, resequenced 1,338 → 1,332) because a stray marker had been breaking token adjacency.

## Scope — what is deliberately not here

Equations split across **several** PyMuPDF blocks still carry their emphasis: the evidence and the variables land in different blocks, so `equation (3)` in `PMC3000079.1` is unchanged. Joining them needs cross-block region grouping — the other half of step 1, which also bears on #442's fragmentation (86 of its 115 remaining mid-sentence splits are this article). Left for its own change rather than bolted on here.

I should also correct a number I quoted while scoping this: an earlier probe counted ~1,650 "noise glyphs", using a regex that cannot tell equation soup from `velocity (*v*)` in running prose. A good share of that was legitimate italics that should stay. **1,154 markers removed** is the honest figure.

## Tests

9 unit tests on the detector, covering both signals in isolation and together, the block-inheritance case, and the prose-quoting-a-formula case that the first draft got wrong. Full PDF suite green, `mypy` clean across 274 source files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)