### PR TITLE
fix(benchmarks): render JATS inline markup as the page prints it

### DIFF
--- a/benchmarks/pmc/oracles.py
+++ b/benchmarks/pmc/oracles.py
@@ -151,54 +151,99 @@ def _tag(element: Any) -> str:
     return element.tag.rsplit("}", 1)[-1] if isinstance(element.tag, str) else ""
 
 
-def _all_text(element: Any) -> str:
-    """Return every rendered character under an element, joined by spaces.
+#: Elements the page prints inside a line of text, contributing no space of their own. A
+#: structural boundary needs a space -- ``<label>Table 2</label>`` must not fuse onto the
+#: caption after it -- but an inline one must not have one, because the page does not print
+#: it: "bla<sub>CTX-M</sub>" is printed ``blaCTX-M`` and "T<sub>a</sub>" is printed ``Ta``.
+#:
+#: Measured over the two development corpora rather than assumed. Across every table cell,
+#: paragraph, title and caption, these are the tags whose text most often abuts a neighbour
+#: with no whitespace between them in the source -- ``xref`` 22,934 times, ``italic`` 6,397,
+#: ``sup`` 4,035, ``sub`` 3,662, ``bold`` 3,290, and the rest in the tens. Block and
+#: container elements abut just as often (``disp-formula`` 244, ``fig`` 80, ``list`` 22) and
+#: are deliberately absent: they begin their own line on the page, so their space is real.
+#: Anything unrecognised keeps its space, which is the safe direction -- a missing space
+#: fuses two words into a token nothing can match, a spurious one only splits them.
+INLINE = frozenset(
+    {
+        "bold",
+        "email",
+        "ext-link",
+        "inline-formula",
+        "italic",
+        "monospace",
+        "named-content",
+        "overline",
+        "roman",
+        "sans-serif",
+        "sc",
+        "strike",
+        "styled-content",
+        "sub",
+        "sup",
+        "underline",
+        "uri",
+        "xref",
+    }
+)
 
-    Joined, never concatenated: concatenation fuses ``<label>Table 2</label>`` onto the
-    caption that follows it into a single bogus token, corrupting a token boundary at every
-    element boundary. Tables have the most boundaries, so an earlier version of the
-    alignment probe made them look unlocatable when they are not.
-    """
-    parts: list[str] = []
 
-    def visit(node: Any) -> None:
-        if _tag(node) in SKIPPED:
-            return
-        if node.text and node.text.strip():
-            parts.append(node.text.strip())
-        for child in node:
-            visit(child)
-            if child.tail and child.tail.strip():
-                parts.append(child.tail.strip())
+def _rendered(element: Any, *, own: bool) -> str:
+    """Return every rendered character under an element, spaced as the page prints it.
 
-    visit(element)
-    return " ".join(parts)
+    Structural boundaries are joined by a space and inline ones are not, so the result is
+    the line of text a reader sees. The alternative -- a space at every element boundary --
+    corrupts a token wherever JATS marks up part of a word, and JATS marks up part of a word
+    constantly: units, gene names, footnote markers and superscript citations all sit inside
+    a printed word. Measured on the table replay over both development corpora, the
+    unconditional space put 3.2% (dev) and 4.3% (tuned) of a table's ground-truth 5-grams
+    permanently out of reach of any converter, and cost the recorded grids 0.029 and 0.035
+    mean containment against a truth they in fact reproduced.
 
+    Parameters
+    ----------
+    element : Any
+        The JATS element to render.
+    own : bool
+        Stop at nested elements that are blocks in their own right. JATS nests block
+        material inside prose -- a ``<table-wrap>`` or ``<disp-formula>`` sits inside the
+        ``<p>`` that introduces it -- and taking the paragraph's full text swallowed the
+        table's caption and every cell into the paragraph, which fused three page objects
+        into one string, deleted the table from the ground truth entirely, and -- because
+        the fused block straddled the paragraph's page and the table's page -- placed it on
+        the wrong one.
 
-def _own_text(element: Any) -> str:
-    """Return an element's text *excluding* nested elements that are blocks in their own right.
-
-    JATS nests block material inside prose: a ``<table-wrap>`` or ``<disp-formula>`` sits
-    inside the ``<p>`` that introduces it. Taking the paragraph's full text swallowed the
-    table's caption and every cell into the paragraph, which fused three page objects into
-    one string, deleted the table from the ground truth entirely, and -- because the fused
-    block straddled the paragraph's page and the table's page -- placed it on the wrong one.
     """
     parts: list[str] = []
 
     def visit(node: Any, *, root: bool) -> None:
         tag = _tag(node)
-        if tag in SKIPPED or (not root and tag in BLOCKS):
+        if tag in SKIPPED or (own and not root and tag in BLOCKS):
             return
-        if node.text and node.text.strip():
-            parts.append(node.text.strip())
+        structural = not root and tag not in INLINE
+        if structural:
+            parts.append(" ")
+        if node.text:
+            parts.append(node.text)
         for child in node:
             visit(child, root=False)
-            if child.tail and child.tail.strip():
-                parts.append(child.tail.strip())
+            if child.tail:
+                parts.append(child.tail)
+        if structural:
+            parts.append(" ")
 
     visit(element, root=True)
-    return " ".join(parts)
+    return " ".join("".join(parts).split())
+
+
+def _all_text(element: Any) -> str:
+    """Return every rendered character under an element, as the page prints it."""
+    return _rendered(element, own=False)
+
+
+def _own_text(element: Any) -> str:
+    """Return an element's text *excluding* nested elements that are blocks in their own right."""
+    return _rendered(element, own=True)
 
 
 def _nested_blocks(element: Any) -> list[Any]:

