### PR TITLE
feat(benchmarks): commit the oracle audit instruments and a heading measure

### DIFF
--- a/benchmarks/comparison/headings.py
+++ b/benchmarks/comparison/headings.py
@@ -1,0 +1,160 @@
+#  Copyright (c) 2025 Tom Villani, Ph.D.
+"""Score section headings across every tool, by structure rather than by text.
+
+The lane's block instruments cannot see headings.  ``MIN_NGRAMS`` drops any block under
+about eight words, which removes 87% of section headings, and lowering the floor does not
+help: ``Introduction`` appears in any article's prose, so a containment test would read
+near 100% for every tool and measure nothing.  What is left is *structure* -- a truth
+heading counts as recovered only when the tool emitted a heading whose text is the same.
+
+That rule needs no threshold, no floor, and no page attribution, so unlike reading order
+and table structure it scores third-party output as readily as our own.
+
+Two figures are reported because the whole-corpus one has a weak control by construction:
+section headings come from a small shared vocabulary (``Introduction``, ``Discussion``,
+``Funding``), so scoring an article against the wrong output still matches some.  The
+subset restricted to headings appearing in fewer than ``COMMON_HEADING_ARTICLES`` articles
+has a near-zero control and is the sharper number.
+
+Usage: ``python benchmarks/comparison/headings.py [tool ...]`` (default: every directory
+under ``out/``).  Reads the same ``articles.json`` and ``out/<tool>/`` layout as
+``score.py``; run the converters first.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import sys
+from collections import Counter
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+REPO = HERE.parents[1]
+sys.path.insert(0, str(REPO))
+
+import fitz  # noqa: E402
+
+from benchmarks.pmc import oracles  # noqa: E402
+from benchmarks.pmc.alignment import normalize  # noqa: E402
+from benchmarks.pmc.corpus import _parse_jats  # noqa: E402
+
+#: An ATX heading line in a tool's markdown.  Every converter here emits ATX; a setext
+#: heading would need adding, and its absence is why this reports emitted counts too --
+#: a tool emitting none at all is visible rather than silently scoring zero.
+ATX = re.compile(r"^(#{1,6})\s+(.*?)\s*$", re.MULTILINE)
+
+#: Ancestors that make a ``<title>`` something other than a section heading.  A reference's
+#: ``<article-title>`` and a section's ``<title>`` are both kind ``title`` to the oracle,
+#: and they are not the same claim about a converter.
+NOT_A_HEADING = frozenset({"ref", "ref-list", "fig", "table-wrap", "front", "article-meta"})
+
+#: A heading string appearing in at least this many articles is corpus vocabulary rather
+#: than a property of one document, and is what keeps the whole-corpus control off zero.
+COMMON_HEADING_ARTICLES = 5
+
+
+def _headings(node: object, ancestors: frozenset[str] = frozenset()) -> list[str]:
+    """Return the normalized text of every section heading under a JATS node."""
+    tag = oracles._tag(node)
+    if tag in oracles.SKIPPED:
+        return []
+    if oracles.BLOCKS.get(tag) == "title":
+        if NOT_A_HEADING & ancestors:
+            return []
+        text = " ".join(normalize(oracles._own_text(node)))
+        return [text] if text else []
+    found: list[str] = []
+    for child in node:  # type: ignore[attr-defined]
+        found.extend(_headings(child, ancestors | {tag}))
+    return found
+
+
+def _emitted(markdown: str) -> set[str]:
+    """Return the normalized text of every ATX heading in a tool's markdown."""
+    return {" ".join(normalize(match.group(2))) for match in ATX.finditer(markdown)} - {""}
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Score every requested tool's headings against the JATS section titles."""
+    argv = sys.argv[1:] if argv is None else argv
+    out_root = HERE / "out"
+    tools = argv or sorted(directory.name for directory in out_root.iterdir() if directory.is_dir())
+    articles = json.loads((HERE / "articles.json").read_text(encoding="utf-8"))["articles"]
+
+    truth: dict[str, set[str]] = {}
+    printed: dict[str, set[str]] = {}
+    for article in articles:
+        root, _ = _parse_jats(Path(article["xml_path"]).read_bytes())
+        wanted = set(_headings(root))
+        if not wanted:
+            continue
+        truth[article["article_id"]] = wanted
+        with fitz.open(article["pdf_path"]) as document:
+            page = " ".join(normalize(" ".join(p.get_text() for p in document)))
+        printed[article["article_id"]] = {heading for heading in wanted if heading in page}
+
+    frequency: Counter[str] = Counter()
+    for wanted in truth.values():
+        frequency.update(wanted)
+    rare = {heading for heading, seen in frequency.items() if seen < COMMON_HEADING_ARTICLES}
+
+    total = sum(len(wanted) for wanted in truth.values())
+    rare_total = sum(len(wanted & rare) for wanted in truth.values())
+    print(
+        f"{total:,} section headings across {len(truth)} articles; {rare_total:,} of them "
+        f"appear in fewer than {COMMON_HEADING_ARTICLES} articles"
+    )
+
+    order = list(truth)
+    for tool in tools:
+        heads: dict[str, set[str]] = {}
+        for article_id in order:
+            markdown = out_root / tool / f"{article_id}.md"
+            if markdown.exists():
+                heads[article_id] = _emitted(markdown.read_text(encoding="utf-8"))
+        if not heads:
+            print(f"\n{tool}: no outputs yet")
+            continue
+
+        verdicts: Counter[str] = Counter()
+        emitted = matched = control = rare_matched = rare_control = rare_seen = 0
+        for index, article_id in enumerate(order):
+            if article_id not in heads:
+                continue
+            wanted = truth[article_id]
+            mine = heads[article_id]
+            neighbour = heads.get(order[(index + 1) % len(order)], set())
+            body = " ".join(normalize((out_root / tool / f"{article_id}.md").read_text(encoding="utf-8")))
+            emitted += len(mine)
+            matched += len(wanted & mine)
+            control += len(wanted & neighbour)
+            rare_seen += len(wanted & rare)
+            rare_matched += len(wanted & rare & mine)
+            rare_control += len(wanted & rare & neighbour)
+            for heading in wanted:
+                if heading in mine:
+                    verdicts["recovered as a heading"] += 1
+                elif heading not in printed[article_id]:
+                    verdicts["the page never printed it"] += 1
+                elif heading in body:
+                    verdicts["emitted, but not as a heading"] += 1
+                else:
+                    verdicts["absent from the output"] += 1
+
+        scored = sum(verdicts.values())
+        on_page = scored - verdicts["the page never printed it"]
+        print(f"\n{tool}  ({scored:,} truth headings, {emitted:,} headings emitted)")
+        for kind, count in verdicts.most_common():
+            print(f"   {kind:32s} {count:6,d} {count / scored:7.1%}")
+        print(f"   {'-> share of PRINTED headings':32s} {verdicts['recovered as a heading'] / on_page:14.1%}")
+        print(f"   {'-> precision of emitted headings':32s} {matched / emitted:14.1%}")
+        print(f"   {'control: the WRONG article':32s} {control / scored:14.1%}")
+        print(
+            f"   {'rare headings only':32s} {rare_matched / rare_seen:14.1%}   control {rare_control / rare_seen:.1%}"
+        )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/benchmarks/pmc/README.md
+++ b/benchmarks/pmc/README.md
@@ -518,6 +518,54 @@ candidate. What exposed it was the payload's own `ocr_articles` field listing 2 
 a true baseline must list 11. Patch the *function* the option feeds, and confirm an arm is the
 arm from a field recording what the parser did, never from the score it produced.
 
