### PR TITLE
chore(benchmarks): re-record the born-digital lane against the corrected truth

### DIFF
--- a/benchmarks/pmc/reference.json
+++ b/benchmarks/pmc/reference.json
@@ -5,9 +5,9 @@
     "bucket": "pmc-oa-opendata",
     "complete_corpus": true,
     "oracle_schema_version": 3,
-    "all2md_commit": "a83600aa5068b3146b4aa22c64649a5664588890",
+    "all2md_commit": "2925f5cbd3653a194f5742a920089f1ece105375",
     "worktree_dirty": false,
-    "created_at": "2026-08-27T02:14:44.375859+00:00",
+    "created_at": "2026-08-29T02:11:04.230889+00:00",
     "python": "3.12.3 (main, Jun 19 2026, 12:46:00) [GCC 13.3.0]",
     "platform": "linux",
     "parser_runtime": {
@@ -39,190 +39,190 @@
     "ground_truth_blocks": 11503,
     "coverage": {
       "count": 66.0,
-      "mean": 0.9650180243987616,
-      "median": 0.9844624081486973,
-      "minimum": 0.09476843910806175,
-      "maximum": 1.1974210089736823,
-      "stdev": 0.13519930586338003
+      "mean": 0.9321573948937522,
+      "median": 0.9546637748177358,
+      "minimum": 0.09348198970840481,
+      "maximum": 1.1222493887530562,
+      "stdev": 0.13109413309353415
     },
-    "tables_expected": 121,
+    "tables_expected": 122,
     "tables_emitted": 162,
     "tables_deposited_as_images": 19,
     "table_surplus": {
-      "examined": 56,
-      "in_text_layer": 41,
-      "words_in_text_layer": 56,
+      "examined": 55,
+      "in_text_layer": 40,
+      "words_in_text_layer": 55,
       "by_source": {
-        "jats_table": 16,
+        "jats_table": 15,
         "jats_prose": 0,
         "outside_jats": 40
       }
     },
-    "pages_with_expected_table": 94,
+    "pages_with_expected_table": 95,
     "pages_with_emitted_table": 119
   },
   "projection": {
     "assignments": {
-      "clean": 7167,
-      "spans": 319,
-      "tokens": 987,
-      "phrase": 1476,
-      "inherited": 1078,
-      "excluded": 476
+      "clean": 7183,
+      "spans": 320,
+      "tokens": 976,
+      "phrase": 1479,
+      "inherited": 1077,
+      "excluded": 468
     },
     "excluded_reasons": {
-      "missing": 328,
-      "split": 104,
+      "missing": 329,
+      "split": 95,
       "too_short": 44
     },
-    "error_budget": 0.041380509432322,
+    "error_budget": 0.04068503868556029,
     "unsplit_spans": 42
   },
   "article_recall": {
-    "recall": 0.6234699606962381,
-    "recovered": 5552,
-    "scored": 8905,
-    "too_short": 2598,
-    "ceiling": 0.624480628860191,
-    "attainable": 5561,
-    "recovered_attainable": 5499,
-    "attainable_recall": 0.9888509260924294,
+    "recall": 0.6377625519487813,
+    "recovered": 5678,
+    "scored": 8903,
+    "too_short": 2600,
+    "ceiling": 0.639222733909918,
+    "attainable": 5691,
+    "recovered_attainable": 5628,
+    "attainable_recall": 0.988929889298893,
     "by_kind": {
       "table": {
-        "recovered": 92,
-        "attainable": 110,
-        "recovered_attainable": 91,
+        "recovered": 101,
+        "attainable": 119,
+        "recovered_attainable": 101,
         "scored": 123,
-        "attainable_recall": 0.8272727272727273
+        "attainable_recall": 0.8487394957983193
       },
       "text_block": {
-        "recovered": 3172,
-        "attainable": 3160,
-        "recovered_attainable": 3142,
-        "scored": 6356,
-        "attainable_recall": 0.9943037974683544
+        "recovered": 3264,
+        "attainable": 3256,
+        "recovered_attainable": 3236,
+        "scored": 6355,
+        "attainable_recall": 0.9938574938574939
       },
       "title": {
-        "recovered": 2288,
-        "attainable": 2291,
-        "recovered_attainable": 2266,
-        "scored": 2426,
-        "attainable_recall": 0.9890877346137058
+        "recovered": 2313,
+        "attainable": 2316,
+        "recovered_attainable": 2291,
+        "scored": 2425,
+        "attainable_recall": 0.9892055267702936
       }
     },
-    "control_recall": 0.003593486805165637,
-    "control_scored": 8905,
-    "discrimination": 0.6198764738910724
+    "control_recall": 0.003594294058182635,
+    "control_scored": 8903,
+    "discrimination": 0.6341682578905986
   },
   "article_precision": {
-    "precision": 0.95495810996471,
-    "supported": 425388,
-    "emitted": 445452,
-    "resequenced": 18153,
-    "novel": 1911,
-    "novel_share": 0.004290024514425797,
-    "duplication": 0.0044821697256734365,
-    "excess": 2118,
-    "occurrences": 472539,
-    "control_precision": 0.007073713890609987,
-    "control_emitted": 445452,
-    "discrimination": 0.9478843960741
+    "precision": 0.9556333301155917,
+    "supported": 425684,
+    "emitted": 445447,
+    "resequenced": 17865,
+    "novel": 1898,
+    "novel_share": 0.0042608885007644004,
+    "duplication": 0.004480072459934354,
+    "excess": 2117,
+    "occurrences": 472537,
+    "control_precision": 0.007073793290784313,
+    "control_emitted": 445447,
+    "discrimination": 0.9485595368248074
   },
   "figure_binding": {
-    "binding_rate": 0.6697674418604651,
-    "bound": 144,
+    "binding_rate": 0.6837209302325581,
+    "bound": 147,
     "scored": 215,
     "too_short": 13,
     "misfiled_rate": 0.0,
     "misfiled": 0,
-    "caption_recall": 0.9441860465116279,
-    "present": 203,
+    "caption_recall": 0.9767441860465116,
+    "present": 210,
     "images_emitted": 429,
     "captioned_emitted": 189,
     "control_binding_rate": 0.0,
     "control_scored": 215,
-    "discrimination": 0.6697674418604651
+    "discrimination": 0.6837209302325581
   },
   "dimensions": {
     "block_structure_similarity": {
       "count": 706.0,
-      "mean": 0.5499574971987709,
+      "mean": 0.5501373336250662,
       "median": 0.5714285714285714,
       "minimum": 0.023255813953488413,
       "maximum": 1.0,
-      "stdev": 0.2097840312915306,
+      "stdev": 0.20915394386129518,
       "direction": "higher",
-      "control_mean": 0.44583625928580606,
-      "discrimination": 0.10412123791296479,
+      "control_mean": 0.4461596914177608,
+      "discrimination": 0.10397764220730543,
       "mutation_drop": {
-        "reversed": 0.016936323989963087,
-        "shuffled": 0.032316026954744746,
-        "halved": 0.08099013859927681
+        "reversed": 0.01694626840500665,
+        "shuffled": 0.03187297910293168,
+        "halved": 0.08114643085417762
       },
       "ungateable": "compares kind sequences without inspecting the text under a block, so content-free output scores 1.0 (issue #256); eleven text categories collapse to `text_block`, so fully reversed output scores exactly 1.0 on 153 of the 981 pinned pages; and on the born-digital lane it separates own-page from wrong-page output by only ~0.06 while *rising* when half the emitted content is deleted, which rewards dropping blocks"
     },
     "reading_order_similarity": {
       "count": 706.0,
-      "mean": 0.8285568821629603,
-      "median": 0.9096736596736597,
+      "mean": 0.8299363230374033,
+      "median": 0.9090909090909091,
       "minimum": 0.0,
       "maximum": 1.0,
-      "stdev": 0.21006762109393606,
+      "stdev": 0.20958124022791658,
       "direction": "higher",
-      "control_mean": 0.29148169879066094,
-      "discrimination": 0.5370751833722993,
+      "control_mean": 0.29338972141271175,
+      "discrimination": 0.5365466016246916,
       "mutation_drop": {
-        "reversed": 0.5320390292731018,
-        "shuffled": 0.24531955117934107,
-        "halved": 0.32885072613550737
+        "reversed": 0.5332049130421304,
+        "shuffled": 0.2459461590669233,
+        "halved": 0.3273702029100698
       }
     },
     "table_content_similarity": {
       "count": 123.0,
-      "mean": 0.6111204479311206,
-      "median": 0.8669014084507043,
+      "mean": 0.6289993592315243,
+      "median": 0.8911070780399274,
       "minimum": 0.0,
       "maximum": 1.0,
-      "stdev": 0.415797760655914,
+      "stdev": 0.4201418138943769,
       "direction": "higher",
-      "control_mean": 0.03946981709701299,
-      "discrimination": 0.5716506308341076,
+      "control_mean": 0.039315415599305716,
+      "discrimination": 0.5896839436322185,
       "mutation_drop": {
         "reversed": 0.0,
         "shuffled": 0.0,
-        "halved": 0.6067551420455266
+        "halved": 0.6219460235829645
       }
     },
     "table_structure_similarity": {
       "count": 123.0,
-      "mean": 0.6215252012916203,
-      "median": 0.8532536091359622,
+      "mean": 0.6359474653854718,
+      "median": 0.8666666666666667,
       "minimum": 0.0,
       "maximum": 1.0,
-      "stdev": 0.4124209192264495,
+      "stdev": 0.413284755690187,
       "direction": "higher",
-      "control_mean": 0.09394104610544118,
-      "discrimination": 0.5275841551861791,
+      "control_mean": 0.09373701848386773,
+      "discrimination": 0.542210446901604,
       "mutation_drop": {
         "reversed": 0.0,
         "shuffled": 0.0,
-        "halved": 0.617531736367868
+        "halved": 0.6287750374950218
       }
     },
     "text_content_similarity": {
       "count": 706.0,
-      "mean": 0.6832651408246185,
-      "median": 0.7082209683552323,
+      "mean": 0.6897131366646299,
+      "median": 0.7140346322468694,
       "minimum": 0.010652463382157085,
       "maximum": 0.993987493987494,
-      "stdev": 0.22225978245930622,
+      "stdev": 0.22238346057923006,
       "direction": "higher",
-      "control_mean": 0.2334649247442188,
-      "discrimination": 0.4498002160803998,
+      "control_mean": 0.2336517054813915,
+      "discrimination": 0.4560614311832384,
       "mutation_drop": {
-        "reversed": 0.2921978901158989,
-        "shuffled": 0.20266960746984378,
-        "halved": 0.2935467843711363
+        "reversed": 0.29573047484180887,
+        "shuffled": 0.20501856683222974,
+        "halved": 0.2959575760909976
       }
     }
   },

