### PR TITLE
fix(benchmarks): project every table a table-wrap carries, and re-record

### DIFF
--- a/benchmarks/pmc/benchmark.py
+++ b/benchmarks/pmc/benchmark.py
@@ -70,7 +70,16 @@ from benchmarks.pmc.pages import ASSIGNMENTS, assign_pages, index_pages
 #: attribute the oracle never read, so recall *fell* as figure binding improved -- 101 of
 #: the 103 "lost" captions on the held-out corpus were in the output the whole time (#406).
 #: No payload key changes shape; the measurement underneath every recall figure does.
-SCHEMA_VERSION = 6
+#: 7 projects every ``<table>`` a ``<table-wrap>`` carries. Under 6 only the first was read,
+#: so a wide table the publisher split for the page contributed half its columns to the
+#: ground truth and the other half went unasked-for -- 5.3% of this corpus's table text,
+#: and every tool that did extract it was charged with emitting text nothing could match.
+#: Rows nested inside a cell's own table are no longer counted twice either. A ground-truth
+#: change must bump this even though no payload key moves: the artifact is only meaningful
+#: against the truth that produced it, and `test_the_reference_was_produced_by_the_current_payload_shape`
+#: is what stops a projection edit from landing while the recorded figures quietly describe
+#: an older one.
+SCHEMA_VERSION = 7
 #: 3 = the shared projection admits any container of inline text, by shape rather than by
 #: type name, so a node holding inline content with no ``Paragraph`` wrapper is no longer
 #: invisible to measurement (#443). ``SCHEMA_VERSION`` deliberately does *not* move with

--- a/benchmarks/pmc/oracles.py
+++ b/benchmarks/pmc/oracles.py
@@ -272,6 +272,29 @@ def _positive_span(value: str | None) -> int:
     return max(1, span)
 
 