--- a/changelog.d/pmc-truth-inline-markup.fixed.md
+++ b/changelog.d/pmc-truth-inline-markup.fixed.md
@@ -1,0 +1,26 @@
+- **The PMC born-digital ground truth no longer prints a space where the page prints
+  none.** The JATS projection joined every element's text with a space so that
+  `<label>Table 2</label>` could not fuse onto the caption after it. Structural
+  boundaries do need that space; inline ones do not, and JATS marks up part of a word
+  constantly -- `bla<sub>CTX-M</sub>` is printed `blaCTX-M`, `T<sub>a</sub>` is `Ta`,
+  `et al.<sup>12</sup>` is `et al.12`, `VAS 1<sup>st</sup> week` is `VAS 1st week`.
+  Every such boundary put five n-grams of ground truth beyond the reach of any
+  converter, all2md included, and the tables carry the most of them. The projection now
+  renders an element as the page prints it: the source's own whitespace inside a line,
+  a space only at a structural boundary. The set of inline elements is measured, not
+  assumed -- across both development corpora these are the tags whose text abuts a
+  neighbour with no whitespace in the source, `xref` 22,934 times down to the tens --
+  and anything unrecognised keeps its space, because a missing space fuses two words
+  into a token nothing can match while a spurious one only splits them.
+
+  Measured on the recorded table replay over the two development corpora, correcting
+  the truth alone moves mean n-gram containment from 0.814 to 0.843 (66-article dev)
+  and 0.804 to 0.839 (110-article tuned), with 38 of the 41 tables that move getting
+  better; several tables that scored 0.1 to 0.7 were in fact reproduced whole. For
+  comparison, an oracle that cuts every recorded grid's columns at the best position --
+  a perfect fix for tables the detector fuses side by side -- is worth 0.004 and 0.013
+  on the same corpora, so the artifact was larger than the defect it was hiding. About
+  3% of the ground truth's prose 5-grams are affected too. `benchmarks/pmc/reference.json`
+  was recorded against the old projection and must be re-recorded before its figures are
+  read again; the lane does not run on per-PR CI, so nothing is gated on it in the
+  meantime.

--- a/tests/unit/test_pmc_oracle.py
+++ b/tests/unit/test_pmc_oracle.py
@@ -48,7 +48,7 @@ def test_a_table_nested_in_a_paragraph_is_its_own_block() -> None:
     assert tables[0].table is not None
     assert tables[0].table.rows == 2
     # The paragraph keeps its own words and the cross-reference, and none of the table's.
-    assert prose[0].text == "Results appear in Table 1 ."
+    assert prose[0].text == "Results appear in Table 1."
     assert "Characteristics" not in prose[0].text
     assert "Control" not in prose[0].text
     # Caption and cell text reach the text stream as separate page objects.
@@ -195,10 +195,36 @@ def test_the_verdicts_reported_are_exactly_the_ones_the_payload_publishes() -> N
     assert sum(verdicts.values()) == 2
 
 
-def test_element_text_is_joined_not_concatenated() -> None:
+def test_a_structural_boundary_keeps_its_space() -> None:
     """Concatenation fused ``<label>Table 2</label>`` onto its caption as one bogus token."""
