### PR TITLE
docs: correct the claims that ship with the release

### DIFF
--- a/README.md
+++ b/README.md
@@ -455,7 +455,7 @@ See the [MCP documentation](https://all2md.readthedocs.io/en/latest/mcp.html) an
 Most document tooling in CI answers *"did it run?"*. all2md ships a GitHub Action that answers *"is the output still as good as it was?"* — it scores every matched document and fails the build when fidelity degrades:
 
 ```yaml
-- uses: thomas-villani/all2md@v1.10.1
+- uses: thomas-villani/all2md@v1.13.0
   with:
     paths: docs/**/*.md
     roundtrip-fail-under: 97
@@ -487,7 +487,7 @@ all2md's conversion quality is measured, not asserted — against three independ
 
 Current figures, their controls, and — just as important — what each lane structurally *cannot* see are documented in [Conversion Fidelity](https://all2md.readthedocs.io/en/latest/benchmarks.html).
 
-**How does it compare to other converters?** A fourth lane ([`benchmarks/comparison/`](benchmarks/comparison/)) scores pymupdf4llm and Docling with the same instruments, on a held-out 110-article corpus the development work has never tuned against, with every tool's output re-parsed through one normalization path. The 2026-08 reading: all2md has by far the lowest invented-text rate (0.84%, vs 5.5% for pymupdf4llm — whose defaults now auto-OCR born-digital pages — and 2.9% for Docling) and is the fastest of the three, while pymupdf4llm leads raw text survival and Docling leads table cell preservation. Full results, ground rules, and the caveats that bound them are in that lane's [README](benchmarks/comparison/README.md) and dated `results-*.json` snapshots.
+**How does it compare to other converters?** A fourth lane ([`benchmarks/comparison/`](benchmarks/comparison/)) scores pymupdf4llm and Docling with the same instruments, on a 110-article corpus held out from the born-digital lane, with every tool's output re-parsed through one normalization path. In the reading of 2026-08-23, all2md has by far the lowest invented-text rate (0.62%, vs 5.64% for pymupdf4llm — whose defaults now auto-OCR born-digital pages — and 2.87% for Docling) and is the fastest of the three, while pymupdf4llm edges raw text survival and Docling leads table cell preservation. Two caveats bound that reading: it predates the column-layout fixes released since, and parts of that work were tuned against this corpus — so it is a dated snapshot, not a current held-out score. Refreshing the corpus behind a sealed holdout is the next step. Full results, ground rules, and the caveats that bound them are in that lane's [README](benchmarks/comparison/README.md) and dated `results-*.json` snapshots.
 
 ## Frequently asked questions
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -50,7 +50,8 @@ all2md implements several security measures to protect against common vulnerabil
 
 - **File Format Validation**: Multi-stage format detection (extension, MIME type, magic bytes)
 - **Path Traversal Protection**: Validates file paths to prevent directory traversal attacks
-- **File Size Limits**: Configurable limits to prevent resource exhaustion
+- **Asset Size Limits**: Configurable caps on embedded and fetched assets
+  (`max_asset_size_bytes`) to prevent resource exhaustion
 
 ### 2. Network Security
 
@@ -68,14 +69,17 @@ all2md implements several security measures to protect against common vulnerabil
 
 ### 4. HTML/Document Security
 
-- **HTML Sanitization**: Optional HTML content sanitization using bleach
+- **HTML Sanitization**: Optional stripping of dangerous elements and attributes
+  (`strip_dangerous_elements`), using bleach when the `sanitizer` extra is installed
 - **JavaScript Removal**: Strips JavaScript from HTML documents
 - **Attribute Sanitization**: Removes dangerous HTML attributes
 - **Sandboxed Rendering**: HTML rendering uses security-conscious defaults
 
 ### 5. Dependency Security
 
-- **Minimal Core Dependencies**: Core library has only 2 dependencies (tomli-w, pyyaml)
+- **Minimal Core Dependencies**: Core library has three runtime dependencies
+  (tomli-w, pyyaml, platformdirs), plus tomli and typing_extensions as
+  backports on Python 3.10
 - **Optional Dependencies**: Install only what you need, reducing attack surface
 - **Regular Updates**: Dependencies are regularly updated via Dependabot
 - **Security Scanning**: Automated dependency vulnerability scanning
@@ -95,11 +99,26 @@ When using all2md, follow these best practices:
 
 ```python
 from all2md import to_markdown
-from all2md.utils.security import validate_file_path
+from all2md.utils.security import resolve_file_url_to_path, validate_local_file_access
 
-# Always validate file paths before processing
-file_path = validate_file_path(user_provided_path)
-markdown = to_markdown(file_path)
+# Decide explicitly whether a user-supplied file:// URL may be read
+if not validate_local_file_access(
+    user_provided_url,
+    allow_local_files=True,
+    local_file_allowlist=["/srv/uploads"],
+):
+    raise PermissionError(user_provided_url)
+
+markdown = to_markdown(resolve_file_url_to_path(user_provided_url))
+```
+
+When you write attachments out, validate the destination the same way:
+
+```python
+from all2md.utils.security import validate_safe_output_directory
+
+# Raises SecurityError on ../ traversal or a sensitive system directory
+output_dir = validate_safe_output_directory("./attachments")
 ```
 
 ### 2. Disable Remote Fetching in Production
@@ -108,11 +127,11 @@ markdown = to_markdown(file_path)
 from all2md import to_markdown, HtmlOptions
 from all2md.options.common import NetworkFetchOptions
 
-# Disable remote fetching for untrusted input
+# Remote fetching is already off by default; this states it explicitly
 network_opts = NetworkFetchOptions(
-    enabled=False,  # Disable all remote fetching
+    allow_remote_fetch=False,  # Disable all remote fetching
 )
-html_opts = HtmlOptions(network_fetch=network_opts)
+html_opts = HtmlOptions(network=network_opts)
 markdown = to_markdown('document.html', parser_options=html_opts)
 ```
 
@@ -122,33 +141,53 @@ markdown = to_markdown('document.html', parser_options=html_opts)
 from all2md import to_markdown, HtmlOptions
 
 # Enable HTML sanitization for untrusted HTML content
-opts = HtmlOptions(sanitize_html=True)
+opts = HtmlOptions(
+    strip_dangerous_elements=True,  # Remove script, style, event handlers
+    strip_comments=True,            # Drop comments (on by default)
+)
 markdown = to_markdown('untrusted.html', parser_options=opts)
 ```
 
-### 4. Set File Size Limits
+Add `strip_framework_attributes=True` when the converted output will be
+re-rendered in a browser running Alpine/Vue/Angular/HTMX. See
+[HTML sanitization](docs/source/security.rst) for the full element and
+attribute lists.
+
+### 4. Cap Asset Sizes
+
+all2md does not impose a limit on the size of the document you hand it — check
+that yourself before calling `to_markdown`. What it does cap is the size of any
+asset it extracts or fetches out of that document:
 
 ```python
-from all2md import to_markdown
-from all2md.options.base import BaseParserOptions
+from all2md import to_markdown, HtmlOptions
 
-# Set reasonable file size limits
-opts = BaseParserOptions(max_file_size=10 * 1024 * 1024)  # 10 MB
-markdown = to_markdown('document.pdf', parser_options=opts)
+# Refuse to pull in any single asset larger than 10 MB (default: 50 MB)
+opts = HtmlOptions(max_asset_size_bytes=10 * 1024 * 1024)
+markdown = to_markdown('document.html', parser_options=opts)
 ```
 
 ### 5. Validate Archive Contents
 
+Zip-bomb and path-traversal checks run automatically on every ZIP-backed
+format (`.zip`, `.docx`, `.pptx`, `.xlsx`, `.epub`). To tighten the thresholds,
+or to screen an archive before handing it over, call the validator directly:
+
 ```python
 from all2md import to_markdown
 from all2md.options.archive import ArchiveOptions
+from all2md.utils.security import validate_zip_archive
 
-# Enable security checks for archives
-opts = ArchiveOptions(
-    check_zip_bomb=True,
-    max_archive_size=100 * 1024 * 1024,  # 100 MB
-    max_extracted_size=500 * 1024 * 1024,  # 500 MB
+# Raises ZipFileSecurityError if the archive looks like a bomb
+validate_zip_archive(
+    'archive.zip',
+    max_compression_ratio=50.0,          # default 100.0
+    max_uncompressed_size=500 * 1024 * 1024,  # default 1 GB
+    max_entries=1000,                    # default 10000
 )
+
+# Limit how far nested archives are followed
+opts = ArchiveOptions(max_depth=2)
 markdown = to_markdown('archive.zip', parser_options=opts)
 ```
 
@@ -169,13 +208,13 @@ markdown = to_markdown('archive.zip', parser_options=opts)
 ### 3. HTML Documents
 
 - HTML can contain embedded scripts and external resources
-- Use `sanitize_html=True` for untrusted content
+- Use `strip_dangerous_elements=True` for untrusted content
 - External resources (images, CSS) are not fetched by default
 
 ### 4. Archive Formats
 
 - Nested archives can cause resource exhaustion
-- ZIP bombs are detected but configure appropriate limits
+- ZIP bombs are detected; use `validate_zip_archive` to tighten the limits
 - Always validate extracted file paths
 
 ### 5. MCP Server

--- a/action.yml
+++ b/action.yml
@@ -37,7 +37,7 @@ inputs:
   all2md-version:
     description: >-
       Version to install. Empty (the default) matches the tag this action was
-      referenced by, so @v1.10.1 gates with all2md 1.10.1 -- the scores are the
+      referenced by, so @v1.13.0 gates with all2md 1.13.0 -- the scores are the
       library's, so pinning them together keeps your thresholds meaningful.
       Use "latest" to always take the newest release, or give an exact version.
     required: false

--- a/changelog.d/463-pre-release-docs.fixed.md
+++ b/changelog.d/463-pre-release-docs.fixed.md
@@ -1,0 +1,29 @@
+- **`SECURITY.md`'s hardening recipes now run.** Every one of the five "best
+  practices" examples failed on import or construction: `validate_file_path` does
+  not exist, `NetworkFetchOptions.enabled` is `allow_remote_fetch`,
+  `HtmlOptions.network_fetch` is `network`, `HtmlOptions.sanitize_html` is
+  `strip_dangerous_elements`, `BaseParserOptions.max_file_size` does not exist,
+  and `ArchiveOptions` has none of `check_zip_bomb`/`max_archive_size`/
+  `max_extracted_size`. A reader who copied the remote-fetch or sanitization
+  recipe got a `TypeError`, not the hardening they asked for. All five now use
+  the real API and are executed as written. The document also claimed a
+  configurable per-file size limit, which the library has never had — the real
+  cap is `max_asset_size_bytes` on extracted and fetched assets — and undercounted
+  the core dependencies at two.
+- **The documented GitHub Action pin moves with the release.** `README.md`,
+  `docs/source/github_action.rst` and `action.yml` all showed
+  `thomas-villani/all2md@v1.10.1`. The action resolves the library version from
+  the tag it was referenced by, so copying the documented snippet gated your
+  documents with all2md 1.10.1 — three releases behind — while the surrounding
+  prose explained that the pin is what keeps thresholds meaningful. The pin is now
+  a `bump-my-version` target, so it cannot fall behind again.
+- **Sphinx no longer advertises image input.** `docs/source/index.rst` listed
+  "Images (PNG/JPEG/GIF)" as a supported format. There is no image parser and
+  `image` is not a `DocumentFormat`; a PNG falls through to the plain-text
+  fallback and comes back as mojibake.
+- **The converter comparison in `README.md` is dated and caveated.** It quoted the
+  superseded 2026-08-19 reading (0.84% / 5.5% / 2.9%) as "the 2026-08 reading"
+  when the lane now holds two, and described the corpus as one "the development
+  work has never tuned against" — no longer true, since the column-layout work
+  released since was developed against it. The figures are now the 2026-08-23
+  reading, carrying both caveats.

--- a/docs/source/github_action.rst
+++ b/docs/source/github_action.rst
@@ -10,13 +10,13 @@ score falls below a threshold you set.
 
 .. code-block:: yaml
 
-   - uses: thomas-villani/all2md@v1.10.1
+   - uses: thomas-villani/all2md@v1.13.0
      with:
        paths: docs/**/*.md
        roundtrip-fail-under: 97
 
 The action lives in the ``all2md`` repository itself rather than a separate one,
-so ``@v1.10.1`` installs all2md 1.10.1. That matters more than it looks: the
+so ``@v1.13.0`` installs all2md 1.13.0. That matters more than it looks: the
 gate's verdict *is* the library's score, so if the action version could drift from
 the library version, your thresholds would quietly change meaning underneath you.
 
@@ -34,7 +34,7 @@ Quick Start
        runs-on: ubuntu-latest
        steps:
          - uses: actions/checkout@v5
-         - uses: thomas-villani/all2md@v1.10.1
+         - uses: thomas-villani/all2md@v1.13.0
            with:
              paths: |
                docs/**/*.md
@@ -47,7 +47,7 @@ step outputs so later steps can use them:
 
 .. code-block:: yaml
 
-         - uses: thomas-villani/all2md@v1.10.1
+         - uses: thomas-villani/all2md@v1.13.0
            id: gate
            with:
              paths: docs/**/*.md

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -91,7 +91,7 @@ Supported Formats
   PDF, Word (DOCX), PowerPoint (PPTX), HTML/MHTML, Email (EML), EPUB, RTF, OpenDocument (ODT/ODP with bidirectional support)
 
 **Data & Other**
-  Excel (XLSX), CSV/TSV, Jupyter Notebooks (IPYNB), Archives (TAR/7Z/RAR/ZIP), Images (PNG/JPEG/GIF), 200+ text formats
+  Excel (XLSX), CSV/TSV, Jupyter Notebooks (IPYNB), Archives (TAR/7Z/RAR/ZIP), 200+ text formats
 
 **Markup**
   Markdown, reStructuredText, AsciiDoc, Org-Mode, MediaWiki, LaTeX, OpenAPI/Swagger, Textile

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -541,6 +541,31 @@ filename = "mcpb/pyproject.toml"
 search = '>={current_version}'
 replace = '>={new_version}'
 
+# The composite action lives in this repository, so its documented pin has to
+# move with the release or users are gated at an old library version -- the pin
+# sat at v1.10.1 across three releases before this was automated. `default: ""`
+# in action.yml resolves the version from the tag the action was referenced by,
+# so these are documentation pins only; there is no separate version to bump.
+[[tool.bumpversion.files]]
+filename = "README.md"
+search = "all2md@v{current_version}"
+replace = "all2md@v{new_version}"
+
+[[tool.bumpversion.files]]
+filename = "docs/source/github_action.rst"
+search = "all2md@v{current_version}"
+replace = "all2md@v{new_version}"
+
+[[tool.bumpversion.files]]
+filename = "docs/source/github_action.rst"
+search = "``@v{current_version}`` installs all2md {current_version}"
+replace = "``@v{new_version}`` installs all2md {new_version}"
+
+[[tool.bumpversion.files]]
+filename = "action.yml"
+search = "@v{current_version} gates with all2md {current_version}"
+replace = "@v{new_version} gates with all2md {new_version}"
+
 # uv.lock records the project's own version. Anchor the match on the preceding
 # `name = "all2md"` line: a bare version search would also match any dependency
 # that happens to be pinned at the same version. Without this, a release tag


### PR DESCRIPTION
Four documentation defects that would ship with v1.14.0. Each was verified against the live API, not inferred.

## SECURITY.md's hardening examples all crash

Every one of the five "Security Best Practices" examples failed on import or construction:

| what it said | reality |
|---|---|
| `from all2md.utils.security import validate_file_path` | does not exist → `ImportError` |
| `NetworkFetchOptions(enabled=False)` | field is `allow_remote_fetch` → `TypeError` |
| `HtmlOptions(network_fetch=...)` | field is `network` → `TypeError` |
| `HtmlOptions(sanitize_html=True)` | field is `strip_dangerous_elements` |
| `BaseParserOptions(max_file_size=...)` | does not exist |
| `ArchiveOptions(check_zip_bomb=, max_archive_size=, max_extracted_size=)` | none of the three exist |

This is the worst of the four: someone following the remote-fetch or sanitization recipe gets a `TypeError`, not the hardening they asked for — and in a document whose whole purpose is to be copied by people hardening an untrusted-input path.

All five now use the real API. Every Python block in the file was extracted and executed as written (six blocks, six pass; `validate_zip_archive` re-run against a real archive since the stub path only proves the signature).

Two adjacent claims were wrong too: a "configurable file size limit" the library has never had (the real cap is `max_asset_size_bytes`, on extracted and fetched assets — the document now says plainly that all2md does not bound the input document, so you should), and "only 2 dependencies" against an actual three unconditional plus two Python 3.10 backports.

## The Action pin sat three releases behind

`README.md`, `docs/source/github_action.rst` and `action.yml` all showed `thomas-villani/all2md@v1.10.1`. The action lives in this repository and resolves its library version from the tag it was referenced by, so the documented snippet gated documents with all2md 1.10.1 — while the prose two lines below explains that pinning them together is what keeps your thresholds meaningful.

Pinned to `v1.13.0` (the current release, correct as of this commit) **and added as `bump-my-version` targets**, so the release bump carries all four call sites forward. Verified by dry run: `README.md`, `docs/source/github_action.rst` and `action.yml` now appear in the bump's file list, and a scratch-repo test confirms all three occurrences within the `.rst` are replaced, not just the first.

That automation is the actual fix — the pin has been bumped by hand and missed three times.

## Sphinx advertised image input

`docs/source/index.rst` listed "Images (PNG/JPEG/GIF)" as a supported format. There is no image parser, `image` is not a `DocumentFormat`, and a PNG handed to `to_markdown` falls through to the plain-text fallback and returns mojibake (`'\x89PNG \x1a \x00…'`). Claim removed. `attachments.rst`'s image references are about *extracted* images and are correct.

## README's comparison was stale, and its holdout claim no longer true

It quoted the superseded 2026-08-19 reading — 0.84% / 5.5% / 2.9% — as "the 2026-08 reading", when the lane now holds two 2026-08 readings. Updated to the recorded 2026-08-23 figures (0.62% / 5.64% / 2.87%, read from `results-2026-08-23.json`) and dated explicitly.

More importantly it described the corpus as one "the development work has never tuned against". That stopped being true: the column-layout work released since (#440, #450, #445) was developed directly against this corpus, using its recorded geometry and `lost_blocks.json` to choose rules and thresholds. The paragraph now carries both caveats — the reading predates the fixes released since, *and* parts of that work were tuned against the corpus — so it reads as a dated snapshot rather than a current held-out score, and names the sealed-holdout refresh as the next step.

## Checks

- Six SECURITY.md snippets extracted and executed — all pass
- `sphinx-build -W --keep-going` — clean
- Root-markdown fidelity gate at the CI threshold: `README.md` 100, `SECURITY.md` 100 (zero headroom by design, so this needed checking)
- `bump-my-version bump minor --dry-run` — all four new targets matched
- pre-commit on every changed file; `compile_changelog.py --check`; lint-gate, changelog and published-figures tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)