--- a/changelog.d/pmc-rerecord-truth-fix.changed.md
+++ b/changelog.d/pmc-rerecord-truth-fix.changed.md
@@ -1,0 +1,20 @@
+- **benchmarks/pmc: the born-digital lane is re-recorded against the corrected ground
+  truth.** `reference.json` now holds the CI reading taken on `main` at `2925f5c`, the
+  first since the JATS projection stopped printing a space the page does not print. Almost
+  all of the movement is that correction rather than a parser change, and the published
+  page says so: raw recall 62.3% → **63.8%**, table attainable-recall 82.7% → **84.9%**,
+  `table_content_similarity` 0.611 → **0.629**, `table_structure_similarity` 0.622 →
+  **0.636**, `text_content_similarity` 0.683 → **0.690**, caption recall 94.4% →
+  **97.7%**, supported share 95.5% → **95.6%**. **Recall of what is attainable is
+  unchanged at 98.9%** — the correction puts more of the ground truth inside the ceiling
+  and recovers it in the same proportion, which is what a published ceiling is for. Ground
+  truth coverage of the page falls 0.965 → **0.932** for the same reason, and its maximum
+  falls 1.197 → **1.122**: the projection was claiming more words than the page shows,
+  which is precisely the direction a spurious space produces.
+
+- **docs: one published table-surplus figure was stale, and the figures gate could not see
+  it.** The census reports the surplus split by source; the page prints both halves, but
+  only the first is a snippet the gate renders from the artifact. `outside_jats` fell from
+  42 to 40 at the previous re-record and the derived "the other 22" was never updated. It
+  now reads **20**. The gate covers declared snippets, not the prose around them, which is
+  the second time that gap has produced a stale published number.