-    blocks, _ = oracles.project_jats(_jats("<p><italic>Table 2</italic>obtained results</p>"))
-    assert "2obtained" not in blocks[0].text
+    _, projection = oracles.project_jats(
+        _jats(
+            "<table-wrap><label>Table 2</label><caption><p>Obtained results</p></caption>"
+            "<table><tr><th>Group</th></tr><tr><td>Control</td></tr></table></table-wrap>"
+        )
+    )
+    assert "Table 2 Obtained results" in projection.text_blocks
+
+
+def test_an_inline_boundary_does_not_get_a_space_the_page_never_prints() -> None:
+    """JATS marks up part of a word constantly, and a space there is a word the page lacks.
+
+    A space at every element boundary spelled "bla<sub>CTX-M</sub>" as two words where the
+    page prints ``blaCTX-M``, and did the same to units, footnote markers and superscript
+    citations. Measured on the table replay over both development corpora it put 3.2% (dev)
+    and 4.3% (tuned) of a table's ground-truth 5-grams permanently out of reach.
+    """
+    cell = ElementTree.fromstring("<td>bla<sub>CTX-M</sub></td>")
+    assert oracles._all_text(cell) == "blaCTX-M"
+
+    footnote = ElementTree.fromstring("<td>Bonnet et al.<sup>12</sup></td>")
+    assert oracles._all_text(footnote) == "Bonnet et al.12"
+
+
+def test_the_source_decides_the_space_around_an_inline_run() -> None:
+    """Inline elements are not always fused: the XML's own whitespace still governs."""
+    blocks, _ = oracles.project_jats(_jats("<p>Isolates of <italic>E. coli</italic> were typed.</p>"))
+    assert blocks[0].text == "Isolates of E. coli were typed."
 
 
 def test_coverage_reports_ground_truth_against_the_page_rather_than_assuming_it() -> None:


### PR DESCRIPTION
## What

The PMC born-digital ground truth joined every JATS element's text with a space, so
`bla<sub>CTX-M</sub>` became `bla CTX-M` against a page that prints `blaCTX-M`. The same
happened to `T<sub>a</sub>` → `T a`, `et al.<sup>12</sup>` → `et al. 12`, `VAS
1<sup>st</sup> week` → `VAS 1 st week`, and `<italic>MPa</italic>` inside a parenthesis →
`( MPa )`. Every one of those boundaries destroys five n-grams of ground truth that no
converter can ever match.

The rule the old code was protecting is real — `<label>Table 2</label>` must not fuse onto
the caption after it — but it applies to *structural* boundaries, not inline ones. The
projection now preserves the source's own whitespace inside a line and adds a space only at
a structural boundary.

The set of inline elements is measured rather than assumed: across every table cell,
paragraph, title and caption of both development corpora, these are the tags whose text
abuts a neighbour with no whitespace in the source (`xref` 22,934 times, `italic` 6,397,
`sup` 4,035, `sub` 3,662, `bold` 3,290, the rest in the tens). Block and container elements
abut just as often (`disp-formula` 244, `fig` 80, `list` 22) and are deliberately excluded —
they begin their own line, so their space is real. Anything unrecognised keeps its space,
which is the safe direction: a missing space fuses two words into a token nothing can match,
a spurious one only splits them.

## Measured

On the recorded table replay (225 truth tables across the two development corpora), holding
the converter fixed and correcting only the truth:

| corpus | truth as projected | truth as printed |
|---|---|---|
| dev (66 articles, 105 tables) | 0.8141 | **0.8428** (+0.0287) |
| tuned (110 articles, 130 tables) | 0.8038 | **0.8387** (+0.0349) |

38 of the 41 tables that move get better; the 3 that lose, lose ≤0.10 and are all in one
article. Several tables scoring 0.11–0.77 were in fact being reproduced whole —
PMC6750072.1 0.111 → 1.000, PMC7750051.1 0.313 → 0.954, PMC5250647.1 0.438 → 0.948.

For scale: an oracle that cuts every recorded grid's columns at the best position — a
*perfect* fix for tables the detector fuses side by side — is worth +0.004 (dev) and +0.013
(tuned) on the same corpora. The measurement artifact was several times larger than the
structural defect it was hiding, which is why this lands before any further table work.

About 3% of the ground truth's prose 5-grams change too, so this is not confined to tables.

## Follow-up

`benchmarks/pmc/reference.json` was recorded against the old projection and needs
re-recording (`pmc-borndigital.yml`, ~24 min, dispatched from `main` after this merges) before
its figures are read again. The lane does not run on per-PR CI, so nothing is gated on it in
the meantime and `tests/unit/test_published_benchmark_figures.py` stays green because the
docs and the artifact are still consistent with each other.

## Tests

`test_element_text_is_joined_not_concatenated` asserted the old behaviour on a synthetic
`<p><italic>Table 2</italic>obtained results</p>`. Its real concern — the label/caption
fusion — is now pinned on the shape it actually occurs in, and two new tests pin the inline
side: that `<td>bla<sub>CTX-M</sub></td>` renders `blaCTX-M`, and that the source's own
whitespace still governs (`Isolates of <italic>E. coli</italic> were typed.`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)