### PR TITLE
fix(benchmarks): compare one spelling of a path in the cache containment check (#455)

### DIFF
--- a/benchmarks/pmc/corpus.py
+++ b/benchmarks/pmc/corpus.py
@@ -480,9 +480,49 @@ def _prepare_cache_dir(cache_dir: Path, manifest_sha256: str) -> Path:
     return corpus_dir
 
 
+# Win32's extended-length path spelling.  ``Path.resolve()`` normally strips it before
+# returning, but the strip is *verified* against the filesystem, and that verification
+# can fail transiently while another thread is creating a directory along the path --
+# which is exactly what the materialization workers below do to a cold cache.
+_EXTENDED_PREFIX = "\\\\?\\"
+_EXTENDED_UNC_PREFIX = "\\\\?\\UNC\\"
+
+
+def _strip_extended_prefix(resolved: str) -> str:
+    r"""Rewrite an extended-length path back to its ordinary spelling.
+
+    Kept separate from :func:`_canonical`, and taking a string rather than a ``Path``,
+    because a ``Path`` built from the prefixed spelling is already lost: ``pathlib``
+    reads ``\\?\C:`` as a UNC root, so ``Path(r"\\?\C:\cache").resolve()`` does not
+    round-trip.  The rewrite has to happen on the text ``resolve()`` returned, before
+    anything parses it again.
+    """
+    if sys.platform != "win32":
+        # A backslash is an ordinary filename character elsewhere, and a POSIX file
+        # really named ``\\?\...`` must keep its name.
+        return resolved
+    if resolved.startswith(_EXTENDED_UNC_PREFIX):
+        return "\\\\" + resolved[len(_EXTENDED_UNC_PREFIX) :]
+    if resolved.startswith(_EXTENDED_PREFIX):
+        return resolved[len(_EXTENDED_PREFIX) :]
+    return resolved
+
+
+def _canonical(path: Path) -> Path:
+    r"""Resolve to the one spelling a containment check can compare.
+
+    Two spellings of one directory are not equal to :meth:`Path.relative_to`, which
+    compares path *parts*: ``\\?\C:\cache\...`` begins with the part ``\\?\C:\`` while
+    ``C:\cache`` begins with ``C:\``.  So a containment check that resolved one side
+    while a sibling ``mkdir`` was in flight rejected a path plainly inside its own root,
+    and a cold cache materialized by more than one worker did that every time (#455).
+    """
+    return Path(_strip_extended_prefix(str(path.resolve())))
+
+
 def _require_contained(path: Path, root: Path) -> None:
     try:
-        path.resolve().relative_to(root.resolve())
+        _canonical(path).relative_to(_canonical(root))
     except ValueError as exc:
         raise CorpusCacheError(f"cache artifact escapes supplied directory: {path}") from exc
 

--- a/benchmarks/pmc/corpus.py
+++ b/benchmarks/pmc/corpus.py
@@ -488,24 +488,34 @@ _EXTENDED_PREFIX = "\\\\?\\"
 _EXTENDED_UNC_PREFIX = "\\\\?\\UNC\\"
 
 
-def _strip_extended_prefix(resolved: str) -> str:
-    r"""Rewrite an extended-length path back to its ordinary spelling.
+# Branched at module level, like `_acquire_lock` below, so a type checker analyses only
+# the branch that exists on the host rather than reporting the other one unreachable.
+if sys.platform == "win32":
 
-    Kept separate from :func:`_canonical`, and taking a string rather than a ``Path``,
-    because a ``Path`` built from the prefixed spelling is already lost: ``pathlib``
-    reads ``\\?\C:`` as a UNC root, so ``Path(r"\\?\C:\cache").resolve()`` does not
-    round-trip.  The rewrite has to happen on the text ``resolve()`` returned, before
-    anything parses it again.
-    """
-    if sys.platform != "win32":
-        # A backslash is an ordinary filename character elsewhere, and a POSIX file
-        # really named ``\\?\...`` must keep its name.
+    def _strip_extended_prefix(resolved: str) -> str:
+        r"""Rewrite an extended-length path back to its ordinary spelling.
+
+        Kept separate from :func:`_canonical`, and taking a string rather than a ``Path``,
+        because a ``Path`` built from the prefixed spelling is already lost: ``pathlib``
+        reads ``\\?\C:`` as a UNC root, so ``Path(r"\\?\C:\cache").resolve()`` does not
+        round-trip.  The rewrite has to happen on the text ``resolve()`` returned, before
+        anything parses it again.
+        """
+        if resolved.startswith(_EXTENDED_UNC_PREFIX):
+            return "\\\\" + resolved[len(_EXTENDED_UNC_PREFIX) :]
+        if resolved.startswith(_EXTENDED_PREFIX):
+            return resolved[len(_EXTENDED_PREFIX) :]
         return resolved
-    if resolved.startswith(_EXTENDED_UNC_PREFIX):
-        return "\\\\" + resolved[len(_EXTENDED_UNC_PREFIX) :]
-    if resolved.startswith(_EXTENDED_PREFIX):
-        return resolved[len(_EXTENDED_PREFIX) :]
-    return resolved
+
+else:
+
+    def _strip_extended_prefix(resolved: str) -> str:
+        r"""Return the path unchanged: only Win32 has an extended-length spelling.
+
+        A backslash is an ordinary filename character here, so a file really named
+        ``\\?\...`` must keep its name.
+        """
+        return resolved
 
 
 def _canonical(path: Path) -> Path:

--- a/changelog.d/455-cache-containment-spellings.fixed.md
+++ b/changelog.d/455-cache-containment-spellings.fixed.md
@@ -1,0 +1,15 @@
+- **benchmarks/pmc: a cold corpus cache no longer rejects its own directories** (#455).
+  Materializing more than one article ran the workers concurrently, and each called
+  ``mkdir(parents=True)`` on the shared ``articles/`` parent. ``Path.resolve()`` normally
+  strips Win32's ``\?\`` extended-length prefix before returning, but that strip is
+  verified against the filesystem and the verification fails while a sibling directory is
+  being created — so one worker resolved ``\?\C:\cache\…\PMC1.1`` while the corpus root
+  resolved to plain ``C:\cache\…``. ``relative_to`` compares path *parts*, and the
+  prefixed spelling begins with ``\?\C:\`` rather than ``C:\``, so the containment check
+  reported that a directory had escaped the root it was plainly inside. The check now
+  compares one spelling of each path. It was only ever a cold cache and only ever more
+  than one article — a single article materializes on the calling thread, and once
+  ``articles/`` exists there is no ``mkdir`` left to race — which is why it read as a
+  Windows flake rather than a defect. Scoring any manifest subset on a cold cache failed
+  outright; ``test_a_withdrawn_article_does_not_disturb_the_others`` was intermittently
+  red for the same reason.

--- a/tests/unit/test_pmc_corpus.py
+++ b/tests/unit/test_pmc_corpus.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import hashlib
 import json
+import sys
 from pathlib import Path
 from typing import Any
 
@@ -694,7 +695,7 @@ def test_jats_blocks_join_with_a_separator() -> None:
     from benchmarks.pmc.alignment import jats_blocks, normalize
 
     root = ElementTree.fromstring(
-        "<article><table-wrap><label>Table 2</label>" "<caption><p>Obtained values</p></caption></table-wrap></article>"
+        "<article><table-wrap><label>Table 2</label><caption><p>Obtained values</p></caption></table-wrap></article>"
     )
     table = next(text for kind, text in jats_blocks(root) if kind == "table-wrap")
 
@@ -872,3 +873,68 @@ def test_equal_scoring_pages_break_toward_the_earliest() -> None:
     placement = place_block(block, [_grams(text), _grams("filler"), _grams(text)])
 
     assert placement.page == 0
+
+
+_ON_WINDOWS = pytest.mark.skipif(sys.platform != "win32", reason="the extended-length prefix is Win32-only")
+
+
+class TestCacheContainmentAcrossPathSpellings:
+    r"""A cold cache materialized by more than one worker rejected its own paths (#455).
+
+    ``Path.resolve()`` normally strips Win32's ``\\?\`` extended-length prefix before
+    returning, but the strip is verified against the filesystem, and that verification
+    fails while another thread is creating a directory along the path.  The workers do
+    exactly that: each calls ``mkdir(parents=True)`` on ``articles/``, so on a cold cache
+    one thread resolves ``\\?\C:\cache\...\PMC1.1`` while the corpus root resolves to
+    plain ``C:\cache\...``.  ``relative_to`` compares path *parts*, and the prefixed
+    spelling begins with ``\\?\C:\`` rather than ``C:\``, so the check reported that a
+    directory had escaped the root it was plainly inside.
+
+    Only a cold cache, and only more than one article: ``_materialize`` runs a single
+    article on the calling thread, and once ``articles/`` exists there is no mkdir left
+    to race.  That is why it read as a flake for so long.
+    """
+
+    @_ON_WINDOWS
+    def test_the_extended_length_prefix_is_rewritten(self) -> None:
+        assert corpus._strip_extended_prefix(r"\\?\C:\cache\corpus\PMC1.1") == r"C:\cache\corpus\PMC1.1"
+
+    @_ON_WINDOWS
+    def test_a_unc_extended_path_keeps_its_share(self) -> None:
+        assert corpus._strip_extended_prefix(r"\\?\UNC\server\share\cache") == r"\\server\share\cache"
+
+    @_ON_WINDOWS
+    def test_the_two_spellings_compare_as_the_same_directory(self, tmp_path: Path) -> None:
+        """The comparison itself, with both spellings forced rather than raced."""
+        child = tmp_path / "corpus" / "articles" / "PMC1.1"
+        child.mkdir(parents=True)
+
+        prefixed = Path(corpus._strip_extended_prefix("\\\\?\\" + str(child)))
+
+        assert prefixed.relative_to(corpus._canonical(tmp_path / "corpus")) == Path("articles/PMC1.1")
+
+    def test_an_ordinary_path_is_left_alone(self) -> None:
+        assert corpus._strip_extended_prefix("/var/cache/corpus") == "/var/cache/corpus"
+
+    @pytest.mark.skipif(sys.platform == "win32", reason="a backslash is an ordinary filename character on POSIX")
+    def test_a_posix_file_really_named_that_keeps_its_name(self) -> None:
+        assert corpus._strip_extended_prefix("\\\\?\\odd") == "\\\\?\\odd"
+
+    def test_a_path_outside_the_root_is_still_rejected(self, tmp_path: Path) -> None:
+        """Not a licence to skip the check -- an escaping path must still be refused."""
+        root = tmp_path / "corpus"
+        root.mkdir()
+
+        with pytest.raises(corpus.CorpusCacheError, match="escapes supplied directory"):
+            corpus._require_contained(root / ".." / ".." / "elsewhere", root)
+
+    def test_a_cold_cache_materializes_concurrently(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        """The regression itself: several workers, twelve articles, nothing on disk yet."""
+        article_ids = [f"PMC{2000000 + index}.1" for index in range(12)]
+        manifest_path = _write_manifest(tmp_path, _manifest_payload(article_ids))
+        _install_downloader(monkeypatch)
+
+        snapshot = corpus.load_corpus(tmp_path / "cache", manifest_path=manifest_path, workers=8)
+
+        assert [article.article_id for article in snapshot.articles] == article_ids
+        assert snapshot.complete is True


### PR DESCRIPTION
Closes #455.

## Not a flake

I wrote this off as a Windows flake twice. It is a real defect, and it is deterministic:
driving `_materialize` over twelve articles on eight workers raised it **30 times out of 30**.

Materializing more than one article runs the workers concurrently, and each calls
`mkdir(parents=True)` on the shared `articles/` parent. `Path.resolve()` normally strips
Win32's `\?\` extended-length prefix before returning — but that strip is *verified*
against the filesystem, and the verification fails while a sibling directory is being
created. So one worker resolves

```
path : \?\C:\Users\...\abcdef1234567890\articles\PMC5.1
root :     C:\Users\...\abcdef1234567890
```

`relative_to` compares path **parts**, and `\?\C:\...` begins with the part `\?\C:\`
while the root begins with `C:\`. The check then reports that a directory has escaped the
root it is plainly inside.

## Why it looked like a flake

```python
if len(selected) == 1:   outcomes = [materialize(selected[0])]   # calling thread — always fine
else:                    ThreadPoolExecutor(...)                 # races
```

A one-article manifest always passes. And it only bites a **cold** cache — once
`articles/` exists there is no `mkdir` left to race, and every later resolve is
consistent. Linux never sees it at all, since `\?\` does not exist there.

## Consequences it was actually causing

- **Scoring any manifest subset on a cold cache failed outright.** During #442 I worked
  around it by copying article directories in by hand.
- `test_a_withdrawn_article_does_not_disturb_the_others` (which runs `workers=2`) was
  intermittently red on Windows.

## The fix

The containment check now compares one spelling of each path. The rewrite is a separate
string-level function on purpose: a `Path` built from the prefixed spelling is already
lost — pathlib reads `\?\C:` as a UNC root, so `Path(r"\?\C:\cache").resolve()` does not
round-trip. It has to happen on the text `resolve()` returned, before anything parses it
again. Windows only; a backslash is an ordinary filename character elsewhere and a POSIX
file really named `\?\...` must keep its name.

## Verified both ways

- The new `test_a_cold_cache_materializes_concurrently` (12 articles, 8 workers, nothing
  on disk) **fails with the rewrite neutralised** and passes with it — so the guard bites.
- Scoring a fresh four-article subset now materializes a cold cache that previously failed.
- `test_a_path_outside_the_root_is_still_rejected` — this is not a licence to skip the check.
- UNC extended paths keep their share; POSIX strings are untouched.

Full `test_pmc_corpus.py` green; ruff and mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