+def _own_rows(table: Any) -> list[Any]:
+    """Return a table's own ``<tr>`` elements, not those of a table nested in one of its cells.
+
+    ``iter()`` is recursive, so a nested table used to contribute its rows to the outer
+    table's count *and* its text twice -- once through the enclosing cell's rendered text,
+    which is correct because the page prints it there, and again as rows of its own.
+    """
+    found: list[Any] = []
+
+    def visit(node: Any) -> None:
+        for child in node:
+            tag = _tag(child)
+            if tag == "table":
+                continue
+            if tag == "tr":
+                found.append(child)
+            else:
+                visit(child)
+
+    visit(table)
+    return found
+
+
 def _jats_table(table: Any) -> TableProjection:
     """Project a JATS ``<table>`` with the same counting rules the HTML side uses.
 
@@ -285,9 +308,7 @@ def _jats_table(table: Any) -> TableProjection:
     columns = 0
     cell_slots = 0
     cells: list[str] = []
-    for row in table.iter():
-        if _tag(row) != "tr":
-            continue
+    for row in _own_rows(table):
         rows += 1
         row_columns = 0
         for cell in row:
@@ -307,22 +328,63 @@ def _caption_of(element: Any) -> str:
     return " ".join(parts)
 
 
-def _table_wrap(element: Any) -> JatsBlock:
-    table = next((child for child in element.iter() if _tag(child) == "table"), None)
-    projection = _jats_table(table) if table is not None else None
+def _wrapped_tables(element: Any) -> list[Any]:
+    """Return the ``<table>`` elements a wrap carries, excluding any nested inside a cell.
+
+    Descending into a table would return a table nested in one of its own cells as a
+    sibling, and its text is already inside the outer table's cell text -- it would be
+    counted twice.
+    """
+    found: list[Any] = []
+
+    def visit(node: Any) -> None:
+        for child in node:
+            if _tag(child) == "table":
+                found.append(child)
+            else:
+                visit(child)
+
+    visit(element)
+    return found
+
+
+def _table_wrap(element: Any) -> Iterator[JatsBlock]:
+    """Yield one block per table a ``<table-wrap>`` carries.
+
+    A publisher splitting a wide table for the page puts each half in its own ``<table>``
+    under one wrap -- same rows, different columns. Reading only the first discarded the
+    rest of the truth silently: 5.3% of the development corpus's table text sat in the
+    halves nobody was asked to match, which flattered nothing and penalised every tool
+    that extracted them, since emitted text with no truth behind it scores as novel.
+
+    Each ``<table>`` becomes its own block rather than one merged block, because merging
+    would have to guess whether the parts are stacked (sum the rows) or side by side (sum
+    the columns), and the structure figures would inherit the guess.
+    """
+    tables = _wrapped_tables(element)
     # Footnotes under the table are rendered beneath it, so they belong to the caption
     # stream rather than to the cell text, which is compared against Table nodes.
     foot = " ".join(_all_text(child) for child in element if _tag(child) == "table-wrap-foot")
     caption = " ".join(part for part in (_caption_of(element), foot) if part)
-    if projection is None:
+    if not tables:
         # A table-wrap with no table renders as a graphic plus its caption: real page
         # content, but nothing a Table node could match. Scoring it as an empty table would
         # punish a parser for the absence of something that was never there. Flagged rather
         # than merely absorbed, so the count can be reported beside the table totals: the
         # page prints a table the parser extracts from the text layer, and it lands in
         # `tables_emitted` with nothing on the expected side to answer it.
-        return JatsBlock(kind="text_block", text=caption, caption="", image_table=True)
-    return JatsBlock(kind="table", text=projection.text, caption=caption, table=projection)
+        yield JatsBlock(kind="text_block", text=caption, caption="", image_table=True)
+        return
+    for index, table in enumerate(tables):
+        projection = _jats_table(table)
+        # One caption is printed above the whole wrap, so it belongs to the first part
+        # alone; repeating it would score the same printed line once per part.
+        yield JatsBlock(
+            kind="table",
+            text=projection.text,
+            caption=caption if index == 0 else "",
+            table=projection,
+        )
 
 
 def walk(root: Any) -> Iterator[JatsBlock]:
@@ -344,7 +406,7 @@ def walk(root: Any) -> Iterator[JatsBlock]:
         return
     kind = BLOCKS.get(tag)
     if kind == "table":
-        yield _table_wrap(root)
+        yield from _table_wrap(root)
         return
     if tag == "fig":
         caption = _caption_of(root)

--- a/benchmarks/pmc/reference.json
+++ b/benchmarks/pmc/reference.json
@@ -1,13 +1,13 @@
 {
-  "schema_version": 6,
+  "schema_version": 7,
   "provenance": {
     "corpus_pin": "ffad81e6f9a6499a5889fdedaa001f8b251fac49faced83bed9dc15866e0dd00",
     "bucket": "pmc-oa-opendata",
     "complete_corpus": true,
     "oracle_schema_version": 3,
-    "all2md_commit": "2925f5cbd3653a194f5742a920089f1ece105375",
+    "all2md_commit": "7c93f17c9c139318065543463da0c31ddc75a8a3",
     "worktree_dirty": false,
-    "created_at": "2026-08-29T02:11:04.230889+00:00",
+    "created_at": "2026-08-31T18:22:56.405143+00:00",
     "python": "3.12.3 (main, Jun 19 2026, 12:46:00) [GCC 13.3.0]",
     "platform": "linux",
     "parser_runtime": {
@@ -36,35 +36,35 @@
     "articles_scored": 66,
     "articles_converted": 66,
     "pages_scored": 706,
-    "ground_truth_blocks": 11503,
+    "ground_truth_blocks": 11507,
     "coverage": {
       "count": 66.0,
-      "mean": 0.9321573948937522,
-      "median": 0.9546637748177358,
+      "mean": 0.9331671045435238,
+      "median": 0.9556443397911896,
       "minimum": 0.09348198970840481,
       "maximum": 1.1222493887530562,
-      "stdev": 0.13109413309353415
+      "stdev": 0.13134175691895295
     },
-    "tables_expected": 122,
+    "tables_expected": 127,
     "tables_emitted": 162,
     "tables_deposited_as_images": 19,
     "table_surplus": {
-      "examined": 55,
-      "in_text_layer": 40,
-      "words_in_text_layer": 55,
+      "examined": 47,
+      "in_text_layer": 35,
+      "words_in_text_layer": 47,
       "by_source": {
-        "jats_table": 15,
+        "jats_table": 13,
         "jats_prose": 0,
-        "outside_jats": 40
+        "outside_jats": 34
       }
     },
-    "pages_with_expected_table": 95,
+    "pages_with_expected_table": 96,
     "pages_with_emitted_table": 119
   },
   "projection": {
     "assignments": {
-      "clean": 7183,
-      "spans": 320,
+      "clean": 7185,
+      "spans": 322,
       "tokens": 976,
       "phrase": 1479,
       "inherited": 1077,
@@ -75,25 +75,25 @@
       "split": 95,
       "too_short": 44
     },
-    "error_budget": 0.04068503868556029,
-    "unsplit_spans": 42
+    "error_budget": 0.04067089597636221,
+    "unsplit_spans": 43
   },
   "article_recall": {
-    "recall": 0.6377625519487813,
-    "recovered": 5678,
-    "scored": 8903,
+    "recall": 0.6378129561019423,
+    "recovered": 5681,
+    "scored": 8907,
     "too_short": 2600,
-    "ceiling": 0.639222733909918,
-    "attainable": 5691,
-    "recovered_attainable": 5628,
-    "attainable_recall": 0.988929889298893,
+    "ceiling": 0.6393847535646121,
+    "attainable": 5695,
+    "recovered_attainable": 5631,
+    "attainable_recall": 0.9887620719929763,
     "by_kind": {
       "table": {
-        "recovered": 101,
-        "attainable": 119,
-        "recovered_attainable": 101,
-        "scored": 123,
-        "attainable_recall": 0.8487394957983193
+        "recovered": 104,
+        "attainable": 123,
+        "recovered_attainable": 104,
+        "scored": 127,
+        "attainable_recall": 0.8455284552845529
       },
       "text_block": {
         "recovered": 3264,
@@ -110,23 +110,23 @@
         "attainable_recall": 0.9892055267702936
       }
     },
-    "control_recall": 0.003594294058182635,
-    "control_scored": 8903,
-    "discrimination": 0.6341682578905986
+    "control_recall": 0.003592679914673852,
+    "control_scored": 8907,
+    "discrimination": 0.6342202761872685
   },
   "article_precision": {
-    "precision": 0.9556333301155917,
-    "supported": 425684,
-    "emitted": 445447,
-    "resequenced": 17865,
+    "precision": 0.9562883607742422,
+    "supported": 425971,
+    "emitted": 445442,
+    "resequenced": 17573,
     "novel": 1898,
-    "novel_share": 0.0042608885007644004,
+    "novel_share": 0.004260936328410882,
     "duplication": 0.004480072459934354,
     "excess": 2117,
     "occurrences": 472537,
-    "control_precision": 0.007073793290784313,
-    "control_emitted": 445447,
-    "discrimination": 0.9485595368248074
+    "control_precision": 0.007073872692741142,
+    "control_emitted": 445442,
+    "discrimination": 0.949214488081501
   },
   "figure_binding": {
     "binding_rate": 0.6837209302325581,
@@ -146,83 +146,83 @@
   "dimensions": {
     "block_structure_similarity": {
       "count": 706.0,
-      "mean": 0.5501373336250662,
+      "mean": 0.5515790576234474,
       "median": 0.5714285714285714,
       "minimum": 0.023255813953488413,
       "maximum": 1.0,
-      "stdev": 0.20915394386129518,
+      "stdev": 0.20835091938239486,
       "direction": "higher",
-      "control_mean": 0.4461596914177608,
-      "discrimination": 0.10397764220730543,
+      "control_mean": 0.4468847689841981,
+      "discrimination": 0.10469428863924929,
       "mutation_drop": {
         "reversed": 0.01694626840500665,
         "shuffled": 0.03187297910293168,
-        "halved": 0.08114643085417762
+        "halved": 0.08306029838419246
       },
       "ungateable": "compares kind sequences without inspecting the text under a block, so content-free output scores 1.0 (issue #256); eleven text categories collapse to `text_block`, so fully reversed output scores exactly 1.0 on 153 of the 981 pinned pages; and on the born-digital lane it separates own-page from wrong-page output by only ~0.06 while *rising* when half the emitted content is deleted, which rewards dropping blocks"
     },
     "reading_order_similarity": {
       "count": 706.0,
-      "mean": 0.8299363230374033,
+      "mean": 0.8318248971639377,
       "median": 0.9090909090909091,
       "minimum": 0.0,
       "maximum": 1.0,
-      "stdev": 0.20958124022791658,
+      "stdev": 0.20427215158867193,
       "direction": "higher",
       "control_mean": 0.29338972141271175,
-      "discrimination": 0.5365466016246916,
+      "discrimination": 0.538435175751226,
       "mutation_drop": {
-        "reversed": 0.5332049130421304,
-        "shuffled": 0.2459461590669233,
-        "halved": 0.3273702029100698
+        "reversed": 0.5393427789533674,
+        "shuffled": 0.24948723555417543,
+        "halved": 0.32878663350497067
       }
     },
     "table_content_similarity": {
       "count": 123.0,
-      "mean": 0.6289993592315243,
-      "median": 0.8911070780399274,
+      "mean": 0.6456127611988337,
+      "median": 0.9022222222222223,
       "minimum": 0.0,
       "maximum": 1.0,
-      "stdev": 0.4201418138943769,
+      "stdev": 0.4169742079161735,
       "direction": "higher",
-      "control_mean": 0.039315415599305716,
-      "discrimination": 0.5896839436322185,
+      "control_mean": 0.0426763376123394,
+      "discrimination": 0.6029364235864944,
       "mutation_drop": {
         "reversed": 0.0,
         "shuffled": 0.0,
-        "halved": 0.6219460235829645
+        "halved": 0.6555451119897688
       }
     },
     "table_structure_similarity": {
       "count": 123.0,
-      "mean": 0.6359474653854718,
+      "mean": 0.6536222770236981,
       "median": 0.8666666666666667,
       "minimum": 0.0,
       "maximum": 1.0,
-      "stdev": 0.413284755690187,
+      "stdev": 0.4109969221338547,
       "direction": "higher",
-      "control_mean": 0.09373701848386773,
-      "discrimination": 0.542210446901604,
+      "control_mean": 0.09813262287947211,
+      "discrimination": 0.555489654144226,
       "mutation_drop": {
         "reversed": 0.0,
         "shuffled": 0.0,
-        "halved": 0.6287750374950218
+        "halved": 0.6626760457277132
       }
     },
     "text_content_similarity": {
       "count": 706.0,
-      "mean": 0.6897131366646299,
-      "median": 0.7140346322468694,
+      "mean": 0.6919077328680012,
+      "median": 0.7147269954392326,
       "minimum": 0.010652463382157085,
       "maximum": 0.993987493987494,
-      "stdev": 0.22238346057923006,
+      "stdev": 0.21954227611389018,
       "direction": "higher",
-      "control_mean": 0.2336517054813915,
-      "discrimination": 0.4560614311832384,
+      "control_mean": 0.2343756921995961,
+      "discrimination": 0.45753204066840514,
       "mutation_drop": {
-        "reversed": 0.29573047484180887,
-        "shuffled": 0.20501856683222974,
-        "halved": 0.2959575760909976
+        "reversed": 0.2961958729036337,
+        "shuffled": 0.2053849265913479,
+        "halved": 0.2965567608459487
       }
     }
   },

--- a/changelog.d/pmc-truth-split-table-wraps.fixed.md
+++ b/changelog.d/pmc-truth-split-table-wraps.fixed.md
@@ -1,0 +1,26 @@
+- **benchmarks/pmc: the ground truth no longer discards half of a table the publisher split
+  for the page.** A wide table is often typeset as two `<table>` elements under one
+  `<table-wrap>` — the same rows, the left columns and then the right — and the projection
+  read only the first, so the remaining columns were absent from the truth entirely. That is
+  not a rounding error: it is **5.3% of the development corpus's table text**, sitting in
+  halves no converter was ever asked to match, and every tool that *did* extract them was
+  charged for emitting text with nothing behind it. Each `<table>` a wrap carries is now its
+  own truth table, which needs no guess about whether the parts are stacked or side by side —
+  merging them would have had to pick one and the structure figures would have inherited it.
+  The caption stays on the first part, because the page prints it once.
+
+  Found by auditing the table scoring path end to end, after three separate instrument
+  defects surfaced in a single day. Two other checks in the same audit came back clean and
+  are now pinned by tests rather than by memory: `colspan` text is not duplicated (a spanning
+  cell is printed once and counted once), and table footnotes belong to the caption stream
+  rather than to cell text. A third found a second latent bug — a table nested inside a cell
+  had its rows counted as the outer table's *and* its text counted twice — which had zero
+  incidence on either development corpus but is fixed here rather than left waiting for the
+  article that has one.
+
+  The lane's `SCHEMA_VERSION` moves to 7 with it. No payload key changes shape; the ground
+  truth underneath every figure does, and the schema pin is what stops a projection edit from
+  landing while the recorded artifact quietly describes an older one — a gap worth naming,
+  because none of the three existing guards could see a truth change: the corpus pin hashes
+  the manifest, the schema pin covered payload shape, and the published-figures test compares
+  the page against the recorded file rather than against a fresh run.

--- a/docs/source/benchmarks.rst
+++ b/docs/source/benchmarks.rst
@@ -99,7 +99,7 @@ Did the text survive?
      -
    * - Raw recall
      - 63.8%
-     - of 8,903 ground-truth blocks
+     - of 8,907 ground-truth blocks
    * - Attainable ceiling
      - 63.9%
      - what the PDF's own text layer reproduces
@@ -122,6 +122,16 @@ boundary (#470) — moves raw recall from 62.3% to 63.8% and table attainable-re
 82.7% to 84.9% with the parser untouched. Recall of *attainable* blocks does not move at
 all: the correction puts more of the ground truth inside the ceiling and recovers it in the
 same proportion, which is the behaviour a ceiling is for.
+
+A second correction of the same kind followed, and it moves the table figure the other way.
+A wide table is often typeset as two ``<table>`` elements under one ``<table-wrap>`` — the
+same rows, the left columns and then the right — and the projection read only the first, so
+5.3% of this corpus's table text sat in halves no converter was ever asked to match. Adding
+them puts four more tables on the expected side, three of which are already recovered, and
+table attainable-recall reads **84.6%**. A correction that lowers a published figure is
+worth as much as one that raises it: the number was measured against a truth that was
+missing, and both directions are the instrument getting more honest rather than the parser
+moving.
 
 An earlier movement was the same kind of thing: the shared oracle was blind to captions the
 parser had correctly bound to their figures — the text left the paragraph stream for a
@@ -168,13 +178,13 @@ By block kind:
      - 2,291
      - **98.9%**
    * - Tables
-     - 119 of 123
-     - 101
-     - **84.9%**
+     - 123 of 127
+     - 104
+     - **84.6%**
 
 The middle column counts only blocks inside the ceiling, so each row's share is its own
 two counts divided. A few more blocks are recovered than that: 3,264 text blocks, 2,313
-titles and 101 tables come out matching the ground truth, including some the PDF's own text
+titles and 104 tables come out matching the ground truth, including some the PDF's own text
 layer does not reproduce. Those count as recovered and on neither side of the share, which
 is why the larger count is not the one printed here.
 
@@ -207,7 +217,7 @@ Unsupported output is therefore split in two:
      - **95.6%**
      - the n-gram appears in the document's text layer
    * - Resequenced
-     - 4.0%
+     - 3.9%
      - every word is in the document, in a new adjacency
    * - **Novel**
      - **0.4%**
@@ -219,7 +229,7 @@ Unsupported output is therefore split in two:
      - 0.7%
      - wants to be ~0%
 
-Over 445,447 emitted n-grams, 1,898 are novel. Reporting the raw unsupported figure instead
+Over 445,442 emitted n-grams, 1,898 are novel. Reporting the raw unsupported figure instead
 would have made the result roughly ten times worse than the parser deserves.
 
 Duplication is counted apart from both, because it is invisible to either. Text emitted
@@ -251,32 +261,32 @@ Tables
 The bottleneck has moved. An earlier recording under-emitted — 92 tables against 121
 expected, with detection refusing to commit on the borderless *booktabs*-style tables
 journals actually print — and after word-gutter grids and two-column regions were admitted
-behind measured guards, the artifact reads **162 emitted against 122
+behind measured guards, the artifact reads **162 emitted against 127
 expected**, with tables emitted on 119 pages
-against the 95 that carry one in the ground truth.
+against the 96 that carry one in the ground truth.
 
 The surplus is not invention, and that is now measured rather than asserted. Every table
-emitted on a page carrying more tables than the ground truth expects — **55** of them — is
+emitted on a page carrying more tables than the ground truth expects — **47** of them — is
 put to two questions. The first does not involve JATS at all: does the PDF's own text layer
 hold this table's words? Text in the layer was printed on the page, so a table failing here
-is the only kind that could have been invented. **55 of 55** pass. The second asks where
+is the only kind that could have been invented. **47 of 47** pass. The second asks where
 that text sits in the ground truth, and the verdict that would matter is prose committed to
-a grid — a parser turning running text into a table it invented. That is **0 of 55**.
+a grid — a parser turning running text into a table it invented. That is **0 of 47**.
 
-Only 40 of the 55 also match the *order* of the text layer, and that gap is a grid doing its
+Only 35 of the 47 also match the *order* of the text layer, and that gap is a grid doing its
 job rather than a fault: re-cutting a page's words into cells changes their adjacency, which
 is why the invention test is asked of the words and not of the 5-grams.
 
-What the surplus is instead is accounting, with two named causes. **15** of the 55 trace to a
+What the surplus is instead is accounting, with two named causes. **13** of the 47 trace to a
 JATS ``<table>`` that the expected count assigns to another page — a table continuing across
 a page break is one ``<table-wrap>`` and several printed tables, and the expected count does
 not credit continuations. And **19** ``<table-wrap>`` elements across five articles carry no
 ``<table>`` markup at all: those publishers deposited their tables as images, so the ground
 truth holds no cell text for them and the tables those pages print can never reach the
 expected side, however well they are extracted. Those five articles alone contribute 20 of
-the **40** tables the census files outside JATS.
+the **34** tables the census files outside JATS.
 
-The other 20 are in the page's own text layer and match no JATS block in order. The
+The other 14 are in the page's own text layer and match no JATS block in order. The
 instrument stops there rather than guessing: it does not distinguish text JATS never
 recorded from a table re-cut into cells in an order JATS does not declare. Unordered token
 containment would answer neither, because an article's tables and its prose share a
@@ -297,7 +307,8 @@ measured, fixed behind guards (#416, #417), and the figure recovered to 77.3%. A
 mechanism followed the same route: ``find_tables()`` drew column boundaries and bbox edges
 straight through cell content, cutting values mid-word where neither guard could see it —
 dissolving those boundaries on structural evidence and healing the cut values in place
-(#419) took the figure to 82.7%, and the ground-truth correction above to **84.9%**.
+(#419) took the figure to 82.7%, the inline-markup correction above to 84.9%, and
+projecting every table a ``<table-wrap>`` carries to **84.6%**.
 The trade still stands with eyes open — a table
 recovered *as a table* is what downstream consumers need — but it is a trade, and the
 artifact says so rather than netting the two effects into one flattering number.
@@ -320,25 +331,25 @@ pages:
      - Wrong page
      - Gap
    * - ``reading_order_similarity``
-     - 0.830
+     - 0.832
      - 0.293
-     - **0.537**
+     - **0.538**
    * - ``text_content_similarity``
-     - 0.690
+     - 0.692
      - 0.234
-     - **0.456**
+     - **0.458**
    * - ``table_content_similarity``
-     - 0.629
-     - 0.039
-     - **0.590**
+     - 0.646
+     - 0.043
+     - **0.603**
    * - ``table_structure_similarity``
-     - 0.636
-     - 0.094
-     - **0.542**
+     - 0.654
+     - 0.098
+     - **0.555**
    * - ``block_structure_similarity``
-     - 0.550
-     - 0.446
-     - 0.104 — **not gated**
+     - 0.552
+     - 0.447
+     - 0.105 — **not gated**
 
 The two table dimensions score only the 123 pages that carry a table on either side; the
 other three score all 706.

--- a/tests/unit/test_pmc_oracle.py
+++ b/tests/unit/test_pmc_oracle.py
@@ -122,6 +122,78 @@ def test_a_table_with_markup_is_not_counted_as_deposited_as_an_image() -> None:
     assert [(block.kind, block.image_table) for block in blocks] == [("table", False)]
 
 
+def test_every_table_a_wrap_carries_is_projected_not_only_the_first() -> None:
+    """A wide table split for the page puts each half in its own ``<table>``, one wrap.
+
+    Reading only the first discarded the rest of the truth silently. Measured on the
+    development corpus: four wraps in one article, holding **5.3% of that corpus's entire
+    table text**, in halves nobody was ever asked to match -- so every tool that did
+    extract them was charged for text with no truth behind it.
+    """
+    blocks, projection = oracles.project_jats(
+        _jats(
+            "<table-wrap><label>Table 2</label><caption><p>Split across the page</p></caption>"
+            "<table><tr><th>Left</th></tr><tr><td>alpha</td></tr></table>"
+            "<table><tr><th>Right</th></tr><tr><td>omega</td></tr></table>"
+            "</table-wrap>"
+        )
+    )
+    tables = [block for block in blocks if block.kind == "table"]
+    assert len(tables) == 2, "the second half of a split table must not be discarded"
+    assert "alpha" in tables[0].text and "omega" in tables[1].text
+    assert len(projection.tables) == 2
+
+
+def test_a_split_wrap_prints_its_caption_once_so_only_the_first_part_carries_it() -> None:
+    """The page prints one caption above the whole wrap, not one above each half."""
+    blocks, _ = oracles.project_jats(
+        _jats(
+            "<table-wrap><label>Table 2</label><caption><p>Printed once</p></caption>"
+            "<table><tr><td>alpha</td></tr></table>"
+            "<table><tr><td>omega</td></tr></table>"
+            "</table-wrap>"
+        )
+    )
+    captions = [block.caption for block in blocks if block.kind == "table"]
+    assert "Printed once" in captions[0]
+    assert captions[1] == "", "repeating the caption would score one printed line twice"
+
+
+def test_a_table_nested_in_a_cell_is_not_projected_as_a_second_table() -> None:
+    """Its text is already inside the outer table's cell text; yielding it counts it twice."""
+    blocks, _ = oracles.project_jats(
+        _jats(
+            "<table-wrap><caption><p>Outer</p></caption>"
+            "<table><tr><td>outer cell"
+            "<table><tr><td>inner</td></tr></table>"
+            "</td></tr></table></table-wrap>"
+        )
+    )
+    tables = [block for block in blocks if block.kind == "table"]
+    assert len(tables) == 1
+    assert tables[0].text.count("inner") == 1
+
+
+def test_table_footnotes_are_scored_as_caption_rather_than_as_cell_text() -> None:
+    """They render beneath the table, and a Table node's cells are not where they land.
+
+    About 7% of a table's printed text is its footnotes on both development corpora, so
+    this is not a rounding decision -- it is why a table's cell text and what the page
+    prints under the table are not the same measurement.
+    """
+    blocks, _ = oracles.project_jats(
+        _jats(
+            "<table-wrap><caption><p>Head</p></caption>"
+            "<table><tr><td>cell</td></tr></table>"
+            "<table-wrap-foot><p>Values are means.</p></table-wrap-foot>"
+            "</table-wrap>"
+        )
+    )
+    table = next(block for block in blocks if block.kind == "table")
+    assert "Values are means" in table.caption
+    assert "Values are means" not in table.text
+
+
 # ---------------------------------------------------------------------------
 # What the surplus tables are
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Found by auditing the table scoring path end to end, after three separate instrument defects surfaced in a single day. The audit was deliberately bounded — the table scoring path only, JATS and cached output, no new CPU — and most of it came back clean. This is what did not.