+## Auditing the oracle: `benchmarks.pmc.audit`
+
+Every figure this lane publishes rests on the JATS projection being a faithful account of
+what the page prints. That assumption went unexamined for months and was wrong: the
+projection joined every element's text with a space, so the truth read `bla CTX-M` where the
+page prints `blaCTX-M`. Correcting it moved table containment on the development corpora by
+several times what a *perfect* column splitter was worth, and moved the published table
+figure 82.7% -> 84.9% with the parser untouched (#470).
+
+So the oracle now gets audited by running something rather than by noticing. Each check
+reads only the cached corpus -- JATS and the PDF's own text layer -- so none of them convert
+anything, and each takes about a minute:
+
+```bash
+python -m benchmarks.pmc.audit ceiling       # where blocks sit against the 0.80 attainable bar
+python -m benchmarks.pmc.audit unscored      # what the MIN_NGRAMS floor removes, per kind
+python -m benchmarks.pmc.audit titles        # section heading? reference entry? float label?
+python -m benchmarks.pmc.audit duplicates    # blocks repeating another block's exact text
+python -m benchmarks.pmc.audit unprintable   # projected words the text layer never holds
+```
+
+`--manifest` and `--cache` default to the development corpus. **Do not point them at the
+sealed holdout while developing** — reading it is a scoring act, not a development one.
+
+What the first run (2026-08-29) found, on the 66-article development corpus:
+
+- **The 0.80 bar is not a knife edge.** Containment against the text layer is sharply
+  bimodal on both development corpora — 78% of tables and 94.5% of titles sit at exactly
+  1.0, and 4.1% of text blocks fall within ±0.05 of the bar. The published attainable-recall
+  figures do not turn on the threshold.
+- **Duplicates are benign.** 0.19% of scored blocks repeat another block's exact text (a
+  reference cited twice, a shared affiliation). Set containment gives both copies the same
+  verdict, so it double-weights rather than distorts.
+- **Unprintable words are handled by the ceiling.** 2.6% of projected words never appear in
+  the text layer — ORCID digits, institution identifiers, licence URLs, 55% of them bare
+  numbers — and they sit in blocks that fail the ceiling anyway.
+- **The floor is a real blind spot, and the `title` row is not what it looks like.**
+  `MIN_NGRAMS = 4` never scores **22.6%** of ground-truth blocks, including **41% of
+  titles**. Of the title blocks that are scored, **2,208 are reference-list entries and 148
+  are section headings** — 86.7% of section headings are under the floor, because
+  `Introduction` and `Discussion` are two words. Tables are unaffected at 0%.
+
+  Lowering the floor cannot fix that: `Introduction` appears in any article's prose, so a
+  containment test would read near 100% for every converter. A heading measure needs
+  *structure* — see `benchmarks/comparison/headings.py`, which matches a truth heading only
+  against a heading the tool actually emitted, and which needs no page attribution and so
+  scores third-party output too.
+
 ## Licences
 
 The OA subset is not uniformly licensed. Each article's licence is read out of its own

