### PR TITLE
fix(pdf): count a column's filled runs only where they start a row

### DIFF
--- a/changelog.d/pdf-table-centred-cell-runs.fixed.md
+++ b/changelog.d/pdf-table-centred-cell-runs.fixed.md
@@ -1,0 +1,26 @@
+- **A PDF table that centres its cells vertically no longer has its row grouping thrown
+  away.** A guard refuses a grouping when one of a group's columns is filled in three or
+  more separate runs, reasoning that a cell fills contiguous lines so a column inside one
+  logical row is a single run. The reasoning holds for the cell but not for the grid of
+  printed lines it is read out of: where the cells of one logical row are set at different
+  heights, the extractor emits a line per distinct baseline, so a wrapped cell's lines
+  alternate with its taller neighbours' and that one cell shows up as several runs. A
+  gene/locus table printing "SH2B3" and "[64]" on either side of a line holding only the
+  middle columns was condemned on exactly that count, and kept 0.15 of its text where its
+  own printed lines allow all of it. A run is now counted only where the line starting it
+  fills most of the grid's columns, which is what separates a row from a fragment; the
+  bar sits at four fifths because a real row does leave a column empty where a value
+  repeats, and the table this guard exists to protect elides a name on every row after
+  the first of a group.
+
+  This came out of an audit for heuristics fitted to the corpus they were developed
+  against, and it is the clearest case the audit found. The guard predates the corpus
+  drawn afterwards and fires on both -- 30 groupings across 10 articles -- but on the
+  corpus it was measured against it never changes an outcome, while on the corpus drawn
+  afterwards it costs 0.0289 mean n-gram containment against JATS ground truth across
+  eight tables, three of which the fix takes to the best score their printed lines
+  permit. Measured over the 225 truth tables of both development corpora the change moves
+  n-gram containment 0.778 to 0.807 on the newer corpus with eight tables better and none
+  worse, leaves the older one byte-identical, and takes tables recovered whole from 53 to
+  54. Every fill share from 0.7 to 1.0 scores identically, so the bar is a plateau rather
+  than a fitted peak. The sealed holdout was not consulted.

--- a/src/all2md/parsers/_pdf_tables.py
+++ b/src/all2md/parsers/_pdf_tables.py
@@ -262,6 +262,30 @@ MIN_ROW_MARKER_TABLE_LINES = 4
 # How alike two columns' filled-line sets must be, as Jaccard overlap, to count as
 # naming the same rows.
 ROW_MARKER_AGREEMENT_MIN = 0.7
+# A run only marks a distinct cell when the line that starts it is a *row*. Vertically
+# centred cells make that qualification necessary: when the cells of one logical row
+# differ in height the extractor emits a line per distinct baseline, so a single wrapped
+# cell's lines alternate with its taller neighbours' and that one cell shows up as
+# several runs. A placenta comparison table sets "Inflammatory gene / expression / [52]"
+# on lines 1, 3 and 5 of one logical row -- three runs, one cell -- so the run count
+# condemned a correct grouping and the table kept 0.15 of its text where its own printed
+# lines allow all of it.
+#
+# What separates the two shapes is what the run *starts* on. A fragment fills one or two
+# of the grid's columns; a row fills nearly all of them. The table this guard exists to
+# protect is a miRNA table whose every printed line fills five or six of six columns,
+# eliding only a repeated name -- so gating the count on line fill keeps it (its bad
+# grouping still shows far more than two dense runs) while releasing the centred ones.
+# Four fifths, because a real row does leave a column empty where a value repeats, and
+# the bar has to sit under that.
+#
+# The ungated count was the clearest case of a rule fitted to the corpus it was written
+# against. It fires on both development corpora -- 30 groupings across 10 articles -- but
+# on the corpus it was measured on it never changes an outcome, while on the corpus drawn
+# afterwards it costs 0.0289 mean containment across eight tables, three of which the gate
+# takes to the best score their printed lines permit. The gate itself is a plateau and not
+# a peak: every fill share from 0.7 to 1.0 scores identically.
+ROW_STACK_MIN_LINE_FILL = 0.8
 
 # Row bboxes may overlap by at most this much before the merge distrusts them as
 # line geometry. Printed lines never overlap beyond font-box slop; find_tables()
@@ -1380,6 +1404,15 @@ def _numeric_cell_count(row: list[str]) -> int:
     return sum(1 for cell in row if cell and _mostly_numeric_cell(cell))
 
 
