### PR TITLE
fix(pdf): stop one gutter-crossing block erasing a two-column page (#440)

### DIFF
--- a/changelog.d/440-column-crossing-tolerance.fixed.md
+++ b/changelog.d/440-column-crossing-tolerance.fixed.md
@@ -1,0 +1,22 @@
+- **PDF: a single block printed across the gutter no longer erases a two-column page**
+  (#440). The channel test merges the blocks' x-intervals and reads the complement as the
+  gutter, which is all-or-nothing: one block bridging it fuses the two runs, the page has
+  no channel at all, and it is read line by line in y — so both columns interleave and
+  every adjacency dies, even though dozens of blocks on each side agree where the gutter
+  is. #445 and #450 handled the common culprit, page *furniture*, by trimming bands off
+  the ends; a block in the middle of the body is not reachable that way, because no band
+  trim will ever discard it. A last-resort search now asks the question the other way
+  round — for each candidate x, how many blocks does it cut? — and tolerates one crosser.
+  Three guards keep it honest. The page must name exactly **one** gutter: several is the
+  signature of an undetected table rather than a layout, and one held-out page offers
+  twelve. The two sides must be **columns**, comparable in width: a title page sets its
+  affiliations 123pt wide beside a 317pt abstract, and reading that as two columns hoists
+  the introduction above the article's own title (distance from the page centre does *not*
+  separate the two — the sidebar and a genuinely repaired reference page sit 8.9% off it
+  each). And it runs only after every other detector has read the page as a **single
+  column**, because that single-column reading is the defect it repairs; run any earlier
+  it overrides the gap fallback on five pages and costs 20 supported n-grams. Across the
+  110-article held-out corpus it moves 4 pages of 1,184, all of them from one column to
+  two, for **+31 supported n-grams and one block's containment rising 0.93 → 1.00**, with
+  no article and no block worse. Nothing is discarded: the crossing block is still
+  emitted, and every block on the page still votes.

--- a/src/all2md/constants.py
+++ b/src/all2md/constants.py
@@ -803,6 +803,30 @@ PDF_COLUMN_CHANNEL_MIN_Y_OVERLAP_RATIO = 0.3  # Of the smaller side's y-span
 # trim that would discard body discards 14.8% or more, so this bar sits about 2.5x
 # clear of each side of a 6x gap.
 PDF_COLUMN_CHANNEL_MAX_TRIM_HEIGHT_SHARE = 0.06
+# How many blocks may cross the gutter before a channel is refused (#440). The channel
+# test above is all-or-nothing: it merges the x-intervals and reads the complement, so a
+# *single* block bridging the gutter fuses the two runs and erases a channel that dozens
+# of blocks on each side support. Page furniture was the common culprit and the trim
+# above handles it, but a stray body block does it too -- a wide figure label, a formula
+# set across the measure.
+#
+# One is deliberately not two. Over the 110-article held-out corpus, allowing one crosser
+# while still demanding the page name exactly one gutter moves 7 pages of 1,184; allowing
+# two moves 9 and three moves 7, and the extra pages at those settings are the weak ones
+# (three blocks a side, a gutter nowhere near the page centre). The uniqueness demand is
+# what keeps this honest: several admissible gutters on one page is the signature of an
+# undetected table, and one held-out page offers twelve of them.
+PDF_COLUMN_CHANNEL_MAX_CROSSING_BLOCKS = 1
+# How unequal the two sides of a tolerated gutter may be (#440). Allowing a crosser lets
+# the search see gutters the strict test never had to judge, and one of them is not a
+# layout at all: a title page sets its affiliations 123pt wide beside a 317pt abstract,
+# and reading that as two columns hoists the introduction above the article's own title.
+# A journal sets its real columns to one measure -- every held-out page this repairs
+# divides 240-260pt against 240-260pt, a ratio of 0.94 to 1.00, against 0.39 for the
+# title page. Distance from the page centre does NOT separate them: the affiliation
+# sidebar and a repaired reference page both sit 8.9% off it. The admitted set is
+# identical anywhere in 0.6-0.7, so this sits in the middle of that plateau.
+PDF_COLUMN_CHANNEL_MIN_WIDTH_SYMMETRY = 0.65
 
 # Line-level resegmentation of gutter-merged blocks (#405). On 64 of 455 dev-corpus
 # pages PyMuPDF fuses both columns of a tight-gutter page into a single block, so no

--- a/src/all2md/parsers/_pdf_columns.py
+++ b/src/all2md/parsers/_pdf_columns.py
@@ -15,9 +15,11 @@ from collections import defaultdict
 
 from all2md.constants import (
     DEFAULT_COLUMN_GAP_THRESHOLD,
+    PDF_COLUMN_CHANNEL_MAX_CROSSING_BLOCKS,
     PDF_COLUMN_CHANNEL_MAX_TRIM_HEIGHT_SHARE,
     PDF_COLUMN_CHANNEL_MIN_BLOCKS_PER_SIDE,
     PDF_COLUMN_CHANNEL_MIN_WIDTH,
+    PDF_COLUMN_CHANNEL_MIN_WIDTH_SYMMETRY,
     PDF_COLUMN_CHANNEL_MIN_Y_OVERLAP_RATIO,
     PDF_COLUMN_FREQ_THRESHOLD_RATIO,
     PDF_COLUMN_GAP_QUANTIZATION,
@@ -416,11 +418,84 @@ def _channel_boundaries(kept: list[tuple[float, float, float, float]]) -> list[f
     return boundaries
 
 
+def _tolerant_boundaries(kept: list[tuple[float, float, float, float]], max_crossing: int) -> list[float]:
+    """Find the page's gutter when a handful of blocks are printed across it (#440).
+
+    :func:`_channel_boundaries` reads the complement of the merged x-intervals, so it
+    cannot see a gutter at all once anything bridges it: one block fuses the two runs and
+    the page has no channel to report. This asks the question the other way round --
+    *for each candidate x, how many blocks does it cut?* -- which survives a crosser.
+
+    Every other guard is unchanged, and two more are added, because tolerating a crosser
+    admits gutters the strict test never had to judge.
+
+    The result must be unique. Several admissible gutters on one page is the signature of
+    an undetected table rather than a layout, and a held-out reference page offers twelve;
+    without the uniqueness demand this would claim it.
+
+    And the two sides must be *columns* -- comparable in width. A journal sets its two
+    columns to one measure, so every page this repairs divides 240-260pt against 240-260pt.
+    A title page does not: its affiliations run 123pt beside a 317pt abstract, and reading
+    that as two columns hoists the introduction above the article's own title. Nothing else
+    separates the two, the offset from the page centre least of all -- the affiliation
+    sidebar and a repaired reference page sit equally far off it, at 8.9% each.
+
+    Returns
+    -------
+    list of float
+        The single admitted gutter, or empty. Never more than one entry: a page naming
+        several is refused outright rather than split on the best of them.
+
+    """
+    if len(kept) < 2 * PDF_COLUMN_CHANNEL_MIN_BLOCKS_PER_SIDE:
+        return []
+    margin = PDF_COLUMN_CHANNEL_MIN_WIDTH / 2
+    candidates = sorted({edge for bbox in kept for edge in (bbox[0], bbox[2], (bbox[0] + bbox[2]) / 2)})
+
+    admitted: list[tuple[float, int, int]] = []
+    for x in candidates:
+        left = [bbox for bbox in kept if bbox[2] <= x - margin]
+        right = [bbox for bbox in kept if bbox[0] >= x + margin]
+        if len(left) < PDF_COLUMN_CHANNEL_MIN_BLOCKS_PER_SIDE or len(right) < PDF_COLUMN_CHANNEL_MIN_BLOCKS_PER_SIDE:
+            continue
+        crossing = sum(1 for bbox in kept if bbox[0] < x < bbox[2])
+        if crossing > max_crossing:
+            continue
+        left_width = max(b[2] for b in left) - min(b[0] for b in left)
+        right_width = max(b[2] for b in right) - min(b[0] for b in right)
+        widest = max(left_width, right_width)
+        if widest <= 0 or min(left_width, right_width) < PDF_COLUMN_CHANNEL_MIN_WIDTH_SYMMETRY * widest:
+            continue
+        left_y0, left_y1 = min(b[1] for b in left), max(b[3] for b in left)
+        right_y0, right_y1 = min(b[1] for b in right), max(b[3] for b in right)
+        overlap = min(left_y1, right_y1) - max(left_y0, right_y0)
+        smaller_span = min(left_y1 - left_y0, right_y1 - right_y0)
+        if smaller_span <= 0 or overlap < PDF_COLUMN_CHANNEL_MIN_Y_OVERLAP_RATIO * smaller_span:
+            continue
+        admitted.append((x, crossing, min(len(left), len(right))))
+    if not admitted:
+        return []
+
+    # Adjacent candidates describe the same gutter -- every x across its width qualifies --
+    # so they are grouped before the page is judged to name one or several.
+    groups: list[list[tuple[float, int, int]]] = [[admitted[0]]]
+    for candidate in admitted[1:]:
+        if candidate[0] - groups[-1][-1][0] <= PDF_COLUMN_CHANNEL_MIN_WIDTH:
+            groups[-1].append(candidate)
+        else:
+            groups.append([candidate])
+    if len(groups) != 1:
+        return []
+    best = min(groups[0], key=lambda entry: (entry[1], -entry[2]))
+    return [best[0]]
+
+
 def _detect_columns_by_channel(
     blocks: list,
     block_ranges: list[tuple[float, float]],
     page_width: float,
     spanning_threshold: float,
+    allow_crossing: bool = False,
 ) -> list[list[dict]] | None:
     """Admit tight-gutter columns on structural evidence (#405).
 
@@ -463,6 +538,11 @@ def _detect_columns_by_channel(
         (headings, full-width paragraphs): they neither define nor veto a
         channel, and are assigned to a column by center like the other
         detectors do.
+    allow_crossing : bool, default False
+        Whether to fall back on :func:`_tolerant_boundaries`, which admits a gutter
+        a block or two are printed across. Off for the ordinary attempt and on only
+        for the last one, once every other detector has read the page as a single
+        column -- that single-column reading is the defect it repairs (#440).
 
     Returns
     -------
@@ -511,7 +591,15 @@ def _detect_columns_by_channel(
                 boundaries, furniture, kept = candidates, trimmed, body
                 break
         else:
-            return None
+            # Last resort: the gutter is there but something is printed across it, so
+            # the complement of the merged x-runs cannot see it (#440). Furniture is
+            # the common culprit and the trim above handles it; a stray body block --
+            # a wide figure label, a formula set across the measure -- is not reachable
+            # that way, because it sits in the middle of the body and no band trim
+            # will ever discard it.
+            boundaries = _tolerant_boundaries(kept, PDF_COLUMN_CHANNEL_MAX_CROSSING_BLOCKS) if allow_crossing else []
+            if not boundaries:
+                return None
 
     content_top = min(bbox[1] for bbox in kept)
     content_bottom = max(bbox[3] for bbox in kept)
@@ -808,4 +896,15 @@ def detect_columns(
             return columns
 
     # Fallback to simple gap detection
-    return _detect_columns_by_gaps(blocks, block_ranges, x_coords, column_gap_threshold, force_multi_column)
+    fallback = _detect_columns_by_gaps(blocks, block_ranges, x_coords, column_gap_threshold, force_multi_column)
+    if len(fallback) > 1 or column_gap_threshold > DEFAULT_COLUMN_GAP_THRESHOLD:
+        return fallback
+
+    # Truly last resort: the page reads as one column, so its two sides are about to be
+    # sorted together in y and interleaved line by line. Only now is it worth admitting a
+    # gutter with something printed across it (#440) -- the defect this repairs *is* the
+    # single-column reading, so a page that already found columns has nothing to repair.
+    # Measured over the held-out corpus, tolerating a crosser ahead of this fallback moved
+    # five pages away from a multi-column answer and cost 20 supported n-grams; used here,
+    # it repairs four pages and gains 31.
+    return _detect_columns_by_channel(blocks, block_ranges, page_width, spanning_threshold, True) or fallback

--- a/tests/unit/formats/pdf/test_pdf_column_channel_footer.py
+++ b/tests/unit/formats/pdf/test_pdf_column_channel_footer.py
@@ -26,7 +26,8 @@ a 20.7pt gutter, with the footer printed at both distances.
 
 import pytest
 
-from all2md.parsers._pdf_columns import detect_columns
+from all2md.constants import PDF_COLUMN_CHANNEL_MAX_TRIM_HEIGHT_SHARE
+from all2md.parsers._pdf_columns import _furniture_trims, detect_columns
 
 pytestmark = [pytest.mark.unit, pytest.mark.pdf]
 
@@ -97,21 +98,44 @@ class TestFooterDoesNotVetoTheChannel:
 class TestOnlyFurnitureIsDiscarded:
     """A band big enough to be a column is body, and body never gets dropped."""
 
-    def test_a_figure_split_body_is_left_alone(self) -> None:
-        """Two substantial bands with a bridging block: no guess about which half.
-
-        Dropping the smaller band here would admit a channel on half a page's
-        evidence. Measured on the held-out corpus, every page this rejects would
-        have discarded 6, 17, 27 or 39 blocks, against exactly 2 for every page
-        it accepts.
-        """
+    @staticmethod
+    def _figure_split_body() -> list[dict]:
+        """Two substantial two-column bands with a block bridging the gutter."""
         upper = [{"bbox": [28.3, 50.0 + i * 30.0, GUTTER_LEFT, 78.0 + i * 30.0]} for i in range(4)]
         upper += [{"bbox": [GUTTER_RIGHT, 50.0 + i * 30.0, PAGE_RIGHT, 78.0 + i * 30.0]} for i in range(4)]
         lower = [{"bbox": [28.3, 400.0 + i * 30.0, GUTTER_LEFT, 428.0 + i * 30.0]} for i in range(4)]
         lower += [{"bbox": [GUTTER_RIGHT, 400.0 + i * 30.0, PAGE_RIGHT, 428.0 + i * 30.0]} for i in range(4)]
-        bridge = [{"bbox": [211.5, 404.0, 383.7, 415.0]}]
+        return upper + lower + [{"bbox": [211.5, 404.0, 383.7, 415.0]}]
 
-        assert len(detect_columns(upper + lower + bridge)) == 1
+    def test_no_trim_will_discard_a_band_big_enough_to_be_a_column(self) -> None:
+        """The guard itself: no guess about which half of the page is body.
+
+        Dropping the smaller band here would admit a channel on half a page's
+        evidence. Measured on the held-out corpus, every page this rejects would
+        have discarded 6, 17, 27 or 39 blocks, against exactly 2 for every page
+        it accepts. Asserted against the trims directly rather than through a
+        column count, because the two say different things about this page --
+        see the test below.
+        """
+        boxes = [tuple(block["bbox"]) for block in self._figure_split_body()]
+
+        assert _furniture_trims(boxes, PDF_COLUMN_CHANNEL_MAX_TRIM_HEIGHT_SHARE) == []
+
+    def test_the_page_still_splits_on_evidence_that_discards_nothing(self) -> None:
+        """It is a two-column page, and #440's crossing tolerance now reads it as one.
+
+        This assertion used to be ``== 1``. Nothing about the trim guard above has
+        weakened -- it still refuses this page outright. What changed is that a
+        *last resort* now runs after every other detector has read the page as a
+        single column: it tolerates the bridging block instead of discarding
+        anything, so all 17 blocks vote and the bridge is still emitted. The harm
+        the guard above exists to prevent -- admitting a channel on half a page's
+        evidence, the other half thrown away -- cannot arise on that path.
+        """
+        blocks = self._figure_split_body()
+
+        assert len(detect_columns(blocks)) == 2
+        assert all(any(block in column for column in detect_columns(blocks)) for block in blocks)
 
     def test_a_single_column_page_is_not_split_by_stripping_its_footer(self) -> None:
         """Removing furniture must not manufacture a channel out of nothing."""

--- a/tests/unit/formats/pdf/test_pdf_column_crossing_tolerance.py
+++ b/tests/unit/formats/pdf/test_pdf_column_crossing_tolerance.py
@@ -1,0 +1,154 @@
+"""One block printed across the gutter must not erase the whole channel (#440).
+
+``_detect_columns_by_channel`` merges the blocks' x-intervals and reads the
+complement as the gutter. That test is all-or-nothing: a *single* block bridging
+the gutter fuses the two runs, the page has no channel at all, and it is read
+line-by-line in y -- so both columns interleave and every adjacency dies, even
+though dozens of blocks on each side agree where the gutter is.
+
+Page furniture was the common culprit and #445 handles it by trimming bands off
+the ends of the page. A block in the middle of the body is not reachable that
+way: no band trim will ever discard it. A wide figure label, or a formula set
+across the measure, still erases the channel.
+
+The tolerant search asks the question the other way round -- for each candidate
+x, how many blocks does it cut? -- which survives a crosser. What keeps that
+honest is uniqueness: several admissible gutters on one page is the signature of
+an undetected table, not a layout, and one held-out reference page offers twelve.
+
+The geometry is the real thing, from page 6 of PMC7250022.1 in the held-out
+corpus: a 569pt page with its gutter at x=297.6.
+"""
+
+import pytest
+
+from all2md.constants import PDF_COLUMN_CHANNEL_MAX_CROSSING_BLOCKS
+from all2md.parsers._pdf_columns import _tolerant_boundaries, detect_columns
+
+pytestmark = [pytest.mark.unit, pytest.mark.pdf]
+
+GUTTER_LEFT, GUTTER_RIGHT = 288.0, 307.0
+PAGE_RIGHT = 569.0
+
+
+def _two_columns(rows: int = 8) -> list[dict]:
+    """A two-column page: ``rows`` stacked blocks each side of a 19pt gutter."""
+    blocks = []
+    for i in range(rows):
+        top = 50.0 + i * 36.0
+        blocks.append({"bbox": [28.0, top, GUTTER_LEFT, top + 35.0]})
+        blocks.append({"bbox": [GUTTER_RIGHT, top, PAGE_RIGHT, top + 35.0]})
+    return blocks
+
+
+def _crossing_block(top: float = 200.0) -> dict:
+    """A body block printed across the gutter -- a wide figure label."""
+    return {"bbox": [180.0, top, 420.0, top + 12.0]}
+
+
+def _boxes(blocks: list[dict]) -> list[tuple[float, float, float, float]]:
+    return [tuple(block["bbox"]) for block in blocks]
+
+
+class TestOneCrossingBlock:
+    def test_a_clean_two_column_page_splits(self) -> None:
+        """The control: without a crosser this page always split."""
+        assert len(detect_columns(_two_columns(), 20)) == 2
+
+    def test_a_single_crossing_block_no_longer_erases_the_channel(self) -> None:
+        blocks = [*_two_columns(), _crossing_block()]
+
+        assert len(detect_columns(blocks, 20)) == 2
+
+    def test_the_crossing_block_is_still_emitted(self) -> None:
+        """Tolerating it must not mean dropping it."""
+        crosser = _crossing_block()
+        columns = detect_columns([*_two_columns(), crosser], 20)
+
+        assert any(crosser in column for column in columns)
+
+    def test_the_columns_keep_their_own_blocks(self) -> None:
+        """Every left block lands left of every right block, which is the whole point."""
+        columns = detect_columns([*_two_columns(), _crossing_block()], 20)
+        left, right = columns[0], columns[-1]
+
+        assert all(block["bbox"][2] <= GUTTER_LEFT for block in left if block["bbox"][0] < 100)
+        assert all(block["bbox"][0] >= GUTTER_RIGHT for block in right if block["bbox"][0] > 300)
+
+
+class TestWhatTheToleranceRefuses:
+    def test_more_crossers_than_allowed_still_veto(self) -> None:
+        crossers = [_crossing_block(200.0 + 40 * i) for i in range(PDF_COLUMN_CHANNEL_MAX_CROSSING_BLOCKS + 1)]
+
+        assert _tolerant_boundaries(_boxes([*_two_columns(), *crossers]), PDF_COLUMN_CHANNEL_MAX_CROSSING_BLOCKS) == []
+
+    def test_a_page_naming_several_gutters_is_refused_outright(self) -> None:
+        """An undetected table offers many admissible gutters; a layout offers one.
+
+        Refused rather than split on the best of them -- picking a winner among
+        several is how a table's column structure becomes the page's.
+        """
+        grid = []
+        for row in range(8):
+            top = 50.0 + row * 36.0
+            for x0 in (28.0, 150.0, 280.0, 410.0):
+                grid.append({"bbox": [x0, top, x0 + 100.0, top + 35.0]})
+
+        assert _tolerant_boundaries(_boxes(grid), PDF_COLUMN_CHANNEL_MAX_CROSSING_BLOCKS) == []
+
+    def test_too_few_blocks_a_side_is_refused(self) -> None:
+        """A crossing allowance does not lower the evidence bar the sides must clear."""
+        thin = _two_columns(rows=1)
+
+        assert _tolerant_boundaries(_boxes([*thin, _crossing_block()]), PDF_COLUMN_CHANNEL_MAX_CROSSING_BLOCKS) == []
+
+    def test_sides_that_do_not_overlap_in_y_are_refused(self) -> None:
+        """Stacked, not side by side.
+
+        A y-sort cannot interleave these, so there is nothing for a channel to repair.
+        """
+        stacked = []
+        for i in range(6):
+            stacked.append({"bbox": [28.0, 50.0 + i * 36.0, GUTTER_LEFT, 85.0 + i * 36.0]})
+        for i in range(6):
+            stacked.append({"bbox": [GUTTER_RIGHT, 600.0 + i * 36.0, PAGE_RIGHT, 635.0 + i * 36.0]})
+
+        assert _tolerant_boundaries(_boxes(stacked), PDF_COLUMN_CHANNEL_MAX_CROSSING_BLOCKS) == []
+
+    def test_an_indented_quotation_does_not_make_a_gutter(self) -> None:
+        """It overlaps the body in x, so no candidate x separates the two sides."""
+        body = [{"bbox": [28.0, 50.0 + i * 36.0, PAGE_RIGHT, 85.0 + i * 36.0]} for i in range(6)]
+        quote = [{"bbox": [80.0, 300.0 + i * 20.0, 500.0, 318.0 + i * 20.0]} for i in range(3)]
+
+        assert _tolerant_boundaries(_boxes([*body, *quote]), PDF_COLUMN_CHANNEL_MAX_CROSSING_BLOCKS) == []
+
+    def test_no_blocks_names_no_gutter(self) -> None:
+        assert _tolerant_boundaries([], PDF_COLUMN_CHANNEL_MAX_CROSSING_BLOCKS) == []
+
+
+class TestTheSidesMustBeColumns:
+    """Tolerating a crosser exposes gutters the strict test never had to judge.
+
+    One of them is not a layout at all. A journal title page sets its affiliations
+    in a narrow band beside a wide abstract, and reading that as two columns hoists
+    the introduction above the article's own title -- which is what PMC8250095.2
+    did before this guard, at 123pt against 317pt.
+    """
+
+    def _lopsided(self) -> list[dict]:
+        """A narrow affiliation sidebar beside a wide abstract, as on a title page."""
+        blocks = [{"bbox": [28.0, 100.0 + i * 30.0, 151.0, 128.0 + i * 30.0]} for i in range(5)]
+        blocks += [{"bbox": [175.0, 100.0 + i * 30.0, 492.0, 128.0 + i * 30.0]} for i in range(5)]
+        return blocks
+
+    def test_a_narrow_sidebar_beside_a_wide_body_is_not_two_columns(self) -> None:
+        assert _tolerant_boundaries(_boxes(self._lopsided()), PDF_COLUMN_CHANNEL_MAX_CROSSING_BLOCKS) == []
+
+    def test_two_columns_of_one_measure_still_qualify(self) -> None:
+        """The control for the guard above: equal columns are what a journal sets."""
+        found = _tolerant_boundaries(
+            _boxes([*_two_columns(), _crossing_block()]), PDF_COLUMN_CHANNEL_MAX_CROSSING_BLOCKS
+        )
+
+        assert len(found) == 1
+        assert GUTTER_LEFT < found[0] < GUTTER_RIGHT


### PR DESCRIPTION
Takes the **proportional veto** the issue names as its second suggestion, and which #445
deliberately did not attempt.

## The defect

`_channel_boundaries` merges the blocks' x-intervals and reads the complement as the
gutter. That is all-or-nothing: **one** block bridging the gutter fuses the two runs, the
page has no channel at all, and it is read line by line in y — so both columns interleave
and every adjacency dies, though dozens of blocks a side agree where the gutter is.

#445 and #450 handled the common culprit, page *furniture*, by trimming bands off the
ends. A block in the middle of the body is not reachable that way: no band trim will ever
discard it.

## What this does

A last-resort search asks the question the other way round — *for each candidate x, how
many blocks does it cut?* — and tolerates one crosser. **Three guards, each earned by a
page it otherwise got wrong.**

| guard | the page that taught it |
|---|---|
| exactly **one** gutter | several is an undetected table, not a layout — one held-out page offers **twelve** |
| sides comparable in **width** | a title page: 123pt of affiliations beside a 317pt abstract, split so the introduction landed above the article's own title |
| **last resort** only | run ahead of the gap fallback it overrode five pages that already had columns, costing 20 supported n-grams |

Worth stating because it is the rule one reaches for first and it fails: **distance from
the page centre does not separate the good from the bad.** The affiliation sidebar and a
genuinely repaired reference page sit **8.9% off centre each**. Only the column widths tell
them apart — 0.39 against 0.94–1.00.

The last-resort placement is not a tuning choice: the single-column reading *is* the defect
being repaired, so a page that already found columns has nothing to repair.

## Measured

Replayed `detect_columns` over recorded geometry for all **1,184** held-out pages. The
recording reproduces `main` on **every one** — that control is what licenses the replay.
Then the affected articles were scored against their own JATS, both sides from one
committed tree.

**4 pages move, all from one column to two:**

| article | supported n-grams | emitted | block shares |
|---|---|---|---|
| PMC5750208.1 | 8,516 → **8,521** (+5) | 9,652 → 9,645 | — |
| PMC6250011.1 | 7,894 → **7,901** (+7) | 8,570 → 8,577 | — |
| PMC7250022.1 | 8,225 → **8,244** (+19) | 8,780 → 8,779 | **0.93 → 1.00** |

**+31 supported n-grams, one block's containment to 1.00, no article and no block worse.**

Nothing is discarded — the crossing block is still emitted and every block still votes.

### What it looks like

`PMC7250022.1` p6, word count identical (9694 → 9694), pure re-ordering:

**before**
```
Café, under large *Tilia* sp. in a grazed field on calcareous soil, 21 Sep. 2012, … O-F245330\

***Holotype***: **Norway**, Oslo, ved Gausta, 22 Sep. 1952, F-E Eckblad, O-F72594. *Additional materials examined*: **Norway**, Møre og Romsdal, …
```

**after**
```
***Holotype***: **Norway**, Oslo, ved Gausta, 22 Sep. 1952, F-E Eckblad, O-F72594.

***Epitype*** (designated here): **Norway**, Oslo, Bygdøy, S. of Rodeløkken Café, under large *Tilia* sp. …

*Additional materials examined*: **Norway**, Møre og Romsdal, …
```

Three taxonomic entries, separated and in reading order. The fragment that began mid-phrase
gets its head back — and that restored block is the one whose containment goes to 1.00.

### A note on which instrument sees this

The recall threshold reads **zero** here: 0 blocks recovered, 0 degraded across 866
attainable blocks. That is not the change doing nothing. This defect swaps *paragraph-sized*
chunks, so within each chunk the n-grams survive and a long block sits at ~0.99 either way.
What #450 fixed was different — short *reference titles* split across the seam, n-grams
destroyed, which is why that one scored 14 blocks. Interleaving manufactures n-grams the
document never contained, so the instrument that sees it is **precision**, not recall.

## One existing test changed

`test_a_figure_split_body_is_left_alone` asserted such a page stays at one column. Tracing
it through the cascade, the gap fallback gives it one column — so that assertion was pinning
the defect rather than guarding against it. What the test genuinely guards, that no trim
discards a band big enough to be a column, is **untouched** (`_furniture_trims` still returns
nothing for that geometry) and is now asserted against the trims directly, where a column
count cannot obscure it.

Full unit suite green; ruff and mypy clean across 274 files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
