### PR TITLE
docs(benchmarks): publish the heading reading and stop excluding it from the lane's scope

### DIFF
--- a/benchmarks/comparison/README.md
+++ b/benchmarks/comparison/README.md
@@ -41,13 +41,52 @@ The numbers are only comparable because of four rules, all of which cost us some
    committed `results-*.json` was recorded against. A new reading against new versions
    is a new dated file, never an edit to an old one.
 
-**What this lane measures is deliberately narrow: article-level text survival and
-invented text.** Those are the two instruments with published false-positive controls
-that third-party output can enter. The page-level instruments (reading order, table
-*structure*, heading fidelity) require all2md's page attribution and cannot score other
-tools — and text survival alone structurally favors low-structure converters: the
-highest-recall converter imaginable dumps the raw text layer with no structure at all.
-Quote these numbers with that asymmetry attached.
+**What this lane measures is deliberately narrow: article-level text survival, invented
+text, and section headings.** Those are the instruments with published false-positive
+controls that third-party output can enter. The remaining page-level instruments (reading
+order, table *structure*) require all2md's page attribution and cannot score other tools.
+
+Text survival alone structurally favors low-structure converters — the highest-recall
+converter imaginable dumps the raw text layer with no structure at all — and that is the
+asymmetry the heading measure counterweights. Quote the recall numbers with it attached.
+
+## Section headings (`headings.py`)
+
+`score.py` cannot see a heading: `MIN_NGRAMS = 4` drops any block under about eight words,
+which removes 87% of section headings, and lowering the floor does not rescue them because
+`Introduction` appears in any article's prose and containment would read near 100% for
+everyone. So headings are scored by *structure* instead — a truth heading counts as
+recovered only when the tool emitted a heading with the same text. That rule needs no
+threshold and no page attribution, which is why it scores third-party output as readily as
+our own.
+
+Run it after the converters, against the same `out/` tree `score.py` reads:
+
+```
+python benchmarks/comparison/headings.py
+```
+
+It prints rather than writing to `results-*.json`, so the reading is recorded here.
+**2026-08-29 outputs, sealed holdout, 1,795 section headings.** The figure is the share of
+headings *the page actually printed* that were emitted as headings:
+
+| tool | printed headings recovered as headings |
+|---|---|
+| all2md | 76.4% |
+| docling | 77.4% |
+| pymupdf4llm | 76.6% |
+
+**Every tool loses about a quarter of section headings into the prose stream**, and the
+three are within a point of each other — this is a shared blind spot of the whole field,
+not a place all2md trails. Two controls are reported because the shared vocabulary of
+`Introduction`/`Discussion`/`Funding` keeps the whole-corpus control off zero at 13.7%;
+restricted to headings appearing in fewer than five articles it falls to 1.5%, and that is
+the sharper number.
+
+A depth-agreement metric is deliberately absent. Aligning each article's best offset makes
+it gameable by a converter that emits every heading at one level, and in probing, a flat
+emitter led on it. The sound version is pairwise relative depth, and it lands with the
+measure rather than as a script.
 
 ## Reading, 2026-08-29 (`results-2026-08-29.json`) — the sealed holdout, corrected truth
 

--- a/changelog.d/comparison-heading-reading.changed.md
+++ b/changelog.d/comparison-heading-reading.changed.md
@@ -1,0 +1,16 @@
+- **benchmarks/comparison: the heading measure's reading is published, and the lane's scope
+  sentence stops excluding it.** The README claimed heading fidelity "requires all2md's page
+  attribution and cannot score other tools", which stopped being true when
+  `benchmarks/comparison/headings.py` landed — it matches a truth heading only against a
+  heading the tool emitted, which needs no page attribution and so scores third-party output
+  as readily as our own. Reading order and table *structure* are still all2md-only, and the
+  sentence now says only that.
+
+  Its first reading was recorded in a commit message and nowhere a reader would look, so it
+  now sits with the lane's other readings: on the sealed holdout's 1,795 section headings,
+  **all2md 76.4%, Docling 77.4%, pymupdf4llm 76.6%** of the headings the page actually
+  printed. **Every tool loses about a quarter of them into the prose stream** and the three
+  sit within a point of each other — a blind spot of the field rather than a place all2md
+  trails. Two controls are quoted with it, because the shared vocabulary of
+  `Introduction`/`Discussion`/`Funding` holds the whole-corpus control at 13.7%; on headings
+  appearing in fewer than five articles it falls to 1.5%.


### PR DESCRIPTION
Follow-on to #473, which landed `benchmarks/comparison/headings.py` but left two things behind in `benchmarks/comparison/README.md`.

## The scope sentence was false

The README told readers:

> The page-level instruments (reading order, table *structure*, heading fidelity) require all2md's page attribution and cannot score other tools

`headings.py` matches a truth heading only against a heading the tool actually emitted — structure, not text — which needs no threshold, no floor and **no page attribution**. It scores third-party output as readily as our own; its own docstring says so. Reading order and table structure are still all2md-only, and the sentence now says only that.

## The reading lived in a commit message

#473's numbers were recorded in its commit body and nowhere a reader of the comparison lane would look. `benchmarks/pmc/README.md` points *at* the script but carries none of its figures, and `headings.py` prints rather than writing to `results-*.json`, so there was no artifact. They now sit under a `## Section headings` section with the lane's other readings:

| tool | printed headings recovered as headings |
|---|---|
| all2md | 76.4% |
| docling | 77.4% |
| pymupdf4llm | 76.6% |

Sealed holdout, 1,795 section headings, the same 2026-08-29 outputs `score.py` was run against. **The point worth quoting is that all three sit within a point of each other** — losing about a quarter of section headings into the prose stream is a blind spot of the field, not a place all2md trails.

Both controls come with it (13.7% whole-corpus, from the shared `Introduction`/`Discussion`/`Funding` vocabulary; 1.5% restricted to headings appearing in fewer than five articles), and so does the reason the depth-agreement metric is deliberately absent — it is gameable by a converter that emits every heading at one level, and a flat emitter led on it in probing. Recording that stops it being proposed again.

## Scope

Documentation only. No source, no tests, no recorded figures changed. `scripts/compile_changelog.py --check` passes and `tests/unit/test_compile_changelog.py` is 46 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)