+def _line_fills_a_row(row: list[str], width: int) -> bool:
+    """Whether a printed line holds enough of the grid's columns to be a row of it.
+
+    A line filling one or two columns of a wide grid is a wrapped fragment; a line
+    filling nearly all of them is a row, whatever the lines around it do.
+    """
+    return width > 0 and sum(1 for cell in row if cell) / width >= ROW_STACK_MIN_LINE_FILL
+
+
 def _groups_stack_column_cells(line_rows: list[list[str]], groups: list[list[int]]) -> bool:
     """Whether any group holds a column with three-plus separate filled runs.
 
@@ -1387,7 +1420,13 @@ def _groups_stack_column_cells(line_rows: list[list[str]], groups: list[list[int
     (two tolerated -- a ragged prose cell can leave one hole). Three or more runs is a
     stack of distinct cells: the group is fusing rows, however plausible its gap
     structure looked, and the grouping that proposed it cannot be trusted.
+
+    Only runs that begin on a *row* are counted. A grid line holding one or two of the
+    grid's columns is a fragment, and centred cells scatter one cell's fragments down a
+    column: the run count alone cannot tell that from a stack, and reading it as a stack
+    throws away correct groupings on every table that centres its cells.
     """
+    width = max(len(row) for row in line_rows)
     for group in groups:
         columns = max(len(line_rows[index]) for index in group)
         for column in range(columns):