--- a/benchmarks/pmc/audit.py
+++ b/benchmarks/pmc/audit.py
@@ -1,0 +1,363 @@
+#  Copyright (c) 2025 Tom Villani, Ph.D.
+"""Audit the ground-truth oracle itself, rather than the parser it scores.
+
+Every figure this lane publishes rests on the JATS projection being a faithful account of
+what the page prints.  That assumption went unexamined for months and was wrong: the
+projection joined every element's text with a space, so the ground truth read ``bla CTX-M``
+where the page prints ``blaCTX-M``, and the penalty that produced was several times larger
+than the structural defect it was hiding (#470).  These checks exist so that the next such
+error is found by running something rather than by noticing.
+
+They read only the cached corpus -- JATS and the PDF's own text layer -- so none of them
+convert anything, and each takes about a minute over a development corpus.
+
+Usage, from the repository root::
+
+    python -m benchmarks.pmc.audit ceiling
+    python -m benchmarks.pmc.audit unscored --manifest benchmarks/pmc/manifest-tuned.json
+
+``--manifest`` defaults to the development corpus and ``--cache`` to the lane's own cache
+directory; the corpus must already be materialized (``python -m benchmarks.pmc load``).
+
+**Do not point these at the sealed holdout while developing.**  Reading it is a scoring act,
+not a development one -- see :file:`benchmarks/pmc/README.md`.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from collections import Counter
+from collections.abc import Callable, Iterator
+from pathlib import Path
+from typing import Any, NamedTuple
+
+HERE = Path(__file__).resolve().parent
+REPO = HERE.parents[1]
+sys.path.insert(0, str(REPO))
+
+import fitz  # noqa: E402
+
+from benchmarks.pmc import oracles  # noqa: E402
+from benchmarks.pmc.alignment import MIN_NGRAMS, ngrams, normalize  # noqa: E402
+from benchmarks.pmc.article import RECALL_MIN  # noqa: E402
+from benchmarks.pmc.corpus import DEFAULT_MANIFEST, _parse_jats, read_manifest  # noqa: E402
+
+DEFAULT_CACHE = HERE / ".cache"
+
+#: Where a block's containment against the PDF text layer is reported.  The bands narrow
+#: around ``RECALL_MIN`` because the question that matters is whether that bar slices
+#: through a crowd or separates two clear populations.
+BANDS: tuple[tuple[float, float], ...] = (
+    (0.0, 0.2),
+    (0.2, 0.5),
+    (0.5, 0.7),
+    (0.7, 0.75),
+    (0.75, 0.8),
+    (0.8, 0.85),
+    (0.85, 0.9),
+    (0.9, 0.95),
+    (0.95, 1.0),
+    (1.0, 1.01),
+)
+
+
+class Article(NamedTuple):
+    """One cached article: its id and the two files these instruments read."""
+
+    article_id: str
+    xml: Path
+    pdf: Path
+
+
+def articles(manifest: Path, cache: Path) -> list[Article]:
+    """Return the cached articles a manifest pins, in id order.
+
+    The cache root is keyed by the manifest's own digest, exactly as `corpus.load_corpus`
+    keys it, so a manifest edit reads a different directory rather than silently reusing
+    the articles selected under the old one.
+
+    Parameters
+    ----------
+    manifest : Path
+        Committed manifest naming the corpus.
+    cache : Path
+        Cache directory the corpus was materialized into.
+
+    Returns
+    -------
+    list[Article]
+        Every article directory holding both a JATS file and a PDF.
+
+    """
+    root = cache / read_manifest(manifest).sha256[:16] / "articles"
+    if not root.is_dir():
+        raise SystemExit(
+            f"corpus not materialized at {root}\n"
+            f"run: python -m benchmarks.pmc load --manifest {manifest} --cache {cache}"
+        )
+    found: list[Article] = []
+    for directory in sorted(root.iterdir()):
+        xml = next(directory.glob("*.xml"), None)
+        pdf = next(directory.glob("*.pdf"), None)
+        if xml is not None and pdf is not None:
+            found.append(Article(directory.name, xml, pdf))
+    return found
+
+
+def _projected(article: Article) -> tuple[tuple[Any, ...], Any]:
+    root, _ = _parse_jats(article.xml.read_bytes())
+    return oracles.project_jats(root)
+
+
+def _page_text(article: Article) -> str:
+    with fitz.open(article.pdf) as document:
+        return " ".join(page.get_text() for page in document)
+
+
+def _title_sources(node: Any, ancestors: frozenset[str] = frozenset()) -> Iterator[tuple[str, str]]:
+    """Yield ``(what produced it, text)`` for every ``title``-kind block under a node."""
+    tag = oracles._tag(node)
+    if tag in oracles.SKIPPED:
+        return
+    if oracles.BLOCKS.get(tag) == "title":
+        text = oracles._own_text(node)
+        if text:
+            if {"ref", "ref-list"} & ancestors:
+                where = "a reference-list entry"
+            elif {"front", "article-meta"} & ancestors:
+                where = "the article's own title"
+            elif {"table-wrap", "fig"} & ancestors:
+                where = "a float's label"
+            elif {"sec", "abstract", "body"} & ancestors:
+                where = "a section heading"
+            else:
+                where = "elsewhere"
+            yield where, text
+        return
+    for child in node:
+        yield from _title_sources(child, ancestors | {tag})
+
+
+def ceiling(corpus: list[Article]) -> None:
+    """Report where blocks sit against the attainable bar, per kind.
+
+    ``RECALL_MIN`` is all-or-nothing, so a crowd sitting just either side of it would mean
+    the published attainable-recall figures turn on the threshold rather than on the
+    output.  A sharply bimodal distribution means they do not.
+
+    Parameters
+    ----------
+    corpus : list[Article]
+        Articles to read.
+
+    """
+    shares: dict[str, list[float]] = {}
+    for article in corpus:
+        blocks, _ = _projected(article)
+        page = ngrams(normalize(_page_text(article)))
+        for block in blocks:
+            grams = ngrams(normalize(block.text))
+            if len(grams) >= MIN_NGRAMS:
+                shares.setdefault(block.kind, []).append(len(grams & page) / len(grams))
+
+    for kind in sorted(shares):
+        values = shares[kind]
+        attainable = sum(1 for value in values if value >= RECALL_MIN)
+        print(f"\n{kind}: {len(values):,} scored, {attainable:,} attainable ({attainable / len(values):.1%})")
+        for low, high in BANDS:
+            count = sum(1 for value in values if low <= value < high)
+            if not count:
+                continue
+            label = "exactly 1.0" if low >= 1.0 else f"{low:.2f}-{high:.2f}"
+            if low == RECALL_MIN:
+                mark = "  <- just over the bar"
+            elif high == RECALL_MIN:
+                mark = "  <- just under"
+            else:
+                mark = ""
+            print(f"   {label:>12s} {count:6,d} {count / len(values):6.1%}{mark}")
+
+
+def unscored(corpus: list[Article]) -> None:
+    """Report what the ``MIN_NGRAMS`` floor removes, per kind.
+
+    A block under about eight words is never scored, because a two-word block matches by
+    accident.  The artifact records the count as ``too_short`` and says nothing about what
+    it is.  It is mostly section headings -- the one structure a Markdown converter is most
+    obviously judged on.
+
+    Parameters
+    ----------
+    corpus : list[Article]
+        Articles to read.
+
+    """
+    total: Counter[str] = Counter()
+    short: Counter[str] = Counter()
+    words: Counter[str] = Counter()
+    examples: dict[str, list[str]] = {}
+    for article in corpus:
+        blocks, _ = _projected(article)
+        for block in blocks:
+            total[block.kind] += 1
+            if len(ngrams(normalize(block.text))) < MIN_NGRAMS:
+                short[block.kind] += 1
+                words[block.kind] += len(normalize(block.text))
+                examples.setdefault(block.kind, []).append(block.text[:44])
+
+    print(f"{'kind':12s} {'total':>8s} {'unscored':>9s} {'share':>8s} {'mean words':>11s}")
+    for kind in sorted(total):
+        count = short[kind]
+        mean = words[kind] / count if count else 0.0
+        print(f"{kind:12s} {total[kind]:8,d} {count:9,d} {count / total[kind]:8.1%} {mean:11.1f}")
+    scored_total = sum(total.values())
+    print(f"{'ALL':12s} {scored_total:8,d} {sum(short.values()):9,d} {sum(short.values()) / scored_total:8.1%}")
+    for kind, rows in sorted(examples.items()):
+        print(f"\n{kind}: {' | '.join(rows[:8])}")
+
+
+def titles(corpus: list[Article]) -> None:
+    """Attribute every ``title`` block to the ancestor that produced it.
+
+    The published by-kind table has one ``title`` row.  A section heading and a
+    reference-list entry both land in it, the floor removes them at very different rates,
+    and the row reads as a claim about heading structure.  This says what it is made of.
+
+    Parameters
+    ----------
+    corpus : list[Article]
+        Articles to read.
+
+    """
+    scored: Counter[str] = Counter()
+    short: Counter[str] = Counter()
+    for article in corpus:
+        root, _ = _parse_jats(article.xml.read_bytes())
+        for where, text in _title_sources(root):
+            if len(ngrams(normalize(text))) < MIN_NGRAMS:
+                short[where] += 1
+            else:
+                scored[where] += 1
+
+    print(f"{'title blocks come from':26s} {'scored':>8s} {'unscored':>9s} {'unscored share':>15s}")
+    for where in sorted(set(scored) | set(short)):
+        seen, missed = scored[where], short[where]
+        print(f"{where:26s} {seen:8,d} {missed:9,d} {missed / (seen + missed):15.1%}")
+    print(f"{'ALL':26s} {sum(scored.values()):8,d} {sum(short.values()):9,d}")
+
+
+def duplicates(corpus: list[Article]) -> None:
+    """Count truth blocks repeating another block's exact text in the same article.
+
+    Scoring is set containment per block, so a repeat is checked twice against the same
+    output and gets the same verdict both times: it double-weights rather than distorts.
+    Reported so that stays a measured claim rather than an assumption.
+
+    Parameters
+    ----------
+    corpus : list[Article]
+        Articles to read.
+
+    """
+    scored = repeats = 0
+    pairs: Counter[str] = Counter()
+    for article in corpus:
+        blocks, _ = _projected(article)
+        seen: dict[str, str] = {}
+        for block in blocks:
+            if len(ngrams(normalize(block.text))) < MIN_NGRAMS:
+                continue
+            scored += 1
+            key = " ".join(normalize(block.text))
+            if key in seen:
+                repeats += 1
+                pairs[" + ".join(sorted((seen[key], block.kind)))] += 1
+            else:
+                seen[key] = block.kind
+
+    print(
+        f"{repeats} of {scored:,} scored blocks ({repeats / scored:.2%}) repeat another "
+        f"block's exact text in the same article"
+    )
+    for kinds, count in pairs.most_common():
+        print(f"   {kinds}: {count}")
+
+
+def unprintable(corpus: list[Article]) -> None:
+    """Report projected words the PDF's own text layer never holds.
+
+    ``coverage`` is reported rather than asserted, so a projection claiming words the page
+    does not show is invisible in the published figures and only deflates every tool's
+    recall.  Most of what this finds -- ORCID digits, institution identifiers, licence URLs
+    -- sits in blocks that fail the ceiling anyway, which is what the ceiling is for.
+
+    Parameters
+    ----------
+    corpus : list[Article]
+        Articles to read.
+
+    """
+    rows: list[tuple[str, int, int, list[str]]] = []
+    for article in corpus:
+        _, projection = _projected(article)
+        page = set(normalize(_page_text(article)))
+        truth = normalize(" ".join(projection.text_blocks))
+        missing = [word for word in truth if word not in page]
+        rows.append((article.article_id, len(truth), len(missing), missing))
+
+    rows.sort(key=lambda row: -row[2] / max(row[1], 1))
+    print(f"{'article':18s} {'truth':>8s} {'absent':>7s} {'share':>7s}   examples")
+    for name, truth_words, absent, missing in rows[:15]:
+        sample = " ".join(dict.fromkeys(missing))[:82]
+        print(f"{name:18s} {truth_words:8,d} {absent:7,d} {absent / max(truth_words, 1):7.1%}   {sample}")
+
+    total_truth = sum(row[1] for row in rows)
+    total_absent = sum(row[2] for row in rows)
+    print(
+        f"\n{len(rows)} articles: {total_absent:,} of {total_truth:,} projected words "
+        f"({total_absent / total_truth:.3%}) are absent from the PDF's own text layer"
+    )
+
+    shape: Counter[str] = Counter()
+    for _name, _truth_words, _absent, missing in rows:
+        for word in missing:
+            if re.fullmatch(r"\d+", word):
+                shape["a bare number"] += 1
+            elif len(word) == 1:
+                shape["a single character"] += 1
+            elif re.search(r"\d", word):
+                shape["mixed letters and digits"] += 1
+            else:
+                shape["a word"] += 1
+    print("\nshape of the absent words:")
+    for kind, count in shape.most_common():
+        print(f"   {kind:26s} {count:8,d} {count / total_absent:7.1%}")
+
+
+CHECKS: dict[str, Callable[[list[Article]], None]] = {
+    "ceiling": ceiling,
+    "duplicates": duplicates,
+    "titles": titles,
+    "unprintable": unprintable,
+    "unscored": unscored,
+}
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Run one audit over a materialized corpus."""
+    parser = argparse.ArgumentParser(prog="python -m benchmarks.pmc.audit", description=__doc__)
+    parser.add_argument("check", choices=sorted(CHECKS), help="which audit to run")
+    parser.add_argument("--manifest", type=Path, default=DEFAULT_MANIFEST, help="corpus manifest")
+    parser.add_argument("--cache", type=Path, default=DEFAULT_CACHE, help="cache directory")
+    args = parser.parse_args(argv)
+
+    corpus = articles(args.manifest, args.cache)
+    print(f"{args.check}: {len(corpus)} articles from {args.manifest.name}\n", flush=True)
+    CHECKS[args.check](corpus)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/changelog.d/oracle-audit-instruments.added.md
+++ b/changelog.d/oracle-audit-instruments.added.md
@@ -1,0 +1,30 @@
+- **benchmarks/pmc: the ground-truth oracle can now be audited by running something, rather
+  than by noticing.** `python -m benchmarks.pmc.audit` carries five checks over a cached
+  corpus — where blocks sit against the attainable bar, what the `MIN_NGRAMS` floor removes,
+  what the published `title` row is actually made of, blocks repeating another block's text,
+  and projected words the PDF's text layer never holds. None of them convert anything, so
+  each runs in about a minute. They exist because the projection's element-boundary space
+  (#470) went unexamined for months while every figure in the lane rested on it, and the
+  penalty it produced was several times larger than the structural defect it hid.
+
+  The first run found three things clear and one not. The 0.80 attainable bar is sharply
+  bimodal on both development corpora and so is not a knife edge; duplicate truth blocks are
+  0.19% and benign under set containment; and the 2.6% of projected words the text layer
+  lacks (ORCID digits, institution identifiers, licence URLs) sit in blocks the ceiling
+  already excludes. But the floor never scores **22.6% of ground-truth blocks, including 41%
+  of titles** — and of the title blocks that are scored, 2,208 are reference-list entries
+  against 148 section headings, because `Introduction` and `Discussion` are two words. The
+  published `title` figure is largely a statement about reference lists. Tables are
+  unaffected at 0% unscored.
+
+- **benchmarks/comparison: section headings can be scored, and across every tool.** A truth
+  heading counts as recovered only when the converter emitted a *heading* with the same text
+  — structure rather than containment, which is what makes it immune to the floor problem
+  above and to `Introduction` appearing in every article's prose. It needs no page
+  attribution, so unlike reading order and table structure it scores third-party output as
+  readily as our own. On the sealed holdout's 1,795 section headings, **every tool loses
+  about a quarter of them into the prose stream**: all2md recovers 76.4% of printed
+  headings, Docling 77.4%, pymupdf4llm 76.6%. Two controls are reported, because scoring an
+  article against the wrong output still matches 13.7% on a shared vocabulary of
+  `Introduction`/`Discussion`/`Funding`; restricted to headings appearing in fewer than five
+  articles the control is 1.5% and all2md reads 77.1%.


### PR DESCRIPTION
**Independent of #471 and #472** — purely additive, no shared files, so it targets `main`
and gets CI immediately. Merge in any order.

The instruments that found the #470 ground-truth defect were living in a scratch directory.
The projection's element-boundary space went unexamined for months while every published
figure rested on it, so the checks that would have caught it belong in the repo.

## `python -m benchmarks.pmc.audit`

Five checks over a cached corpus. None convert anything; each runs in about a minute. The
cache root is derived from the manifest digest the way `load_corpus` derives it, so a
manifest edit reads a different directory rather than silently reusing the old one.

```bash
python -m benchmarks.pmc.audit ceiling       # where blocks sit against the 0.80 attainable bar
python -m benchmarks.pmc.audit unscored      # what the MIN_NGRAMS floor removes, per kind
python -m benchmarks.pmc.audit titles        # section heading? reference entry? float label?
python -m benchmarks.pmc.audit duplicates    # blocks repeating another block's exact text
python -m benchmarks.pmc.audit unprintable   # projected words the text layer never holds
```

**Three came back clear.** The 0.80 bar is sharply bimodal on both development corpora, so
the published attainable-recall figures do not turn on the threshold. Duplicate truth blocks
are 0.19% and benign under set containment. The 2.6% of projected words the text layer lacks
(ORCID digits, institution identifiers, licence URLs) sit in blocks the ceiling already
excludes.

**One did not.** The floor never scores **22.6% of ground-truth blocks, including 41% of
titles** — and of the title blocks that *are* scored, **2,208 are reference-list entries
against 148 section headings**, because `Introduction` and `Discussion` are two words. The
published `title` figure is largely a statement about reference lists. Tables are unaffected
at 0% unscored, so the table figures stand.

## `benchmarks/comparison/headings.py`

Lowering the floor cannot fix that — `Introduction` appears in any article's prose, so
containment would read near 100% for every converter. So this matches a truth heading only
against a heading the tool actually **emitted**: structure, not text. No threshold, no floor,
and no page attribution, which means it scores third-party output as readily as our own.

On the sealed holdout's 1,795 section headings:

| | all2md | docling | pymupdf4llm |
|---|---|---|---|
| recovered as a heading | 74.9% | 76.1% | 75.0% |
| **emitted, but not as a heading** | **23.0%** | 21.4% | 22.5% |
| the page never printed it | 1.9% | 1.7% | 2.0% |
| share of PRINTED headings | 76.4% | 77.4% | 76.6% |
| precision of emitted headings | 63.3% | 68.4% | 69.8% |
| control: the wrong article | 13.7% | 13.7% | 14.0% |
| rare headings only | 77.1% (control 1.5%) | 77.9% (1.5%) | 76.4% (1.5%) |

**Every tool loses about a quarter of a document's headings into the prose stream**, within a
point of each other. Two controls are reported because the shared vocabulary of
`Introduction`/`Discussion`/`Funding` keeps the whole-corpus one at 13.7%.

## What is deliberately not here

The depth-agreement metric. Aligning each article's best offset makes it gameable by a
converter that emits every heading at one level, and a flat emitter led on it. The sound
version is pairwise relative depth, and it lands with the real measure rather than as a
script.

## Known follow-up

`benchmarks/comparison/README.md` still lists heading fidelity among the instruments that
"require all2md's page attribution and cannot score other tools". That is now false. The
correction is deferred rather than made here, because #472 rewrites that file and this PR
stays conflict-free.

## Checks

ruff, ruff format and mypy clean over `benchmarks/`; `tests/unit -k "pmc or benchmark or
published or holdout"` green with one POSIX-only skip. Both scripts were run and reproduce
the figures quoted above; `audit unscored` totals 11,503 blocks and 2,600 too-short, matching
`reference.json` exactly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