## A split `<table-wrap>` lost half its table

A wide table is often typeset as two `<table>` elements under one `<table-wrap>` — the same rows, the left columns and then the right. The projection took `next(...)` of that iterator, so the remaining columns never reached the ground truth at all.

Not a rounding error. On the development corpus that is 1,412 words, **5.3% of the corpus's entire table text**, sitting in halves no converter was ever asked to match — and every tool that *did* extract them was charged for emitting text with nothing behind it. On the sealed holdout it is 0.54%; on the tuned corpus, zero.

Each `<table>` now becomes its own truth table. Merging them would have to guess whether the parts are stacked (sum the rows) or side by side (sum the columns), and the structure figures would inherit the guess. The caption stays on the first part, because the page prints it once.

## A second, latent bug the guard caught

Writing the regression test for nested tables failed against the *existing* code: `_jats_table` walked rows with `iter()`, so a table nested inside a cell had its rows counted as the outer table's **and** its text counted twice (`'outer cell inner inner'`, rows 2). Zero incidence on either development corpus — fixed here rather than left for the article that has one.

## The guard, which is the part worth keeping

**None of the three existing guards could see a truth change.** The corpus pin hashes the manifest; the schema pin covered payload *shape*; and the published-figures test compares the page against the *recorded file*, not against a fresh run. #470 changed this same projection and was re-recorded out of discipline, not because anything would have caught it.