--- a/changelog.d/pmc-truth-inline-markup.fixed.md
+++ b/changelog.d/pmc-truth-inline-markup.fixed.md
@@ -21,6 +21,5 @@
   a perfect fix for tables the detector fuses side by side -- is worth 0.004 and 0.013
   on the same corpora, so the artifact was larger than the defect it was hiding. About
   3% of the ground truth's prose 5-grams are affected too. `benchmarks/pmc/reference.json`
-  was recorded against the old projection and must be re-recorded before its figures are
-  read again; the lane does not run on per-PR CI, so nothing is gated on it in the
-  meantime.
+  and every published figure drawn from it are re-recorded against the corrected
+  projection in the same release.

--- a/docs/source/benchmarks.rst
+++ b/docs/source/benchmarks.rst
@@ -90,10 +90,10 @@ Did the text survive?
      - Value
      -
    * - Raw recall
-     - 62.3%
-     - of 8,905 ground-truth blocks
+     - 63.8%
+     - of 8,903 ground-truth blocks
    * - Attainable ceiling
-     - 62.4%
+     - 63.9%
      - what the PDF's own text layer reproduces
    * - **Recall of what is attainable**
      - **98.9%**
@@ -102,8 +102,20 @@ Did the text survive?
      - 0.4%
      - wants to be ~0%
 
