### PR TITLE
fix(benchmarks): stop scoring a printed section number as a lost heading

### DIFF
--- a/benchmarks/comparison/README.md
+++ b/benchmarks/comparison/README.md
@@ -67,21 +67,30 @@ python benchmarks/comparison/headings.py
 ```
 
 It prints rather than writing to `results-*.json`, so the reading is recorded here.
-**2026-08-29 outputs, sealed holdout, 1,795 section headings.** The figure is the share of
+**2026-08-29 outputs, sealed holdout, 1,790 section headings.** The figure is the share of
 headings *the page actually printed* that were emitted as headings:
 
 | tool | printed headings recovered as headings |
 |---|---|
-| all2md | 76.4% |
-| docling | 77.4% |
-| pymupdf4llm | 76.6% |
+| all2md | 79.0% |
+| docling | 80.3% |
+| pymupdf4llm | 79.2% |
 
-**Every tool loses about a quarter of section headings into the prose stream**, and the
-three are within a point of each other — this is a shared blind spot of the whole field,
+**Every tool loses about a fifth of section headings into the prose stream**, and the three
+are within about a point of each other — this is a shared blind spot of the whole field,
 not a place all2md trails. Two controls are reported because the shared vocabulary of
-`Introduction`/`Discussion`/`Funding` keeps the whole-corpus control off zero at 13.7%;
-restricted to headings appearing in fewer than five articles it falls to 1.5%, and that is
+`Introduction`/`Discussion`/`Funding` keeps the whole-corpus control off zero at 15.6%;
+restricted to headings appearing in fewer than five articles it falls to 1.4%, and that is
 the sharper number.
+
+**These replace a first reading of 76.4 / 77.4 / 76.6, which charged every tool with losing
+headings it had printed correctly.** JATS keeps a section number in a `<label>` sibling of
+`<title>` and the projection reads only the title, so truth said `Discussion` where the page
+— and any tool faithful to it — said `4 Discussion`. The number is now stripped from both
+sides before matching. On the development corpus it was 8.4% of all headings: of 99 numbered
+headings all2md was charged with losing, **97 had been emitted correctly, number and all**.
+It moved all three tools by a similar amount, so the ordering and the shared-blind-spot
+reading are unchanged; what changes is that a fifth of the reported loss was the measure's.
 
 A depth-agreement metric is deliberately absent. Aligning each article's best offset makes
 it gameable by a converter that emits every heading at one level, and in probing, a flat

--- a/benchmarks/comparison/headings.py
+++ b/benchmarks/comparison/headings.py
@@ -10,6 +10,15 @@ heading counts as recovered only when the tool emitted a heading whose text is t
 That rule needs no threshold, no floor, and no page attribution, so unlike reading order
 and table structure it scores third-party output as readily as our own.
 
+A section number is stripped from both sides before matching.  JATS keeps it in a
+``<label>`` sibling of ``<title>``, which ``_own_text`` does not read, so truth says
+``Discussion`` where the page -- and every tool that reads the page faithfully -- says
+``4 Discussion``.  Scored literally that is a miss for printing exactly what is there, and
+it is not a small correction: it was 8.4% of the development corpus's headings, and both
+baselines emit numbered headings at a similar rate.  Stripping the same run of tokens from
+both sides is symmetric, so a heading that genuinely opens with a number loses it on both
+sides and still matches.
+
 Two figures are reported because the whole-corpus one has a weak control by construction:
 section headings come from a small shared vocabulary (``Introduction``, ``Discussion``,
 ``Funding``), so scoring an article against the wrong output still matches some.  The
@@ -54,6 +63,14 @@ NOT_A_HEADING = frozenset({"ref", "ref-list", "fig", "table-wrap", "front", "art
 COMMON_HEADING_ARTICLES = 5
 
 
+def _unnumbered(heading: str) -> str:
+    """Return a normalized heading without its leading section number, if it has one."""
+    tokens = heading.split()
+    while tokens and all(character.isdigit() or character == "." for character in tokens[0]):
+        tokens = tokens[1:]
+    return " ".join(tokens)
+
+
 def _headings(node: object, ancestors: frozenset[str] = frozenset()) -> list[str]:
     """Return the normalized text of every section heading under a JATS node."""
     tag = oracles._tag(node)
@@ -62,7 +79,7 @@ def _headings(node: object, ancestors: frozenset[str] = frozenset()) -> list[str
     if oracles.BLOCKS.get(tag) == "title":
         if NOT_A_HEADING & ancestors:
             return []
-        text = " ".join(normalize(oracles._own_text(node)))
+        text = _unnumbered(" ".join(normalize(oracles._own_text(node))))
         return [text] if text else []
     found: list[str] = []
     for child in node:  # type: ignore[attr-defined]
@@ -72,7 +89,7 @@ def _headings(node: object, ancestors: frozenset[str] = frozenset()) -> list[str
 
 def _emitted(markdown: str) -> set[str]:
     """Return the normalized text of every ATX heading in a tool's markdown."""
-    return {" ".join(normalize(match.group(2))) for match in ATX.finditer(markdown)} - {""}
+    return {_unnumbered(" ".join(normalize(match.group(2)))) for match in ATX.finditer(markdown)} - {""}
 
 
 def main(argv: list[str] | None = None) -> int:

--- a/changelog.d/comparison-heading-reading.changed.md
+++ b/changelog.d/comparison-heading-reading.changed.md
@@ -7,10 +7,10 @@
   sentence now says only that.
 
   Its first reading was recorded in a commit message and nowhere a reader would look, so it
-  now sits with the lane's other readings: on the sealed holdout's 1,795 section headings,
-  **all2md 76.4%, Docling 77.4%, pymupdf4llm 76.6%** of the headings the page actually
-  printed. **Every tool loses about a quarter of them into the prose stream** and the three
-  sit within a point of each other — a blind spot of the field rather than a place all2md
+  now sits with the lane's other readings: on the sealed holdout's 1,790 section headings,
+  **all2md 79.0%, Docling 80.3%, pymupdf4llm 79.2%** of the headings the page actually
+  printed. **Every tool loses about a fifth of them into the prose stream** and the three sit
+  within about a point of each other — a blind spot of the field rather than a place all2md
   trails. Two controls are quoted with it, because the shared vocabulary of
-  `Introduction`/`Discussion`/`Funding` holds the whole-corpus control at 13.7%; on headings
-  appearing in fewer than five articles it falls to 1.5%.
+  `Introduction`/`Discussion`/`Funding` holds the whole-corpus control at 15.6%; on headings
+  appearing in fewer than five articles it falls to 1.4%.

--- a/changelog.d/heading-measure-section-numbers.fixed.md
+++ b/changelog.d/heading-measure-section-numbers.fixed.md
@@ -1,0 +1,18 @@
+- **benchmarks/comparison: the heading measure no longer scores a printed section number as
+  a miss.** JATS keeps a section number in a `<label>` sibling of `<title>`, and the
+  projection reads only the title, so the ground truth said `Discussion` where the page said
+  `4 Discussion` — and every converter that printed what the page prints was charged with
+  losing the heading. `headings.py` now strips a leading run of number tokens from both the
+  truth and the emitted heading, which is symmetric: a heading that genuinely opens with a
+  number loses it on both sides and still matches.
+
+  It was not a rounding correction. On the development corpus numbered headings are 8.4% of
+  all section headings, and of the 99 all2md was charged with losing, **97 had been emitted
+  correctly, number and all** — a recovery rate of 2.0% that is really 97.0%. Both baselines
+  emit numbered headings at a similar rate (13.1% and 13.5% of their emitted headings), so
+  the sealed-holdout reading moves for all three and the ordering does not change: printed
+  headings recovered goes **all2md 76.4% -> 79.0%, Docling 77.4% -> 80.3%, pymupdf4llm 76.6%
+  -> 79.2%**. The whole-corpus control rises with it, 13.7% -> 15.6%, since stripping numbers
+  makes the shared heading vocabulary collide slightly more; the rare-heading control is
+  unmoved at 1.4%. The finding that every tool loses a fifth of section headings into the
+  prose stream stands, one fifth smaller than first published.

--- a/changelog.d/oracle-audit-instruments.added.md
+++ b/changelog.d/oracle-audit-instruments.added.md
@@ -22,9 +22,9 @@
   — structure rather than containment, which is what makes it immune to the floor problem
   above and to `Introduction` appearing in every article's prose. It needs no page
   attribution, so unlike reading order and table structure it scores third-party output as
-  readily as our own. On the sealed holdout's 1,795 section headings, **every tool loses
-  about a quarter of them into the prose stream**: all2md recovers 76.4% of printed
-  headings, Docling 77.4%, pymupdf4llm 76.6%. Two controls are reported, because scoring an
-  article against the wrong output still matches 13.7% on a shared vocabulary of
+  readily as our own. On the sealed holdout's 1,790 section headings, **every tool loses
+  about a fifth of them into the prose stream**: all2md recovers 79.0% of printed headings,
+  Docling 80.3%, pymupdf4llm 79.2%. Two controls are reported, because scoring an article
+  against the wrong output still matches 15.6% on a shared vocabulary of
   `Introduction`/`Discussion`/`Funding`; restricted to headings appearing in fewer than five
-  articles the control is 1.5% and all2md reads 77.1%.
+  articles the control is 1.4% and all2md reads 79.0%.


### PR DESCRIPTION
Found while triaging heading misses by mechanism on the development corpus — the step the heading work was going to begin with. One class read 2% recovery where every other layout class read 80–95%, and the cause was the measure, not the parser.

## The defect

JATS keeps a section number in a `<label>` sibling of `<title>`, and the oracle's projection reads only the title. Truth therefore says `Discussion` where the page says `4 Discussion`. `headings.py` matches exactly, so **a converter that printed what the page prints was charged with losing the heading.**

Both sides now lose a leading run of number tokens before matching. Symmetry is the point: a heading that genuinely opens with a number is stripped on both sides and still matches, so the rule cannot manufacture agreement that isn't there.

## It is not a rounding correction

On the development corpus numbered headings are **8.4% of all section headings**, and of the 99 all2md was charged with losing, **97 had been emitted correctly, number and all** (`4 discussion`, `2 materials and methods`, `2 2 image matching`). That class reads 2.0% recovery; it is really 97.0%.

Both baselines print numbers at a similar rate — 13.1% of docling's emitted headings open with one, 13.5% of pymupdf4llm's — so the sealed-holdout reading moves for all three and **the ordering does not change**:

| tool | printed headings recovered, published | corrected |
|---|---|---|
| all2md | 76.4% | **79.0%** |
| docling | 77.4% | **80.3%** |
| pymupdf4llm | 76.6% | **79.2%** |

The whole-corpus control rises with it, 13.7% → 15.6%, because stripping numbers lets the shared `Introduction`/`Discussion`/`Funding` vocabulary collide a little more often; the rare-heading control is unmoved at 1.4%. Five truth headings collapse into duplicates of another heading in the same article once their numbers are gone, which is why the corpus reads 1,790 rather than 1,795.

## What survives, and what does not

The finding #473 and #475 published **survives**: every tool loses about a fifth of section headings into the prose stream, and the three sit within about a point of each other — a blind spot of the field, not a place all2md trails. What does not survive is its size. **A fifth of the loss it reported was the measure's own.**

The figures are corrected wherever they were quoted: `benchmarks/comparison/README.md`, and both unreleased changelog fragments (#473's and #475's), which would otherwise have compiled into the next release carrying superseded numbers.

## Scope

The measure, the README reading, and changelog fragments. No parser source, no tests, no recorded figures. `scripts/compile_changelog.py --check` passes; `tests/unit/test_compile_changelog.py` and `tests/unit/test_pmc_holdout_seal.py` are 50 passed; ruff, ruff format and mypy are clean on the changed module.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