`SCHEMA_VERSION` already exists for exactly this — "the measurement underneath every recall figure" changing — so it moves to 7, and CI now fails with *"reference.json is a schema 6 payload but the lane now emits 7 — re-record the reference"* until the artifact is refreshed. Four projection properties are pinned by hermetic tests as well, so they hold in CI where a corpus-based check could only ever skip: split wraps, caption-printed-once, no nested double-count, and footnotes belonging to the caption stream.

## The re-record

Dispatched from this branch (run `33422123023`, commit `7c93f17`, clean worktree, corpus pin unchanged) — dispatching from `main` would have recorded against the old projection and wasted the run.

| | before | after |
|---|---|---|
| ground-truth blocks | 11,503 | 11,507 |
| tables expected | 123 | 127 |
| **table attainable-recall** | **84.9%** | **84.6%** |
| `table_content_similarity` | 0.629 | **0.646** |
| `table_structure_similarity` | 0.636 | **0.654** |
| resequenced | 4.0% | **3.9%** |

Three of the four new tables were already being recovered, so the headline table figure *falls*: the parser did not move, the truth it is measured against did. The dimensions rise for the same reason — text all2md already emitted now has truth behind it instead of counting as surplus. A correction that lowers a published figure is worth as much as one that raises it.

## The page, including what the gate cannot see

All seventeen declared snippets, plus the two failure shapes the recorded procedure warns about and the gate genuinely missed:

- **A derived sentence.** "The other 20" is `outside_jats` minus a per-article count; `outside_jats` fell 40 → 34, so it becomes 14 while the 20 it subtracts is untouched.
- **Two narrative claims of 84.9%**, which the gate accepted because that string still existed elsewhere on the page — one of them presenting it as the *current* figure. Both now carry 84.6% and name the correction that moved it.

Overall attainable recall is unchanged at 98.9%; raw recall stays 63.8%.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