-Part of the most recent movement in these figures is a *measurement* correction, not a
-parser change, and it is flagged as such: the shared oracle was blind to captions the
+The most recent movement in these figures is a *measurement* correction rather than a
+parser change, and it is flagged as such. The projection joined every JATS element's text
+with a space, so that ``<label>Table 2</label>`` could not fuse onto the caption after it.
+Structural boundaries do need that space; inline ones do not, and JATS marks up part of a
+word constantly — ``bla<sub>CTX-M</sub>`` is printed ``blaCTX-M``, ``et al.<sup>12</sup>``
+is ``et al.12``. Every such boundary put five n-grams of ground truth beyond the reach of
+any converter, and the tables carried the most of them. Rendering an element as the page
+prints it — the source's own whitespace inside a line, a space only at a structural
+boundary (#470) — moves raw recall from 62.3% to 63.8% and table attainable-recall from
+82.7% to 84.9% with the parser untouched. Recall of *attainable* blocks does not move at
+all: the correction puts more of the ground truth inside the ceiling and recovers it in the
+same proportion, which is the behaviour a ceiling is for.
+
+An earlier movement was the same kind of thing: the shared oracle was blind to captions the
 parser had correctly bound to their figures — the text left the paragraph stream for a
 ``caption`` attribute the projection never read, so recall *fell* as figure binding
 improved. On the held-out corpus, 101 of the 103 caption blocks the instruments called
@@ -119,7 +131,7 @@ the table repairs below, the furniture-trimmed column channel and the crossing
 tolerance that followed), and
 the held-out corpus moved the same way it was never tuned against.
 
-Raw recall is 62.3%, and that figure is close to meaningless on its own. A large share of
+Raw recall is 63.8%, and that figure is close to meaningless on its own. A large share of
 any JATS article cannot be recovered by *any* parser, because the markup records words in an
 order the page never prints — author affiliation blocks, structured metadata, citation
 fields. Charging a PDF parser for failing to reproduce text the PDF does not contain
@@ -140,21 +152,21 @@ By block kind:
      - Recovered of those
      - Share of attainable
    * - Text blocks