@@ -1396,7 +1435,7 @@ def _groups_stack_column_cells(line_rows: list[list[str]], groups: list[list[int
             for index in group:
                 row = line_rows[index]
                 filled = column < len(row) and bool(row[column])
-                if filled and not previous_filled:
+                if filled and not previous_filled and _line_fills_a_row(row, width):
                     runs += 1
                 previous_filled = filled
             if runs > ROW_GROUP_MAX_COLUMN_RUNS:

--- a/tests/unit/formats/pdf/test_pdf_stacked_cell_runs.py
+++ b/tests/unit/formats/pdf/test_pdf_stacked_cell_runs.py
@@ -1,0 +1,151 @@
+#  Copyright (c) 2025 Tom Villani, Ph.D.
+#
+# tests/unit/formats/pdf/test_pdf_stacked_cell_runs.py
+"""A column filled in several runs is a stack of cells only where those runs start rows.
+
+``_groups_stack_column_cells`` refuses a row grouping when one of its columns is filled in
+three or more separate runs, on the reasoning that a cell fills contiguous lines, so a
+column inside one logical row is one run. That reasoning holds for the cell; it does not
+hold for the grid of printed lines the cell is read out of. Where a table centres its
+cells vertically, the cells of one logical row sit at different heights and the extractor
+emits a line per distinct baseline, so a single wrapped cell's lines alternate with its
+taller neighbours' and that one cell appears as several runs.
+
+The two shapes are told apart by what the runs start on. A line holding one or two of the
+grid's columns is a fragment of a row; a line holding nearly all of them is a row. Both
+fixtures here are verbatim from the corpus drawn after the guard was written, which is
+where the distinction first cost anything -- on the corpus the guard was measured against
+it never changes an outcome at all.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from all2md.parsers._pdf_tables import (
+    _groups_stack_column_cells,
+    _line_fills_a_row,
+    merge_continuation_lines,
+)
+
+pytestmark = [pytest.mark.unit, pytest.mark.pdf, pytest.mark.table]
+
+
+class TestACentredCellIsNotAStackOfCells:
+    """One wrapped cell scattered down a column by its neighbours' heights."""
+
+    # PMC12250033.1's gene/locus table, verbatim: 17 printed lines, 4 columns, 7 rows.
+    # "SH2B3" and "[64]" are one cell printed on lines 1 and 3, with line 2 holding only
+    # the middle columns -- so column 0 shows two runs there, and column 1 three of them
+    # across the MTHFR row below.
+    LINES = [
+        ["Gene/Locus", "Function", "Associated with", "Implication"],
+        ["SH2B3", "Immune and vascular", "", "Shared inflammatory and"],
+        ["", "", "PE, HTN", ""],
+        ["[64]", "regulation", "", "hypertensive pathways"],
+        ["FTO", "Metabolic and vascular", "", ""],
+        ["", "", "Obesity, HDP, HTN", "Metabolic–vascular interface"],
+        ["[64]", "signaling", "", ""],
+        ["eNOS (NOS3)", "NO production,", "HDP, endothelial", "Impaired vascular tone and"],
+        ["[65]", "vasodilation", "dysfunction", "endothelial function"],
+        ["", "Methylation,", "", ""],
+        ["MTHFR", "", "", "Endothelial stress, oxidative"],
+        ["", "homocysteine", "PE, HTN", ""],
+        ["[66]", "", "", "damage"],
+        ["", "metabolism", "", ""],
+        ["Hypertension PRS", "Cumulative genetic", "", "Predictive of postpartum"],
+        ["", "", "HDP, later-life HTN", ""],
+        ["[67]", "burden", "", "risk"],
+    ]
+
+    EXTENTS = [
+        (412.3195495605469, 420.2896423339844),
+        (426.6610107421875, 434.631103515625),
+        (431.3940124511719, 439.3641052246094),
+        (436.1260070800781, 444.0960998535156),
+        (450.3919982910156, 458.3620910644531),
+        (455.1239929199219, 463.0940856933594),
+        (459.8559875488281, 467.8260803222656),
+        (474.12298583984375, 482.09307861328125),
+        (483.58697509765625, 491.55706787109375),
+        (497.8529968261719, 505.8230895996094),
+        (502.5849914550781, 510.5550842285156),
+        (507.3179931640625, 515.2880859375),
+        (512.0499877929688, 520.0200805664062),
+        (516.781982421875, 524.7520751953125),
+        (531.0479736328125, 539.01806640625),
+        (535.780029296875, 543.7501220703125),
+        (540.5130004882812, 548.4830932617188),
+    ]
+
+    def test_the_wrapped_label_keeps_its_row(self) -> None:
+        merged = merge_continuation_lines([list(row) for row in self.LINES], self.EXTENTS)
+
+        assert len(merged) == 7
+        assert merged[1][0].split("\n") == ["SH2B3", "[64]"]
+        assert merged[1][2] == "PE, HTN"
+        # Three printed lines of one cell, not three cells.
+        assert merged[5][1].split("\n") == ["Methylation,", "homocysteine", "metabolism"]
+
+    def test_the_grouping_is_not_read_as_a_stack(self) -> None:
+        """The runs are real; what they start on is what makes them fragments."""
+        groups = [[0], [1, 2, 3], [4, 5, 6]]
+
+        assert _groups_stack_column_cells(self.LINES, groups) is False
+
+        # Counting runs without asking what starts them sees column 1 filled three times
+        # over the MTHFR row -- the count the guard used to refuse the whole grouping on.
+        filled = [bool(self.LINES[index][1]) for index in (9, 10, 11, 12, 13)]
+        runs = sum(1 for i, cell in enumerate(filled) if cell and not (i and filled[i - 1]))
+        assert runs == 3
+
+
+class TestAStackOfRealRowsIsStillRefused:
+    """Lines that each fill the grid are rows, however the grouping wants to read them."""
+
+    # PMC5250647.1's miRNA table, verbatim: every printed line is a complete data row,
+    # empty only in the column where a repeated name is elided. Its gap structure invites
+    # fusing the body into one row, which would interleave the whole table column-wise.
+    LINES = [
+        ["miRNA", "Delivery", "Compound", "Model", "Effectb", "Source"],
+        ["mmu-miR-126a", "Intravitreal injection", "miR-mimic", "OIR", "; Retinal NV", "[114]"],
+        ["mmu-miR-128a", "Intravitreal injection", "miR-mimic", "OIR", "; Retinal NV", "[105]"],
+        ["mmu-miR-132a", "Intraocular injection", "anti-miR", "OIR", "; NV", "[106]"],
+        ["mmu-miR-150a", "Intraocular injection", "pre-miR", "OIR", "; Retinal NV", "[90]"],
+        ["", "Intraocular injection", "pre-miR", "Laser induced CNV", "; Choroidal NV", "[90]"],
+        ["", "Intravitreal injection", "miR-mimic", "OIR", "; Retinal NV", "[108]"],
+        ["", "Knockout mice", "miR-150-/-", "Laser induced CNV", ": Choroidal NV", "[108]"],
+        ["mmu-miR-155a", "Knockout mice", "miR-155-/-", "OIR", ": Retinal NV", "[75]"],
+        ["", "Knockout mice", "miR-155-/-", "Retinal development", "; Vascular area", "[75]"],
+        ["", "Intravitreal injection", "miR-mimic", "Retinal development", "; Vascular area", "[75]"],
+        ["mmu-miR-184a", "Intraocular injection", "pre-miR", "OIR", "; Retinal NV", "[90]"],
+        ["mmu-miR-23/27a", "Intravitreal injection", "anti-miR", "Laser induced CNV", "; Choroidal NV", "[107]"],
+        ["mmu-miR-24a", "Subretinal", "miR-mimic", "Laser induced CNV", "; Choroidal NV", "[109]"],
+        ["mmu-miR-31a", "Intraocular injection", "pre-miR", "OIR", "; Retinal NV", "[90]"],
+        ["", "Intraocular injection", "pre-miR", "Laser induced CNV", "; Choroidal NV", "[90]"],
+    ]
+
+    def test_complete_rows_are_not_fused_into_one(self) -> None:
+        groups = [[0], list(range(1, 16))]
+
+        assert _groups_stack_column_cells(self.LINES, groups) is True
+
+    def test_an_elided_leading_column_does_not_disqualify_a_row(self) -> None:
+        """Five columns of six is still a row, and the bar has to sit under that.
+
+        Real rows do leave a column empty where a value repeats -- this table elides the
+        miRNA name on every row after the first of a group. Were the bar set at every
+        column, those rows would read as fragments and the guard would stop seeing them.
+        """
+        elided = self.LINES[5]
+
+        assert not elided[0]
+        assert sum(1 for cell in elided if cell) == 5
+        assert _line_fills_a_row(elided, 6) is True
+
+    def test_a_fragment_of_a_row_is_not_one(self) -> None:
+        """The other side of the same bar, from the centred table above."""
+        fragment = TestACentredCellIsNotAStackOfCells.LINES[2]
+
+        assert sum(1 for cell in fragment if cell) == 1
+        assert _line_fills_a_row(fragment, 4) is False


### PR DESCRIPTION
## What

`_groups_stack_column_cells` refuses a row grouping when one of a group's columns is filled in three or more separate runs, reasoning that a cell fills contiguous lines so a column inside one logical row is a single run.

The reasoning holds for the cell. It does not hold for the grid of printed lines the cell is read out of. Where a table centres its cells vertically, the cells of one logical row sit at different heights and the extractor emits a line per distinct baseline — so a wrapped cell's lines alternate with its taller neighbours', and that one cell shows up as several runs.

PMC12250033.1 prints `SH2B3` and `[64]` on either side of a line holding only the middle columns. Two runs from one cell, three in the column below it, and the whole grouping was condemned; the table kept 0.15 of its text where its own printed lines allow all of it.

A run is now counted only where the line that starts it fills most of the grid's columns — which is what separates a row from a fragment. The bar is four fifths, because a real row *does* leave a column empty where a value repeats: the miRNA table this guard exists to protect elides the name on every row after the first of a group, and still fires.

## Why this one

It came out of an audit for rules fitted to the corpus they were developed against, and it is the clearest case the audit found.

The guard predates the corpus drawn in the 2026-08-27 refresh, which shares no articles with the older one — so that corpus is genuinely held out for it. The guard fires on both, 30 groupings across 10 articles. On the corpus it was measured against it **never changes an outcome**. On the corpus drawn afterwards it **costs 0.0289** mean n-gram containment across eight tables, three of which this fix takes to the best score their printed lines permit.

## Measured

Against JATS ground truth, per truth table, over both development corpora:

| corpus | before | after | better | worse | recovered whole |
|---|---|---|---|---|---|
| dev (100 tables) | 0.8458 | 0.8458 | 0 | 0 | 46 → 46 |
| tuned (125 tables) | 0.7777 | 0.8065 (+0.0289) | 8 | 0 | 53 → 54 |

Every fill share from 0.7 to 1.0 scores identically, so the bar sits on a plateau rather than a fitted peak. The sealed holdout was not consulted.

A second candidate — making the numeric-fusion guard skip blank lines when testing adjacency — was measured and **dropped**: it earns nothing on top of #468, and shipping an unmeasured rule is the failure this audit is about.

## Tests

`tests/unit/formats/pdf/test_pdf_stacked_cell_runs.py`, five tests on both shapes taken verbatim from the corpus: the centred table that must merge, and the miRNA table that must still be refused.

🤖 Generated with [Claude Code](https://claude.com/claude-code)