-     - 3,160 of 6,356
-     - 3,142
+     - 3,256 of 6,355
+     - 3,236
      - **99.4%**
    * - Titles
-     - 2,291 of 2,426
-     - 2,266
+     - 2,316 of 2,425
+     - 2,291
      - **98.9%**
    * - Tables
-     - 110 of 123
-     - 91
-     - **82.7%**
+     - 119 of 123
+     - 101
+     - **84.9%**
 
 The middle column counts only blocks inside the ceiling, so each row's share is its own
-two counts divided. A few more blocks are recovered than that: 3,172 text blocks, 2,288
-titles and 92 tables come out matching the ground truth, including some the PDF's own text
+two counts divided. A few more blocks are recovered than that: 3,264 text blocks, 2,313
+titles and 101 tables come out matching the ground truth, including some the PDF's own text
 layer does not reproduce. Those count as recovered and on neither side of the share, which
 is why the larger count is not the one printed here.
 
@@ -184,10 +196,10 @@ Unsupported output is therefore split in two:
      - Share
      - Meaning
    * - Supported
-     - **95.5%**
+     - **95.6%**
      - the n-gram appears in the document's text layer
    * - Resequenced
-     - 4.1%
+     - 4.0%
      - every word is in the document, in a new adjacency
    * - **Novel**
      - **0.4%**
@@ -199,7 +211,7 @@ Unsupported output is therefore split in two:
      - 0.7%
      - wants to be ~0%
 
-Over 445,452 emitted n-grams, 1,911 are novel. Reporting the raw unsupported figure instead
+Over 445,447 emitted n-grams, 1,898 are novel. Reporting the raw unsupported figure instead
 would have made the result roughly ten times worse than the parser deserves.
 
 Duplication is counted apart from both, because it is invisible to either. Text emitted
@@ -231,23 +243,23 @@ Tables
 The bottleneck has moved. An earlier recording under-emitted — 92 tables against 121
 expected, with detection refusing to commit on the borderless *booktabs*-style tables
 journals actually print — and after word-gutter grids and two-column regions were admitted
-behind measured guards, the artifact reads **162 emitted against 121
+behind measured guards, the artifact reads **162 emitted against 122
 expected**, with tables emitted on 119 pages
-against the 94 that carry one in the ground truth.
+against the 95 that carry one in the ground truth.
 
 The surplus is not invention, and that is now measured rather than asserted. Every table
-emitted on a page carrying more tables than the ground truth expects — **56** of them — is
+emitted on a page carrying more tables than the ground truth expects — **55** of them — is
 put to two questions. The first does not involve JATS at all: does the PDF's own text layer
 hold this table's words? Text in the layer was printed on the page, so a table failing here
-is the only kind that could have been invented. **56 of 56** pass. The second asks where
+is the only kind that could have been invented. **55 of 55** pass. The second asks where
 that text sits in the ground truth, and the verdict that would matter is prose committed to
-a grid — a parser turning running text into a table it invented. That is **0 of 56**.
+a grid — a parser turning running text into a table it invented. That is **0 of 55**.
 
-Only 41 of the 56 also match the *order* of the text layer, and that gap is a grid doing its
+Only 40 of the 55 also match the *order* of the text layer, and that gap is a grid doing its
 job rather than a fault: re-cutting a page's words into cells changes their adjacency, which
 is why the invention test is asked of the words and not of the 5-grams.
 
-What the surplus is instead is accounting, with two named causes. **16** of the 56 trace to a
+What the surplus is instead is accounting, with two named causes. **15** of the 55 trace to a
 JATS ``<table>`` that the expected count assigns to another page — a table continuing across
 a page break is one ``<table-wrap>`` and several printed tables, and the expected count does
 not credit continuations. And **19** ``<table-wrap>`` elements across five articles carry no
@@ -256,7 +268,7 @@ truth holds no cell text for them and the tables those pages print can never rea
 expected side, however well they are extracted. Those five articles alone contribute 20 of
 the **40** tables the census files outside JATS.
 
-The other 22 are in the page's own text layer and match no JATS block in order. The
+The other 20 are in the page's own text layer and match no JATS block in order. The
 instrument stops there rather than guessing: it does not distinguish text JATS never
 recorded from a table re-cut into cells in an order JATS does not declare. Unordered token
 containment would answer neither, because an article's tables and its prose share a
@@ -277,7 +289,8 @@ measured, fixed behind guards (#416, #417), and the figure recovered to 77.3%. A
 mechanism followed the same route: ``find_tables()`` drew column boundaries and bbox edges
 straight through cell content, cutting values mid-word where neither guard could see it —
 dissolving those boundaries on structural evidence and healing the cut values in place
-(#419) took the figure to **82.7%**. The trade still stands with eyes open — a table
+(#419) took the figure to 82.7%, and the ground-truth correction above to **84.9%**.
+The trade still stands with eyes open — a table
 recovered *as a table* is what downstream consumers need — but it is a trade, and the
 artifact says so rather than netting the two effects into one flattering number.
 
@@ -299,21 +312,21 @@ pages:
      - Wrong page
      - Gap
    * - ``reading_order_similarity``
-     - 0.829
-     - 0.291
+     - 0.830
+     - 0.293
      - **0.537**
    * - ``text_content_similarity``
-     - 0.683
-     - 0.233
-     - **0.450**
+     - 0.690
+     - 0.234
+     - **0.456**
    * - ``table_content_similarity``
-     - 0.611
+     - 0.629
      - 0.039
-     - **0.572**
+     - **0.590**
    * - ``table_structure_similarity``
-     - 0.622
+     - 0.636
      - 0.094
-     - **0.528**
+     - **0.542**
    * - ``block_structure_similarity``
      - 0.550
      - 0.446


### PR DESCRIPTION
`benchmarks/pmc/reference.json` now holds the CI reading taken on `main` at `2925f5c`
([run 33227170074](https://github.com/thomas-villani/all2md/actions/runs/33227170074)), the
first since #470 stopped the JATS projection printing a space the page does not print.

## What moved, and why

Almost all of it is the measurement correction rather than a parser change, and
`docs/source/benchmarks.rst` now says so in the same place it flags the caption-oracle
correction:

| Figure | Before | After |
|---|---|---|
| Raw recall | 62.3% | **63.8%** |
| **Recall of what is attainable** | **98.9%** | **98.9%** |
| Tables, share of attainable | 82.7% | **84.9%** |
| Text blocks | 99.4% | 99.4% |
| Titles | 98.9% | 98.9% |
| Supported share | 95.5% | **95.6%** |
| Novel share | 0.43% | 0.43% |
| `text_content_similarity` | 0.683 | **0.690** |
| `table_content_similarity` | 0.611 | **0.629** |
| `table_structure_similarity` | 0.622 | **0.636** |
| `reading_order_similarity` | 0.829 | 0.830 |
| Caption recall | 94.4% | **97.7%** |

**Recall of what is attainable is unchanged**, and that is the reading that matters: the
correction puts more of the ground truth inside the ceiling (attainable 5,561 → 5,691) and
recovers it in the same proportion. A ceiling that absorbs a truth correction without
moving the score is doing its job.

Coverage of the page falls 0.965 → 0.932 and its maximum 1.197 → 1.122 for the same
reason — the projection had been claiming more words than the page shows, exactly the
direction a spurious space produces.

## One stale figure the gate could not see

`table_surplus.by_source.outside_jats` fell 42 → 40 at the previous re-record, and the
derived sentence "the other 22 are in the page's own text layer" was never updated. It now
reads **20**. The figures gate renders declared snippets from the artifact and requires the
page to contain them; this half of the split is not one. That is the second stale published
number that inventory has missed, so the page was grepped for every old value after the
gate went green, and the diff was read row by row.

## Checks

- `tests/unit/test_published_benchmark_figures.py` green (20 snippets were stale; all
  updated).
- `tests/unit -k "pmc or omnidoc or benchmark or published or holdout"` green, one
  POSIX-only skip.
- Changelog fragments validate; #470's fragment loses its "must be re-recorded" caveat,
  since both halves now ship in the same release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
